### PR TITLE
Add Refaster rule for `Flux#concat` for a single Mono or Flux

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -161,8 +161,8 @@ final class ReactorTemplates {
     }
   }
 
-  /** Don't use {@link Flux#concat(Publisher)} with only a single {@link Mono}. */
-  static final class FluxConcatMono<T> {
+  /** Prefer {@link Mono#flux()}} over more contrived alternatives. */
+  static final class MonoFlux<T> {
     @BeforeTemplate
     Flux<T> before(Mono<T> mono) {
       return Flux.concat(mono);
@@ -174,8 +174,8 @@ final class ReactorTemplates {
     }
   }
 
-  /** Don't use {@link Flux#concat(Publisher)} with only a single {@link Flux}. */
-  static final class FluxConcatFlux<T> {
+  /** Don't unnecessarily invoke {@link Flux#concat(Publisher)}. */
+  static final class FluxIdentity<T> {
     @BeforeTemplate
     Flux<T> before(Flux<T> flux) {
       return Flux.concat(flux);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestInput.java
@@ -49,12 +49,12 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Mono.just("foo").flatMapMany(s -> Mono.just(s + s));
   }
 
-  Flux<String> testFluxConcatMono() {
+  Flux<String> testMonoFlux() {
     return Flux.concat(Mono.just("foo"));
   }
 
-  Flux<String> testFluxConcatFlux() {
-    return Flux.concat(Flux.just("foo", "bar"));
+  Flux<String> testFluxIdentity() {
+    return Flux.concat(Flux.just("foo"));
   }
 
   ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestOutput.java
@@ -50,12 +50,12 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Mono.just("foo").flatMap(s -> Mono.just(s + s)).flux();
   }
 
-  Flux<String> testFluxConcatMono() {
+  Flux<String> testMonoFlux() {
     return Mono.just("foo").flux();
   }
 
-  Flux<String> testFluxConcatFlux() {
-    return Flux.just("foo", "bar");
+  Flux<String> testFluxIdentity() {
+    return Flux.just("foo");
   }
 
   ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {


### PR DESCRIPTION
Thx to @rickie for contributing :+1: 