### PR TITLE
Enable `nohttp-checkstyle`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -746,6 +746,7 @@
                                     <module name="VisibilityModifier" />
                                 </module>
                                 <module name="UniqueProperties" />
+                                <module name="io.spring.nohttp.checkstyle.check.NoHttpCheck" />
                             </module>
                         </checkstyleRules>
                         <failOnViolation>false</failOnViolation>
@@ -770,6 +771,11 @@
                             <groupId>com.puppycrawl.tools</groupId>
                             <artifactId>checkstyle</artifactId>
                             <version>10.3.2</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>io.spring.nohttp</groupId>
+                            <artifactId>nohttp-checkstyle</artifactId>
+                            <version>0.0.10</version>
                         </dependency>
                     </dependencies>
                     <executions>


### PR DESCRIPTION
Suggested commit message:
```
Enable `nohttp-checkstyle` (#206)

While this Checkstyle configuration only flags `http://` usages in
Maven-managed source files (thus not in e.g. `pom.xml` or `README.md`
files), this is a low-effort improvement.
```