### PR TITLE
Add withMessage + String.format Refaster template

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJThrowingCallableTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJThrowingCallableTemplates.java
@@ -321,7 +321,9 @@ final class AssertJThrowingCallableTemplates {
     }
   }
 
-  static final class ThrowableAssertAlternativeHasMessageArgs {
+  // XXX: Drop this template in favour of a generic Error Prone check which flags
+  // `String.format(...)` arguments to a wide range of format methods.
+  static final class AbstractThrowableAssertHasMessage {
     @BeforeTemplate
     AbstractThrowableAssert<?, ? extends Throwable> before(
         AbstractThrowableAssert<?, ? extends Throwable> abstractThrowableAssert,
@@ -339,21 +341,23 @@ final class AssertJThrowingCallableTemplates {
     }
   }
 
-  static final class ThrowableAssertAlternativeWithFailMessageArgs {
+  // XXX: Drop this template in favour of a generic Error Prone check which flags
+  // `String.format(...)` arguments to a wide range of format methods.
+  static final class AbstractThrowableAssertWithFailMessage {
     @BeforeTemplate
     AbstractThrowableAssert<?, ? extends Throwable> before(
         AbstractThrowableAssert<?, ? extends Throwable> abstractThrowableAssert,
         String message,
-        @Repeated Object parameters) {
-      return abstractThrowableAssert.withFailMessage(String.format(message, parameters));
+        @Repeated Object args) {
+      return abstractThrowableAssert.withFailMessage(String.format(message, args));
     }
 
     @AfterTemplate
     AbstractThrowableAssert<?, ? extends Throwable> after(
         AbstractThrowableAssert<?, ? extends Throwable> abstractThrowableAssert,
         String message,
-        @Repeated Object parameters) {
-      return abstractThrowableAssert.withFailMessage(message, parameters);
+        @Repeated Object args) {
+      return abstractThrowableAssert.withFailMessage(message, args);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/AssertJThrowingCallableTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/AssertJThrowingCallableTemplatesTestInput.java
@@ -97,24 +97,24 @@ final class AssertJThrowingCallableTemplatesTest implements RefasterTemplateTest
   }
 
   ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
-      testThrowableAssertAlternativeHasMessageArgs() {
+      testAbstractThrowableAssertHasMessage() {
     return ImmutableSet.of(
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage(String.format("foo %s", "bar")),
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage(String.format("foo %s %f", "bar", 1)));
+            .hasMessage(String.format("foo %s %s", "bar", 1)));
   }
 
   ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
-      testThrowableAssertAlternativeWithFailMessageArgs() {
+      testAbstractThrowableAssertWithFailMessage() {
     return ImmutableSet.of(
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
             .withFailMessage(String.format("foo %s", "bar")),
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
-            .withFailMessage(String.format("foo %s %f", "bar", 1)));
+            .withFailMessage(String.format("foo %s %s", "bar", 1)));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/AssertJThrowingCallableTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/AssertJThrowingCallableTemplatesTestOutput.java
@@ -114,24 +114,24 @@ final class AssertJThrowingCallableTemplatesTest implements RefasterTemplateTest
   }
 
   ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
-      testThrowableAssertAlternativeHasMessageArgs() {
+      testAbstractThrowableAssertHasMessage() {
     return ImmutableSet.of(
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
             .hasMessage("foo %s", "bar"),
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
-            .hasMessage("foo %s %f", "bar", 1));
+            .hasMessage("foo %s %s", "bar", 1));
   }
 
   ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
-      testThrowableAssertAlternativeWithFailMessageArgs() {
+      testAbstractThrowableAssertWithFailMessage() {
     return ImmutableSet.of(
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
             .withFailMessage("foo %s", "bar"),
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
-            .withFailMessage("foo %s %f", "bar", 1));
+            .withFailMessage("foo %s %s", "bar", 1));
   }
 }


### PR DESCRIPTION
Implement Refaster rules for AssertJException class for error messages and `String.format`. Usage of `String.format` is redundant since equivalent methods are provided by AssertJ.