### PR TITLE
Improve build and deployment concurrency handling

### DIFF
--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -38,7 +38,6 @@ jobs:
       group: pages
       cancel-in-progress: true
     permissions:
-      contents: read
       id-token: write
       pages: write
     runs-on: ubuntu-22.04

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -3,6 +3,9 @@ on:
   pull_request:
   push:
     branches: [ master, website ]
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.head_ref != null }}
 jobs:
   build:
     permissions:
@@ -34,9 +37,6 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/website'
     needs: build
-    concurrency:
-      group: pages
-      cancel-in-progress: true
     permissions:
       id-token: write
       pages: write

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -3,10 +3,12 @@ on:
   pull_request:
   push:
     branches: [ master, website ]
+permissions:
+  contents: read
+  id-token: write
+  pages: write
 jobs:
   build:
-    permissions:
-      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
@@ -37,10 +39,6 @@ jobs:
     concurrency:
       group: pages
       cancel-in-progress: true
-    permissions:
-      contents: read
-      id-token: write
-      pages: write
     runs-on: ubuntu-22.04
     environment:
       name: github-pages

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -3,12 +3,10 @@ on:
   pull_request:
   push:
     branches: [ master, website ]
-permissions:
-  contents: read
-  id-token: write
-  pages: write
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
@@ -39,6 +37,10 @@ jobs:
     concurrency:
       group: pages
       cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     runs-on: ubuntu-22.04
     environment:
       name: github-pages

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -32,13 +32,12 @@ jobs:
         with:
           path: ./website/_site
   deploy:
-    if: github.ref == 'refs/heads/website'
+    #if: github.ref == 'refs/heads/website'
     needs: build
     concurrency:
       group: pages
       cancel-in-progress: true
     permissions:
-      contents: read
       id-token: write
       pages: write
     runs-on: ubuntu-22.04

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -3,10 +3,10 @@ on:
   pull_request:
   push:
     branches: [ master, website ]
-permissions:
-  contents: read
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
@@ -38,6 +38,7 @@ jobs:
       group: pages
       cancel-in-progress: true
     permissions:
+      contents: read
       id-token: write
       pages: write
     runs-on: ubuntu-22.04

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -7,9 +7,6 @@ permissions:
   contents: read
   id-token: write
   pages: write
-concurrency:
-  group: pages
-  cancel-in-progress: true
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -39,6 +36,9 @@ jobs:
   deploy:
     if: github.ref == 'refs/heads/website'
     needs: build
+    concurrency:
+      group: pages
+      cancel-in-progress: true
     runs-on: ubuntu-22.04
     environment:
       name: github-pages

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -38,7 +38,6 @@ jobs:
       group: pages
       cancel-in-progress: true
     permissions:
-      id-token: write
       pages: write
     runs-on: ubuntu-22.04
     environment:

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -5,8 +5,6 @@ on:
     branches: [ master, website ]
 permissions:
   contents: read
-  id-token: write
-  pages: write
 jobs:
   build:
     runs-on: ubuntu-22.04
@@ -39,6 +37,10 @@ jobs:
     concurrency:
       group: pages
       cancel-in-progress: true
+    permissions:
+      contents: read
+      id-token: write
+      pages: write
     runs-on: ubuntu-22.04
     environment:
       name: github-pages

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -32,12 +32,13 @@ jobs:
         with:
           path: ./website/_site
   deploy:
-    #if: github.ref == 'refs/heads/website'
+    if: github.ref == 'refs/heads/website'
     needs: build
     concurrency:
       group: pages
       cancel-in-progress: true
     permissions:
+      id-token: write
       pages: write
     runs-on: ubuntu-22.04
     environment:

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -5,7 +5,6 @@ on:
     branches: [ master, website ]
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: ${{ github.head_ref != null }}
 jobs:
   build:
     permissions:


### PR DESCRIPTION
Suggested commit message:
```
Improve build and deployment concurrency handling (#284)

Builds for the same branch are now serialized. Among other things this prevents
concurrent deployments.

While there, reduce the permission assigned to each of the two jobs.
```