### PR TITLE
Fix build-time Refaster template loading

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterCheck.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterCheck.java
@@ -195,7 +195,7 @@ public final class RefasterCheck extends BugChecker implements CompilationUnitTr
 
   private static ImmutableSet<ResourceInfo> getClassPathResources() {
     try {
-      return ClassPath.from(ClassLoader.getSystemClassLoader()).getResources();
+      return ClassPath.from(RefasterCheck.class.getClassLoader()).getResources();
     } catch (IOException e) {
       throw new UncheckedIOException("Failed to scan classpath for resources", e);
     }


### PR DESCRIPTION
Suggested commit message:
```
Fix build-time Refaster template loading (#121)

When using the system classloader, `RefasterCheckTest` is able to
successfully load the Refaster templates from the classpath, causing the
tests to pass. However, when during a build the Java compiler loads
`RefasterCheck`, the templates on the annotation processor classpath are
_not_ exposed through the system classloader.
```

To see the issue for yourself, apply the following patch and observe how before this change the redundant negations aren't flagged:
```diff
diff --git a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
index 7bc2d3ef..0947a468 100644
--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
@@ -54,7 +54,7 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
     }
 
     ClassTree tree = JavacTrees.instance(context).getTree(taskEvent.getTypeElement());
-    if (tree == null || !containsRefasterTemplates(tree)) {
+    if (tree == null || !!!containsRefasterTemplates(tree)) {
       return;
     }
 
```