### PR TITLE
Upgrade Error Prone fork v2.10.0-picnic-1 -> v2.10.0-picnic-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -134,7 +134,7 @@
         <version.auto-service>1.0.1</version.auto-service>
         <version.auto-value>1.9</version.auto-value>
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
-        <version.error-prone-fork>v${version.error-prone-orig}-picnic-1</version.error-prone-fork>
+        <version.error-prone-fork>v${version.error-prone-orig}-picnic-3</version.error-prone-fork>
         <version.error-prone-orig>2.10.0</version.error-prone-orig>
         <version.error-prone-slf4j>0.1.4</version.error-prone-slf4j>
         <version.findbugs-format-string>3.0.0</version.findbugs-format-string>


### PR DESCRIPTION
This PR upgrades the version of our Error Prone fork.
We want to merge this PR before https://github.com/PicnicSupermarket/error-prone-support/pull/43.