### PR TITLE
Introduce `{Mono,Flux}#zipWith{,Iterable}` Refaster rules

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -94,6 +94,11 @@
             <scope>provided</scope>
         </dependency>
         <dependency>
+            <groupId>io.projectreactor.addons</groupId>
+            <artifactId>reactor-extra</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>io.reactivex.rxjava2</groupId>
             <artifactId>rxjava</artifactId>
             <scope>provided</scope>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -106,6 +106,53 @@ final class ReactorRules {
     }
   }
 
+  /**
+   * Prefer {@link Flux#zip(Publisher, Publisher)} over a chained {@link Flux#zipWith(Publisher)}.
+   */
+  static final class FluxZip<T, S> {
+    @BeforeTemplate
+    Flux<Tuple2<T, S>> before(Flux<T> flux, Publisher<S> other) {
+      return flux.zipWith(other);
+    }
+
+    @AfterTemplate
+    Flux<Tuple2<T, S>> after(Flux<T> flux, Publisher<S> other) {
+      return Flux.zip(flux, other);
+    }
+  }
+
+  /**
+   * Prefer {@link Flux#zip(Publisher, Publisher)} with a chained combinator over a chained {@link
+   * Flux#zipWith(Publisher, BiFunction)}.
+   */
+  static final class FluxZipWithCombinator<T, S, R> {
+    @BeforeTemplate
+    Flux<R> before(Flux<T> flux, Publisher<S> other, BiFunction<T, S, R> combinator) {
+      return flux.zipWith(other, combinator);
+    }
+
+    @AfterTemplate
+    Flux<R> after(Flux<T> flux, Publisher<S> other, BiFunction<T, S, R> combinator) {
+      return Flux.zip(flux, other).map(function(combinator));
+    }
+  }
+
+  /**
+   * Prefer {@link Flux#zipWithIterable(Iterable)} with a chained combinator over {@link
+   * Flux#zipWithIterable(Iterable, BiFunction)}.
+   */
+  static final class FluxZipWithIterable<T, S, R> {
+    @BeforeTemplate
+    Flux<R> before(Flux<T> flux, Iterable<S> iterable, BiFunction<T, S, R> combinator) {
+      return flux.zipWithIterable(iterable, combinator);
+    }
+
+    @AfterTemplate
+    Flux<R> after(Flux<T> flux, Iterable<S> iterable, BiFunction<T, S, R> combinator) {
+      return flux.zipWithIterable(iterable).map(function(combinator));
+    }
+  }
+
   /** Don't unnecessarily defer {@link Mono#error(Throwable)}. */
   static final class MonoDeferredError<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -148,6 +148,7 @@ final class ReactorRules {
     }
 
     @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     Flux<R> after(Flux<T> flux, Iterable<S> iterable, BiFunction<T, S, R> combinator) {
       return flux.zipWithIterable(iterable).map(function(combinator));
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -77,7 +77,11 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Mono#zip(Mono, Mono)} over a chained {@link Mono#zipWith(Mono)}. */
+  /**
+   * Prefer {@link Mono#zip(Mono, Mono)} over a chained {@link Mono#zipWith(Mono)}, as the former
+   * better conveys that the {@link Mono}s may be subscribed to concurrently, and generalizes to
+   * combining three or more reactive streams.
+   */
   static final class MonoZip<T, S> {
     @BeforeTemplate
     Mono<Tuple2<T, S>> before(Mono<T> mono, Mono<S> other) {
@@ -92,7 +96,8 @@ final class ReactorRules {
 
   /**
    * Prefer {@link Mono#zip(Mono, Mono)} with a chained combinator over a chained {@link
-   * Mono#zipWith(Mono, BiFunction)}.
+   * Mono#zipWith(Mono, BiFunction)}, as the former better conveys that the {@link Mono}s may be
+   * subscribed to concurrently, and generalizes to combining three or more reactive streams.
    */
   static final class MonoZipWithCombinator<T, S, R> {
     @BeforeTemplate
@@ -107,7 +112,9 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link Flux#zip(Publisher, Publisher)} over a chained {@link Flux#zipWith(Publisher)}.
+   * Prefer {@link Flux#zip(Publisher, Publisher)} over a chained {@link Flux#zipWith(Publisher)},
+   * as the former better conveys that the {@link Publisher}s may be subscribed to concurrently, and
+   * generalizes to combining three or more reactive streams.
    */
   static final class FluxZip<T, S> {
     @BeforeTemplate
@@ -123,7 +130,8 @@ final class ReactorRules {
 
   /**
    * Prefer {@link Flux#zip(Publisher, Publisher)} with a chained combinator over a chained {@link
-   * Flux#zipWith(Publisher, BiFunction)}.
+   * Flux#zipWith(Publisher, BiFunction)}, as the former better conveys that the {@link Publisher}s
+   * may be subscribed to concurrently, and generalizes to combining three or more reactive streams.
    */
   static final class FluxZipWithCombinator<T, S, R> {
     @BeforeTemplate
@@ -139,7 +147,7 @@ final class ReactorRules {
 
   /**
    * Prefer {@link Flux#zipWithIterable(Iterable)} with a chained combinator over {@link
-   * Flux#zipWithIterable(Iterable, BiFunction)}.
+   * Flux#zipWithIterable(Iterable, BiFunction)}, as the former generally yields more readable code.
    */
   static final class FluxZipWithIterable<T, S, R> {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -47,6 +47,20 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").zipWith(Mono.just(2), (string, count) -> string.repeat(count));
   }
 
+  Flux<Tuple2<String, Integer>> testFluxZip() {
+    return Flux.just("foo", "bar").zipWith(Flux.just(1, 2));
+  }
+
+  Flux<String> testFluxZipWithCombinator() {
+    return Flux.just("foo", "bar")
+        .zipWith(Flux.just(1, 2), (string, count) -> string.repeat(count));
+  }
+
+  Flux<String> testFluxZipWithIterable() {
+    return Flux.just("foo", "bar")
+        .zipWithIterable(ImmutableSet.of(1, 2), (string, count) -> string.repeat(count));
+  }
+
   Mono<Void> testMonoDeferredError() {
     return Mono.defer(() -> Mono.error(new IllegalStateException()));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -44,7 +44,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Mono<String> testMonoZipWithCombinator() {
-    return Mono.just("foo").zipWith(Mono.just(2), (string, count) -> string.repeat(count));
+    return Mono.just("foo").zipWith(Mono.just(1), String::repeat);
   }
 
   Flux<Tuple2<String, Integer>> testFluxZip() {
@@ -52,13 +52,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Flux<String> testFluxZipWithCombinator() {
-    return Flux.just("foo", "bar")
-        .zipWith(Flux.just(1, 2), (string, count) -> string.repeat(count));
+    return Flux.just("foo", "bar").zipWith(Flux.just(1, 2), String::repeat);
   }
 
   Flux<String> testFluxZipWithIterable() {
-    return Flux.just("foo", "bar")
-        .zipWithIterable(ImmutableSet.of(1, 2), (string, count) -> string.repeat(count));
+    return Flux.just("foo", "bar").zipWithIterable(ImmutableSet.of(1, 2), String::repeat);
   }
 
   Mono<Void> testMonoDeferredError() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -15,6 +15,7 @@ import reactor.core.publisher.Mono;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
 import reactor.util.context.Context;
+import reactor.util.function.Tuple2;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
@@ -36,6 +37,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Mono.fromCallable(() -> Optional.of(1).orElse(null)),
         Mono.fromSupplier(() -> Optional.of(2).orElse(null)));
+  }
+
+  Mono<Tuple2<String, Integer>> testMonoZip() {
+    return Mono.just("foo").zipWith(Mono.just(1));
+  }
+
+  Mono<String> testMonoZipWithCombinator() {
+    return Mono.just("foo").zipWith(Mono.just(2), (string, count) -> string.repeat(count));
   }
 
   Mono<Void> testMonoDeferredError() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -3,6 +3,7 @@ package tech.picnic.errorprone.refasterrules;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
+import static reactor.function.TupleUtils.function;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
@@ -47,8 +48,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Mono<String> testMonoZipWithCombinator() {
-    return Mono.zip(Mono.just("foo"), Mono.just(2))
-        .map(TupleUtils.function((string, count) -> string.repeat(count)));
+    return Mono.zip(Mono.just("foo"), Mono.just(1)).map(TupleUtils.function(String::repeat));
   }
 
   Flux<Tuple2<String, Integer>> testFluxZip() {
@@ -57,13 +57,13 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Flux<String> testFluxZipWithCombinator() {
     return Flux.zip(Flux.just("foo", "bar"), Flux.just(1, 2))
-        .map(TupleUtils.function((string, count) -> string.repeat(count)));
+        .map(TupleUtils.function(String::repeat));
   }
 
   Flux<String> testFluxZipWithIterable() {
     return Flux.just("foo", "bar")
         .zipWithIterable(ImmutableSet.of(1, 2))
-        .map(TupleUtils.function((string, count) -> string.repeat(count)));
+        .map(function(String::repeat));
   }
 
   Mono<Void> testMonoDeferredError() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -14,9 +14,11 @@ import java.util.concurrent.Callable;
 import java.util.function.Supplier;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+import reactor.function.TupleUtils;
 import reactor.test.StepVerifier;
 import reactor.test.publisher.PublisherProbe;
 import reactor.util.context.Context;
+import reactor.util.function.Tuple2;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
@@ -38,6 +40,15 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(1))),
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(2))));
+  }
+
+  Mono<Tuple2<String, Integer>> testMonoZip() {
+    return Mono.zip(Mono.just("foo"), Mono.just(1));
+  }
+
+  Mono<String> testMonoZipWithCombinator() {
+    return Mono.zip(Mono.just("foo"), Mono.just(2))
+        .map(TupleUtils.function((string, count) -> string.repeat(count)));
   }
 
   Mono<Void> testMonoDeferredError() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -51,6 +51,21 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         .map(TupleUtils.function((string, count) -> string.repeat(count)));
   }
 
+  Flux<Tuple2<String, Integer>> testFluxZip() {
+    return Flux.zip(Flux.just("foo", "bar"), Flux.just(1, 2));
+  }
+
+  Flux<String> testFluxZipWithCombinator() {
+    return Flux.zip(Flux.just("foo", "bar"), Flux.just(1, 2))
+        .map(TupleUtils.function((string, count) -> string.repeat(count)));
+  }
+
+  Flux<String> testFluxZipWithIterable() {
+    return Flux.just("foo", "bar")
+        .zipWithIterable(ImmutableSet.of(1, 2))
+        .map(TupleUtils.function((string, count) -> string.repeat(count)));
+  }
+
   Mono<Void> testMonoDeferredError() {
     return Mono.error(() -> new IllegalStateException());
   }


### PR DESCRIPTION
These proposed Refaster rules are solely meant to increase the readability when zipping publishers.

In the PR description I'll explain the proposal for `Mono#zipWith()`, but the same applies for the other proposed rules.

---


For example, `Mono#zipWith()` usages make it look like both `Mono`s are not retrieved concurrently, but have a sequential dependency like usages of `Mono#zipWhen()` require.

The following example illustrates the limited readability of `Mono#zipWith()` usages:
```java
Mono<String> zipWithExample(String id) {
  return aService.getA(id).zipWith(bService.getB(id), this::combineAsString);
}
```
Reactive publishers should be "streams of data", but in this example it's not apparent that a tuple is created and ultimately mapped to a string.

This PR suggests to rewrite such examples to the following:
```java
Mono<String> zipExample(String id) {
  return Mono.zip(aService.getA(id), bService.getB(id))
    .map(this::combineAsString);
}
```
As a result, the following this should be more apparent:
1. Both `Mono`s are resolved concurrently to a tuple.
2. There is a non-reactive mapping step.


---


Suggested commit message:
```
Introduce `{Mono,Flux}#zipWith()` Refaster rules (#293)
```
