### PR TITLE
PSM-585 Add error-prone rule for controller method argument annotations

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -103,6 +103,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>jakarta.servlet</groupId>
+            <artifactId>jakarta.servlet-api</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>javax.xml.bind</groupId>
             <artifactId>jaxb-api</artifactId>
             <scope>test</scope>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotationCheck.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotationCheck.java
@@ -24,26 +24,25 @@ import com.google.errorprone.matchers.Matcher;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 
-// XXX: TODOs for Stephan (besides the other XXXes):
-// 1. Tweak documentation and class name.
-// 2. Review tests.
 /**
- * A {@link BugChecker} which flags Spring HTTP request parameter or body annotations as missing if
- * Spring HTTP request mapping annotations are present.
+ * A {@link BugChecker} which flags {@code @RequestMapping} methods that have one or more parameters
+ * that appear to lack a relevant annotation.
  *
  * <p>Matched mappings are {@code @{Delete,Get,Patch,Post,Put,Request}Mapping}.
  */
 @AutoService(BugChecker.class)
 @BugPattern(
-    name = "RequestParameterAnnotation",
-    summary = "Flag missing parameter annotations for Spring HTTP request mappings.",
+    name = "RequestMappingAnnotation",
+    summary = "Make sure all `@RequestMapping` method parameters are annotated",
     linkType = LinkType.NONE,
     severity = SeverityLevel.WARNING,
     tags = StandardTags.LIKELY_ERROR,
     providesFix = ProvidesFix.REQUIRES_HUMAN_ATTENTION)
-public final class RequestParameterAnnotationCheck extends BugChecker implements MethodTreeMatcher {
+public final class RequestMappingAnnotationCheck extends BugChecker implements MethodTreeMatcher {
   private static final long serialVersionUID = 1L;
   private static final String ANN_PACKAGE_PREFIX = "org.springframework.web.bind.annotation.";
+  // XXX: Generalize this logic to fully support Spring meta-annotations, then update the class
+  // documentation.
   private static final Matcher<Tree> HAS_MAPPING_ANNOTATION =
       annotations(
           AT_LEAST_ONE,
@@ -67,8 +66,7 @@ public final class RequestParameterAnnotationCheck extends BugChecker implements
                           isType(ANN_PACKAGE_PREFIX + "PathVariable"),
                           isType(ANN_PACKAGE_PREFIX + "RequestBody"),
                           isType(ANN_PACKAGE_PREFIX + "RequestHeader"),
-                          isType(ANN_PACKAGE_PREFIX + "RequestParam"),
-                          isType("tech.picnic.webapp.JsonParam"))),
+                          isType(ANN_PACKAGE_PREFIX + "RequestParam"))),
                   isSameType("java.io.InputStream"),
                   isSameType("javax.servlet.http.HttpServletRequest"),
                   isSameType("javax.servlet.http.HttpServletResponse"),

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotationCheckTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotationCheckTest.java
@@ -3,15 +3,19 @@ package tech.picnic.errorprone.bugpatterns;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 
-public final class RequestParameterAnnotationCheckTest {
+public final class RequestMappingAnnotationCheckTest {
   private final CompilationTestHelper compilationTestHelper =
-      CompilationTestHelper.newInstance(RequestParameterAnnotationCheck.class, getClass());
+      CompilationTestHelper.newInstance(RequestMappingAnnotationCheck.class, getClass());
 
   @Test
   public void testIdentification() {
     compilationTestHelper
         .addSourceLines(
             "A.java",
+            "import java.io.InputStream;",
+            "import javax.servlet.http.HttpServletRequest;",
+            "import javax.servlet.http.HttpServletResponse;",
+            "import org.springframework.http.HttpMethod;",
             "import org.springframework.web.bind.annotation.DeleteMapping;",
             "import org.springframework.web.bind.annotation.GetMapping;",
             "import org.springframework.web.bind.annotation.PatchMapping;",
@@ -19,17 +23,25 @@ public final class RequestParameterAnnotationCheckTest {
             "import org.springframework.web.bind.annotation.PostMapping;",
             "import org.springframework.web.bind.annotation.PutMapping;",
             "import org.springframework.web.bind.annotation.RequestBody;",
+            "import org.springframework.web.bind.annotation.RequestHeader;",
             "import org.springframework.web.bind.annotation.RequestMapping;",
             "import org.springframework.web.bind.annotation.RequestMethod;",
             "import org.springframework.web.bind.annotation.RequestParam;",
+            "import org.springframework.web.context.request.WebRequest;",
             "",
             "interface A {",
-            "  A properNoMapping();",
-            "  A properNoMapping(String param);",
-            "  @GetMapping A properNoParameters();",
-            "  @PostMapping A properRequestBody(@RequestBody String body);",
-            "  @DeleteMapping A properPathVariable(@PathVariable String param);",
+            "  A noMapping();",
+            "  A noMapping(String param);",
+            "  @DeleteMapping A properNoParameters();",
+            "  @GetMapping A properPathVariable(@PathVariable String param);",
+            "  @PatchMapping A properRequestBody(@RequestBody String body);",
+            "  @PostMapping A properRequestHeader(@RequestHeader String header);",
             "  @PutMapping A properRequestParam(@RequestParam String param);",
+            "  @RequestMapping A properInputStream(InputStream input);",
+            "  @RequestMapping A properHttpServletRequest(HttpServletRequest request);",
+            "  @RequestMapping A properHttpServletResponse(HttpServletResponse response);",
+            "  @RequestMapping A properHttpMethod(HttpMethod method);",
+            "  @RequestMapping A properWebRequest(WebRequest request);",
             "",
             "  // BUG: Diagnostic contains:",
             "  @DeleteMapping A delete(String param);",
@@ -47,13 +59,13 @@ public final class RequestParameterAnnotationCheckTest {
             "  @PutMapping A put(String param);",
             "",
             "  // BUG: Diagnostic contains:",
-            "  @PostMapping A multiple1(String param, String param2);",
+            "  @RequestMapping A requestMultiple(String param, String param2);",
             "",
             "  // BUG: Diagnostic contains:",
-            "  @PostMapping A multiple2(String param, @RequestBody String param2);",
+            "  @RequestMapping A requestFirstParamViolation(String param, @PathVariable String param2);",
             "",
             "  // BUG: Diagnostic contains:",
-            "  @PostMapping A multiple3(@RequestBody String param, String param2);",
+            "  @RequestMapping A requestSecondParamViolation(@RequestBody String param, String param2);",
             "}")
         .doTest();
   }

--- a/pom.xml
+++ b/pom.xml
@@ -243,6 +243,11 @@
                 <version>2.1.6</version>
             </dependency>
             <dependency>
+                <groupId>jakarta.servlet</groupId>
+                <artifactId>jakarta.servlet-api</artifactId>
+                <version>4.0.4</version>
+            </dependency>
+            <dependency>
                 <groupId>javax.xml.bind</groupId>
                 <artifactId>jaxb-api</artifactId>
                 <version>2.3.1</version>


### PR DESCRIPTION
[JIRA PSM-585](https://picnic.atlassian.net/browse/PSM-585) - Add error-prone rule for controller method args annotations

#### Subjective
Controller method arguments without a proper annotation should produce a warning as it's most likely some.

#### Notes
First review was partially performed [on slack](https://teampicnic.slack.com/archives/C0172BMUWNL/p1595675419005000). As a result of this, some TODOs are still open and should be discussed in this PR.