### PR TITLE
Introduce `release.yml` to improve GitHub release notes generation

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,32 +1,29 @@
 changelog:
   exclude:
     labels:
-      - ignore-changelog
+      - "ignore-changelog"
   categories:
-    - title: ":rocket: New Error Prone checks"
-      labels:
-        - "error prone check"
-    - title: ":sunny: New Refaster templates"
-      labels:
-        - "refaster template"
-    - title: ":sparkles: New features and improvements"
+    - title: ":rocket: New Error Prone checks and Refaster templates"
       labels:
         - "new feature"
-        - improvement
+    - title: ":sparkles: Improvements"
+      labels:
+        - "improvement"
     - title: ":warning: Update considerations and deprecations"
       labels:
         - "breaking change"
-        - deprecation
+        - "deprecation"
     - title: ":bug: Bug fixes"
       labels:
-        - bug
-    - title: ":books: Documentation, tests and build"
+        - "bug"
+        - "bug fix"
+    - title: ":books: Documentation, test and build improvements"
       labels:
-        - documentation
-        - chores
+        - "documentation"
+        - "chore"
     - title: ":chart_with_upwards_trend: Dependency upgrades"
       labels:
-        - dependencies
+        - "dependencies"
     - title: "Other changes"
       labels:
         - "*"


### PR DESCRIPTION
See an overview of the labels [here](https://github.com/PicnicSupermarket/error-prone-support/labels).
The official documentation for automated release notes on GitHub can be found [here](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes). 

To verify the changes, I updated the base branch and created a tag `v0.2.1` and compared it with `v0.1.0`.

<details>
<summary>This was the output ⏬</summary>

<!-- Release notes generated using configuration in .github/release.yml at v0.2.1 -->

## What's Changed
### :sparkles: New features and improvements
* Exempt `@RequestAttribute` from `RequestMappingAnnotation` check by @ddeya in https://github.com/PicnicSupermarket/error-prone-support/pull/189
* Rewrite another `ThrowableAssertAlternative#withMessage(String, Object...)` expression by @ivan-fedorov in https://github.com/PicnicSupermarket/error-prone-support/pull/190
* Introduce `NestedOptionals` check by @Venorcis in https://github.com/PicnicSupermarket/error-prone-support/pull/202
* Drop various vacuous null checks by @Stephan202 in https://github.com/PicnicSupermarket/error-prone-support/pull/191
* Introduce `ImmutablesSortedSetComparator` check by @ferdinand-swoboda in https://github.com/PicnicSupermarket/error-prone-support/pull/102
* Require static import of `com.google.errorprone.matchers.Matchers` methods by @oxkitsune in https://github.com/PicnicSupermarket/error-prone-support/pull/201
* Don't enforce sorting of Spring resource locations by @Ptijohn in https://github.com/PicnicSupermarket/error-prone-support/pull/204
* Introduce `NonEmptyMono` check by @cernat-catalin in https://github.com/PicnicSupermarket/error-prone-support/pull/200
* Prefer `String#valueOf` over `Objects#toString` by @Stephan202 in https://github.com/PicnicSupermarket/error-prone-support/pull/192
* Fix several `RxJava2Adapter` Refaster templates by @Stephan202 in https://github.com/PicnicSupermarket/error-prone-support/pull/205
### :book: Documentation, Tests and Build
* Enable Error Prone's `VoidMissingNullable` check by @Stephan202 in https://github.com/PicnicSupermarket/error-prone-support/pull/180
* Improve `StreamMapToOptionalGet` Refaster template documentation by @rickie in https://github.com/PicnicSupermarket/error-prone-support/pull/203
* Enable `nohttp-checkstyle` by @Stephan202 in https://github.com/PicnicSupermarket/error-prone-support/pull/206
* Drop unnecessary dependency declarations by @Stephan202 in https://github.com/PicnicSupermarket/error-prone-support/pull/208
### :warning: Dependency Upgrades
* Upgrade Project Reactor 2020.0.21 -> 2020.0.22 by @Picnic-Bot in https://github.com/PicnicSupermarket/error-prone-support/pull/187
* Upgrade maven-javadoc-plugin 3.4.0 -> 3.4.1 by @Picnic-Bot in https://github.com/PicnicSupermarket/error-prone-support/pull/195
* Upgrade Mockito 4.6.1 -> 4.7.0 by @Picnic-Bot in https://github.com/PicnicSupermarket/error-prone-support/pull/196
* Upgrade org.apache.maven:maven-plugin-api 3.6.3 -> 3.8.6 by @Picnic-Bot in https://github.com/PicnicSupermarket/error-prone-support/pull/184
* Upgrade Spring Boot 2.7.2 -> 2.7.3 by @Picnic-Bot in https://github.com/PicnicSupermarket/error-prone-support/pull/207
* Upgrade pitest-maven-plugin 1.9.4 -> 1.9.5 by @Picnic-Bot in https://github.com/PicnicSupermarket/error-prone-support/pull/211
* Upgrade Immutables 2.9.0 -> 2.9.1 by @Picnic-Bot in https://github.com/PicnicSupermarket/error-prone-support/pull/210

## New Contributors
* @ddeya made their first contribution in https://github.com/PicnicSupermarket/error-prone-support/pull/189
* @Venorcis made their first contribution in https://github.com/PicnicSupermarket/error-prone-support/pull/202
* @ferdinand-swoboda made their first contribution in https://github.com/PicnicSupermarket/error-prone-support/pull/102
* @Ptijohn made their first contribution in https://github.com/PicnicSupermarket/error-prone-support/pull/204
* @cernat-catalin made their first contribution in https://github.com/PicnicSupermarket/error-prone-support/pull/200

**Full Changelog**: https://github.com/PicnicSupermarket/error-prone-support/compare/v0.1.0...v0.2.1

</details>

Open questions:
- Do we want a single `enhancement` label or two labels saying `new feature` and `improvement` (and perhaps add more)? 
- If we use `refaster template` and `error prone check` do we need `new feature` and `improvement` after all? (I think it'd be nice to keep them).
- Do we want the `ignore-changelog` label? 

Let me know what you think!

