### PR TITLE
Clarify `MapToNullable` Refaster template

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/OptionalTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/OptionalTemplates.java
@@ -167,9 +167,9 @@ final class OptionalTemplates {
   }
 
   /**
-   * Prefer {@link Optional#map} over a {@link Optional#flatMap} that wraps a method invocation
-   * capable of returning {@code null} in an {@link Optional}. The former already transforms {@code
-   * null} to {@link Optional#empty()}.
+   * Prefer {@link Optional#map} over a {@link Optional#flatMap} which wraps the result of a
+   * transformation in an {@link Optional}; the former operation transforms {@code null} to {@link
+   * Optional#empty()}.
    */
   abstract static class MapToNullable<T, S> {
     @Placeholder


### PR DESCRIPTION
Today I learned something. Took me a few steps to figure out _why_ this Refaster template was a thing. Decided to add a comment on it to clarify such that the next one does not have to discover this. 

Suggested commit message (feel free to tweak):

```
Clarify `MapToNullable` Refaster template (#150)
```