### PR TITLE
Generate reproducible build output

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -515,6 +515,25 @@
                     </executions>
                 </plugin>
                 <plugin>
+                    <groupId>io.github.git-commit-id</groupId>
+                    <artifactId>git-commit-id-maven-plugin</artifactId>
+                    <version>5.0.0</version>
+                    <configuration>
+                        <injectAllReactorProjects>true</injectAllReactorProjects>
+                        <runOnlyOnce>true</runOnlyOnce>
+                        <skipPoms>false</skipPoms>
+                        <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
+                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>retrieve-git-info</id>
+                            <goals>
+                                <goal>revision</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                </plugin>
+                <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-checkstyle-plugin</artifactId>
                     <version>3.2.0</version>
@@ -1259,35 +1278,16 @@
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>3.9.1.2184</version>
                 </plugin>
-                <plugin>
-                    <groupId>pl.project13.maven</groupId>
-                    <artifactId>git-commit-id-plugin</artifactId>
-                    <version>4.9.10</version>
-                    <configuration>
-                        <injectAllReactorProjects>true</injectAllReactorProjects>
-                        <runOnlyOnce>true</runOnlyOnce>
-                        <skipPoms>false</skipPoms>
-                        <dateFormat>yyyy-MM-dd'T'HH:mm:ssXXX</dateFormat>
-                    </configuration>
-                    <executions>
-                        <execution>
-                            <id>retrieve-git-info</id>
-                            <goals>
-                                <goal>revision</goal>
-                            </goals>
-                        </execution>
-                    </executions>
-                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-source-plugin</artifactId>
+                <groupId>io.github.git-commit-id</groupId>
+                <artifactId>git-commit-id-maven-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>pl.project13.maven</groupId>
-                <artifactId>git-commit-id-plugin</artifactId>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-source-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Suggested commit message:
```
Generate reproducible build output (#243)

By deriving `project.build.outputTimestamp` from the timestamp of the 
most recent commit, the timestamp embedded in generated JARs no longer
depends on the exact time at which the artifacts are built. As such
repeated executions of `mvn clean install` yield byte-for-byte identical
results.

This change requires replacing `buildnumber-maven-plugin` with
`git-commit-id-maven-plugin`.

See https://maven.apache.org/guides/mini/guide-reproducible-builds.html
```