### PR TITLE
Resolve build warnings

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJThrowingCallableTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJThrowingCallableTemplates.java
@@ -268,9 +268,9 @@ final class AssertJThrowingCallableTemplates {
   }
 
   static final class AssertThatThrownByIOExceptionHasMessage {
+    @BeforeTemplate
     @SuppressWarnings(
         "AssertThatThrownByIOException" /* Matches strictly more specific expressions. */)
-    @BeforeTemplate
     AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
       return assertThatIOException().isThrownBy(throwingCallable).withMessage(message);
     }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTraceCheckTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTraceCheckTest.java
@@ -47,8 +47,8 @@ public final class ScheduledTransactionTraceCheckTest {
 
   // XXX: Enable this test for all JREs once https://github.com/google/error-prone/pull/2820 is
   // merged and released.
-  @Test
   @DisabledForJreRange(min = JRE.JAVA_12)
+  @Test
   void replacement() {
     refactoringTestHelper
         .addInputLines(


### PR DESCRIPTION
Suggested commit message:
```
Resolve build warnings (#122)
```

Two things:
- I think that this shows that using `SeverityLevel.SUGGESTION` doesn't really work in the current setup, unless we rely on a CI build applying the `patch` profile. But since such an extra patch build takes extra time, I'm not sure that's a desirable end state.
- I noticed that `-Perror-prone-fork -Pself-check -Ppatch -Derror-prone.patch-checks=''` doesn't work; I had to explicitly specify `LexicographicalAnnotationListing`. This indicates that the changes of google/error-prone#947 no longer fully work. That requires separate investigation.