### PR TITLE
Enable Checkstyle's `LocalVariableName` check

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -676,9 +676,7 @@
                                     <module name="InnerAssignment" />
                                     <module name="InvalidJavadocPosition" />
                                     <module name="JavadocBlockTagLocation" />
-                                    <module name="LocalVariableName">
-                                        <property name="format" value="^[a-z][a-zA-Z0-9]*$"/>
-                                    </module>
+                                    <module name="LocalVariableName" />
                                     <module name="MatchXpath">
                                         <property name="query" value="//BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[contains(@text, '@author')]]" />
                                         <message key="matchxpath.match" value="Avoid the `@author` Javadoc tag; Git history suffices." />


### PR DESCRIPTION
After a discussion we found out that there is currently no check that validates local variable names. 
Checkstyle has a configurable check for this.
In this PR we enable that check. 