### PR TITLE
Update `XXX` comments to reference google/error-prone#2706

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListMultimapTemplates.java
@@ -33,7 +33,7 @@ final class ImmutableListMultimapTemplates {
    * Prefer {@link ImmutableListMultimap#builder()} over the associated constructor on constructions
    * that produce a less-specific type.
    */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableListMultimapBuilder<K, V> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableListTemplates.java
@@ -26,7 +26,7 @@ final class ImmutableListTemplates {
   private ImmutableListTemplates() {}
 
   /** Prefer {@link ImmutableList#builder()} over the associated constructor. */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableListBuilder<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableMapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableMapTemplates.java
@@ -27,7 +27,7 @@ final class ImmutableMapTemplates {
   private ImmutableMapTemplates() {}
 
   /** Prefer {@link ImmutableMap#builder()} over the associated constructor. */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableMapBuilder<K, V> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableMultisetTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableMultisetTemplates.java
@@ -19,7 +19,7 @@ final class ImmutableMultisetTemplates {
   private ImmutableMultisetTemplates() {}
 
   /** Prefer {@link ImmutableMultiset#builder()} over the associated constructor. */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableMultisetBuilder<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetMultimapTemplates.java
@@ -27,7 +27,7 @@ final class ImmutableSetMultimapTemplates {
   private ImmutableSetMultimapTemplates() {}
 
   /** Prefer {@link ImmutableSetMultimap#builder()} over the associated constructor. */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableSetMultimapBuilder<K, V> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSetTemplates.java
@@ -23,7 +23,7 @@ final class ImmutableSetTemplates {
   private ImmutableSetTemplates() {}
 
   /** Prefer {@link ImmutableSet#builder()} over the associated constructor. */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableSetBuilder<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSortedMapTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ImmutableSortedMapTemplates.java
@@ -35,7 +35,7 @@ final class ImmutableSortedMapTemplates {
    * Prefer {@link ImmutableSortedMap#naturalOrder()} over the alternative that requires explicitly
    * providing the {@link Comparator}.
    */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableSortedMapNaturalOrderBuilder<K extends Comparable<? super K>, V> {
     @BeforeTemplate
@@ -53,7 +53,7 @@ final class ImmutableSortedMapTemplates {
    * Prefer {@link ImmutableSortedMap#reverseOrder()} over the alternative that requires explicitly
    * providing the {@link Comparator}.
    */
-  // XXX: This drops generic type information, sometimes leading to non-compilable code. See:
+  // XXX: This drops generic type information, sometimes leading to non-compilable code. See
   // https://github.com/google/error-prone/pull/2706.
   static final class ImmutableSortedMapReverseOrderBuilder<K extends Comparable<? super K>, V> {
     @BeforeTemplate


### PR DESCRIPTION
I think it'd be nice to update these XXX's for clarity. 

These changes would have been part of https://github.com/PicnicSupermarket/error-prone-support/pull/46 but we didn't merge that one because we don't want to have incompatibilities with the original Error Prone.