### PR TITLE
Fix default branch reference in GitHub Actions definition

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,8 @@ name: Build and verify
 on:
   pull_request:
   push:
-    branches: [$default-branch]
+    branches:
+      - master
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,8 +2,7 @@ name: Build and verify
 on:
   pull_request:
   push:
-    branches:
-      - master
+    branches: [master]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,7 +2,7 @@ name: Build and verify
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [ master ]
 permissions:
   contents: read
 jobs:

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -33,7 +33,7 @@ jobs:
       - name: Upload website as artifact
         uses: actions/upload-pages-artifact@v1.0.4
   deploy:
-    if: github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
+    if: github.ref == 'refs/heads/master'
     needs: build
     runs-on: ubuntu-22.04
     environment:

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -2,8 +2,7 @@ name: Update `error-prone.picnic.tech` website content
 on:
   pull_request:
   push:
-    branches:
-      - master
+    branches: [master]
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -2,7 +2,8 @@ name: Update `error-prone.picnic.tech` website content
 on:
   pull_request:
   push:
-    branches: [$default-branch]
+    branches:
+      - master
 permissions:
   contents: read
   id-token: write

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -2,7 +2,7 @@ name: Update `error-prone.picnic.tech` website content
 on:
   pull_request:
   push:
-    branches: [master]
+    branches: [ master ]
 permissions:
   contents: read
   id-token: write


### PR DESCRIPTION
In #253 the GHA workflow was edited to use `$default-branch`. Whilst this works in workflow templates, this actually doesn't in a workflow.

Here, we revert to referencing `master` directly.