### PR TITLE
Introduce `Comparators{Min,Max}` Refaster templates

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ComparatorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ComparatorTemplates.java
@@ -19,7 +19,6 @@ import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.ToDoubleFunction;
@@ -263,33 +262,33 @@ final class ComparatorTemplates {
   }
 
   /**
-   * Prefer {@link Comparators#min(Comparable, Comparable)} over {@link
-   * BinaryOperator#minBy(Comparator)}for natural ordering.
+   * Prefer a method reference to {@link Comparators#min(Comparable, Comparable)} over calling
+   * {@link BinaryOperator#minBy(Comparator)} with {@link Comparator#naturalOrder()}.
    */
-  static final class BinaryOperatorMinByNaturalOrder<T extends Comparable<? super T>> {
+  static final class ComparatorsMin<T extends Comparable<? super T>> {
     @BeforeTemplate
-    BiFunction<T, T, T> before() {
+    BinaryOperator<T> before() {
       return BinaryOperator.minBy(naturalOrder());
     }
 
     @AfterTemplate
-    BiFunction<T, T, T> after() {
+    BinaryOperator<T> after() {
       return Comparators::min;
     }
   }
 
   /**
-   * Prefer {@link Comparators#max(Comparable, Comparable)} over {@link
-   * BinaryOperator#maxBy(Comparator)}for natural ordering.
+   * Prefer a method reference to {@link Comparators#max(Comparable, Comparable)} over calling
+   * {@link BinaryOperator#minBy(Comparator)} with {@link Comparator#naturalOrder()}.
    */
-  static final class BinaryOperatorMaxByNaturalOrder<T extends Comparable<? super T>> {
+  static final class ComparatorsMax<T extends Comparable<? super T>> {
     @BeforeTemplate
-    BiFunction<T, T, T> before() {
+    BinaryOperator<T> before() {
       return BinaryOperator.maxBy(naturalOrder());
     }
 
     @AfterTemplate
-    BiFunction<T, T, T> after() {
+    BinaryOperator<T> after() {
       return Comparators::max;
     }
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ComparatorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ComparatorTemplatesTestInput.java
@@ -9,7 +9,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import tech.picnic.errorprone.refaster.test.RefasterTemplateTestCase;
 
@@ -17,12 +16,7 @@ final class ComparatorTemplatesTest implements RefasterTemplateTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        Arrays.class,
-        BinaryOperator.class,
-        Collections.class,
-        ImmutableList.class,
-        ImmutableSet.class,
-        identity());
+        Arrays.class, Collections.class, ImmutableList.class, ImmutableSet.class, identity());
   }
 
   ImmutableSet<Comparator<String>> testNaturalOrder() {
@@ -111,11 +105,11 @@ final class ComparatorTemplatesTest implements RefasterTemplateTestCase {
         Collections.max(ImmutableSet.of(new Object(), new Object()), (a, b) -> 1));
   }
 
-  BiFunction<String, String, String> testBinaryOperatorMinByNaturalOrder() {
+  BinaryOperator<String> testComparatorsMin() {
     return BinaryOperator.minBy(naturalOrder());
   }
 
-  BiFunction<String, String, String> testBinaryOperatorMaxByNaturalOrder() {
+  BinaryOperator<String> testComparatorsMax() {
     return BinaryOperator.maxBy(naturalOrder());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ComparatorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ComparatorTemplatesTestOutput.java
@@ -10,7 +10,6 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
-import java.util.function.BiFunction;
 import java.util.function.BinaryOperator;
 import tech.picnic.errorprone.refaster.test.RefasterTemplateTestCase;
 
@@ -18,12 +17,7 @@ final class ComparatorTemplatesTest implements RefasterTemplateTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        Arrays.class,
-        BinaryOperator.class,
-        Collections.class,
-        ImmutableList.class,
-        ImmutableSet.class,
-        identity());
+        Arrays.class, Collections.class, ImmutableList.class, ImmutableSet.class, identity());
   }
 
   ImmutableSet<Comparator<String>> testNaturalOrder() {
@@ -98,11 +92,11 @@ final class ComparatorTemplatesTest implements RefasterTemplateTestCase {
         Comparators.max(new Object(), new Object(), (a, b) -> 1));
   }
 
-  BiFunction<String, String, String> testBinaryOperatorMinByNaturalOrder() {
+  BinaryOperator<String> testComparatorsMin() {
     return Comparators::min;
   }
 
-  BiFunction<String, String, String> testBinaryOperatorMaxByNaturalOrder() {
+  BinaryOperator<String> testComparatorsMax() {
     return Comparators::max;
   }
 }


### PR DESCRIPTION
Added 2 rules for `BinaryOperator#minBy` and `BinaryOperator#maxBy` when they're called with a `naturalOrder` comparator 