### PR TITLE
Fix Javadoc JAR generation

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,8 +28,8 @@ jobs:
           cache: maven
       - name: Display build environment details
         run: mvn --version
-      - name: Build project against vanilla Error Prone
-        run: mvn -T1C install
+      - name: Build project against vanilla Error Prone, compile Javadoc
+        run: mvn -T1C install javadoc:jar
       - name: Build project with self-check against Error Prone fork
         run: mvn -T1C clean verify -Perror-prone-fork -Pnon-maven-central -Pself-check -s settings.xml
       - name: Remove installed project artifacts

--- a/pom.xml
+++ b/pom.xml
@@ -988,6 +988,13 @@
                     <artifactId>maven-javadoc-plugin</artifactId>
                     <version>3.4.1</version>
                     <configuration>
+                        <additionalJOptions>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
+                        </additionalJOptions>
                         <!-- All relevant doclint checks are performed during
                         the compilation phase; no need to recheck during
                         Javadoc generation. -->
@@ -1012,7 +1019,6 @@
                         <autoVersionSubmodules>true</autoVersionSubmodules>
                         <releaseProfiles>release</releaseProfiles>
                         <tagNameFormat>v@{project.version}</tagNameFormat>
-                        <useReleaseProfile>false</useReleaseProfile>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
Suggested commit message:
```
Fix Javadoc JAR generation (#246)

For performance reasons, the Javadoc JARs are not generated when executing `mvn
install`. They are generally only compiled when running `mvn release:perform`,
as part of the `release` Maven profile.

The downside of this setup is that Javadoc generation issues may not be caught
until release time. This change resolves such an issue. To prevent future
regressions, Javadoc generation is now also performed by the GitHub Actions
build workflow.

While there, drop the deprecated `useReleaseProfile` configuration setting of
the javadoc-maven-plugin, as its value matches the default.
```