### PR TITLE
Rename `Slf4JLogStatementTest` to `Slf4jLogStatementTest`

### DIFF
--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/Slf4jLogStatementTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/Slf4jLogStatementTest.java
@@ -5,7 +5,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 
-final class Slf4JLogStatementTest {
+final class Slf4jLogStatementTest {
   private final CompilationTestHelper compilationTestHelper =
       CompilationTestHelper.newInstance(Slf4jLogStatement.class, getClass());
   private final BugCheckerRefactoringTestHelper refactoringTestHelper =


### PR DESCRIPTION
The test class name is inconsistent with the actual class name. Spotted while generating the documentation website. Decided to split it off given the unforeseeable future of the documentation generation branches. Thought to do it in scope of #288 as we were already renaming files there to make Refaster naming consistent, but this class is unrelated in that regard. 

Suggested commit message:

```
Rename `Slf4JLogStatementTest` to `Slf4jLogStatementTest` (#289)
```