### PR TITLE
Rename package `tech.picnic.errorprone.refaster.{util => matchers}`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJNumberTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJNumberTemplates.java
@@ -19,7 +19,7 @@ import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.AbstractShortAssert;
 import org.assertj.core.api.NumberAssert;
-import tech.picnic.errorprone.refaster.util.IsCharacter;
+import tech.picnic.errorprone.refaster.matchers.IsCharacter;
 
 final class AssertJNumberTemplates {
   private AssertJNumberTemplates() {}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/AssertJTemplates.java
@@ -53,7 +53,7 @@ import org.assertj.core.api.ObjectEnumerableAssert;
 import org.assertj.core.api.OptionalDoubleAssert;
 import org.assertj.core.api.OptionalIntAssert;
 import org.assertj.core.api.OptionalLongAssert;
-import tech.picnic.errorprone.refaster.util.IsArray;
+import tech.picnic.errorprone.refaster.matchers.IsArray;
 
 /** Refaster templates related to AssertJ expressions and statements. */
 // XXX: Most `AbstractIntegerAssert` rules can also be applied for other primitive types. Generate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -24,7 +24,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
-import tech.picnic.errorprone.refaster.util.ThrowsCheckedException;
+import tech.picnic.errorprone.refaster.matchers.ThrowsCheckedException;
 
 /** Refaster templates related to Reactor expressions and statements. */
 final class ReactorTemplates {

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsArray.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsArray.java
@@ -1,4 +1,4 @@
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;
 
 import static com.google.errorprone.matchers.Matchers.isArrayType;
 

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsCharacter.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsCharacter.java
@@ -1,4 +1,4 @@
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;
 
 import static com.google.errorprone.matchers.Matchers.anyOf;
 import static com.google.errorprone.matchers.Matchers.isSameType;

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedException.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedException.java
@@ -1,4 +1,4 @@
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.VisitorState;

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/package-info.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/package-info.java
@@ -6,4 +6,4 @@
  */
 @com.google.errorprone.annotations.CheckReturnValue
 @javax.annotation.ParametersAreNonnullByDefault
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;

--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
@@ -1,4 +1,4 @@
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;
 
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;

--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/IsArrayTest.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/IsArrayTest.java
@@ -1,4 +1,4 @@
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
@@ -7,49 +7,49 @@ import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.bugpatterns.BugChecker;
 import org.junit.jupiter.api.Test;
 
-final class IsCharacterTest {
+final class IsArrayTest {
   @Test
   void matches() {
     CompilationTestHelper.newInstance(MatcherTestChecker.class, getClass())
         .addSourceLines(
             "A.java",
             "class A {",
-            "  String negative1() {",
-            "    return \"a\";",
+            "  Object negative1() {",
+            "    return alwaysNull();",
             "  }",
             "",
-            "  char[] negative2() {",
-            "    return \"a\".toCharArray();",
+            "  String negative2() {",
+            "    return alwaysNull();",
             "  }",
             "",
-            "  byte negative3() {",
-            "    return (byte) 0;",
+            "  int negative3() {",
+            "    return alwaysNull();",
             "  }",
             "",
-            "  int negative4() {",
-            "    return 0;",
-            "  }",
-            "",
-            "  char positive1() {",
+            "  Object[] positive1() {",
             "    // BUG: Diagnostic contains:",
-            "    return 'a';",
+            "    return alwaysNull();",
             "  }",
             "",
-            "  Character positive2() {",
+            "  String[] positive2() {",
             "    // BUG: Diagnostic contains:",
-            "    return (Character) null;",
+            "    return alwaysNull();",
             "  }",
             "",
-            "  char positive3() {",
+            "  int[] positive3() {",
             "    // BUG: Diagnostic contains:",
-            "    return (char) 1;",
+            "    return alwaysNull();",
+            "  }",
+            "",
+            "  private static <T> T alwaysNull() {",
+            "    return null;",
             "  }",
             "}")
         .doTest();
   }
 
-  /** A {@link BugChecker} that simply delegates to {@link IsCharacter}. */
-  @BugPattern(summary = "Flags expressions matched by `IsCharacter`", severity = ERROR)
+  /** A {@link BugChecker} that simply delegates to {@link IsArray}. */
+  @BugPattern(summary = "Flags expressions matched by `IsArray`", severity = ERROR)
   public static final class MatcherTestChecker extends AbstractMatcherTestChecker {
     private static final long serialVersionUID = 1L;
 
@@ -57,7 +57,7 @@ final class IsCharacterTest {
     // https://github.com/checkstyle/checkstyle/issues/10161#issuecomment-1242732120.
     @SuppressWarnings("RedundantModifier")
     public MatcherTestChecker() {
-      super(new IsCharacter());
+      super(new IsArray());
     }
   }
 }

--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/IsCharacterTest.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/IsCharacterTest.java
@@ -1,4 +1,4 @@
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 
@@ -7,49 +7,49 @@ import com.google.errorprone.CompilationTestHelper;
 import com.google.errorprone.bugpatterns.BugChecker;
 import org.junit.jupiter.api.Test;
 
-final class IsArrayTest {
+final class IsCharacterTest {
   @Test
   void matches() {
     CompilationTestHelper.newInstance(MatcherTestChecker.class, getClass())
         .addSourceLines(
             "A.java",
             "class A {",
-            "  Object negative1() {",
-            "    return alwaysNull();",
+            "  String negative1() {",
+            "    return \"a\";",
             "  }",
             "",
-            "  String negative2() {",
-            "    return alwaysNull();",
+            "  char[] negative2() {",
+            "    return \"a\".toCharArray();",
             "  }",
             "",
-            "  int negative3() {",
-            "    return alwaysNull();",
+            "  byte negative3() {",
+            "    return (byte) 0;",
             "  }",
             "",
-            "  Object[] positive1() {",
+            "  int negative4() {",
+            "    return 0;",
+            "  }",
+            "",
+            "  char positive1() {",
             "    // BUG: Diagnostic contains:",
-            "    return alwaysNull();",
+            "    return 'a';",
             "  }",
             "",
-            "  String[] positive2() {",
+            "  Character positive2() {",
             "    // BUG: Diagnostic contains:",
-            "    return alwaysNull();",
+            "    return (Character) null;",
             "  }",
             "",
-            "  int[] positive3() {",
+            "  char positive3() {",
             "    // BUG: Diagnostic contains:",
-            "    return alwaysNull();",
-            "  }",
-            "",
-            "  private static <T> T alwaysNull() {",
-            "    return null;",
+            "    return (char) 1;",
             "  }",
             "}")
         .doTest();
   }
 
-  /** A {@link BugChecker} that simply delegates to {@link IsArray}. */
-  @BugPattern(summary = "Flags expressions matched by `IsArray`", severity = ERROR)
+  /** A {@link BugChecker} that simply delegates to {@link IsCharacter}. */
+  @BugPattern(summary = "Flags expressions matched by `IsCharacter`", severity = ERROR)
   public static final class MatcherTestChecker extends AbstractMatcherTestChecker {
     private static final long serialVersionUID = 1L;
 
@@ -57,7 +57,7 @@ final class IsArrayTest {
     // https://github.com/checkstyle/checkstyle/issues/10161#issuecomment-1242732120.
     @SuppressWarnings("RedundantModifier")
     public MatcherTestChecker() {
-      super(new IsArray());
+      super(new IsCharacter());
     }
   }
 }

--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedExceptionTest.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedExceptionTest.java
@@ -1,4 +1,4 @@
-package tech.picnic.errorprone.refaster.util;
+package tech.picnic.errorprone.refaster.matchers;
 
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 


### PR DESCRIPTION
Suggested commit message:
```
Move `Matcher`s in `refaster-support` from `.util` to `.matchers` package (#267)
```