### PR TITLE
Introduce `{Mono,Flux}OnErrorComplete` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -271,20 +271,7 @@ final class ReactorTemplates {
     }
   }
 
-  /** Prefer {@link Flux#onErrorComplete()} over more contrived alternatives */
-  static final class FluxOnErrorComplete<T> {
-    @BeforeTemplate
-    Flux<T> before(Flux<T> flux) {
-      return flux.onErrorResume(e -> Flux.empty());
-    }
-
-    @AfterTemplate
-    Flux<T> after(Flux<T> flux) {
-      return flux.onErrorComplete();
-    }
-  }
-
-  /** Prefer {@link Mono#onErrorComplete()} over more contrived alternatives */
+  /** Prefer {@link Mono#onErrorComplete()} over more contrived alternatives. */
   static final class MonoOnErrorComplete<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono) {
@@ -294,6 +281,19 @@ final class ReactorTemplates {
     @AfterTemplate
     Mono<T> after(Mono<T> mono) {
       return mono.onErrorComplete();
+    }
+  }
+
+  /** Prefer {@link Flux#onErrorComplete()} over more contrived alternatives. */
+  static final class FluxOnErrorComplete<T> {
+    @BeforeTemplate
+    Flux<T> before(Flux<T> flux) {
+      return flux.onErrorResume(e -> Flux.empty());
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flux<T> flux) {
+      return flux.onErrorComplete();
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -271,6 +271,32 @@ final class ReactorTemplates {
     }
   }
 
+  /** Prefer {@link Flux#onErrorComplete()} over more contrived alternatives */
+  static final class FluxOnErrorComplete<T> {
+    @BeforeTemplate
+    Flux<T> before(Flux<T> flux) {
+      return flux.onErrorResume(e -> Flux.empty());
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flux<T> flux) {
+      return flux.onErrorComplete();
+    }
+  }
+
+  /** Prefer {@link Mono#onErrorComplete()} over more contrived alternatives */
+  static final class MonoOnErrorComplete<T> {
+    @BeforeTemplate
+    Mono<T> before(Mono<T> mono) {
+      return mono.onErrorResume(e -> Mono.empty());
+    }
+
+    @AfterTemplate
+    Mono<T> after(Mono<T> mono) {
+      return mono.onErrorComplete();
+    }
+  }
+
   /** Prefer {@link PublisherProbe#empty()}} over more verbose alternatives. */
   static final class PublisherProbeEmpty<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -288,7 +288,7 @@ final class ReactorTemplates {
   static final class FluxOnErrorComplete<T> {
     @BeforeTemplate
     Flux<T> before(Flux<T> flux) {
-      return flux.onErrorResume(e -> Flux.empty());
+      return flux.onErrorResume(e -> Refaster.anyOf(Mono.empty(), Flux.empty()));
     }
 
     @AfterTemplate
@@ -301,7 +301,7 @@ final class ReactorTemplates {
   static final class PublisherProbeEmpty<T> {
     @BeforeTemplate
     PublisherProbe<T> before() {
-      return Refaster.anyOf(PublisherProbe.of(Mono.empty()), PublisherProbe.of(Flux.empty()));
+      return PublisherProbe.of(Refaster.anyOf(Mono.empty(), Flux.empty()));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
@@ -99,8 +99,10 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Mono.just(1).onErrorResume(e -> Mono.empty());
   }
 
-  Flux<Integer> testFluxOnErrorComplete() {
-    return Flux.just(1).onErrorResume(e -> Flux.empty());
+  ImmutableSet<Flux<Integer>> testFluxOnErrorComplete() {
+    return ImmutableSet.of(
+        Flux.just(1).onErrorResume(e -> Mono.empty()),
+        Flux.just(2).onErrorResume(e -> Flux.empty()));
   }
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
@@ -95,6 +95,14 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
+  Flux<Object> testFluxOnErrorComplete() {
+    return Flux.error(new IllegalStateException()).onErrorResume(e -> Flux.empty());
+  }
+
+  Mono<Object> testMonoOnErrorComplete() {
+    return Mono.error(new IllegalStateException()).onErrorResume(e -> Mono.empty());
+  }
+
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {
     return ImmutableSet.of(PublisherProbe.of(Mono.empty()), PublisherProbe.of(Flux.empty()));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
@@ -95,12 +95,12 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
-  Flux<Object> testFluxOnErrorComplete() {
-    return Flux.error(new IllegalStateException()).onErrorResume(e -> Flux.empty());
+  Mono<Integer> testMonoOnErrorComplete() {
+    return Mono.just(1).onErrorResume(e -> Mono.empty());
   }
 
-  Mono<Object> testMonoOnErrorComplete() {
-    return Mono.error(new IllegalStateException()).onErrorResume(e -> Mono.empty());
+  Flux<Integer> testFluxOnErrorComplete() {
+    return Flux.just(1).onErrorResume(e -> Flux.empty());
   }
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
@@ -98,8 +98,8 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Mono.just(1).onErrorComplete();
   }
 
-  Flux<Integer> testFluxOnErrorComplete() {
-    return Flux.just(1).onErrorComplete();
+  ImmutableSet<Flux<Integer>> testFluxOnErrorComplete() {
+    return ImmutableSet.of(Flux.just(1).onErrorComplete(), Flux.just(2).onErrorComplete());
   }
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
@@ -94,12 +94,12 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
-  Flux<Object> testFluxOnErrorComplete() {
-    return Flux.error(new IllegalStateException()).onErrorComplete();
+  Mono<Integer> testMonoOnErrorComplete() {
+    return Mono.just(1).onErrorComplete();
   }
 
-  Mono<Object> testMonoOnErrorComplete() {
-    return Mono.error(new IllegalStateException()).onErrorComplete();
+  Flux<Integer> testFluxOnErrorComplete() {
+    return Flux.just(1).onErrorComplete();
   }
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
@@ -94,6 +94,14 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
+  Flux<Object> testFluxOnErrorComplete() {
+    return Flux.error(new IllegalStateException()).onErrorComplete();
+  }
+
+  Mono<Object> testMonoOnErrorComplete() {
+    return Mono.error(new IllegalStateException()).onErrorComplete();
+  }
+
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {
     return ImmutableSet.of(PublisherProbe.empty(), PublisherProbe.empty());
   }


### PR DESCRIPTION
Add a new refaster template rule that rewrites `.onErrorResume(e -> Mono.empty())` to `.onErrorComplete()`. This is applied to `.onErrorResume(e -> Flux.empty())` as well.