### PR TITLE
Apply Checkstyle to Refaster test resources

### DIFF
--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJBooleanTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJBooleanTemplatesTestInput.java
@@ -7,11 +7,11 @@ import org.assertj.core.api.AbstractBooleanAssert;
 
 final class AssertJBooleanTemplatesTest implements RefasterTemplateTestCase {
   AbstractBooleanAssert<?> testAbstractBooleanAssertIsEqualTo() {
-    return assertThat(true).isNotEqualTo(!false);
+    return assertThat(true).isNotEqualTo(!Boolean.FALSE);
   }
 
   AbstractBooleanAssert<?> testAbstractBooleanAssertIsNotEqualTo() {
-    return assertThat(true).isEqualTo(!false);
+    return assertThat(true).isEqualTo(!Boolean.FALSE);
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsTrue() {
@@ -23,7 +23,7 @@ final class AssertJBooleanTemplatesTest implements RefasterTemplateTestCase {
   }
 
   AbstractBooleanAssert<?> testAssertThatBooleanIsTrue() {
-    return assertThat(!true).isFalse();
+    return assertThat(!Boolean.TRUE).isFalse();
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsFalse() {
@@ -35,6 +35,6 @@ final class AssertJBooleanTemplatesTest implements RefasterTemplateTestCase {
   }
 
   AbstractBooleanAssert<?> testAssertThatBooleanIsFalse() {
-    return assertThat(!true).isTrue();
+    return assertThat(!Boolean.TRUE).isTrue();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJBooleanTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssertJBooleanTemplatesTestOutput.java
@@ -7,11 +7,11 @@ import org.assertj.core.api.AbstractBooleanAssert;
 
 final class AssertJBooleanTemplatesTest implements RefasterTemplateTestCase {
   AbstractBooleanAssert<?> testAbstractBooleanAssertIsEqualTo() {
-    return assertThat(true).isEqualTo(false);
+    return assertThat(true).isEqualTo(Boolean.FALSE);
   }
 
   AbstractBooleanAssert<?> testAbstractBooleanAssertIsNotEqualTo() {
-    return assertThat(true).isNotEqualTo(false);
+    return assertThat(true).isNotEqualTo(Boolean.FALSE);
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsTrue() {
@@ -23,7 +23,7 @@ final class AssertJBooleanTemplatesTest implements RefasterTemplateTestCase {
   }
 
   AbstractBooleanAssert<?> testAssertThatBooleanIsTrue() {
-    return assertThat(true).isTrue();
+    return assertThat(Boolean.TRUE).isTrue();
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsFalse() {
@@ -35,6 +35,6 @@ final class AssertJBooleanTemplatesTest implements RefasterTemplateTestCase {
   }
 
   AbstractBooleanAssert<?> testAssertThatBooleanIsFalse() {
-    return assertThat(true).isFalse();
+    return assertThat(Boolean.TRUE).isFalse();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssortedTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssortedTemplatesTestInput.java
@@ -60,10 +60,10 @@ final class AssortedTemplatesTest implements RefasterTemplateTestCase {
   // XXX: Only the first statement is rewritten. Make smarter.
   ImmutableSet<Boolean> testLogicalImplication() {
     return ImmutableSet.of(
-        toString().isEmpty() || (!toString().isEmpty() && true),
-        !toString().isEmpty() || (toString().isEmpty() && true),
-        3 < 4 || (3 >= 4 && true),
-        3 >= 4 || (3 < 4 && true));
+        toString().isEmpty() || (!toString().isEmpty() && Boolean.TRUE),
+        !toString().isEmpty() || (toString().isEmpty() && Boolean.TRUE),
+        3 < 4 || (3 >= 4 && Boolean.TRUE),
+        3 >= 4 || (3 < 4 && Boolean.TRUE));
   }
 
   Stream<String> testUnboundedSingleElementStream() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssortedTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/AssortedTemplatesTestOutput.java
@@ -62,10 +62,10 @@ final class AssortedTemplatesTest implements RefasterTemplateTestCase {
   // XXX: Only the first statement is rewritten. Make smarter.
   ImmutableSet<Boolean> testLogicalImplication() {
     return ImmutableSet.of(
-        toString().isEmpty() || true,
-        !toString().isEmpty() || (toString().isEmpty() && true),
-        3 < 4 || (3 >= 4 && true),
-        3 >= 4 || (3 < 4 && true));
+        toString().isEmpty() || Boolean.TRUE,
+        !toString().isEmpty() || (toString().isEmpty() && Boolean.TRUE),
+        3 < 4 || (3 >= 4 && Boolean.TRUE),
+        3 >= 4 || (3 < 4 && Boolean.TRUE));
   }
 
   Stream<String> testUnboundedSingleElementStream() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/EqualityTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/EqualityTemplatesTestInput.java
@@ -27,13 +27,13 @@ final class EqualityTemplatesTest implements RefasterTemplateTestCase {
   }
 
   boolean testDoubleNegation() {
-    return !!true;
+    return !!Boolean.TRUE;
   }
 
   ImmutableSet<Boolean> testNegation() {
     return ImmutableSet.of(
-        true ? !false : false,
-        !(true == false),
+        Boolean.TRUE ? !Boolean.FALSE : Boolean.FALSE,
+        !(Boolean.TRUE == Boolean.FALSE),
         !((byte) 3 == (byte) 4),
         !((short) 3 == (short) 4),
         !(3 == 4),
@@ -45,8 +45,8 @@ final class EqualityTemplatesTest implements RefasterTemplateTestCase {
 
   ImmutableSet<Boolean> testIndirectDoubleNegation() {
     return ImmutableSet.of(
-        true ? false : !false,
-        !(true != false),
+        Boolean.TRUE ? Boolean.FALSE : !Boolean.FALSE,
+        !(Boolean.TRUE != Boolean.FALSE),
         !((byte) 3 != (byte) 4),
         !((short) 3 != (short) 4),
         !(3 != 4),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/EqualityTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/EqualityTemplatesTestOutput.java
@@ -27,13 +27,13 @@ final class EqualityTemplatesTest implements RefasterTemplateTestCase {
   }
 
   boolean testDoubleNegation() {
-    return true;
+    return Boolean.TRUE;
   }
 
   ImmutableSet<Boolean> testNegation() {
     return ImmutableSet.of(
-        true != false,
-        true != false,
+        Boolean.TRUE != Boolean.FALSE,
+        Boolean.TRUE != Boolean.FALSE,
         (byte) 3 != (byte) 4,
         (short) 3 != (short) 4,
         3 != 4,
@@ -45,8 +45,8 @@ final class EqualityTemplatesTest implements RefasterTemplateTestCase {
 
   ImmutableSet<Boolean> testIndirectDoubleNegation() {
     return ImmutableSet.of(
-        true == false,
-        true == false,
+        Boolean.TRUE == Boolean.FALSE,
+        Boolean.TRUE == Boolean.FALSE,
         (byte) 3 == (byte) 4,
         (short) 3 == (short) 4,
         3 == 4,

--- a/pom.xml
+++ b/pom.xml
@@ -721,6 +721,10 @@
                         </sourceDirectories>
                         <testSourceDirectories>
                             <testSourceDirectory>${project.build.testSourceDirectory}</testSourceDirectory>
+                            <!-- Refaster input and output test files represent
+                            valid Java code, exposed as resources on the test
+                            classpath. -->
+                            <testSourceDirectory>${basedir}/src/test/resources</testSourceDirectory>
                         </testSourceDirectories>
                     </configuration>
                     <dependencies>


### PR DESCRIPTION
:exclamation: This PR is on top of #141 :exclamation: 

Suggested commit message:
```
Apply Checkstyle to Refaster test resources (#146)

Similar to formatting the `*TemplatesTest{In,Out}put.java` files to enforce
certain style aspects, this is expected to reduce future code review effort.

The test code changes were applied to appease the
`SimplifyBooleanExpression` check.
```