### PR TITLE
Migrate from JSR 305 to JSpecify

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -65,11 +65,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
         </dependency>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FormatStringConcatenation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FormatStringConcatenation.java
@@ -32,7 +32,7 @@ import com.sun.source.util.SimpleTreeVisitor;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.bugpatterns.util.SourceCode;
 
 /**
@@ -207,7 +207,7 @@ public final class FormatStringConcatenation extends BugChecker
   }
 
   private static class ReplacementArgumentsConstructor
-      extends SimpleTreeVisitor<Void, VisitorState> {
+      extends SimpleTreeVisitor<@Nullable Void, VisitorState> {
     private final StringBuilder formatString = new StringBuilder();
     private final List<Tree> formatArguments = new ArrayList<>();
     private final String formatSpecifier;
@@ -216,9 +216,8 @@ public final class FormatStringConcatenation extends BugChecker
       this.formatSpecifier = formatSpecifier;
     }
 
-    @Nullable
     @Override
-    public Void visitBinary(BinaryTree tree, VisitorState state) {
+    public @Nullable Void visitBinary(BinaryTree tree, VisitorState state) {
       if (tree.getKind() == Kind.PLUS && isStringTyped(tree, state)) {
         tree.getLeftOperand().accept(this, state);
         tree.getRightOperand().accept(this, state);
@@ -229,15 +228,13 @@ public final class FormatStringConcatenation extends BugChecker
       return null;
     }
 
-    @Nullable
     @Override
-    public Void visitParenthesized(ParenthesizedTree tree, VisitorState state) {
+    public @Nullable Void visitParenthesized(ParenthesizedTree tree, VisitorState state) {
       return tree.getExpression().accept(this, state);
     }
 
-    @Nullable
     @Override
-    protected Void defaultAction(Tree tree, VisitorState state) {
+    protected @Nullable Void defaultAction(Tree tree, VisitorState state) {
       appendExpression(tree);
       return null;
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
@@ -40,7 +40,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.bugpatterns.util.AnnotationAttributeMatcher;
 import tech.picnic.errorprone.bugpatterns.util.SourceCode;
 
@@ -184,17 +184,15 @@ public final class LexicographicalAnnotationAttributeListing extends BugChecker
   private static ImmutableList<ImmutableList<String>> getStructure(ExpressionTree array) {
     ImmutableList.Builder<ImmutableList<String>> nodes = ImmutableList.builder();
 
-    new TreeScanner<Void, Void>() {
-      @Nullable
+    new TreeScanner<@Nullable Void, @Nullable Void>() {
       @Override
-      public Void visitIdentifier(IdentifierTree node, @Nullable Void unused) {
+      public @Nullable Void visitIdentifier(IdentifierTree node, @Nullable Void unused) {
         nodes.add(ImmutableList.of(node.getName().toString()));
         return super.visitIdentifier(node, unused);
       }
 
-      @Nullable
       @Override
-      public Void visitLiteral(LiteralTree node, @Nullable Void unused) {
+      public @Nullable Void visitLiteral(LiteralTree node, @Nullable Void unused) {
         Object value = ASTHelpers.constValue(node);
         nodes.add(
             value instanceof String
@@ -204,9 +202,8 @@ public final class LexicographicalAnnotationAttributeListing extends BugChecker
         return super.visitLiteral(node, unused);
       }
 
-      @Nullable
       @Override
-      public Void visitPrimitiveType(PrimitiveTypeTree node, @Nullable Void unused) {
+      public @Nullable Void visitPrimitiveType(PrimitiveTypeTree node, @Nullable Void unused) {
         nodes.add(ImmutableList.of(node.getPrimitiveTypeKind().toString()));
         return super.visitPrimitiveType(node, unused);
       }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
@@ -26,7 +26,7 @@ import com.sun.tools.javac.util.Convert;
 import java.util.Formattable;
 import java.util.Iterator;
 import java.util.List;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.bugpatterns.util.SourceCode;
 
 /**

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/package-info.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/package-info.java
@@ -1,4 +1,4 @@
 /** Picnic Error Prone Contrib checks. */
-@org.jspecify.nullness.NullMarked
 @com.google.errorprone.annotations.CheckReturnValue
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.bugpatterns;

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/package-info.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/package-info.java
@@ -1,4 +1,4 @@
 /** Picnic Error Prone Contrib checks. */
+@org.jspecify.nullness.NullMarked
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
 package tech.picnic.errorprone.bugpatterns;

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/package-info.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/package-info.java
@@ -1,4 +1,4 @@
 /** Auxiliary utilities for use by Error Prone checks. */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.bugpatterns.util;

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssortedRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssortedRules.java
@@ -27,7 +27,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /**
@@ -89,14 +89,12 @@ final class AssortedRules {
 
   static final class MapGetOrNull<K, V, L> {
     @BeforeTemplate
-    @Nullable
-    V before(Map<K, V> map, L key) {
+    @Nullable V before(Map<K, V> map, L key) {
       return map.getOrDefault(key, null);
     }
 
     @AfterTemplate
-    @Nullable
-    V after(Map<K, V> map, L key) {
+    @Nullable V after(Map<K, V> map, L key) {
       return map.get(key);
     }
   }
@@ -134,8 +132,7 @@ final class AssortedRules {
     }
 
     @AfterTemplate
-    @Nullable
-    T after(Iterator<T> iterator, T defaultValue) {
+    @Nullable T after(Iterator<T> iterator, T defaultValue) {
       return Iterators.getNext(iterator, defaultValue);
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MultimapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MultimapRules.java
@@ -7,7 +7,7 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Collection;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to expressions dealing with {@link Multimap}s. */
@@ -50,8 +50,7 @@ final class MultimapRules {
    */
   static final class MultimapGet<K, V> {
     @BeforeTemplate
-    @Nullable
-    Collection<V> before(Multimap<K, V> multimap, K key) {
+    @Nullable Collection<V> before(Multimap<K, V> multimap, K key) {
       return Refaster.anyOf(multimap.asMap(), Multimaps.asMap(multimap)).get(key);
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
@@ -9,7 +9,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Objects;
 import java.util.function.Predicate;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to expressions dealing with (possibly) null values. */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -16,7 +16,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Stream;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to expressions dealing with {@link Optional}s. */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -16,7 +16,7 @@ import java.util.Collection;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to expressions dealing with {@link String}s. */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/package-info.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/package-info.java
@@ -1,4 +1,4 @@
 /** Picnic Refaster rules. */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.refasterrules;

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/RequestParamTypeTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/RequestParamTypeTest.java
@@ -19,7 +19,7 @@ final class RequestParamTypeTest {
             "import java.util.List;",
             "import java.util.Map;",
             "import java.util.Set;",
-            "import javax.annotation.Nullable;",
+            "import org.jspecify.nullness.Nullable;",
             "import org.springframework.web.bind.annotation.DeleteMapping;",
             "import org.springframework.web.bind.annotation.GetMapping;",
             "import org.springframework.web.bind.annotation.PostMapping;",

--- a/pom.xml
+++ b/pom.xml
@@ -244,11 +244,6 @@
                 <version>${version.auto-value}</version>
             </dependency>
             <dependency>
-                <groupId>com.google.code.findbugs</groupId>
-                <artifactId>jsr305</artifactId>
-                <version>3.0.2</version>
-            </dependency>
-            <dependency>
                 <groupId>com.google.googlejavaformat</groupId>
                 <artifactId>google-java-format</artifactId>
                 <version>1.15.0</version>
@@ -628,11 +623,15 @@
                                         </property>
                                         <property name="illegalClasses" value="com.mongodb.lang.Nullable">
                                             <!-- Instead, please use
-                                            `javax.annotation.Nullable`. -->
+                                            `org.jspecify.nullness.Nullable`. -->
                                         </property>
                                         <property name="illegalClasses" value="io.micrometer.core.lang.Nullable">
                                             <!-- Instead, please use
-                                            `javax.annotation.Nullable`. -->
+                                            `org.jspecify.nullness.Nullable`. -->
+                                        </property>
+                                        <property name="illegalClasses" value="javax.annotation.Nullable">
+                                            <!-- Instead, please use
+                                            `org.jspecify.nullness.Nullable`. -->
                                         </property>
                                         <property name="illegalClasses" value="javax.annotation.concurrent.Immutable">
                                             <!-- Instead, please use
@@ -648,7 +647,7 @@
                                         </property>
                                         <property name="illegalClasses" value="org.springframework.lang.Nullable">
                                             <!-- Instead, please use
-                                            `javax.annotation.Nullable`. -->
+                                            `org.jspecify.nullness.Nullable`. -->
                                         </property>
                                         <property name="illegalPkgs" value="com.amazonaws.annotation" />
                                         <property name="illegalPkgs" value="com.beust.jcommander.internal" />

--- a/refaster-compiler/pom.xml
+++ b/refaster-compiler/pom.xml
@@ -37,13 +37,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
         </dependency>
     </dependencies>
 </project>

--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
@@ -28,10 +28,10 @@ import java.io.ObjectOutputStream;
 import java.io.UncheckedIOException;
 import java.lang.annotation.Annotation;
 import java.util.Map;
-import javax.annotation.Nullable;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
 import javax.tools.StandardLocation;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.refaster.AnnotatedCompositeCodeTransformer;
 
 /**
@@ -71,10 +71,10 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
 
   private ImmutableMap<ClassTree, CodeTransformer> compileRefasterRules(ClassTree tree) {
     ImmutableMap.Builder<ClassTree, CodeTransformer> rules = ImmutableMap.builder();
-    new TreeScanner<Void, ImmutableClassToInstanceMap<Annotation>>() {
-      @Nullable
+    new TreeScanner<@Nullable Void, ImmutableClassToInstanceMap<Annotation>>() {
       @Override
-      public Void visitClass(ClassTree node, ImmutableClassToInstanceMap<Annotation> annotations) {
+      public @Nullable Void visitClass(
+          ClassTree node, ImmutableClassToInstanceMap<Annotation> annotations) {
         ClassSymbol symbol = ASTHelpers.getSymbol(node);
 
         ImmutableList<CodeTransformer> transformers =
@@ -105,7 +105,7 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
 
   private static boolean containsRefasterRules(ClassTree tree) {
     return Boolean.TRUE.equals(
-        new TreeScanner<Boolean, Void>() {
+        new TreeScanner<Boolean, @Nullable Void>() {
           @Override
           public Boolean visitAnnotation(AnnotationTree node, @Nullable Void unused) {
             Symbol sym = ASTHelpers.getSymbol(node);

--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/package-info.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/package-info.java
@@ -3,5 +3,5 @@
  * files on the classpath.
  */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.refaster.plugin;

--- a/refaster-runner/pom.xml
+++ b/refaster-runner/pom.xml
@@ -52,11 +52,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>provided</scope>
@@ -65,6 +60,11 @@
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/package-info.java
+++ b/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/package-info.java
@@ -1,4 +1,4 @@
 /** Exposes Refaster rules found on the classpath through a regular Error Prone check. */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.refaster.runner;

--- a/refaster-support/pom.xml
+++ b/refaster-support/pom.xml
@@ -52,19 +52,18 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
-            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/annotation/package-info.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/annotation/package-info.java
@@ -4,5 +4,5 @@
  * non-patch mode.
  */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.refaster.annotation;

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/package-info.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/package-info.java
@@ -5,5 +5,5 @@
  * com.google.errorprone.refaster.annotation.NotMatches @NotMatches} annotations.
  */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.refaster.matchers;

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/package-info.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/package-info.java
@@ -1,4 +1,4 @@
 /** Assorted classes that aid the compilation or evaluation of Refaster rules. */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.refaster;

--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
@@ -11,7 +11,7 @@ import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreeScanner;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 
 /**
  * An abstract {@link BugChecker} that reports a match for each expression matched by the given
@@ -31,10 +31,9 @@ abstract class AbstractMatcherTestChecker extends BugChecker implements Compilat
 
   @Override
   public Description matchCompilationUnit(CompilationUnitTree compilationUnit, VisitorState state) {
-    new TreeScanner<Void, Void>() {
-      @Nullable
+    new TreeScanner<@Nullable Void, @Nullable Void>() {
       @Override
-      public Void scan(Tree tree, @Nullable Void unused) {
+      public @Nullable Void scan(Tree tree, @Nullable Void unused) {
         if (tree instanceof ExpressionTree && delegate.matches((ExpressionTree) tree, state)) {
           state.reportMatch(
               Description.builder(tree, canonicalName(), null, defaultSeverity(), message())
@@ -44,9 +43,8 @@ abstract class AbstractMatcherTestChecker extends BugChecker implements Compilat
         return super.scan(tree, unused);
       }
 
-      @Nullable
       @Override
-      public Void visitImport(ImportTree node, @Nullable Void unused) {
+      public @Nullable Void visitImport(ImportTree node, @Nullable Void unused) {
         /*
          * We're not interested in matching import statements. While components of these
          * can be `ExpressionTree`s, they will never be matched by Refaster.
@@ -54,9 +52,8 @@ abstract class AbstractMatcherTestChecker extends BugChecker implements Compilat
         return null;
       }
 
-      @Nullable
       @Override
-      public Void visitMethod(MethodTree node, @Nullable Void unused) {
+      public @Nullable Void visitMethod(MethodTree node, @Nullable Void unused) {
         /*
          * We're not interested in matching e.g. parameter and return type declarations. While these
          * can be `ExpressionTree`s, they will never be matched by Refaster.

--- a/refaster-test-support/pom.xml
+++ b/refaster-test-support/pom.xml
@@ -46,13 +46,13 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.jspecify</groupId>
+            <artifactId>jspecify</artifactId>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
+++ b/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
@@ -44,7 +44,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 import tech.picnic.errorprone.refaster.runner.CodeTransformers;
 import tech.picnic.errorprone.refaster.runner.Refaster;
 
@@ -239,16 +239,15 @@ public final class RefasterRuleCollection extends BugChecker implements Compilat
     return value.substring(index + 1);
   }
 
-  private class UnexpectedMatchReporter extends TreeScanner<Void, VisitorState> {
+  private class UnexpectedMatchReporter extends TreeScanner<@Nullable Void, VisitorState> {
     private final ImmutableRangeMap<Integer, String> indexedMatches;
 
     UnexpectedMatchReporter(ImmutableRangeMap<Integer, String> indexedMatches) {
       this.indexedMatches = indexedMatches;
     }
 
-    @Nullable
     @Override
-    public Void visitMethod(MethodTree tree, VisitorState state) {
+    public @Nullable Void visitMethod(MethodTree tree, VisitorState state) {
       if (!ASTHelpers.isGeneratedConstructor(tree)) {
         getRuleUnderTest(tree, state)
             .ifPresent(ruleUnderTest -> reportUnexpectedMatches(tree, ruleUnderTest, state));

--- a/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/package-info.java
+++ b/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/package-info.java
@@ -1,4 +1,4 @@
 /** Opinionated utilities for the testing of Refaster rules. */
 @com.google.errorprone.annotations.CheckReturnValue
-@javax.annotation.ParametersAreNonnullByDefault
+@org.jspecify.nullness.NullMarked
 package tech.picnic.errorprone.refaster.test;

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/ValidRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/ValidRules.java
@@ -8,7 +8,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Placeholder;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Set;
-import javax.annotation.Nullable;
+import org.jspecify.nullness.Nullable;
 
 /** Refaster rule collection to validate that having no violations works as expected. */
 final class ValidRules {


### PR DESCRIPTION
:exclamation: This PR is currently on top of #182 :exclamation:

Suggested commit message:
```
Migrate from JSR 305 to JSpecify (#181)

JSpecify's annotations have more well-defined semantics. Its `@Nullable`
annotation is also a type-use annotation recognized by Google Java
Format, so the formatter places it after any field or method modifiers.

See https://jspecify.dev
```

~This is a draft PR. The build currently fails because `LexicographicalAnnotationListing` now incorrectly suggests swapping `@Nullable` and `@Override` annotations.~ #182 resolves this.
