### PR TITLE
Drop various vacuous null checks

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/EmptyMethod.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/EmptyMethod.java
@@ -20,7 +20,6 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
-import com.sun.tools.javac.code.Symbol.MethodSymbol;
 import java.util.Optional;
 
 /** A {@link BugChecker} which flags empty methods that seemingly can simply be deleted. */
@@ -47,8 +46,7 @@ public final class EmptyMethod extends BugChecker implements MethodTreeMatcher {
       return Description.NO_MATCH;
     }
 
-    MethodSymbol sym = ASTHelpers.getSymbol(tree);
-    if (sym == null || ASTHelpers.methodCanBeOverridden(sym)) {
+    if (ASTHelpers.methodCanBeOverridden(ASTHelpers.getSymbol(tree))) {
       return Description.NO_MATCH;
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/JUnitMethodDeclaration.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/JUnitMethodDeclaration.java
@@ -176,8 +176,7 @@ public final class JUnitMethodDeclaration extends BugChecker implements MethodTr
   }
 
   private static Optional<String> tryCanonicalizeMethodName(MethodTree tree) {
-    return Optional.ofNullable(ASTHelpers.getSymbol(tree))
-        .map(sym -> sym.getQualifiedName().toString())
+    return Optional.of(ASTHelpers.getSymbol(tree).getQualifiedName().toString())
         .filter(name -> name.startsWith(TEST_PREFIX))
         .map(name -> name.substring(TEST_PREFIX.length()))
         .filter(not(String::isEmpty))

--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
@@ -28,7 +28,6 @@ import java.io.ObjectOutputStream;
 import java.io.UncheckedIOException;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import javax.tools.FileObject;
 import javax.tools.JavaFileManager;
@@ -103,16 +102,10 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
   }
 
   private FileObject getOutputFile(TaskEvent taskEvent, ClassTree tree) throws IOException {
-    String packageName =
-        Optional.ofNullable(ASTHelpers.getSymbol(tree))
-            .map(ASTHelpers::enclosingPackage)
-            .map(PackageSymbol::toString)
-            .orElse("");
-    CharSequence className =
-        Optional.ofNullable(ASTHelpers.getSymbol(tree))
-            .map(RefasterRuleCompilerTaskListener::toSimpleFlatName)
-            .orElseGet(tree::getSimpleName);
-    String relativeName = className + ".refaster";
+    ClassSymbol symbol = ASTHelpers.getSymbol(tree);
+    PackageSymbol enclosingPackage = ASTHelpers.enclosingPackage(symbol);
+    String packageName = enclosingPackage == null ? "" : enclosingPackage.toString();
+    String relativeName = toSimpleFlatName(symbol) + ".refaster";
 
     JavaFileManager fileManager = context.get(JavaFileManager.class);
     return fileManager.getFileForOutput(


### PR DESCRIPTION
Suggested commit message:
```
Drop various vacuous null checks (#191)

Recent versions of Error Prone guarantee that `ASTHelpers#getSymbol`
never returns `null`.
```