### PR TITLE
Introduce `RequestParamAnnotationCheck` for invalid types

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestParamTypeCheck.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestParamTypeCheck.java
@@ -24,12 +24,12 @@ import com.sun.source.tree.VariableTree;
 /** A {@link BugChecker} which flags {@code @RequestParam} parameters with an unsupported type. */
 @AutoService(BugChecker.class)
 @BugPattern(
-    name = "RequestParamAnnotation",
+    name = "RequestParamType",
     summary = "`@RequestParam` does not support `ImmutableCollection` and `ImmutableMap` subtypes",
     linkType = NONE,
     severity = ERROR,
     tags = LIKELY_ERROR)
-public final class RequestParamAnnotationCheck extends BugChecker implements VariableTreeMatcher {
+public final class RequestParamTypeCheck extends BugChecker implements VariableTreeMatcher {
   private static final long serialVersionUID = 1L;
   private static final Matcher<VariableTree> HAS_UNSUPPORTED_REQUEST_PARAM =
       allOf(

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/RequestParamTypeCheckTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/RequestParamTypeCheckTest.java
@@ -3,9 +3,9 @@ package tech.picnic.errorprone.bugpatterns;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 
-final class RequestParamAnnotationCheckTest {
+final class RequestParamTypeCheckTest {
   private final CompilationTestHelper compilationTestHelper =
-      CompilationTestHelper.newInstance(RequestParamAnnotationCheck.class, getClass());
+      CompilationTestHelper.newInstance(RequestParamTypeCheck.class, getClass());
 
   @Test
   void identification() {


### PR DESCRIPTION
[[ANS-219](https://picnic.atlassian.net/browse/ANS-219)]

As a follow-up to PicnicSupermarket/picnic-platform#8503:

 - Introduce a new check: **RequestParamAnnotationCheck**;
   - This new check should block any instance of `ImmutableMap`/subtypes of `ImmutableCollection` from being the type of ane `@RequestParam`.