### PR TITLE
Introduce `ImmutableCollection` templates

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListTemplates.java
@@ -41,37 +41,6 @@ final class ImmutableListTemplates {
     }
   }
 
-  /** Prefer {@link ImmutableList#of()} over more contrived alternatives. */
-  static final class EmptyImmutableList<T> {
-    @BeforeTemplate
-    ImmutableList<T> before() {
-      return Refaster.anyOf(
-          ImmutableList.<T>builder().build(), Stream.<T>empty().collect(toImmutableList()));
-    }
-
-    @AfterTemplate
-    ImmutableList<T> after() {
-      return ImmutableList.of();
-    }
-  }
-
-  /**
-   * Prefer {@link ImmutableList#of(Object)} over alternatives that don't communicate the
-   * immutability of the resulting list at the type level.
-   */
-  // XXX: Note that this rewrite rule is incorrect for nullable elements.
-  static final class SingletonImmutableList<T> {
-    @BeforeTemplate
-    List<T> before(T element) {
-      return Collections.singletonList(element);
-    }
-
-    @AfterTemplate
-    ImmutableList<T> after(T element) {
-      return ImmutableList.of(element);
-    }
-  }
-
   /**
    * Prefer {@link ImmutableList#copyOf(Iterable)} and variants over more contrived alternatives.
    */
@@ -188,18 +157,19 @@ final class ImmutableListTemplates {
   }
 
   /**
-   * Prefer {@link ImmutableList#of()} over alternatives that don't communicate the immutability of
-   * the resulting list at the type level.
+   * Prefer {@link ImmutableList#of()} over more contrived alternatives or alternatives that don't
+   * communicate the immutability of the resulting list at the type level.
    */
+  // XXX: The `Stream` variant may be too contrived to warrant inclusion. Review its usage if/when
+  // this and similar Refaster templates are replaced with an Error Prone check.
   static final class ImmutableListOf<T> {
     @BeforeTemplate
     List<T> before() {
-      return Collections.emptyList();
-    }
-
-    @BeforeTemplate
-    List<T> before2() {
-      return List.of();
+      return Refaster.anyOf(
+          ImmutableList.<T>builder().build(),
+          Stream.<T>empty().collect(toImmutableList()),
+          Collections.emptyList(),
+          List.of());
     }
 
     @AfterTemplate
@@ -209,13 +179,16 @@ final class ImmutableListTemplates {
   }
 
   /**
-   * Prefer {@link ImmutableList#of(Object)} over alternatives that don't communicate the
-   * immutability of the resulting list at the type level.
+   * Prefer {@link ImmutableList#of(Object)} over more contrived alternatives or alternatives that
+   * don't communicate the immutability of the resulting list at the type level.
    */
+  // XXX: Note that the replacement of `Collections#singletonList` is incorrect for nullable
+  // elements.
   static final class ImmutableListOf1<T> {
     @BeforeTemplate
     List<T> before(T e1) {
-      return List.of(e1);
+      return Refaster.anyOf(
+          ImmutableList.<T>builder().add(e1).build(), Collections.singletonList(e1), List.of(e1));
     }
 
     @AfterTemplate
@@ -228,6 +201,8 @@ final class ImmutableListTemplates {
    * Prefer {@link ImmutableList#of(Object, Object)} over alternatives that don't communicate the
    * immutability of the resulting list at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableList.builder()` usages.
   static final class ImmutableListOf2<T> {
     @BeforeTemplate
     List<T> before(T e1, T e2) {
@@ -244,6 +219,8 @@ final class ImmutableListTemplates {
    * Prefer {@link ImmutableList#of(Object, Object, Object)} over alternatives that don't
    * communicate the immutability of the resulting list at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableList.builder()` usages.
   static final class ImmutableListOf3<T> {
     @BeforeTemplate
     List<T> before(T e1, T e2, T e3) {
@@ -260,6 +237,8 @@ final class ImmutableListTemplates {
    * Prefer {@link ImmutableList#of(Object, Object, Object, Object)} over alternatives that don't
    * communicate the immutability of the resulting list at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableList.builder()` usages.
   static final class ImmutableListOf4<T> {
     @BeforeTemplate
     List<T> before(T e1, T e2, T e3, T e4) {
@@ -276,6 +255,8 @@ final class ImmutableListTemplates {
    * Prefer {@link ImmutableList#of(Object, Object, Object, Object, Object)} over alternatives that
    * don't communicate the immutability of the resulting list at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableList.builder()` usages.
   static final class ImmutableListOf5<T> {
     @BeforeTemplate
     List<T> before(T e1, T e2, T e3, T e4, T e5) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableMapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableMapTemplates.java
@@ -40,41 +40,6 @@ final class ImmutableMapTemplates {
     }
   }
 
-  /** Prefer {@link ImmutableMap#of()} over more contrived alternatives. */
-  static final class EmptyImmutableMap<K, V> {
-    @BeforeTemplate
-    ImmutableMap<K, V> before() {
-      return ImmutableMap.<K, V>builder().build();
-    }
-
-    @AfterTemplate
-    ImmutableMap<K, V> after() {
-      return ImmutableMap.of();
-    }
-  }
-
-  /**
-   * Prefer {@link ImmutableMap#of(Object, Object)} over more contrived alternatives and
-   * alternatives that don't communicate the immutability of the resulting map at the type level.
-   */
-  // XXX: One can define variants for more than one key-value pair, but at some point the builder
-  // actually produces nicer code. So it's not clear we should add Refaster templates for those
-  // variants.
-  // XXX: Note that the `singletonMap` rewrite rule is incorrect for nullable elements.
-  static final class PairToImmutableMap<K, V> {
-    @BeforeTemplate
-    Map<K, V> before(K key, V value) {
-      return Refaster.anyOf(
-          ImmutableMap.<K, V>builder().put(key, value).build(),
-          Collections.singletonMap(key, value));
-    }
-
-    @AfterTemplate
-    ImmutableMap<K, V> after(K key, V value) {
-      return ImmutableMap.of(key, value);
-    }
-  }
-
   /** Prefer {@link ImmutableMap#of(Object, Object)} over more contrived alternatives. */
   static final class EntryToImmutableMap<K, V> {
     @BeforeTemplate
@@ -243,18 +208,13 @@ final class ImmutableMapTemplates {
   }
 
   /**
-   * Prefer {@link ImmutableMap#of()} over alternatives that don't communicate the immutability of
-   * the resulting list at the type level.
+   * Prefer {@link ImmutableMap#of()} over more contrived alternatives or alternatives that don't
+   * communicate the immutability of the resulting map at the type level.
    */
   static final class ImmutableMapOf<K, V> {
     @BeforeTemplate
     Map<K, V> before() {
-      return Collections.emptyMap();
-    }
-
-    @BeforeTemplate
-    Map<K, V> before2() {
-      return Map.of();
+      return Refaster.anyOf(ImmutableMap.<K, V>builder().build(), Collections.emptyMap(), Map.of());
     }
 
     @AfterTemplate
@@ -264,13 +224,18 @@ final class ImmutableMapTemplates {
   }
 
   /**
-   * Prefer {@link ImmutableMap#of(Object, Object)} over alternatives that don't communicate the
-   * immutability of the resulting list at the type level.
+   * Prefer {@link ImmutableMap#of(Object, Object)} over more contrived alternatives or alternatives
+   * that don't communicate the immutability of the resulting map at the type level.
    */
+  // XXX: Note that the replacement of `Collections#singletonMap` is incorrect for nullable
+  // elements.
   static final class ImmutableMapOf1<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1) {
-      return Map.of(k1, v1);
+      return Refaster.anyOf(
+          ImmutableMap.<K, V>builder().put(k1, v1).build(),
+          Collections.singletonMap(k1, v1),
+          Map.of(k1, v1));
     }
 
     @AfterTemplate
@@ -281,8 +246,9 @@ final class ImmutableMapTemplates {
 
   /**
    * Prefer {@link ImmutableMap#of(Object, Object, Object, Object)} over alternatives that don't
-   * communicate the immutability of the resulting list at the type level.
+   * communicate the immutability of the resulting map at the type level.
    */
+  // XXX: Also rewrite the `ImmutableMap.builder()` variant?
   static final class ImmutableMapOf2<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2) {
@@ -297,8 +263,9 @@ final class ImmutableMapTemplates {
 
   /**
    * Prefer {@link ImmutableMap#of(Object, Object, Object, Object, Object, Object)} over
-   * alternatives that don't communicate the immutability of the resulting list at the type level.
+   * alternatives that don't communicate the immutability of the resulting map at the type level.
    */
+  // XXX: Also rewrite the `ImmutableMap.builder()` variant?
   static final class ImmutableMapOf3<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2, K k3, V v3) {
@@ -313,9 +280,10 @@ final class ImmutableMapTemplates {
 
   /**
    * Prefer {@link ImmutableMap#of(Object, Object, Object, Object, Object, Object, Object, Object)}
-   * over alternatives that don't communicate the immutability of the resulting list at the type
+   * over alternatives that don't communicate the immutability of the resulting map at the type
    * level.
    */
+  // XXX: Also rewrite the `ImmutableMap.builder()` variant?
   static final class ImmutableMapOf4<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
@@ -330,9 +298,10 @@ final class ImmutableMapTemplates {
 
   /**
    * Prefer {@link ImmutableMap#of(Object, Object, Object, Object, Object, Object, Object, Object,
-   * Object, Object)} over alternatives that don't communicate the immutability of the resulting
-   * list at the type level.
+   * Object, Object)} over alternatives that don't communicate the immutability of the resulting map
+   * at the type level.
    */
+  // XXX: Also rewrite the `ImmutableMap.builder()` variant?
   static final class ImmutableMapOf5<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetTemplates.java
@@ -39,37 +39,6 @@ final class ImmutableSetTemplates {
     }
   }
 
-  /** Prefer {@link ImmutableSet#of()} over more contrived alternatives. */
-  static final class EmptyImmutableSet<T> {
-    @BeforeTemplate
-    ImmutableSet<T> before() {
-      return Refaster.anyOf(
-          ImmutableSet.<T>builder().build(), Stream.<T>empty().collect(toImmutableSet()));
-    }
-
-    @AfterTemplate
-    ImmutableSet<T> after() {
-      return ImmutableSet.of();
-    }
-  }
-
-  /**
-   * Prefer {@link ImmutableSet#of(Object)} over alternatives that don't communicate the
-   * immutability of the resulting set at the type level.
-   */
-  // XXX: Note that this rewrite rule is incorrect for nullable elements.
-  static final class SingletonImmutableSet<T> {
-    @BeforeTemplate
-    Set<T> before(T element) {
-      return Collections.singleton(element);
-    }
-
-    @AfterTemplate
-    ImmutableSet<T> after(T element) {
-      return ImmutableSet.of(element);
-    }
-  }
-
   /** Prefer {@link ImmutableSet#copyOf(Iterable)} and variants over more contrived alternatives. */
   static final class IterableToImmutableSet<T> {
     @BeforeTemplate
@@ -140,18 +109,19 @@ final class ImmutableSetTemplates {
   }
 
   /**
-   * Prefer {@link ImmutableSet#of()} over alternatives that don't communicate the immutability of
-   * the resulting list at the type level.
+   * Prefer {@link ImmutableSet#of()} over more contrived alternatives or alternatives that don't
+   * communicate the immutability of the resulting set at the type level.
    */
+  // XXX: The `Stream` variant may be too contrived to warrant inclusion. Review its usage if/when
+  // this and similar Refaster templates are replaced with an Error Prone check.
   static final class ImmutableSetOf<T> {
     @BeforeTemplate
     Set<T> before() {
-      return Collections.emptySet();
-    }
-
-    @BeforeTemplate
-    Set<T> before2() {
-      return Set.of();
+      return Refaster.anyOf(
+          ImmutableSet.<T>builder().build(),
+          Stream.<T>empty().collect(toImmutableSet()),
+          Collections.emptySet(),
+          Set.of());
     }
 
     @AfterTemplate
@@ -161,13 +131,15 @@ final class ImmutableSetTemplates {
   }
 
   /**
-   * Prefer {@link ImmutableSet#of(Object)} over alternatives that don't communicate the
-   * immutability of the resulting list at the type level.
+   * Prefer {@link ImmutableSet#of(Object)} over more contrived alternatives or alternatives that
+   * don't communicate the immutability of the resulting set at the type level.
    */
+  // XXX: Note that the replacement of `Collections#singleton` is incorrect for nullable elements.
   static final class ImmutableSetOf1<T> {
     @BeforeTemplate
     Set<T> before(T e1) {
-      return Set.of(e1);
+      return Refaster.anyOf(
+          ImmutableSet.<T>builder().add(e1).build(), Collections.singleton(e1), Set.of(e1));
     }
 
     @AfterTemplate
@@ -178,8 +150,10 @@ final class ImmutableSetTemplates {
 
   /**
    * Prefer {@link ImmutableSet#of(Object, Object)} over alternatives that don't communicate the
-   * immutability of the resulting list at the type level.
+   * immutability of the resulting set at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableSet.builder()` usages.
   static final class ImmutableSetOf2<T> {
     @BeforeTemplate
     Set<T> before(T e1, T e2) {
@@ -194,8 +168,10 @@ final class ImmutableSetTemplates {
 
   /**
    * Prefer {@link ImmutableSet#of(Object, Object, Object)} over alternatives that don't communicate
-   * the immutability of the resulting list at the type level.
+   * the immutability of the resulting set at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableSet.builder()` usages.
   static final class ImmutableSetOf3<T> {
     @BeforeTemplate
     Set<T> before(T e1, T e2, T e3) {
@@ -210,8 +186,10 @@ final class ImmutableSetTemplates {
 
   /**
    * Prefer {@link ImmutableSet#of(Object, Object, Object, Object)} over alternatives that don't
-   * communicate the immutability of the resulting list at the type level.
+   * communicate the immutability of the resulting set at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableSet.builder()` usages.
   static final class ImmutableSetOf4<T> {
     @BeforeTemplate
     Set<T> before(T e1, T e2, T e3, T e4) {
@@ -226,8 +204,10 @@ final class ImmutableSetTemplates {
 
   /**
    * Prefer {@link ImmutableSet#of(Object, Object, Object, Object, Object)} over alternatives that
-   * don't communicate the immutability of the resulting list at the type level.
+   * don't communicate the immutability of the resulting set at the type level.
    */
+  // XXX: Consider writing an Error Prone check which also flags straightforward
+  // `ImmutableSet.builder()` usages.
   static final class ImmutableSetOf5<T> {
     @BeforeTemplate
     Set<T> before(T e1, T e2, T e3, T e4, T e5) {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableListTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableListTemplatesTestInput.java
@@ -31,16 +31,6 @@ final class ImmutableListTemplatesTest implements RefasterTemplateTestCase {
     return new ImmutableList.Builder<>();
   }
 
-  ImmutableSet<ImmutableList<Integer>> testEmptyImmutableList() {
-    return ImmutableSet.of(
-        ImmutableList.<Integer>builder().build(),
-        Stream.<Integer>empty().collect(toImmutableList()));
-  }
-
-  List<String> testSingletonImmutableList() {
-    return Collections.singletonList("foo");
-  }
-
   ImmutableSet<ImmutableList<Integer>> testIterableToImmutableList() {
     return ImmutableSet.of(
         ImmutableList.of(1).stream().collect(toImmutableList()),
@@ -80,12 +70,16 @@ final class ImmutableListTemplatesTest implements RefasterTemplateTestCase {
     return Stream.of(1).distinct().collect(toImmutableList());
   }
 
-  ImmutableSet<List<Object>> testImmutableListOf() {
-    return ImmutableSet.of(Collections.emptyList(), List.of());
+  ImmutableSet<List<Integer>> testImmutableListOf() {
+    return ImmutableSet.of(
+        ImmutableList.<Integer>builder().build(),
+        Stream.<Integer>empty().collect(toImmutableList()),
+        Collections.<Integer>emptyList(),
+        List.<Integer>of());
   }
 
-  List<Integer> testImmutableListOf1() {
-    return List.of(1);
+  ImmutableSet<List<Integer>> testImmutableListOf1() {
+    return ImmutableSet.of(Collections.singletonList(1), List.of(1));
   }
 
   List<Integer> testImmutableListOf2() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableListTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableListTemplatesTestOutput.java
@@ -32,14 +32,6 @@ final class ImmutableListTemplatesTest implements RefasterTemplateTestCase {
     return ImmutableList.builder();
   }
 
-  ImmutableSet<ImmutableList<Integer>> testEmptyImmutableList() {
-    return ImmutableSet.of(ImmutableList.of(), ImmutableList.of());
-  }
-
-  List<String> testSingletonImmutableList() {
-    return ImmutableList.of("foo");
-  }
-
   ImmutableSet<ImmutableList<Integer>> testIterableToImmutableList() {
     return ImmutableSet.of(
         ImmutableList.copyOf(ImmutableList.of(1)),
@@ -75,12 +67,13 @@ final class ImmutableListTemplatesTest implements RefasterTemplateTestCase {
     return Stream.of(1).collect(toImmutableSet()).asList();
   }
 
-  ImmutableSet<List<Object>> testImmutableListOf() {
-    return ImmutableSet.of(ImmutableList.of(), ImmutableList.of());
+  ImmutableSet<List<Integer>> testImmutableListOf() {
+    return ImmutableSet.of(
+        ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
   }
 
-  List<Integer> testImmutableListOf1() {
-    return ImmutableList.of(1);
+  ImmutableSet<List<Integer>> testImmutableListOf1() {
+    return ImmutableSet.of(ImmutableList.of(1), ImmutableList.of(1));
   }
 
   List<Integer> testImmutableListOf2() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableMapTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableMapTemplatesTestInput.java
@@ -23,16 +23,6 @@ final class ImmutableMapTemplatesTest implements RefasterTemplateTestCase {
     return new ImmutableMap.Builder<>();
   }
 
-  ImmutableMap<String, Integer> testEmptyImmutableMap() {
-    return ImmutableMap.<String, Integer>builder().build();
-  }
-
-  ImmutableSet<Map<String, Integer>> testPairToImmutableMap() {
-    return ImmutableSet.of(
-        ImmutableMap.<String, Integer>builder().put("foo", 1).build(),
-        Collections.singletonMap("bar", 2));
-  }
-
   ImmutableSet<ImmutableMap<String, Integer>> testEntryToImmutableMap() {
     return ImmutableSet.of(
         ImmutableMap.<String, Integer>builder().put(Map.entry("foo", 1)).build(),
@@ -87,12 +77,18 @@ final class ImmutableMapTemplatesTest implements RefasterTemplateTestCase {
             k -> Math.toIntExact(ImmutableMap.of("bar", 2L).get(k))));
   }
 
-  ImmutableSet<Map<Object, Object>> testImmutableMapOf() {
-    return ImmutableSet.of(Collections.emptyMap(), Map.of());
+  ImmutableSet<Map<String, String>> testImmutableMapOf() {
+    return ImmutableSet.of(
+        ImmutableMap.<String, String>builder().build(),
+        Collections.<String, String>emptyMap(),
+        Map.<String, String>of());
   }
 
-  Map<String, String> testImmutableMapOf1() {
-    return Map.of("k1", "v1");
+  ImmutableSet<Map<String, String>> testImmutableMapOf1() {
+    return ImmutableSet.of(
+        ImmutableMap.<String, String>builder().put("k1", "v1").build(),
+        Collections.singletonMap("k1", "v1"),
+        Map.of("k1", "v1"));
   }
 
   Map<String, String> testImmutableMapOf2() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableMapTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableMapTemplatesTestOutput.java
@@ -23,14 +23,6 @@ final class ImmutableMapTemplatesTest implements RefasterTemplateTestCase {
     return ImmutableMap.builder();
   }
 
-  ImmutableMap<String, Integer> testEmptyImmutableMap() {
-    return ImmutableMap.of();
-  }
-
-  ImmutableSet<Map<String, Integer>> testPairToImmutableMap() {
-    return ImmutableSet.of(ImmutableMap.of("foo", 1), ImmutableMap.of("bar", 2));
-  }
-
   ImmutableSet<ImmutableMap<String, Integer>> testEntryToImmutableMap() {
     return ImmutableSet.of(
         ImmutableMap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()),
@@ -73,12 +65,13 @@ final class ImmutableMapTemplatesTest implements RefasterTemplateTestCase {
             Maps.transformValues(ImmutableMap.of("bar", 2L), v -> Math.toIntExact(v))));
   }
 
-  ImmutableSet<Map<Object, Object>> testImmutableMapOf() {
-    return ImmutableSet.of(ImmutableMap.of(), ImmutableMap.of());
+  ImmutableSet<Map<String, String>> testImmutableMapOf() {
+    return ImmutableSet.of(ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
   }
 
-  Map<String, String> testImmutableMapOf1() {
-    return ImmutableMap.of("k1", "v1");
+  ImmutableSet<Map<String, String>> testImmutableMapOf1() {
+    return ImmutableSet.of(
+        ImmutableMap.of("k1", "v1"), ImmutableMap.of("k1", "v1"), ImmutableMap.of("k1", "v1"));
   }
 
   Map<String, String> testImmutableMapOf2() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableSetTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableSetTemplatesTestInput.java
@@ -30,15 +30,6 @@ final class ImmutableSetTemplatesTest implements RefasterTemplateTestCase {
     return new ImmutableSet.Builder<>();
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testEmptyImmutableSet() {
-    return ImmutableSet.of(
-        ImmutableSet.<Integer>builder().build(), Stream.<Integer>empty().collect(toImmutableSet()));
-  }
-
-  Set<String> testSingletonImmutableSet() {
-    return Collections.singleton("foo");
-  }
-
   ImmutableSet<ImmutableSet<Integer>> testIterableToImmutableSet() {
     return ImmutableSet.of(
         ImmutableList.of(1).stream().collect(toImmutableSet()),
@@ -63,12 +54,17 @@ final class ImmutableSetTemplatesTest implements RefasterTemplateTestCase {
     return ImmutableSet.copyOf(Sets.difference(ImmutableSet.of(1), ImmutableSet.of(2)));
   }
 
-  ImmutableSet<Set<Object>> testImmutableSetOf() {
-    return ImmutableSet.of(Collections.emptySet(), Set.of());
+  ImmutableSet<Set<Integer>> testImmutableSetOf() {
+    return ImmutableSet.of(
+        ImmutableSet.<Integer>builder().build(),
+        Stream.<Integer>empty().collect(toImmutableSet()),
+        Collections.<Integer>emptySet(),
+        Set.<Integer>of());
   }
 
-  Set<Integer> testImmutableSetOf1() {
-    return Set.of(1);
+  ImmutableSet<Set<Integer>> testImmutableSetOf1() {
+    return ImmutableSet.of(
+        ImmutableSet.<Integer>builder().add(1).build(), Collections.singleton(1), Set.of(1));
   }
 
   Set<Integer> testImmutableSetOf2() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableSetTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ImmutableSetTemplatesTestOutput.java
@@ -30,14 +30,6 @@ final class ImmutableSetTemplatesTest implements RefasterTemplateTestCase {
     return ImmutableSet.builder();
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testEmptyImmutableSet() {
-    return ImmutableSet.of(ImmutableSet.of(), ImmutableSet.of());
-  }
-
-  Set<String> testSingletonImmutableSet() {
-    return ImmutableSet.of("foo");
-  }
-
   ImmutableSet<ImmutableSet<Integer>> testIterableToImmutableSet() {
     return ImmutableSet.of(
         ImmutableSet.copyOf(ImmutableList.of(1)),
@@ -62,12 +54,13 @@ final class ImmutableSetTemplatesTest implements RefasterTemplateTestCase {
     return Sets.difference(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy();
   }
 
-  ImmutableSet<Set<Object>> testImmutableSetOf() {
-    return ImmutableSet.of(ImmutableSet.of(), ImmutableSet.of());
+  ImmutableSet<Set<Integer>> testImmutableSetOf() {
+    return ImmutableSet.of(
+        ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of());
   }
 
-  Set<Integer> testImmutableSetOf1() {
-    return ImmutableSet.of(1);
+  ImmutableSet<Set<Integer>> testImmutableSetOf1() {
+    return ImmutableSet.of(ImmutableSet.of(1), ImmutableSet.of(1), ImmutableSet.of(1));
   }
 
   Set<Integer> testImmutableSetOf2() {


### PR DESCRIPTION
Introduce templates for `{Set,List,Map}.of(...)` _and_ `Collection.{emptyList,emptyMap,emptySet}()` to `Immutable{Set,List.Map}.of(...)` from zero up to 5 elements.