### PR TITLE
AssertJ: add missing `ImportPolicy` to after template

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
@@ -365,6 +365,7 @@ final class AssertJTemplates {
     }
 
     @AfterTemplate
+    @UseImportPolicy(ImportPolicy.STATIC_IMPORT_ALWAYS)
     ObjectEnumerableAssert<?, S> after(Set<S> set, T element) {
       return assertThat(set).containsExactly(element);
     }


### PR DESCRIPTION
Found this while applying the `AssertJTemplates` to `picnic-payments`. In the `diff` `Assertions.assertThat` occurred. After adding the import policy, and re-running `patch` it was statically imported. 

There are no tests for this template collection yet. However, it is validated on `picnic-payments` and it can be validated by looking at the rest of the templates in this class. It was the _only_ after template that contained `assertThat` _without_ having this import policy. 