### PR TITLE
Prefer `String#valueOf` over `Objects#toString`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/EqualityTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/EqualityTemplates.java
@@ -41,13 +41,11 @@ final class EqualityTemplates {
   // non-null.
   static final class EqualsPredicate<T> {
     @BeforeTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Predicate<T> before(T v) {
       return e -> v.equals(e);
     }
 
     @AfterTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Predicate<T> after(T v) {
       return v::equals;
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/NullTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/NullTemplates.java
@@ -33,13 +33,11 @@ final class NullTemplates {
   /** Prefer {@link Objects#isNull(Object)} over the equivalent lambda function. */
   static final class IsNullFunction<T> {
     @BeforeTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Predicate<T> before() {
       return o -> o == null;
     }
 
     @AfterTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Predicate<T> after() {
       return Objects::isNull;
     }
@@ -48,13 +46,11 @@ final class NullTemplates {
   /** Prefer {@link Objects#nonNull(Object)} over the equivalent lambda function. */
   static final class NonNullFunction<T> {
     @BeforeTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Predicate<T> before() {
       return o -> o != null;
     }
 
     @AfterTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Predicate<T> after() {
       return Objects::nonNull;
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/OptionalTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/OptionalTemplates.java
@@ -81,13 +81,11 @@ final class OptionalTemplates {
   // generalization. If/when Refaster is extended to understand this, delete the template above.
   static final class OptionalOrElseThrowMethodReference<T> {
     @BeforeTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Function<Optional<T>, T> before() {
       return Optional::get;
     }
 
     @AfterTemplate
-    @SuppressWarnings("NoFunctionalReturnType")
     Function<Optional<T>, T> after() {
       return Optional::orElseThrow;
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/StringTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/StringTemplates.java
@@ -13,7 +13,9 @@ import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import javax.annotation.Nullable;
 
 /** Refaster templates related to expressions dealing with {@link String}s. */
@@ -103,6 +105,40 @@ final class StringTemplates {
     @AfterTemplate
     String after(CharSequence delimiter, Iterable<? extends CharSequence> elements) {
       return String.join(delimiter, elements);
+    }
+  }
+
+  /**
+   * Prefer direct invocation of {@link String#valueOf(Object)} over the indirection introduced by
+   * {@link Objects#toString(Object)}.
+   */
+  static final class StringValueOf {
+    @BeforeTemplate
+    String before(Object object) {
+      return Objects.toString(object);
+    }
+
+    @AfterTemplate
+    String after(Object object) {
+      return String.valueOf(object);
+    }
+  }
+
+  /**
+   * Prefer direct delegation to {@link String#valueOf(Object)} over the indirection introduced by
+   * {@link Objects#toString(Object)}.
+   */
+  // XXX: This template is analogous to `StringValueOf` above. Arguably this is its generalization.
+  // If/when Refaster is extended to understand this, delete the template above.
+  static final class StringValueOfMethodReference<T> {
+    @BeforeTemplate
+    Function<Object, String> before() {
+      return Objects::toString;
+    }
+
+    @AfterTemplate
+    Function<Object, String> after() {
+      return String::valueOf;
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StringTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StringTemplatesTestInput.java
@@ -10,7 +10,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterTemplateTestCase;
 
@@ -18,7 +20,7 @@ final class StringTemplatesTest implements RefasterTemplateTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        Arrays.class, Joiner.class, Stream.class, Streams.class, joining(), UTF_8);
+        Arrays.class, Joiner.class, Objects.class, Stream.class, Streams.class, joining(), UTF_8);
   }
 
   ImmutableSet<Boolean> testStringIsEmpty() {
@@ -57,6 +59,14 @@ final class StringTemplatesTest implements RefasterTemplateTestCase {
         Joiner.on("d").join(ImmutableList.of("foo", "bar")),
         Streams.stream(Iterables.cycle(ImmutableList.of("foo", "bar"))).collect(joining("e")),
         ImmutableList.of("foo", "bar").stream().collect(joining("f")));
+  }
+
+  String testStringValueOf() {
+    return Objects.toString("foo");
+  }
+
+  Function<Object, String> testStringValueOfMethodReference() {
+    return Objects::toString;
   }
 
   String testSubstringRemainder() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StringTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/StringTemplatesTestOutput.java
@@ -11,7 +11,9 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterTemplateTestCase;
 
@@ -19,7 +21,7 @@ final class StringTemplatesTest implements RefasterTemplateTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        Arrays.class, Joiner.class, Stream.class, Streams.class, joining(), UTF_8);
+        Arrays.class, Joiner.class, Objects.class, Stream.class, Streams.class, joining(), UTF_8);
   }
 
   ImmutableSet<Boolean> testStringIsEmpty() {
@@ -57,6 +59,14 @@ final class StringTemplatesTest implements RefasterTemplateTestCase {
         String.join("d", ImmutableList.of("foo", "bar")),
         String.join("e", Iterables.cycle(ImmutableList.of("foo", "bar"))),
         String.join("f", ImmutableList.of("foo", "bar")));
+  }
+
+  String testStringValueOf() {
+    return String.valueOf("foo");
+  }
+
+  Function<Object, String> testStringValueOfMethodReference() {
+    return String::valueOf;
   }
 
   String testSubstringRemainder() {


### PR DESCRIPTION
Suggested commit message:
```
Prefer `String#valueOf` over `Objects#toString` (#192)

While there, drop obsolete `NoFunctionalReturnType` warning suppressions.
```

Internally we use `String#valueOf` way more frequently than `Objects#toString`, so let's settle on it.