### PR TITLE
Improve naming of assorted Refaster templates and associated tests

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
@@ -564,7 +564,7 @@ final class AssertJTemplates {
   // Map
   //
 
-  static final class AssertThatMapIsEmpty<K, V> {
+  static final class AbstractMapAssertIsEmpty<K, V> {
     @BeforeTemplate
     @SuppressWarnings("unchecked")
     void before(AbstractMapAssert<?, ?, K, V> mapAssert) {
@@ -615,8 +615,7 @@ final class AssertJTemplates {
     }
   }
 
-  // XXX: Find a better name.
-  static final class AssertThatMapIsEmpty2<K, V> {
+  static final class AssertThatIsEmpty<K, V> {
     @BeforeTemplate
     void before(Map<K, V> map) {
       Refaster.anyOf(
@@ -638,7 +637,7 @@ final class AssertJTemplates {
     }
   }
 
-  static final class AssertThatMapIsNotEmpty<K, V> {
+  static final class AbstractMapAssertIsNotEmpty<K, V> {
     @BeforeTemplate
     AbstractMapAssert<?, ?, K, V> before(AbstractMapAssert<?, ?, K, V> mapAssert) {
       return mapAssert.isNotEqualTo(
@@ -657,8 +656,7 @@ final class AssertJTemplates {
     }
   }
 
-  // XXX: Find a better name.
-  static final class AssertThatMapIsNotEmpty2<K, V> {
+  static final class AssertThatIsNotEmpty<K, V> {
     @BeforeTemplate
     AbstractAssert<?, ?> before(Map<K, V> map) {
       return Refaster.anyOf(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
@@ -615,7 +615,7 @@ final class AssertJTemplates {
     }
   }
 
-  static final class AssertThatIsEmpty<K, V> {
+  static final class AssertThatMapIsEmpty<K, V> {
     @BeforeTemplate
     void before(Map<K, V> map) {
       Refaster.anyOf(
@@ -656,7 +656,7 @@ final class AssertJTemplates {
     }
   }
 
-  static final class AssertThatIsNotEmpty<K, V> {
+  static final class AssertThatMapIsNotEmpty<K, V> {
     @BeforeTemplate
     AbstractAssert<?, ?> before(Map<K, V> map) {
       return Refaster.anyOf(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/DoubleStreamTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/DoubleStreamTemplates.java
@@ -186,7 +186,7 @@ final class DoubleStreamTemplates {
   }
 
   /** Prefer {@link DoubleStream#noneMatch(DoublePredicate)} over more contrived alternatives. */
-  static final class DoubleStreamNoneMatch {
+  static final class DoubleStreamNoneMatchDoublePredicate {
     @BeforeTemplate
     boolean before(DoubleStream stream, DoublePredicate predicate) {
       return Refaster.anyOf(
@@ -201,7 +201,7 @@ final class DoubleStreamTemplates {
     }
   }
 
-  abstract static class DoubleStreamNoneMatch2 {
+  abstract static class DoubleStreamNoneMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse double element);
 
@@ -230,7 +230,7 @@ final class DoubleStreamTemplates {
     }
   }
 
-  static final class DoubleStreamAllMatch {
+  static final class DoubleStreamAllMatchDoublePredicate {
     @BeforeTemplate
     boolean before(DoubleStream stream, DoublePredicate predicate) {
       return stream.noneMatch(predicate.negate());
@@ -242,7 +242,7 @@ final class DoubleStreamTemplates {
     }
   }
 
-  abstract static class DoubleStreamAllMatch2 {
+  abstract static class DoubleStreamAllMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse double element);
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplates.java
@@ -205,7 +205,7 @@ final class ImmutableListMultimapTemplates {
    * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
    * com.google.common.base.Function)} over creating and directly collecting a stream.
    */
-  abstract static class TransformMultimapValuesToImmutableListMultimap<K, V1, V2> {
+  abstract static class ImmutableListMultimapCopyOfMultimapsTransformValues<K, V1, V2> {
     @Placeholder(allowsIdentity = true)
     abstract V2 valueTransformation(@MayOptionallyUse V1 value);
 
@@ -227,7 +227,7 @@ final class ImmutableListMultimapTemplates {
    * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
    * com.google.common.base.Function)} over creating and directly collecting a stream.
    */
-  static final class TransformMultimapValuesToImmutableListMultimap2<K, V1, V2> {
+  static final class ImmutableListMultimapCopyOfMultimapsTransformValuesTransformation<K, V1, V2> {
     // XXX: Drop the `Refaster.anyOf` if we decide to rewrite one to the other.
     @BeforeTemplate
     ImmutableListMultimap<K, V2> before(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplates.java
@@ -121,7 +121,7 @@ final class ImmutableSetMultimapTemplates {
    * Don't map a a stream's elements to map entries, only to subsequently collect them into an
    * {@link ImmutableSetMultimap}. The collection can be performed directly.
    */
-  abstract static class StreamOfMapEntriesToImmutableSetMultimap<E, K, V> {
+  abstract static class StreamCollectToImmutableSetMultimap<E, K, V> {
     @Placeholder(allowsIdentity = true)
     abstract K keyFunction(@MayOptionallyUse E element);
 
@@ -148,7 +148,7 @@ final class ImmutableSetMultimapTemplates {
    * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
    * com.google.common.base.Function)} over creating and directly collecting a stream.
    */
-  abstract static class TransformMultimapValuesToImmutableSetMultimap<K, V1, V2> {
+  abstract static class ImmutableSetMultimapCopyOfMultimapsTransformValues<K, V1, V2> {
     @Placeholder(allowsIdentity = true)
     abstract V2 valueTransformation(@MayOptionallyUse V1 value);
 
@@ -170,7 +170,7 @@ final class ImmutableSetMultimapTemplates {
    * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
    * com.google.common.base.Function)} over creating and directly collecting a stream.
    */
-  static final class TransformMultimapValuesToImmutableSetMultimap2<K, V1, V2> {
+  static final class ImmutableSetMultimapCopyOfMultimapsTransformValuesTransformation<K, V1, V2> {
     // XXX: Drop the `Refaster.anyOf` if we decide to rewrite one to the other.
     @BeforeTemplate
     ImmutableSetMultimap<K, V2> before(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/IntStreamTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/IntStreamTemplates.java
@@ -199,7 +199,7 @@ final class IntStreamTemplates {
   }
 
   /** Prefer {@link IntStream#noneMatch(IntPredicate)} over more contrived alternatives. */
-  static final class IntStreamNoneMatch {
+  static final class IntStreamNoneMatchIntPredicate {
     @BeforeTemplate
     boolean before(IntStream stream, IntPredicate predicate) {
       return Refaster.anyOf(
@@ -214,7 +214,7 @@ final class IntStreamTemplates {
     }
   }
 
-  abstract static class IntStreamNoneMatch2 {
+  abstract static class IntStreamNoneMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse int element);
 
@@ -243,7 +243,7 @@ final class IntStreamTemplates {
     }
   }
 
-  static final class IntStreamAllMatch {
+  static final class IntStreamAllMatchIntPredicate {
     @BeforeTemplate
     boolean before(IntStream stream, IntPredicate predicate) {
       return stream.noneMatch(predicate.negate());
@@ -255,7 +255,7 @@ final class IntStreamTemplates {
     }
   }
 
-  abstract static class IntStreamAllMatch2 {
+  abstract static class IntStreamAllMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse int element);
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/LongStreamTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/LongStreamTemplates.java
@@ -199,7 +199,7 @@ final class LongStreamTemplates {
   }
 
   /** Prefer {@link LongStream#noneMatch(LongPredicate)} over more contrived alternatives. */
-  static final class LongStreamNoneMatch {
+  static final class LongStreamNoneMatchLongPredicate {
     @BeforeTemplate
     boolean before(LongStream stream, LongPredicate predicate) {
       return Refaster.anyOf(
@@ -214,7 +214,7 @@ final class LongStreamTemplates {
     }
   }
 
-  abstract static class LongStreamNoneMatch2 {
+  abstract static class LongStreamNoneMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse long element);
 
@@ -243,7 +243,7 @@ final class LongStreamTemplates {
     }
   }
 
-  static final class LongStreamAllMatch {
+  static final class LongStreamAllMatchLongPredicate {
     @BeforeTemplate
     boolean before(LongStream stream, LongPredicate predicate) {
       return stream.noneMatch(predicate.negate());
@@ -255,7 +255,7 @@ final class LongStreamTemplates {
     }
   }
 
-  abstract static class LongStreamAllMatch2 {
+  abstract static class LongStreamAllMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse long element);
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/StreamTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/StreamTemplates.java
@@ -269,7 +269,7 @@ final class StreamTemplates {
   }
 
   /** Prefer {@link Stream#noneMatch(Predicate)} over more contrived alternatives. */
-  static final class StreamNoneMatch<T> {
+  static final class StreamNoneMatchPredicate<T> {
     @BeforeTemplate
     boolean before(Stream<T> stream, Predicate<? super T> predicate) {
       return Refaster.anyOf(
@@ -284,7 +284,7 @@ final class StreamTemplates {
     }
   }
 
-  abstract static class StreamNoneMatch2<T> {
+  abstract static class StreamNoneMatch<T> {
     @Placeholder(allowsIdentity = true)
     abstract boolean test(@MayOptionallyUse T element);
 
@@ -313,7 +313,7 @@ final class StreamTemplates {
     }
   }
 
-  static final class StreamAllMatch<T> {
+  static final class StreamAllMatchPredicate<T> {
     @BeforeTemplate
     boolean before(Stream<T> stream, Predicate<? super T> predicate) {
       return stream.noneMatch(Refaster.anyOf(not(predicate), predicate.negate()));
@@ -325,7 +325,7 @@ final class StreamTemplates {
     }
   }
 
-  abstract static class StreamAllMatch2<T> {
+  abstract static class StreamAllMatch<T> {
     @Placeholder(allowsIdentity = true)
     abstract boolean test(@MayOptionallyUse T element);
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJEnumerableTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJEnumerableTemplatesTestInput.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.assertj.core.api.EnumerableAssert;
 
-final class AssertJEnumableTemplatesTest implements RefasterTemplateTestCase {
+final class AssertJEnumerableTemplatesTest implements RefasterTemplateTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(Iterables.class);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJEnumerableTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJEnumerableTemplatesTestOutput.java
@@ -6,7 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.assertj.core.api.EnumerableAssert;
 
-final class AssertJEnumableTemplatesTest implements RefasterTemplateTestCase {
+final class AssertJEnumerableTemplatesTest implements RefasterTemplateTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(Iterables.class);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/DoubleStreamTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/DoubleStreamTemplatesTestInput.java
@@ -65,7 +65,7 @@ final class DoubleStreamTemplatesTest implements RefasterTemplateTestCase {
     return DoubleStream.of(1).sorted().findFirst();
   }
 
-  ImmutableSet<Boolean> testDoubleStreamNoneMatch() {
+  ImmutableSet<Boolean> testDoubleStreamNoneMatchDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return ImmutableSet.of(
         !DoubleStream.of(1).anyMatch(n -> n > 1),
@@ -73,7 +73,7 @@ final class DoubleStreamTemplatesTest implements RefasterTemplateTestCase {
         DoubleStream.of(3).filter(pred).findAny().isEmpty());
   }
 
-  boolean testDoubleStreamNoneMatch2() {
+  boolean testDoubleStreamNoneMatch() {
     return DoubleStream.of(1).allMatch(n -> !(n > 1));
   }
 
@@ -83,12 +83,12 @@ final class DoubleStreamTemplatesTest implements RefasterTemplateTestCase {
         DoubleStream.of(2).filter(n -> n > 2).findAny().isPresent());
   }
 
-  boolean testDoubleStreamAllMatch() {
+  boolean testDoubleStreamAllMatchDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return DoubleStream.of(1).noneMatch(pred.negate());
   }
 
-  boolean testDoubleStreamAllMatch2() {
+  boolean testDoubleStreamAllMatch() {
     return DoubleStream.of(1).noneMatch(n -> !(n > 1));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/DoubleStreamTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/DoubleStreamTemplatesTestOutput.java
@@ -65,7 +65,7 @@ final class DoubleStreamTemplatesTest implements RefasterTemplateTestCase {
     return DoubleStream.of(1).min();
   }
 
-  ImmutableSet<Boolean> testDoubleStreamNoneMatch() {
+  ImmutableSet<Boolean> testDoubleStreamNoneMatchDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return ImmutableSet.of(
         DoubleStream.of(1).noneMatch(n -> n > 1),
@@ -73,7 +73,7 @@ final class DoubleStreamTemplatesTest implements RefasterTemplateTestCase {
         DoubleStream.of(3).noneMatch(pred));
   }
 
-  boolean testDoubleStreamNoneMatch2() {
+  boolean testDoubleStreamNoneMatch() {
     return DoubleStream.of(1).noneMatch(n -> n > 1);
   }
 
@@ -82,12 +82,12 @@ final class DoubleStreamTemplatesTest implements RefasterTemplateTestCase {
         DoubleStream.of(1).anyMatch(n -> n > 1), DoubleStream.of(2).anyMatch(n -> n > 2));
   }
 
-  boolean testDoubleStreamAllMatch() {
+  boolean testDoubleStreamAllMatchDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return DoubleStream.of(1).allMatch(pred);
   }
 
-  boolean testDoubleStreamAllMatch2() {
+  boolean testDoubleStreamAllMatch() {
     return DoubleStream.of(1).allMatch(n -> n > 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplatesTestInput.java
@@ -82,13 +82,13 @@ final class ImmutableListMultimapTemplatesTest implements RefasterTemplateTestCa
             .collect(toImmutableListMultimap(n -> n.intValue(), identity())));
   }
 
-  ImmutableListMultimap<String, Integer> testTransformMultimapValuesToImmutableListMultimap() {
+  ImmutableListMultimap<String, Integer> testImmutableListMultimapCopyOfMultimapsTransformValues() {
     return ImmutableListMultimap.of("foo", 1L).entries().stream()
         .collect(toImmutableListMultimap(Map.Entry::getKey, e -> Math.toIntExact(e.getValue())));
   }
 
   ImmutableSet<ImmutableListMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableListMultimap2() {
+      testImmutableListMultimapCopyOfMultimapsTransformValuesTransformation() {
     return ImmutableSet.of(
         ImmutableSetMultimap.of("foo", 1L).asMap().entrySet().stream()
             .collect(

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplatesTestOutput.java
@@ -68,13 +68,13 @@ final class ImmutableListMultimapTemplatesTest implements RefasterTemplateTestCa
         Multimaps.index(ImmutableList.of(3).iterator(), n -> n.intValue()));
   }
 
-  ImmutableListMultimap<String, Integer> testTransformMultimapValuesToImmutableListMultimap() {
+  ImmutableListMultimap<String, Integer> testImmutableListMultimapCopyOfMultimapsTransformValues() {
     return ImmutableListMultimap.copyOf(
         Multimaps.transformValues(ImmutableListMultimap.of("foo", 1L), v -> Math.toIntExact(v)));
   }
 
   ImmutableSet<ImmutableListMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableListMultimap2() {
+      testImmutableListMultimapCopyOfMultimapsTransformValuesTransformation() {
     return ImmutableSet.of(
         ImmutableListMultimap.copyOf(
             Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), Math::toIntExact)),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplatesTestInput.java
@@ -54,19 +54,19 @@ final class ImmutableSetMultimapTemplatesTest implements RefasterTemplateTestCas
             .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableSetMultimap<Integer, String> testStreamOfMapEntriesToImmutableSetMultimap() {
+  ImmutableSetMultimap<Integer, String> testStreamCollectToImmutableSetMultimap() {
     return Stream.of(1, 2, 3)
         .map(n -> Map.entry(n, n.toString()))
         .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  ImmutableSetMultimap<String, Integer> testTransformMultimapValuesToImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapCopyOfMultimapsTransformValues() {
     return ImmutableSetMultimap.of("foo", 1L).entries().stream()
         .collect(toImmutableSetMultimap(Map.Entry::getKey, e -> Math.toIntExact(e.getValue())));
   }
 
   ImmutableSet<ImmutableSetMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableSetMultimap2() {
+      testImmutableSetMultimapCopyOfMultimapsTransformValuesTransformation() {
     return ImmutableSet.of(
         ImmutableSetMultimap.of("foo", 1L).asMap().entrySet().stream()
             .collect(

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplatesTestOutput.java
@@ -47,17 +47,17 @@ final class ImmutableSetMultimapTemplatesTest implements RefasterTemplateTestCas
         ImmutableSetMultimap.copyOf(Iterables.cycle(Map.entry("foo", 1))));
   }
 
-  ImmutableSetMultimap<Integer, String> testStreamOfMapEntriesToImmutableSetMultimap() {
+  ImmutableSetMultimap<Integer, String> testStreamCollectToImmutableSetMultimap() {
     return Stream.of(1, 2, 3).collect(toImmutableSetMultimap(n -> n, n -> n.toString()));
   }
 
-  ImmutableSetMultimap<String, Integer> testTransformMultimapValuesToImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapCopyOfMultimapsTransformValues() {
     return ImmutableSetMultimap.copyOf(
         Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), e -> Math.toIntExact(e)));
   }
 
   ImmutableSet<ImmutableSetMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableSetMultimap2() {
+      testImmutableSetMultimapCopyOfMultimapsTransformValuesTransformation() {
     return ImmutableSet.of(
         ImmutableSetMultimap.copyOf(
             Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), Math::toIntExact)),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/IntStreamTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/IntStreamTemplatesTestInput.java
@@ -69,7 +69,7 @@ final class IntStreamTemplatesTest implements RefasterTemplateTestCase {
     return IntStream.of(1).sorted().findFirst();
   }
 
-  ImmutableSet<Boolean> testIntStreamNoneMatch() {
+  ImmutableSet<Boolean> testIntStreamNoneMatchIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         !IntStream.of(1).anyMatch(n -> n > 1),
@@ -77,7 +77,7 @@ final class IntStreamTemplatesTest implements RefasterTemplateTestCase {
         IntStream.of(3).filter(pred).findAny().isEmpty());
   }
 
-  boolean testIntStreamNoneMatch2() {
+  boolean testIntStreamNoneMatch() {
     return IntStream.of(1).allMatch(n -> !(n > 1));
   }
 
@@ -87,12 +87,12 @@ final class IntStreamTemplatesTest implements RefasterTemplateTestCase {
         IntStream.of(2).filter(n -> n > 2).findAny().isPresent());
   }
 
-  boolean testIntStreamAllMatch() {
+  boolean testIntStreamAllMatchIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return IntStream.of(1).noneMatch(pred.negate());
   }
 
-  boolean testIntStreamAllMatch2() {
+  boolean testIntStreamAllMatch() {
     return IntStream.of(1).noneMatch(n -> !(n > 1));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/IntStreamTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/IntStreamTemplatesTestOutput.java
@@ -69,7 +69,7 @@ final class IntStreamTemplatesTest implements RefasterTemplateTestCase {
     return IntStream.of(1).min();
   }
 
-  ImmutableSet<Boolean> testIntStreamNoneMatch() {
+  ImmutableSet<Boolean> testIntStreamNoneMatchIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         IntStream.of(1).noneMatch(n -> n > 1),
@@ -77,7 +77,7 @@ final class IntStreamTemplatesTest implements RefasterTemplateTestCase {
         IntStream.of(3).noneMatch(pred));
   }
 
-  boolean testIntStreamNoneMatch2() {
+  boolean testIntStreamNoneMatch() {
     return IntStream.of(1).noneMatch(n -> n > 1);
   }
 
@@ -86,12 +86,12 @@ final class IntStreamTemplatesTest implements RefasterTemplateTestCase {
         IntStream.of(1).anyMatch(n -> n > 1), IntStream.of(2).anyMatch(n -> n > 2));
   }
 
-  boolean testIntStreamAllMatch() {
+  boolean testIntStreamAllMatchIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return IntStream.of(1).allMatch(pred);
   }
 
-  boolean testIntStreamAllMatch2() {
+  boolean testIntStreamAllMatch() {
     return IntStream.of(1).allMatch(n -> n > 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/LongStreamTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/LongStreamTemplatesTestInput.java
@@ -69,7 +69,7 @@ final class LongStreamTemplatesTest implements RefasterTemplateTestCase {
     return LongStream.of(1).sorted().findFirst();
   }
 
-  ImmutableSet<Boolean> testLongStreamNoneMatch() {
+  ImmutableSet<Boolean> testLongStreamNoneMatchLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         !LongStream.of(1).anyMatch(n -> n > 1),
@@ -77,7 +77,7 @@ final class LongStreamTemplatesTest implements RefasterTemplateTestCase {
         LongStream.of(3).filter(pred).findAny().isEmpty());
   }
 
-  boolean testLongStreamNoneMatch2() {
+  boolean testLongStreamNoneMatch() {
     return LongStream.of(1).allMatch(n -> !(n > 1));
   }
 
@@ -87,12 +87,12 @@ final class LongStreamTemplatesTest implements RefasterTemplateTestCase {
         LongStream.of(2).filter(n -> n > 2).findAny().isPresent());
   }
 
-  boolean testLongStreamAllMatch() {
+  boolean testLongStreamAllMatchLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return LongStream.of(1).noneMatch(pred.negate());
   }
 
-  boolean testLongStreamAllMatch2() {
+  boolean testLongStreamAllMatch() {
     return LongStream.of(1).noneMatch(n -> !(n > 1));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/LongStreamTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/LongStreamTemplatesTestOutput.java
@@ -69,7 +69,7 @@ final class LongStreamTemplatesTest implements RefasterTemplateTestCase {
     return LongStream.of(1).min();
   }
 
-  ImmutableSet<Boolean> testLongStreamNoneMatch() {
+  ImmutableSet<Boolean> testLongStreamNoneMatchLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         LongStream.of(1).noneMatch(n -> n > 1),
@@ -77,7 +77,7 @@ final class LongStreamTemplatesTest implements RefasterTemplateTestCase {
         LongStream.of(3).noneMatch(pred));
   }
 
-  boolean testLongStreamNoneMatch2() {
+  boolean testLongStreamNoneMatch() {
     return LongStream.of(1).noneMatch(n -> n > 1);
   }
 
@@ -86,12 +86,12 @@ final class LongStreamTemplatesTest implements RefasterTemplateTestCase {
         LongStream.of(1).anyMatch(n -> n > 1), LongStream.of(2).anyMatch(n -> n > 2));
   }
 
-  boolean testLongStreamAllMatch() {
+  boolean testLongStreamAllMatchLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return LongStream.of(1).allMatch(pred);
   }
 
-  boolean testLongStreamAllMatch2() {
+  boolean testLongStreamAllMatch() {
     return LongStream.of(1).allMatch(n -> n > 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StreamTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StreamTemplatesTestInput.java
@@ -99,7 +99,7 @@ final class StreamTemplatesTest implements RefasterTemplateTestCase {
         Stream.of("foo").min(reverseOrder()), Streams.findLast(Stream.of("bar").sorted()));
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch() {
+  ImmutableSet<Boolean> testStreamNoneMatchPredicate() {
     Predicate<String> pred = String::isBlank;
     return ImmutableSet.of(
         !Stream.of("foo").anyMatch(s -> s.length() > 1),
@@ -108,7 +108,7 @@ final class StreamTemplatesTest implements RefasterTemplateTestCase {
         Stream.of("qux").filter(String::isEmpty).findAny().isEmpty());
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch2() {
+  ImmutableSet<Boolean> testStreamNoneMatch() {
     return ImmutableSet.of(
         Stream.of("foo").allMatch(s -> !s.isBlank()), Stream.of(Boolean.TRUE).allMatch(b -> !b));
   }
@@ -119,14 +119,14 @@ final class StreamTemplatesTest implements RefasterTemplateTestCase {
         Stream.of("bar").filter(String::isEmpty).findAny().isPresent());
   }
 
-  ImmutableSet<Boolean> testStreamAllMatch() {
+  ImmutableSet<Boolean> testStreamAllMatchPredicate() {
     Predicate<String> pred = String::isBlank;
     return ImmutableSet.of(
         Stream.of("foo").noneMatch(not(String::isBlank)),
         Stream.of("bar").noneMatch(pred.negate()));
   }
 
-  boolean testStreamAllMatch2() {
+  boolean testStreamAllMatch() {
     return Stream.of("foo").noneMatch(s -> !s.isBlank());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StreamTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StreamTemplatesTestOutput.java
@@ -100,7 +100,7 @@ final class StreamTemplatesTest implements RefasterTemplateTestCase {
         Stream.of("foo").max(naturalOrder()), Stream.of("bar").max(naturalOrder()));
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch() {
+  ImmutableSet<Boolean> testStreamNoneMatchPredicate() {
     Predicate<String> pred = String::isBlank;
     return ImmutableSet.of(
         Stream.of("foo").noneMatch(s -> s.length() > 1),
@@ -109,7 +109,7 @@ final class StreamTemplatesTest implements RefasterTemplateTestCase {
         Stream.of("qux").noneMatch(String::isEmpty));
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch2() {
+  ImmutableSet<Boolean> testStreamNoneMatch() {
     return ImmutableSet.of(
         Stream.of("foo").noneMatch(s -> s.isBlank()), Stream.of(Boolean.TRUE).noneMatch(b -> b));
   }
@@ -119,13 +119,13 @@ final class StreamTemplatesTest implements RefasterTemplateTestCase {
         Stream.of("foo").anyMatch(s -> s.length() > 1), Stream.of("bar").anyMatch(String::isEmpty));
   }
 
-  ImmutableSet<Boolean> testStreamAllMatch() {
+  ImmutableSet<Boolean> testStreamAllMatchPredicate() {
     Predicate<String> pred = String::isBlank;
     return ImmutableSet.of(
         Stream.of("foo").allMatch(String::isBlank), Stream.of("bar").allMatch(pred));
   }
 
-  boolean testStreamAllMatch2() {
+  boolean testStreamAllMatch() {
     return Stream.of("foo").allMatch(s -> s.isBlank());
   }
 }


### PR DESCRIPTION
This PR contains code of #25 . We want to prepare the Refaster templates such that we can easily add the annotations `@Template{,Collection}` in the appropriate places. 
In the afternoon we talked about the reordering of some Refaster templates. I considered doing that in a second commit, but checked the files again, and saw that there is no alphabetical ordering currently, so I left it out.
Also, in the future we most likely want to automate the ordering with another BugPattern 😉, so did not bother to do it right now.

Note: for some Refaster templates our "current" naming scheme does not suffice. 