### PR TITLE
Drop the dependency on `com.google.errorprone:javac`

### DIFF
--- a/.mvn/jvm.config
+++ b/.mvn/jvm.config
@@ -2,6 +2,7 @@
 -XX:SoftRefLRUPolicyMSPerMB=10
 -XX:+UseParallelGC
 --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
@@ -9,5 +10,4 @@
 --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
 --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
---add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
 --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED

--- a/error-prone-contrib/README.md
+++ b/error-prone-contrib/README.md
@@ -33,9 +33,16 @@ Two other goals that one may find relevant:
   `target/pit-reports/index.html` files. For more information check the [PIT
   Maven plugin][pitest-maven].
 
-When loading the project in IntelliJ IDEA (and perhaps other IDEs) errors about
-the inaccessibility of `com.sun.tools.javac.*` classes may be reported. If this
-happens, configure your IDE to enable the `add-exports` profile.
+When running the project's tests in IntelliJ IDEA, you might see the following
+error:
+```
+java: exporting a package from system module jdk.compiler is not allowed with --release
+```
+
+If this happens, go to _Settings -> Build, Execution, Deployment -> Compiler ->
+Java Compiler_ and deselect the option _Use '--release' option for
+cross-compilation (Java 9 and later)_. See [IDEA-288052][idea-288052] for
+details.
 
 ### Contribution guidelines
 
@@ -335,8 +342,9 @@ Refaster's expressiveness:
 [forbidden-apis]: https://github.com/policeman-tools/forbidden-apis
 [fossa]: https://fossa.io
 [google-java-format]: https://github.com/google/google-java-format
+[idea-288052]: https://youtrack.jetbrains.com/issue/IDEA-288052
 [maven]: https://maven.apache.org
 [modernizer-maven-plugin]: https://github.com/gaul/modernizer-maven-plugin
-[sonarcloud]: https://sonarcloud.io
 [pitest]: https://pitest.org
 [pitest-maven]: https://pitest.org/quickstart/maven
+[sonarcloud]: https://sonarcloud.io

--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -70,11 +70,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>javac</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.googlejavaformat</groupId>
             <artifactId>google-java-format</artifactId>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,7 @@
             -XX:SoftRefLRUPolicyMSPerMB=10
             -XX:+UseParallelGC
             --add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
+            --add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
             --add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
             --add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
             --add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
@@ -94,7 +95,6 @@
             --add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
             --add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
             --add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
-            --add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
             --add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
             <!-- The test JVMs are short-running. By disabling certain
             expensive JIT optimizations we actually speed up most tests. -->
@@ -251,11 +251,6 @@
                 <groupId>com.google.code.findbugs</groupId>
                 <artifactId>jsr305</artifactId>
                 <version>3.0.2</version>
-            </dependency>
-            <dependency>
-                <groupId>com.google.errorprone</groupId>
-                <artifactId>javac</artifactId>
-                <version>9+181-r4173-1</version>
             </dependency>
             <dependency>
                 <groupId>com.google.googlejavaformat</groupId>
@@ -846,13 +841,19 @@
                             </path>
                         </annotationProcessorPaths>
                         <compilerArgs>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                             <arg>-Xmaxerrs</arg>
                             <arg>10000</arg>
                             <arg>-Xmaxwarns</arg>
                             <arg>10000</arg>
                         </compilerArgs>
                         <parameters>true</parameters>
-                        <release>${version.jdk}</release>
+                        <source>${version.jdk}</source>
+                        <target>${version.jdk}</target>
                         <!-- Erroneously inverted logic... for details, see
                         https://issues.apache.org/jira/browse/MCOMPILER-209. -->
                         <useIncrementalCompilation>false</useIncrementalCompilation>
@@ -1711,41 +1712,6 @@
                             <artifactId>versions-maven-plugin</artifactId>
                             <configuration>
                                 <rulesUri>file://${path.version-number-rules}</rulesUri>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
-        </profile>
-        <profile>
-            <!-- Some code in this project interfaces directly with the Java
-            compiler. The following `add-exports` arguments are not necessary
-            for the code to compile because `com.google.errorprone:javac` is on
-            the classpath. In fact, enabling this profile when building with
-            Maven on the command line will cause a build failure, because these
-            flags are incompatible with the `release` flag. This profile exists
-            solely to be enabled within an IDE: without them IntelliJ IDEA
-            reports compilation errors. -->
-            <id>add-exports</id>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-compiler-plugin</artifactId>
-                            <configuration>
-                                <compilerArgs combine.children="append">
-                                    <arg>--add-exports</arg>
-                                    <arg>jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                                    <arg>--add-exports</arg>
-                                    <arg>jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                                    <arg>--add-exports</arg>
-                                    <arg>jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-                                    <arg>--add-exports</arg>
-                                    <arg>jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
-                                    <arg>--add-exports</arg>
-                                    <arg>jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                                </compilerArgs>
                             </configuration>
                         </plugin>
                     </plugins>

--- a/refaster-compiler/pom.xml
+++ b/refaster-compiler/pom.xml
@@ -38,11 +38,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>javac</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>

--- a/refaster-runner/pom.xml
+++ b/refaster-runner/pom.xml
@@ -48,11 +48,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>javac</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
             <scope>provided</scope>

--- a/refaster-support/pom.xml
+++ b/refaster-support/pom.xml
@@ -52,11 +52,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>javac</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>

--- a/refaster-test-support/pom.xml
+++ b/refaster-test-support/pom.xml
@@ -51,11 +51,6 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>javac</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>com.google.guava</groupId>
             <artifactId>guava</artifactId>
         </dependency>


### PR DESCRIPTION
Suggested commit message:
```
Drop the dependency on `com.google.errorprone:javac` (#197)

This new setup matches the upstream Error Prone build configuration and
simplifies development against JDK 11+ internal APIs.
```