### PR TITLE
Prefer `flatMapIterable(identity())` over `flatMap(i -> FluxfromIterable(i))`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -314,16 +314,16 @@ final class ReactorTemplates {
    * Prefer {@link Flux#concatMapIterable(Function)} over alternatives that require an additional
    * subscription.
    */
-  static final class ConcatMapIterableIdentity<S> {
+  static final class ConcatMapIterableIdentity<T> {
     @BeforeTemplate
-    Flux<S> before(Flux<? extends Iterable<S>> flux) {
+    Flux<T> before(Flux<? extends Iterable<T>> flux) {
       return Refaster.anyOf(
           flux.concatMap(list -> Flux.fromIterable(list)), flux.concatMap(Flux::fromIterable));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Flux<S> after(Flux<? extends Iterable<S>> flux) {
+    Flux<T> after(Flux<? extends Iterable<T>> flux) {
       return flux.concatMapIterable(identity());
     }
   }
@@ -332,9 +332,9 @@ final class ReactorTemplates {
    * Prefer {@link Flux#concatMapIterable(Function, int)} over alternatives that require an
    * additional subscription.
    */
-  static final class ConcatMapIterableIdentityWithPrefetch<S> {
+  static final class ConcatMapIterableIdentityWithPrefetch<T> {
     @BeforeTemplate
-    Flux<S> before(Flux<? extends Iterable<S>> flux, int prefetch) {
+    Flux<T> before(Flux<? extends Iterable<T>> flux, int prefetch) {
       return Refaster.anyOf(
           flux.concatMap(list -> Flux.fromIterable(list), prefetch),
           flux.concatMap(Flux::fromIterable, prefetch));
@@ -342,7 +342,7 @@ final class ReactorTemplates {
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Flux<S> after(Flux<? extends Iterable<S>> flux, int prefetch) {
+    Flux<T> after(Flux<? extends Iterable<T>> flux, int prefetch) {
       return flux.concatMapIterable(identity(), prefetch);
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -273,19 +273,39 @@ final class ReactorTemplates {
   }
 
   /**
-   * Prefer {@link Flux#flatMapIterable(Function)} (Class)} over {@link Flux#flatMap(Function)} with
+   * Prefer {@link Flux#concatMapIterable(Function)} over {@link Flux#concatMap(Function)} with
    * {@link Flux#fromIterable(Iterable)}.
    */
-  static final class FluxFlatMapIterable<S> {
+  static final class FluxConcatMapFromIterable<S> {
     @BeforeTemplate
     Flux<S> before(Flux<? extends Iterable<S>> flux) {
-      return flux.flatMap(list -> Flux.fromIterable(list));
+      return Refaster.anyOf(
+          flux.concatMap(list -> Flux.fromIterable(list)), flux.concatMap(Flux::fromIterable));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     Flux<S> after(Flux<? extends Iterable<S>> flux) {
-      return flux.flatMapIterable(identity());
+      return flux.concatMapIterable(identity());
+    }
+  }
+
+  /**
+   * Prefer {@link Flux#flatMapIterable(Function, int)} over {@link Flux#flatMap(Function, int)}
+   * with {@link Flux#fromIterable(Iterable)}.
+   */
+  static final class FluxFlatMapFromIterable<S> {
+    @BeforeTemplate
+    Flux<S> before(Flux<? extends Iterable<S>> flux, int concurrency) {
+      return Refaster.anyOf(
+          flux.flatMap(list -> Flux.fromIterable(list), concurrency),
+          flux.flatMap(Flux::fromIterable, concurrency));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    Flux<S> after(Flux<? extends Iterable<S>> flux, int concurrency) {
+      return flux.flatMapIterable(identity(), concurrency);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refastertemplates/ReactorTemplates.java
@@ -2,6 +2,7 @@ package tech.picnic.errorprone.refastertemplates;
 
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.MoreCollectors;
@@ -268,6 +269,23 @@ final class ReactorTemplates {
     @AfterTemplate
     Flux<S> after(Flux<T> flux) {
       return flux.cast(Refaster.<S>clazz());
+    }
+  }
+
+  /**
+   * Prefer {@link Flux#flatMapIterable(Function)} (Class)} over {@link Flux#flatMap(Function)} with
+   * {@link Flux#fromIterable(Iterable)}.
+   */
+  static final class FluxFlatMapIterable<S> {
+    @BeforeTemplate
+    Flux<S> before(Flux<? extends Iterable<S>> flux) {
+      return flux.flatMap(list -> Flux.fromIterable(list));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    Flux<S> after(Flux<? extends Iterable<S>> flux) {
+      return flux.flatMapIterable(identity());
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
@@ -69,8 +69,17 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
         Flux.just(1).flatMap(Mono::just, 1), Flux.just(2).flatMapSequential(Mono::just, 1));
   }
 
+  ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {
+    return ImmutableSet.of(
+        Flux.just(1).flatMap(Mono::just, 1, 3), Flux.just(2).flatMapSequential(Mono::just, 1, 4));
+  }
+
   Flux<Integer> testFluxConcatMapIterable() {
     return Flux.just(1, 2).flatMapIterable(ImmutableList::of);
+  }
+
+  Flux<Integer> testFluxConcatMapIterableWithPrefetch() {
+    return Flux.just(1, 2).flatMapIterable(ImmutableList::of, 3);
   }
 
   Flux<String> testMonoFlatMapToFlux() {
@@ -95,16 +104,16 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
-  ImmutableSet<Flux<String>> testFluxConcatMapFromIterable() {
+  ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {
     return ImmutableSet.of(
-        Flux.just(ImmutableList.of("1")).concatMap(list -> Flux.fromIterable(list)),
-        Flux.just(ImmutableList.of("1")).concatMap(Flux::fromIterable));
+        Flux.just(ImmutableList.of("foo")).concatMap(list -> Flux.fromIterable(list)),
+        Flux.just(ImmutableList.of("bar")).concatMap(Flux::fromIterable));
   }
 
-  ImmutableSet<Flux<String>> testFluxFlatMapFromIterable() {
+  ImmutableSet<Flux<String>> testConcatMapIterableIdentityWithPrefetch() {
     return ImmutableSet.of(
-        Flux.just(ImmutableList.of("1")).flatMap(list -> Flux.fromIterable(list), 1),
-        Flux.just(ImmutableList.of("1")).flatMap(Flux::fromIterable, 2));
+        Flux.just(ImmutableList.of("foo")).concatMap(list -> Flux.fromIterable(list), 1),
+        Flux.just(ImmutableList.of("bar")).concatMap(Flux::fromIterable, 2));
   }
 
   Mono<Integer> testMonoOnErrorComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
@@ -95,8 +95,16 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
-  Flux<String> testFluxFlatMapIterable() {
-    return Flux.just(ImmutableList.of("1")).flatMap(list -> Flux.fromIterable(list));
+  ImmutableSet<Flux<String>> testFluxConcatMapFromIterable() {
+    return ImmutableSet.of(
+        Flux.just(ImmutableList.of("1")).concatMap(list -> Flux.fromIterable(list)),
+        Flux.just(ImmutableList.of("1")).concatMap(Flux::fromIterable));
+  }
+
+  ImmutableSet<Flux<String>> testFluxFlatMapFromIterable() {
+    return ImmutableSet.of(
+        Flux.just(ImmutableList.of("1")).flatMap(list -> Flux.fromIterable(list), 1),
+        Flux.just(ImmutableList.of("1")).flatMap(Flux::fromIterable, 2));
   }
 
   Mono<Integer> testMonoOnErrorComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestInput.java
@@ -95,6 +95,10 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
+  Flux<String> testFluxFlatMapIterable() {
+    return Flux.just(ImmutableList.of("1")).flatMap(list -> Flux.fromIterable(list));
+  }
+
   Mono<Integer> testMonoOnErrorComplete() {
     return Mono.just(1).onErrorResume(e -> Mono.empty());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
@@ -69,8 +69,17 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return ImmutableSet.of(Flux.just(1).concatMap(Mono::just), Flux.just(2).concatMap(Mono::just));
   }
 
+  ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {
+    return ImmutableSet.of(
+        Flux.just(1).concatMap(Mono::just, 3), Flux.just(2).concatMap(Mono::just, 4));
+  }
+
   Flux<Integer> testFluxConcatMapIterable() {
     return Flux.just(1, 2).concatMapIterable(ImmutableList::of);
+  }
+
+  Flux<Integer> testFluxConcatMapIterableWithPrefetch() {
+    return Flux.just(1, 2).concatMapIterable(ImmutableList::of, 3);
   }
 
   Flux<String> testMonoFlatMapToFlux() {
@@ -95,16 +104,16 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
-  ImmutableSet<Flux<String>> testFluxConcatMapFromIterable() {
+  ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {
     return ImmutableSet.of(
-        Flux.just(ImmutableList.of("1")).concatMapIterable(identity()),
-        Flux.just(ImmutableList.of("1")).concatMapIterable(identity()));
+        Flux.just(ImmutableList.of("foo")).concatMapIterable(identity()),
+        Flux.just(ImmutableList.of("bar")).concatMapIterable(identity()));
   }
 
-  ImmutableSet<Flux<String>> testFluxFlatMapFromIterable() {
+  ImmutableSet<Flux<String>> testConcatMapIterableIdentityWithPrefetch() {
     return ImmutableSet.of(
-        Flux.just(ImmutableList.of("1")).flatMapIterable(identity(), 1),
-        Flux.just(ImmutableList.of("1")).flatMapIterable(identity(), 2));
+        Flux.just(ImmutableList.of("foo")).concatMapIterable(identity(), 1),
+        Flux.just(ImmutableList.of("bar")).concatMapIterable(identity(), 2));
   }
 
   Mono<Integer> testMonoOnErrorComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refastertemplates;
 
 import static com.google.common.collect.MoreCollectors.toOptional;
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -92,6 +93,10 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
 
   Flux<Number> testFluxCast() {
     return Flux.just(1).cast(Number.class);
+  }
+
+  Flux<String> testFluxFlatMapIterable() {
+    return Flux.just(ImmutableList.of("1")).flatMapIterable(identity());
   }
 
   Mono<Integer> testMonoOnErrorComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refastertemplates/ReactorTemplatesTestOutput.java
@@ -95,8 +95,16 @@ final class ReactorTemplatesTest implements RefasterTemplateTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
-  Flux<String> testFluxFlatMapIterable() {
-    return Flux.just(ImmutableList.of("1")).flatMapIterable(identity());
+  ImmutableSet<Flux<String>> testFluxConcatMapFromIterable() {
+    return ImmutableSet.of(
+        Flux.just(ImmutableList.of("1")).concatMapIterable(identity()),
+        Flux.just(ImmutableList.of("1")).concatMapIterable(identity()));
+  }
+
+  ImmutableSet<Flux<String>> testFluxFlatMapFromIterable() {
+    return ImmutableSet.of(
+        Flux.just(ImmutableList.of("1")).flatMapIterable(identity(), 1),
+        Flux.just(ImmutableList.of("1")).flatMapIterable(identity(), 2));
   }
 
   Mono<Integer> testMonoOnErrorComplete() {


### PR DESCRIPTION
Suggested commit message:
```
Suggest `Flux#concatMap{,Iterable}` usage in more contexts (#279)
```