### PR TITLE
Fix several `RxJava2Adapter` Refaster templates

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/RxJava2AdapterTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/RxJava2AdapterTemplates.java
@@ -9,7 +9,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import org.reactivestreams.Publisher;
 import reactor.adapter.rxjava.RxJava2Adapter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -39,12 +38,12 @@ final class RxJava2AdapterTemplates {
    */
   static final class FlowableToFlux<T> {
     @BeforeTemplate
-    Publisher<T> before(Flowable<T> flowable) {
+    Flux<T> before(Flowable<T> flowable) {
       return Refaster.anyOf(
-          flowable.compose(Flux::from),
+          Flux.from(flowable),
           flowable.to(Flux::from),
           flowable.as(Flux::from),
-          flowable.compose(RxJava2Adapter::flowableToFlux),
+          RxJava2Adapter.flowableToFlux(flowable),
           flowable.to(RxJava2Adapter::flowableToFlux));
     }
 
@@ -60,12 +59,11 @@ final class RxJava2AdapterTemplates {
    */
   static final class FluxToFlowable<T> {
     @BeforeTemplate
-    Publisher<T> before(Flux<T> flux) {
+    Flowable<T> before(Flux<T> flux) {
       return Refaster.anyOf(
           Flowable.fromPublisher(flux),
-          flux.transform(Flowable::fromPublisher),
           flux.as(Flowable::fromPublisher),
-          flux.transform(RxJava2Adapter::fluxToFlowable));
+          RxJava2Adapter.fluxToFlowable(flux));
     }
 
     @AfterTemplate
@@ -132,12 +130,11 @@ final class RxJava2AdapterTemplates {
    */
   static final class MonoToFlowable<T> {
     @BeforeTemplate
-    Publisher<T> before(Mono<T> mono) {
+    Flowable<T> before(Mono<T> mono) {
       return Refaster.anyOf(
           Flowable.fromPublisher(mono),
-          mono.transform(Flowable::fromPublisher),
           mono.as(Flowable::fromPublisher),
-          mono.transform(RxJava2Adapter::monoToFlowable));
+          RxJava2Adapter.monoToFlowable(mono));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/RxJava2AdapterTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/RxJava2AdapterTemplatesTestInput.java
@@ -7,8 +7,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.util.Arrays;
-import org.reactivestreams.Publisher;
 import reactor.adapter.rxjava.RxJava2Adapter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -21,24 +19,20 @@ final class RxJava2AdapterTemplatesTest implements RefasterTemplateTestCase {
         Completable.complete().to(RxJava2Adapter::completableToMono));
   }
 
-  ImmutableSet<Publisher<Integer>> testFlowableToFlux() {
-    // The `Arrays.asList` is to avoid confusing `javac`; `ImmutableSet.of` uses varargs from the
-    // seventh parameter onwards.
-    return ImmutableSet.copyOf(
-        Arrays.asList(
-            Flowable.just(1).compose(Flux::from),
-            Flowable.just(2).to(Flux::from),
-            Flowable.just(3).as(Flux::from),
-            Flowable.just(4).compose(RxJava2Adapter::flowableToFlux),
-            Flowable.just(5).<Publisher<Integer>>to(RxJava2Adapter::flowableToFlux)));
+  ImmutableSet<Flux<Integer>> testFlowableToFlux() {
+    return ImmutableSet.of(
+        Flux.from(Flowable.just(1)),
+        Flowable.just(2).to(Flux::from),
+        Flowable.just(3).as(Flux::from),
+        RxJava2Adapter.flowableToFlux(Flowable.just(4)),
+        Flowable.just(5).to(RxJava2Adapter::flowableToFlux));
   }
 
-  ImmutableSet<Publisher<String>> testFluxToFlowable() {
+  ImmutableSet<Flowable<String>> testFluxToFlowable() {
     return ImmutableSet.of(
         Flowable.fromPublisher(Flux.just("foo")),
-        Flux.just("bar").transform(Flowable::fromPublisher),
-        Flux.just("baz").as(Flowable::fromPublisher),
-        Flux.just("qux").transform(RxJava2Adapter::fluxToFlowable));
+        Flux.just("bar").as(Flowable::fromPublisher),
+        RxJava2Adapter.fluxToFlowable(Flux.just("baz")));
   }
 
   ImmutableSet<Observable<Integer>> testFluxToObservable() {
@@ -61,12 +55,11 @@ final class RxJava2AdapterTemplatesTest implements RefasterTemplateTestCase {
         RxJava2Adapter.monoToCompletable(Mono.empty()));
   }
 
-  ImmutableSet<Publisher<Integer>> testMonoToFlowable() {
+  ImmutableSet<Flowable<Integer>> testMonoToFlowable() {
     return ImmutableSet.of(
         Flowable.fromPublisher(Mono.just(1)),
-        Mono.just(2).transform(Flowable::fromPublisher),
-        Mono.just(3).as(Flowable::fromPublisher),
-        Mono.just(4).transform(RxJava2Adapter::monoToFlowable));
+        Mono.just(2).as(Flowable::fromPublisher),
+        RxJava2Adapter.monoToFlowable(Mono.just(3)));
   }
 
   Maybe<String> testMonoToMaybe() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/RxJava2AdapterTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/RxJava2AdapterTemplatesTestOutput.java
@@ -7,8 +7,6 @@ import io.reactivex.Flowable;
 import io.reactivex.Maybe;
 import io.reactivex.Observable;
 import io.reactivex.Single;
-import java.util.Arrays;
-import org.reactivestreams.Publisher;
 import reactor.adapter.rxjava.RxJava2Adapter;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -21,24 +19,20 @@ final class RxJava2AdapterTemplatesTest implements RefasterTemplateTestCase {
         Completable.complete().as(RxJava2Adapter::completableToMono));
   }
 
-  ImmutableSet<Publisher<Integer>> testFlowableToFlux() {
-    // The `Arrays.asList` is to avoid confusing `javac`; `ImmutableSet.of` uses varargs from the
-    // seventh parameter onwards.
-    return ImmutableSet.copyOf(
-        Arrays.asList(
-            Flowable.just(1).as(RxJava2Adapter::flowableToFlux),
-            Flowable.just(2).as(RxJava2Adapter::flowableToFlux),
-            Flowable.just(3).as(RxJava2Adapter::flowableToFlux),
-            Flowable.just(4).as(RxJava2Adapter::flowableToFlux),
-            Flowable.just(5).as(RxJava2Adapter::flowableToFlux)));
+  ImmutableSet<Flux<Integer>> testFlowableToFlux() {
+    return ImmutableSet.of(
+        Flowable.just(1).as(RxJava2Adapter::flowableToFlux),
+        Flowable.just(2).as(RxJava2Adapter::flowableToFlux),
+        Flowable.just(3).as(RxJava2Adapter::flowableToFlux),
+        Flowable.just(4).as(RxJava2Adapter::flowableToFlux),
+        Flowable.just(5).as(RxJava2Adapter::flowableToFlux));
   }
 
-  ImmutableSet<Publisher<String>> testFluxToFlowable() {
+  ImmutableSet<Flowable<String>> testFluxToFlowable() {
     return ImmutableSet.of(
         Flux.just("foo").as(RxJava2Adapter::fluxToFlowable),
         Flux.just("bar").as(RxJava2Adapter::fluxToFlowable),
-        Flux.just("baz").as(RxJava2Adapter::fluxToFlowable),
-        Flux.just("qux").as(RxJava2Adapter::fluxToFlowable));
+        Flux.just("baz").as(RxJava2Adapter::fluxToFlowable));
   }
 
   ImmutableSet<Observable<Integer>> testFluxToObservable() {
@@ -61,12 +55,11 @@ final class RxJava2AdapterTemplatesTest implements RefasterTemplateTestCase {
         Mono.empty().as(RxJava2Adapter::monoToCompletable));
   }
 
-  ImmutableSet<Publisher<Integer>> testMonoToFlowable() {
+  ImmutableSet<Flowable<Integer>> testMonoToFlowable() {
     return ImmutableSet.of(
         Mono.just(1).as(RxJava2Adapter::monoToFlowable),
         Mono.just(2).as(RxJava2Adapter::monoToFlowable),
-        Mono.just(3).as(RxJava2Adapter::monoToFlowable),
-        Mono.just(4).as(RxJava2Adapter::monoToFlowable));
+        Mono.just(3).as(RxJava2Adapter::monoToFlowable));
   }
 
   Maybe<String> testMonoToMaybe() {


### PR DESCRIPTION
Suggested commit message:
```
Fix several `RxJava2Adapter` Refaster templates (#205)

This reverts some changes from d2bbee3ed9953598d3e75ff5bd381a2616b8693d
and instead drops some invalid `Flowable#compose` and `Flux#transform`
rewrite rules.
```

Commit referenced is d2bbee3ed9953598d3e75ff5bd381a2616b8693d.