### PR TITLE
Enable Error Prone's `VoidMissingNullable` check

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
@@ -175,21 +175,21 @@ public final class LexicographicalAnnotationAttributeListing extends BugChecker
     new TreeScanner<Void, Void>() {
       @Nullable
       @Override
-      public Void visitIdentifier(IdentifierTree node, Void ctx) {
+      public Void visitIdentifier(IdentifierTree node, @Nullable Void ctx) {
         nodes.add(tokenize(node));
         return super.visitIdentifier(node, ctx);
       }
 
       @Nullable
       @Override
-      public Void visitLiteral(LiteralTree node, Void ctx) {
+      public Void visitLiteral(LiteralTree node, @Nullable Void ctx) {
         nodes.add(tokenize(node));
         return super.visitLiteral(node, ctx);
       }
 
       @Nullable
       @Override
-      public Void visitPrimitiveType(PrimitiveTypeTree node, Void ctx) {
+      public Void visitPrimitiveType(PrimitiveTypeTree node, @Nullable Void ctx) {
         nodes.add(tokenize(node));
         return super.visitPrimitiveType(node, ctx);
       }

--- a/pom.xml
+++ b/pom.xml
@@ -1541,9 +1541,6 @@
                                     -Xep:StaticOrDefaultInterfaceMethod:OFF
                                     <!-- We generally discourage `var` use. -->
                                     -Xep:Varifier:OFF
-                                    <!-- XXX: This check flags false positives.
-                                    See https://github.com/google/error-prone/issues/2679. -->
-                                    -Xep:VoidMissingNullable:OFF
                                     -XepOpt:CheckReturnValue:CheckAllConstructors=true
                                     <!-- XXX: Enable once there are fewer
                                     false-positives.

--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
@@ -72,7 +72,7 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
     return Boolean.TRUE.equals(
         new TreeScanner<Boolean, Void>() {
           @Override
-          public Boolean visitAnnotation(AnnotationTree node, Void v) {
+          public Boolean visitAnnotation(AnnotationTree node, @Nullable Void v) {
             Symbol sym = ASTHelpers.getSymbol(node);
             return (sym != null
                     && sym.getQualifiedName()
@@ -93,7 +93,7 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
     new TreeScanner<Void, Void>() {
       @Nullable
       @Override
-      public Void visitClass(ClassTree node, Void v) {
+      public Void visitClass(ClassTree node, @Nullable Void v) {
         rules.putAll(node, RefasterRuleBuilderScanner.extractRules(node, context));
         return super.visitClass(node, null);
       }


### PR DESCRIPTION
Suggested commit message:
```
Enable Error Prone's `VoidMissingNullable` check (#180)
```