### PR TITLE
add refaster rule for LastStep.verifyError & assertThat

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -317,24 +317,13 @@ final class ReactorTemplates {
     }
   }
 
-  /** Prefer {@link StepVerifier.LastStep#verifyError()} over type check verification */
-  static final class StepVerifierLastStepVerifyErrorAssert {
-    @BeforeTemplate
-    Duration before(StepVerifier.LastStep step) {
-      return step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(Throwable.class));
-    }
-
-    @AfterTemplate
-    Duration after(StepVerifier.LastStep step) {
-      return step.verifyError(Throwable.class);
-    }
-  }
-
   /** Prefer {@link StepVerifier.LastStep#verifyError(Class)} over more verbose alternatives. */
   static final class StepVerifierLastStepVerifyErrorClass<T extends Throwable> {
     @BeforeTemplate
     Duration before(StepVerifier.LastStep step, Class<T> clazz) {
-      return step.expectError(clazz).verify();
+      return Refaster.anyOf(
+          step.expectError(clazz).verify(),
+          step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz)));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestInput.java
@@ -13,6 +13,11 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
 
 final class ReactorTemplatesTest implements RefasterTemplateTestCase {
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(assertThat(0));
+  }
+
   ImmutableSet<Mono<Integer>> testMonoFromOptional() {
     return ImmutableSet.of(
         Mono.fromCallable(() -> Optional.of(1).orElse(null)),
@@ -101,12 +106,11 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return StepVerifier.create(Mono.empty()).expectError().verify();
   }
 
-  Duration testStepVerifierLastStepVerifyErrorClass() {
-    return StepVerifier.create(Mono.empty()).expectError(IllegalArgumentException.class).verify();
-  }
-
-  Duration testStepVerifierLastStepVerifyErrorAssert() {
-    return StepVerifier.create(Mono.empty()).verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(Throwable.class));
+  ImmutableSet<Duration> testStepVerifierLastStepVerifyErrorClass() {
+    return ImmutableSet.of(
+        StepVerifier.create(Mono.empty()).expectError(IllegalArgumentException.class).verify(),
+        StepVerifier.create(Mono.empty())
+            .verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(IllegalStateException.class)));
   }
 
   Duration testStepVerifierLastStepVerifyErrorMatches() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/bugpatterns/ReactorTemplatesTestOutput.java
@@ -14,6 +14,11 @@ import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
 
 final class ReactorTemplatesTest implements RefasterTemplateTestCase {
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(assertThat(0));
+  }
+
   ImmutableSet<Mono<Integer>> testMonoFromOptional() {
     return ImmutableSet.of(
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(1))),
@@ -100,12 +105,10 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return StepVerifier.create(Mono.empty()).verifyError();
   }
 
-  Duration testStepVerifierLastStepVerifyErrorClass() {
-    return StepVerifier.create(Mono.empty()).verifyError(IllegalArgumentException.class);
-  }
-
-  Duration testStepVerifierLastStepVerifyErrorAssert() {
-    return StepVerifier.create(Mono.empty()).verifyError(Throwable.class);
+  ImmutableSet<Duration> testStepVerifierLastStepVerifyErrorClass() {
+    return ImmutableSet.of(
+        StepVerifier.create(Mono.empty()).verifyError(IllegalArgumentException.class),
+        StepVerifier.create(Mono.empty()).verifyError(IllegalStateException.class));
   }
 
   Duration testStepVerifierLastStepVerifyErrorMatches() {


### PR DESCRIPTION
This PR introduces an additional refaster rule for simplification for the usage of Reactor's `LastStep.verifyError` and assertJ `assertThat`.