### PR TITLE
Introduce `{Mono,Flux}Map{,NotNull}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -379,9 +379,6 @@ final class ReactorRules {
    * Prefer {@link Mono#map(Function)} over alternatives that unnecessarily require an inner
    * subscription.
    */
-  // XXX: The `Flux.just` support impacts the return type. Consider moving this to a separate check
-  // that adds `.flux()`. If so, replace the `Publisher` references here and in the test code to
-  // `Mono`.
   // XXX: Also cover `{Mono,Flux}.fromSupplier(() -> transformation(x))`. (Though it'd be more
   // accurate in some cases to use `mapNotNull` in those cases.)
   abstract static class MonoMap<T, S> {
@@ -389,11 +386,8 @@ final class ReactorRules {
     abstract S transformation(@MayOptionallyUse T value);
 
     @BeforeTemplate
-    Publisher<S> before(Mono<T> mono) {
-      return Refaster.anyOf(
-          mono.flatMap(x -> Mono.just(transformation(x))),
-          mono.flatMapMany(x -> Mono.just(transformation(x))),
-          mono.flatMapMany(x -> Flux.just(transformation(x))));
+    Mono<S> before(Mono<T> mono) {
+      return mono.flatMap(x -> Mono.just(transformation(x)));
     }
 
     @AfterTemplate
@@ -453,18 +447,13 @@ final class ReactorRules {
    * Prefer {@link Mono#mapNotNull(Function)} over alternatives that unnecessarily require an inner
    * subscription.
    */
-  // XXX: The `Flux.just` support impacts the return type. Consider moving this to a separate check
-  // that adds `.flux()`. If so, replace the `Publisher` references here and in the test code to
-  // `Mono`.
   abstract static class MonoMapNotNull<T, S> {
     @Placeholder(allowsIdentity = true)
     abstract S transformation(@MayOptionallyUse T value);
 
     @BeforeTemplate
-    Publisher<S> before(Mono<T> mono) {
-      return Refaster.anyOf(
-          mono.flatMap(x -> Mono.justOrEmpty(transformation(x))),
-          mono.flatMapMany(x -> Mono.justOrEmpty(transformation(x))));
+    Mono<S> before(Mono<T> mono) {
+      return mono.flatMap(x -> Mono.justOrEmpty(transformation(x)));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -362,55 +362,54 @@ final class ReactorRules {
    */
   abstract static class MonoFlatMapToFlux<T, S> {
     @Placeholder(allowsIdentity = true)
-    abstract Mono<S> valueTransformation(@MayOptionallyUse T value);
+    abstract Mono<S> transformation(@MayOptionallyUse T value);
 
     @BeforeTemplate
     Flux<S> before(Mono<T> mono) {
-      return mono.flatMapMany(v -> valueTransformation(v));
+      return mono.flatMapMany(v -> transformation(v));
     }
 
     @AfterTemplate
     Flux<S> after(Mono<T> mono) {
-      return mono.flatMap(v -> valueTransformation(v)).flux();
+      return mono.flatMap(v -> transformation(v)).flux();
     }
   }
 
   /**
-   * Don't unnecessarily use {@link Mono#flatMap(Function)} followed by {@link Mono#just(Object)}.
-   * Instead, use {@link Mono#map(Function)} in order to avoid an inner subscription.
+   * Prefer {@link Mono#map(Function)} over alternatives that unnecessarily require an inner
+   * subscription.
    */
-  abstract static class MonoFlatMapJust<T, S> {
+  abstract static class MonoMap<T, S> {
     @Placeholder(allowsIdentity = true)
-    abstract S valueTransformation(@MayOptionallyUse T value);
+    abstract S transformation(@MayOptionallyUse T value);
 
     @BeforeTemplate
     Mono<S> before(Mono<T> mono) {
-      return mono.flatMap(x -> Mono.just(valueTransformation(x)));
+      return mono.flatMap(x -> Mono.just(transformation(x)));
     }
 
     @AfterTemplate
     Mono<S> after(Mono<T> mono) {
-      return mono.map(x -> valueTransformation(x));
+      return mono.map(x -> transformation(x));
     }
   }
 
   /**
-   * Don't unnecessarily use {@link Mono#flatMap(Function)} followed by {@link
-   * Mono#justOrEmpty(Object)}. Instead, use {@link Mono#mapNotNull(Function)} in order to avoid an
-   * inner subscription.
+   * Prefer {@link Mono#mapNotNull(Function)} over alternatives that unnecessarily require an inner
+   * subscription.
    */
-  abstract static class MonoFlatMapJustOrEmpty<T, S> {
+  abstract static class MonoMapNotNull<T, S> {
     @Placeholder(allowsIdentity = true)
-    abstract S valueTransformation(@MayOptionallyUse T value);
+    abstract S transformation(@MayOptionallyUse T value);
 
     @BeforeTemplate
     Mono<S> before(Mono<T> mono) {
-      return mono.flatMap(x -> Mono.justOrEmpty(valueTransformation(x)));
+      return mono.flatMap(x -> Mono.justOrEmpty(transformation(x)));
     }
 
     @AfterTemplate
     Mono<S> after(Mono<T> mono) {
-      return mono.mapNotNull(x -> valueTransformation(x));
+      return mono.mapNotNull(x -> transformation(x));
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -417,6 +417,10 @@ final class ReactorRules {
       return Refaster.anyOf(
           flux.concatMap(x -> Mono.just(transformation(x))),
           flux.concatMap(x -> Flux.just(transformation(x))),
+          flux.concatMap(x -> Mono.just(transformation(x)), prefetch),
+          flux.concatMap(x -> Flux.just(transformation(x)), prefetch),
+          flux.concatMapDelayError(x -> Mono.just(transformation(x))),
+          flux.concatMapDelayError(x -> Flux.just(transformation(x))),
           flux.concatMapDelayError(x -> Mono.just(transformation(x)), prefetch),
           flux.concatMapDelayError(x -> Flux.just(transformation(x)), prefetch),
           flux.concatMapDelayError(x -> Mono.just(transformation(x)), delayUntilEnd, prefetch),
@@ -481,6 +485,8 @@ final class ReactorRules {
     Publisher<S> before(Flux<T> flux, boolean delayUntilEnd, int maxConcurrency, int prefetch) {
       return Refaster.anyOf(
           flux.concatMap(x -> Mono.justOrEmpty(transformation(x))),
+          flux.concatMap(x -> Mono.justOrEmpty(transformation(x)), prefetch),
+          flux.concatMapDelayError(x -> Mono.justOrEmpty(transformation(x))),
           flux.concatMapDelayError(x -> Mono.justOrEmpty(transformation(x)), prefetch),
           flux.concatMapDelayError(
               x -> Mono.justOrEmpty(transformation(x)), delayUntilEnd, prefetch),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -115,15 +115,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<String>> testMonoFlatMapJust() {
-    return ImmutableSet.of(
-        Mono.just("foo").flatMap(s -> Mono.just(String.valueOf(s)))
-    );
+    return ImmutableSet.of(Mono.just("foo").flatMap(s -> Mono.just(String.valueOf(s))));
   }
 
   ImmutableSet<Mono<String>> testMonoFlatMapJustOrEmpty() {
-    return ImmutableSet.of(
-      Mono.just("foo").flatMap(s -> Mono.justOrEmpty(String.valueOf(s)))
-    );
+    return ImmutableSet.of(Mono.just("foo").flatMap(s -> Mono.justOrEmpty(String.valueOf(s))));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -122,10 +122,51 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("baz").flatMapMany(s -> Flux.just(s)));
   }
 
+  ImmutableSet<Flux<String>> testFluxMap() {
+    return ImmutableSet.of(
+        Flux.just("fooConcat").concatMap(s -> Mono.just(s.substring(1))),
+        Flux.just("fooConcat").concatMap(s -> Flux.just("foo")),
+        Flux.just("fooConcat").concatMap(s -> Mono.just(s), 2),
+        Flux.just("fooConcat").concatMap(s -> Flux.just(s), 2),
+        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.just(s)),
+        Flux.just("fooConcatDelay").concatMapDelayError(s -> Flux.just(s)),
+        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.just(s), 2),
+        Flux.just("fooConcatDelay").concatMapDelayError(s -> Flux.just(s), 2),
+        Flux.just("fooFlat").flatMap(s -> Mono.just(s), 2),
+        Flux.just("fooFlat").flatMap(s -> Flux.just(s), 2),
+        Flux.just("fooFlat").flatMap(s -> Mono.just(s), 2, 2),
+        Flux.just("fooFlat").flatMap(s -> Flux.just(s), 2, 2),
+        Flux.just("fooFlatDelay").flatMapDelayError(s -> Mono.just(s), 2, 2),
+        Flux.just("fooFlatDelay").flatMapDelayError(s -> Flux.just(s), 2, 2),
+        Flux.just("fooSeq").flatMapSequential(s -> Mono.just(s), 2),
+        Flux.just("fooSeq").flatMapSequential(s -> Flux.just(s), 2),
+        Flux.just("fooSeq").flatMapSequential(s -> Mono.just(s), 2, 2),
+        Flux.just("fooSeq").flatMapSequential(s -> Flux.just(s), 2, 2),
+        Flux.just("fooSeqDelay").flatMapSequentialDelayError(s -> Mono.just(s), 2, 2),
+        Flux.just("fooSeqDelay").flatMapSequentialDelayError(s -> Flux.just(s), 2, 2),
+        Flux.just("fooSwitch").switchMap(s -> Mono.just(s)),
+        Flux.just("fooSwitch").switchMap(s -> Flux.just(s)));
+  }
+
   ImmutableSet<Publisher<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
         Mono.just("foo").flatMap(s -> Mono.justOrEmpty(s)),
         Mono.just("bar").flatMapMany(s -> Mono.justOrEmpty(s.substring(1))));
+  }
+
+  ImmutableSet<Flux<String>> testFluxMapNotNull() {
+    return ImmutableSet.of(
+        Flux.just("fooConcat").concatMap(s -> Mono.justOrEmpty(s.substring(1))),
+        Flux.just("fooConcat").concatMap(s -> Mono.justOrEmpty("foo"), 2),
+        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.justOrEmpty(s)),
+        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.justOrEmpty(s), 2),
+        Flux.just("fooFlat").flatMap(s -> Mono.justOrEmpty(s), 2),
+        Flux.just("fooFlat").flatMap(s -> Mono.justOrEmpty(s), 2, 2),
+        Flux.just("fooFlatDelay").flatMapDelayError(s -> Mono.justOrEmpty(s), 2, 2),
+        Flux.just("fooSeq").flatMapSequential(s -> Mono.justOrEmpty(s), 2),
+        Flux.just("fooSeq").flatMapSequential(s -> Mono.justOrEmpty(s), 2, 2),
+        Flux.just("fooSeqDelay").flatMapSequentialDelayError(s -> Mono.justOrEmpty(s), 2, 2),
+        Flux.just("fooSwitch").switchMap(s -> Mono.justOrEmpty(s)));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -114,6 +114,18 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").flatMapMany(s -> Mono.just(s + s));
   }
 
+  ImmutableSet<Mono<String>> testMonoFlatMapJust() {
+    return ImmutableSet.of(
+        Mono.just("foo").flatMap(s -> Mono.just(String.valueOf(s)))
+    );
+  }
+
+  ImmutableSet<Mono<String>> testMonoFlatMapJustOrEmpty() {
+    return ImmutableSet.of(
+      Mono.just("foo").flatMap(s -> Mono.justOrEmpty(String.valueOf(s)))
+    );
+  }
+
   Flux<String> testMonoFlux() {
     return Flux.concat(Mono.just("foo"));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -10,6 +10,7 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -111,19 +112,20 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Flux<String> testMonoFlatMapToFlux() {
-    return Mono.just("foo").flatMapMany(s -> Mono.just(s + s));
+    return Mono.just("foo").flatMapMany(s -> Mono.fromSupplier(() -> s + s));
   }
 
-  ImmutableSet<Mono<String>> testMonoMap() {
+  ImmutableSet<Publisher<String>> testMonoMap() {
     return ImmutableSet.of(
         Mono.just("foo").flatMap(s -> Mono.just(s)),
-        Mono.just("bar").flatMap(s -> Mono.just(s.substring(1))));
+        Mono.just("bar").flatMapMany(s -> Mono.just(s.substring(1))),
+        Mono.just("baz").flatMapMany(s -> Flux.just(s)));
   }
 
-  ImmutableSet<Mono<String>> testMonoMapNotNull() {
+  ImmutableSet<Publisher<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
         Mono.just("foo").flatMap(s -> Mono.justOrEmpty(s)),
-        Mono.just("bar").flatMap(s -> Mono.justOrEmpty(s.substring(1))));
+        Mono.just("bar").flatMapMany(s -> Mono.justOrEmpty(s.substring(1))));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -10,7 +10,6 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
@@ -115,11 +114,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").flatMapMany(s -> Mono.fromSupplier(() -> s + s));
   }
 
-  ImmutableSet<Publisher<String>> testMonoMap() {
+  ImmutableSet<Mono<String>> testMonoMap() {
     return ImmutableSet.of(
         Mono.just("foo").flatMap(s -> Mono.just(s)),
-        Mono.just("bar").flatMapMany(s -> Mono.just(s.substring(1))),
-        Mono.just("baz").flatMapMany(s -> Flux.just(s)));
+        Mono.just("bar").flatMap(s -> Mono.just(s.substring(1))),
+        Mono.just("baz").flatMap(s -> Mono.just("bazz")));
   }
 
   ImmutableSet<Flux<String>> testFluxMap() {
@@ -148,10 +147,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("fooSwitch").switchMap(s -> Flux.just(s)));
   }
 
-  ImmutableSet<Publisher<String>> testMonoMapNotNull() {
+  ImmutableSet<Mono<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
         Mono.just("foo").flatMap(s -> Mono.justOrEmpty(s)),
-        Mono.just("bar").flatMapMany(s -> Mono.justOrEmpty(s.substring(1))));
+        Mono.just("bar").flatMap(s -> Mono.justOrEmpty(s.substring(1))),
+        Mono.just("baz").flatMap(s -> Mono.justOrEmpty("bazz")));
   }
 
   ImmutableSet<Flux<String>> testFluxMapNotNull() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -117,56 +117,65 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Mono<String>> testMonoMap() {
     return ImmutableSet.of(
         Mono.just("foo").flatMap(s -> Mono.just(s)),
-        Mono.just("bar").flatMap(s -> Mono.just(s.substring(1))),
-        Mono.just("baz").flatMap(s -> Mono.just("bazz")));
+        Mono.just("bar").flatMap(s -> Mono.just(s.substring(1))));
   }
 
-  ImmutableSet<Flux<String>> testFluxMap() {
+  ImmutableSet<Flux<Integer>> testFluxMap() {
     return ImmutableSet.of(
-        Flux.just("fooConcat").concatMap(s -> Mono.just(s.substring(1))),
-        Flux.just("fooConcat").concatMap(s -> Flux.just("foo")),
-        Flux.just("fooConcat").concatMap(s -> Mono.just(s), 2),
-        Flux.just("fooConcat").concatMap(s -> Flux.just(s), 2),
-        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.just(s)),
-        Flux.just("fooConcatDelay").concatMapDelayError(s -> Flux.just(s)),
-        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.just(s), 2),
-        Flux.just("fooConcatDelay").concatMapDelayError(s -> Flux.just(s), 2),
-        Flux.just("fooFlat").flatMap(s -> Mono.just(s), 2),
-        Flux.just("fooFlat").flatMap(s -> Flux.just(s), 2),
-        Flux.just("fooFlat").flatMap(s -> Mono.just(s), 2, 2),
-        Flux.just("fooFlat").flatMap(s -> Flux.just(s), 2, 2),
-        Flux.just("fooFlatDelay").flatMapDelayError(s -> Mono.just(s), 2, 2),
-        Flux.just("fooFlatDelay").flatMapDelayError(s -> Flux.just(s), 2, 2),
-        Flux.just("fooSeq").flatMapSequential(s -> Mono.just(s), 2),
-        Flux.just("fooSeq").flatMapSequential(s -> Flux.just(s), 2),
-        Flux.just("fooSeq").flatMapSequential(s -> Mono.just(s), 2, 2),
-        Flux.just("fooSeq").flatMapSequential(s -> Flux.just(s), 2, 2),
-        Flux.just("fooSeqDelay").flatMapSequentialDelayError(s -> Mono.just(s), 2, 2),
-        Flux.just("fooSeqDelay").flatMapSequentialDelayError(s -> Flux.just(s), 2, 2),
-        Flux.just("fooSwitch").switchMap(s -> Mono.just(s)),
-        Flux.just("fooSwitch").switchMap(s -> Flux.just(s)));
+        Flux.just(1).concatMap(n -> Mono.just(n)),
+        Flux.just(1).concatMap(n -> Flux.just(n * 2)),
+        Flux.just(1).concatMap(n -> Mono.just(n), 3),
+        Flux.just(1).concatMap(n -> Flux.just(n * 2), 3),
+        Flux.just(1).concatMapDelayError(n -> Mono.just(n)),
+        Flux.just(1).concatMapDelayError(n -> Flux.just(n * 2)),
+        Flux.just(1).concatMapDelayError(n -> Mono.just(n), 3),
+        Flux.just(1).concatMapDelayError(n -> Flux.just(n * 2), 3),
+        Flux.just(1).flatMap(n -> Mono.just(n), 3),
+        Flux.just(1).flatMap(n -> Flux.just(n * 2), 3),
+        Flux.just(1).flatMap(n -> Mono.just(n), 3, 4),
+        Flux.just(1).flatMap(n -> Flux.just(n * 2), 3, 4),
+        Flux.just(1).flatMapDelayError(n -> Mono.just(n), 3, 4),
+        Flux.just(1).flatMapDelayError(n -> Flux.just(n * 2), 3, 4),
+        Flux.just(1).flatMapSequential(n -> Mono.just(n), 3),
+        Flux.just(1).flatMapSequential(n -> Flux.just(n * 2), 3),
+        Flux.just(1).flatMapSequential(n -> Mono.just(n), 3, 4),
+        Flux.just(1).flatMapSequential(n -> Flux.just(n * 2), 3, 4),
+        Flux.just(1).flatMapSequentialDelayError(n -> Mono.just(n), 3, 4),
+        Flux.just(1).flatMapSequentialDelayError(n -> Flux.just(n * 2), 3, 4),
+        Flux.just(1).switchMap(n -> Mono.just(n)),
+        Flux.just(1).switchMap(n -> Flux.just(n * 2)));
   }
 
   ImmutableSet<Mono<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
         Mono.just("foo").flatMap(s -> Mono.justOrEmpty(s)),
-        Mono.just("bar").flatMap(s -> Mono.justOrEmpty(s.substring(1))),
-        Mono.just("baz").flatMap(s -> Mono.justOrEmpty("bazz")));
+        Mono.just("bar").flatMap(s -> Mono.fromSupplier(() -> s.substring(1))));
   }
 
-  ImmutableSet<Flux<String>> testFluxMapNotNull() {
+  ImmutableSet<Flux<Integer>> testFluxMapNotNull() {
     return ImmutableSet.of(
-        Flux.just("fooConcat").concatMap(s -> Mono.justOrEmpty(s.substring(1))),
-        Flux.just("fooConcat").concatMap(s -> Mono.justOrEmpty("foo"), 2),
-        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.justOrEmpty(s)),
-        Flux.just("fooConcatDelay").concatMapDelayError(s -> Mono.justOrEmpty(s), 2),
-        Flux.just("fooFlat").flatMap(s -> Mono.justOrEmpty(s), 2),
-        Flux.just("fooFlat").flatMap(s -> Mono.justOrEmpty(s), 2, 2),
-        Flux.just("fooFlatDelay").flatMapDelayError(s -> Mono.justOrEmpty(s), 2, 2),
-        Flux.just("fooSeq").flatMapSequential(s -> Mono.justOrEmpty(s), 2),
-        Flux.just("fooSeq").flatMapSequential(s -> Mono.justOrEmpty(s), 2, 2),
-        Flux.just("fooSeqDelay").flatMapSequentialDelayError(s -> Mono.justOrEmpty(s), 2, 2),
-        Flux.just("fooSwitch").switchMap(s -> Mono.justOrEmpty(s)));
+        Flux.just(1).concatMap(n -> Mono.justOrEmpty(n)),
+        Flux.just(1).concatMap(n -> Mono.fromSupplier(() -> n * 2)),
+        Flux.just(1).concatMap(n -> Mono.justOrEmpty(n), 3),
+        Flux.just(1).concatMap(n -> Mono.fromSupplier(() -> n * 2), 3),
+        Flux.just(1).concatMapDelayError(n -> Mono.justOrEmpty(n)),
+        Flux.just(1).concatMapDelayError(n -> Mono.fromSupplier(() -> n * 2)),
+        Flux.just(1).concatMapDelayError(n -> Mono.justOrEmpty(n), 3),
+        Flux.just(1).concatMapDelayError(n -> Mono.fromSupplier(() -> n * 2), 3),
+        Flux.just(1).flatMap(n -> Mono.justOrEmpty(n), 3),
+        Flux.just(1).flatMap(n -> Mono.fromSupplier(() -> n * 2), 3),
+        Flux.just(1).flatMap(n -> Mono.justOrEmpty(n), 3, 4),
+        Flux.just(1).flatMap(n -> Mono.fromSupplier(() -> n * 2), 3, 4),
+        Flux.just(1).flatMapDelayError(n -> Mono.justOrEmpty(n), 3, 4),
+        Flux.just(1).flatMapDelayError(n -> Mono.fromSupplier(() -> n * 2), 3, 4),
+        Flux.just(1).flatMapSequential(n -> Mono.justOrEmpty(n), 3),
+        Flux.just(1).flatMapSequential(n -> Mono.fromSupplier(() -> n * 2), 3),
+        Flux.just(1).flatMapSequential(n -> Mono.justOrEmpty(n), 3, 4),
+        Flux.just(1).flatMapSequential(n -> Mono.fromSupplier(() -> n * 2), 3, 4),
+        Flux.just(1).flatMapSequentialDelayError(n -> Mono.justOrEmpty(n), 3, 4),
+        Flux.just(1).flatMapSequentialDelayError(n -> Mono.fromSupplier(() -> n * 2), 3, 4),
+        Flux.just(1).switchMap(n -> Mono.justOrEmpty(n)),
+        Flux.just(1).switchMap(n -> Mono.fromSupplier(() -> n * 2)));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -114,12 +114,16 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").flatMapMany(s -> Mono.just(s + s));
   }
 
-  ImmutableSet<Mono<String>> testMonoFlatMapJust() {
-    return ImmutableSet.of(Mono.just("foo").flatMap(s -> Mono.just(String.valueOf(s))));
+  ImmutableSet<Mono<String>> testMonoMap() {
+    return ImmutableSet.of(
+        Mono.just("foo").flatMap(s -> Mono.just(s)),
+        Mono.just("bar").flatMap(s -> Mono.just(s.substring(1))));
   }
 
-  ImmutableSet<Mono<String>> testMonoFlatMapJustOrEmpty() {
-    return ImmutableSet.of(Mono.just("foo").flatMap(s -> Mono.justOrEmpty(String.valueOf(s))));
+  ImmutableSet<Mono<String>> testMonoMapNotNull() {
+    return ImmutableSet.of(
+        Mono.just("foo").flatMap(s -> Mono.justOrEmpty(s)),
+        Mono.just("bar").flatMap(s -> Mono.justOrEmpty(s.substring(1))));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -120,15 +120,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<String>> testMonoFlatMapJust() {
-    return ImmutableSet.of(
-        Mono.just("foo").map(s -> String.valueOf(s))
-    );
+    return ImmutableSet.of(Mono.just("foo").map(s -> String.valueOf(s)));
   }
 
   ImmutableSet<Mono<String>> testMonoFlatMapJustOrEmpty() {
-    return ImmutableSet.of(
-        Mono.just("foo").mapNotNull(s -> String.valueOf(s))
-    );
+    return ImmutableSet.of(Mono.just("foo").mapNotNull(s -> String.valueOf(s)));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -13,7 +13,6 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
-import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
@@ -120,11 +119,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").flatMap(s -> Mono.fromSupplier(() -> s + s)).flux();
   }
 
-  ImmutableSet<Publisher<String>> testMonoMap() {
+  ImmutableSet<Mono<String>> testMonoMap() {
     return ImmutableSet.of(
         Mono.just("foo").map(s -> s),
         Mono.just("bar").map(s -> s.substring(1)),
-        Mono.just("baz").map(s -> s));
+        Mono.just("baz").map(s -> "bazz"));
   }
 
   ImmutableSet<Flux<String>> testFluxMap() {
@@ -153,9 +152,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("fooSwitch").map(s -> s));
   }
 
-  ImmutableSet<Publisher<String>> testMonoMapNotNull() {
+  ImmutableSet<Mono<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
-        Mono.just("foo").mapNotNull(s -> s), Mono.just("bar").mapNotNull(s -> s.substring(1)));
+        Mono.just("foo").mapNotNull(s -> s),
+        Mono.just("bar").mapNotNull(s -> s.substring(1)),
+        Mono.just("baz").mapNotNull(s -> "bazz"));
   }
 
   ImmutableSet<Flux<String>> testFluxMapNotNull() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.Optional;
 import java.util.concurrent.Callable;
 import java.util.function.Supplier;
+import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.function.TupleUtils;
@@ -116,14 +117,17 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Flux<String> testMonoFlatMapToFlux() {
-    return Mono.just("foo").flatMap(s -> Mono.just(s + s)).flux();
+    return Mono.just("foo").flatMap(s -> Mono.fromSupplier(() -> s + s)).flux();
   }
 
-  ImmutableSet<Mono<String>> testMonoMap() {
-    return ImmutableSet.of(Mono.just("foo").map(s -> s), Mono.just("bar").map(s -> s.substring(1)));
+  ImmutableSet<Publisher<String>> testMonoMap() {
+    return ImmutableSet.of(
+        Mono.just("foo").map(s -> s),
+        Mono.just("bar").map(s -> s.substring(1)),
+        Mono.just("baz").map(s -> s));
   }
 
-  ImmutableSet<Mono<String>> testMonoMapNotNull() {
+  ImmutableSet<Publisher<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
         Mono.just("foo").mapNotNull(s -> s), Mono.just("bar").mapNotNull(s -> s.substring(1)));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -127,9 +127,50 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("baz").map(s -> s));
   }
 
+  ImmutableSet<Flux<String>> testFluxMap() {
+    return ImmutableSet.of(
+        Flux.just("fooConcat").map(s -> s.substring(1)),
+        Flux.just("fooConcat").map(s -> "foo"),
+        Flux.just("fooConcat").map(s -> s),
+        Flux.just("fooConcat").map(s -> s),
+        Flux.just("fooConcatDelay").map(s -> s),
+        Flux.just("fooConcatDelay").map(s -> s),
+        Flux.just("fooConcatDelay").map(s -> s),
+        Flux.just("fooConcatDelay").map(s -> s),
+        Flux.just("fooFlat").map(s -> s),
+        Flux.just("fooFlat").map(s -> s),
+        Flux.just("fooFlat").map(s -> s),
+        Flux.just("fooFlat").map(s -> s),
+        Flux.just("fooFlatDelay").map(s -> s),
+        Flux.just("fooFlatDelay").map(s -> s),
+        Flux.just("fooSeq").map(s -> s),
+        Flux.just("fooSeq").map(s -> s),
+        Flux.just("fooSeq").map(s -> s),
+        Flux.just("fooSeq").map(s -> s),
+        Flux.just("fooSeqDelay").map(s -> s),
+        Flux.just("fooSeqDelay").map(s -> s),
+        Flux.just("fooSwitch").map(s -> s),
+        Flux.just("fooSwitch").map(s -> s));
+  }
+
   ImmutableSet<Publisher<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
         Mono.just("foo").mapNotNull(s -> s), Mono.just("bar").mapNotNull(s -> s.substring(1)));
+  }
+
+  ImmutableSet<Flux<String>> testFluxMapNotNull() {
+    return ImmutableSet.of(
+        Flux.just("fooConcat").mapNotNull(s -> s.substring(1)),
+        Flux.just("fooConcat").mapNotNull(s -> "foo"),
+        Flux.just("fooConcatDelay").mapNotNull(s -> s),
+        Flux.just("fooConcatDelay").mapNotNull(s -> s),
+        Flux.just("fooFlat").mapNotNull(s -> s),
+        Flux.just("fooFlat").mapNotNull(s -> s),
+        Flux.just("fooFlatDelay").mapNotNull(s -> s),
+        Flux.just("fooSeq").mapNotNull(s -> s),
+        Flux.just("fooSeq").mapNotNull(s -> s),
+        Flux.just("fooSeqDelay").mapNotNull(s -> s),
+        Flux.just("fooSwitch").mapNotNull(s -> s));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -119,6 +119,18 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").flatMap(s -> Mono.just(s + s)).flux();
   }
 
+  ImmutableSet<Mono<String>> testMonoFlatMapJust() {
+    return ImmutableSet.of(
+        Mono.just("foo").map(s -> String.valueOf(s))
+    );
+  }
+
+  ImmutableSet<Mono<String>> testMonoFlatMapJustOrEmpty() {
+    return ImmutableSet.of(
+        Mono.just("foo").mapNotNull(s -> String.valueOf(s))
+    );
+  }
+
   Flux<String> testMonoFlux() {
     return Mono.just("foo").flux();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -119,12 +119,13 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").flatMap(s -> Mono.just(s + s)).flux();
   }
 
-  ImmutableSet<Mono<String>> testMonoFlatMapJust() {
-    return ImmutableSet.of(Mono.just("foo").map(s -> String.valueOf(s)));
+  ImmutableSet<Mono<String>> testMonoMap() {
+    return ImmutableSet.of(Mono.just("foo").map(s -> s), Mono.just("bar").map(s -> s.substring(1)));
   }
 
-  ImmutableSet<Mono<String>> testMonoFlatMapJustOrEmpty() {
-    return ImmutableSet.of(Mono.just("foo").mapNotNull(s -> String.valueOf(s)));
+  ImmutableSet<Mono<String>> testMonoMapNotNull() {
+    return ImmutableSet.of(
+        Mono.just("foo").mapNotNull(s -> s), Mono.just("bar").mapNotNull(s -> s.substring(1)));
   }
 
   Flux<String> testMonoFlux() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -120,58 +120,64 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<String>> testMonoMap() {
-    return ImmutableSet.of(
-        Mono.just("foo").map(s -> s),
-        Mono.just("bar").map(s -> s.substring(1)),
-        Mono.just("baz").map(s -> "bazz"));
+    return ImmutableSet.of(Mono.just("foo").map(s -> s), Mono.just("bar").map(s -> s.substring(1)));
   }
 
-  ImmutableSet<Flux<String>> testFluxMap() {
+  ImmutableSet<Flux<Integer>> testFluxMap() {
     return ImmutableSet.of(
-        Flux.just("fooConcat").map(s -> s.substring(1)),
-        Flux.just("fooConcat").map(s -> "foo"),
-        Flux.just("fooConcat").map(s -> s),
-        Flux.just("fooConcat").map(s -> s),
-        Flux.just("fooConcatDelay").map(s -> s),
-        Flux.just("fooConcatDelay").map(s -> s),
-        Flux.just("fooConcatDelay").map(s -> s),
-        Flux.just("fooConcatDelay").map(s -> s),
-        Flux.just("fooFlat").map(s -> s),
-        Flux.just("fooFlat").map(s -> s),
-        Flux.just("fooFlat").map(s -> s),
-        Flux.just("fooFlat").map(s -> s),
-        Flux.just("fooFlatDelay").map(s -> s),
-        Flux.just("fooFlatDelay").map(s -> s),
-        Flux.just("fooSeq").map(s -> s),
-        Flux.just("fooSeq").map(s -> s),
-        Flux.just("fooSeq").map(s -> s),
-        Flux.just("fooSeq").map(s -> s),
-        Flux.just("fooSeqDelay").map(s -> s),
-        Flux.just("fooSeqDelay").map(s -> s),
-        Flux.just("fooSwitch").map(s -> s),
-        Flux.just("fooSwitch").map(s -> s));
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2),
+        Flux.just(1).map(n -> n),
+        Flux.just(1).map(n -> n * 2));
   }
 
   ImmutableSet<Mono<String>> testMonoMapNotNull() {
     return ImmutableSet.of(
-        Mono.just("foo").mapNotNull(s -> s),
-        Mono.just("bar").mapNotNull(s -> s.substring(1)),
-        Mono.just("baz").mapNotNull(s -> "bazz"));
+        Mono.just("foo").mapNotNull(s -> s), Mono.just("bar").mapNotNull(s -> s.substring(1)));
   }
 
-  ImmutableSet<Flux<String>> testFluxMapNotNull() {
+  ImmutableSet<Flux<Integer>> testFluxMapNotNull() {
     return ImmutableSet.of(
-        Flux.just("fooConcat").mapNotNull(s -> s.substring(1)),
-        Flux.just("fooConcat").mapNotNull(s -> "foo"),
-        Flux.just("fooConcatDelay").mapNotNull(s -> s),
-        Flux.just("fooConcatDelay").mapNotNull(s -> s),
-        Flux.just("fooFlat").mapNotNull(s -> s),
-        Flux.just("fooFlat").mapNotNull(s -> s),
-        Flux.just("fooFlatDelay").mapNotNull(s -> s),
-        Flux.just("fooSeq").mapNotNull(s -> s),
-        Flux.just("fooSeq").mapNotNull(s -> s),
-        Flux.just("fooSeqDelay").mapNotNull(s -> s),
-        Flux.just("fooSwitch").mapNotNull(s -> s));
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2),
+        Flux.just(1).mapNotNull(n -> n),
+        Flux.just(1).mapNotNull(n -> n * 2));
   }
 
   Flux<String> testMonoFlux() {


### PR DESCRIPTION
Based on a suggestion from [here](https://github.com/PicnicSupermarket/picnic-platform/pull/8878#discussion_r851248541).

Adds a Refaster template to prefer `mono.map(x -> valueTransformation(x))` over the `mono.flatMap(x -> Mono.just(valueTransformation(x)))`

This avoids an unnecessary inner inner subscription. 