### PR TITLE
`ImmutableSetMultiMapTemplates`: Don't modify the identifier of the lambda

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplates.java
@@ -162,7 +162,7 @@ final class ImmutableSetMultimapTemplates {
     @AfterTemplate
     ImmutableSetMultimap<K, V2> after(Multimap<K, V1> multimap) {
       return ImmutableSetMultimap.copyOf(
-          Multimaps.transformValues(multimap, v -> valueTransformation(v)));
+          Multimaps.transformValues(multimap, e -> valueTransformation(e)));
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableSetMultimapTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableSetMultimapTemplatesTestOutput.java
@@ -53,7 +53,7 @@ final class ImmutableSetMultimapTemplatesTest implements RefasterTemplateTestCas
 
   ImmutableSetMultimap<String, Integer> testTransformMultimapValuesToImmutableSetMultimap() {
     return ImmutableSetMultimap.copyOf(
-        Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), v -> Math.toIntExact(v)));
+        Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), e -> Math.toIntExact(e)));
   }
 
   ImmutableSet<ImmutableSetMultimap<String, Integer>>


### PR DESCRIPTION
When the identifier in the after template is different then in the before template, the identifier is updated. This is a side-effect which we generally do not want. Perhaps we should create a check for this in the future 😉 