### PR TITLE
Fix and simplify documented example compiler output

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,16 +119,13 @@ code with Maven should yield two compiler warnings:
 ```sh
 $ mvn clean install
 ...
-[INFO] -------------------------------------------------------------
-[WARNING] COMPILATION WARNING :
-[INFO] -------------------------------------------------------------
-[WARNING] Example.java:[9,34] [tech.picnic.errorprone.refasterrules.BigDecimalRules.BigDecimalZero]
+[INFO] Example.java:[9,34] [Refaster Rule] BigDecimalRules.BigDecimalZero: Refactoring opportunity
+    (see https://error-prone.picnic.tech/refasterrules/BigDecimalRules#BigDecimalZero)
   Did you mean 'return BigDecimal.ZERO;'?
+...
 [WARNING] Example.java:[13,35] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
     (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
   Did you mean 'return set;' or '@SuppressWarnings("IdentityConversion") public ImmutableSet<Integer> getSet() {'?
-[INFO] 2 warnings
-[INFO] -------------------------------------------------------------
 ...
 ```
 


### PR DESCRIPTION
Full output when running in an example project below (with `<showWarnings>true</showWarnings>`)

As one is an `INFO` message and the other a `COMPILATION WARNING` I've cleaned the result up.

```sh
[INFO] /Users/japborst/Documents/dev/error-prone-demo/src/main/java/com/example/Example.java:[9,34] [Refaster Rule] BigDecimalRules.BigDecimalZero: Refactoring opportunity
    (see https://error-prone.picnic.tech/refasterrules/BigDecimalRules#BigDecimalZero)
  Did you mean 'return BigDecimal.ZERO;'?
[INFO] -------------------------------------------------------------
[WARNING] COMPILATION WARNING :
[INFO] -------------------------------------------------------------
[WARNING] /Users/japborst/Documents/dev/error-prone-demo/src/main/java/com/example/Example.java:[14,35] [IdentityConversion] This method invocation appears redundant; remove it or suppress this warning and add a comment explaining its purpose
    (see https://error-prone.picnic.tech/bugpatterns/IdentityConversion)
  Did you mean 'return set;' or '@SuppressWarnings("IdentityConversion") public ImmutableSet<Integer> getSet() {'?
[INFO] 1 warning
[INFO] -------------------------------------------------------------
[INFO] -------------------------------------------------------------
[ERROR] COMPILATION ERROR :
[INFO] -------------------------------------------------------------
[ERROR] warnings found and -Werror specified
[INFO] 1 error
```