### PR TITLE
Make the build JDK 18+ compatible

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AmbiguousJsonCreator.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AmbiguousJsonCreator.java
@@ -36,6 +36,9 @@ public final class AmbiguousJsonCreator extends BugChecker implements Annotation
   private static final Matcher<AnnotationTree> IS_JSON_CREATOR_ANNOTATION =
       isType("com.fasterxml.jackson.annotation.JsonCreator");
 
+  /** Instantiates the default {@link AmbiguousJsonCreator}. */
+  public AmbiguousJsonCreator() {}
+
   @Override
   public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
     if (!IS_JSON_CREATOR_ANNOTATION.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AmbiguousJsonCreator.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AmbiguousJsonCreator.java
@@ -36,7 +36,7 @@ public final class AmbiguousJsonCreator extends BugChecker implements Annotation
   private static final Matcher<AnnotationTree> IS_JSON_CREATOR_ANNOTATION =
       isType("com.fasterxml.jackson.annotation.JsonCreator");
 
-  /** Instantiates the default {@link AmbiguousJsonCreator}. */
+  /** Instantiates a new {@link AmbiguousJsonCreator} instance. */
   public AmbiguousJsonCreator() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AssertJIsNull.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AssertJIsNull.java
@@ -44,6 +44,9 @@ public final class AssertJIsNull extends BugChecker implements MethodInvocationT
           argumentCount(1),
           argument(0, nullLiteral()));
 
+  /** Instantiates the default {@link AssertJIsNull}. */
+  public AssertJIsNull() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!ASSERT_IS_EQUAL_TO_NULL.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AssertJIsNull.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AssertJIsNull.java
@@ -44,7 +44,7 @@ public final class AssertJIsNull extends BugChecker implements MethodInvocationT
           argumentCount(1),
           argument(0, nullLiteral()));
 
-  /** Instantiates the default {@link AssertJIsNull}. */
+  /** Instantiates a new {@link AssertJIsNull} instance. */
   public AssertJIsNull() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AutowiredConstructor.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AutowiredConstructor.java
@@ -38,6 +38,9 @@ public final class AutowiredConstructor extends BugChecker implements ClassTreeM
   private static final MultiMatcher<Tree, AnnotationTree> AUTOWIRED_ANNOTATION =
       annotations(AT_LEAST_ONE, isType("org.springframework.beans.factory.annotation.Autowired"));
 
+  /** Instantiates the default {@link AutowiredConstructor}. */
+  public AutowiredConstructor() {}
+
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {
     List<MethodTree> constructors = ASTHelpers.getConstructors(tree);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AutowiredConstructor.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/AutowiredConstructor.java
@@ -38,7 +38,7 @@ public final class AutowiredConstructor extends BugChecker implements ClassTreeM
   private static final MultiMatcher<Tree, AnnotationTree> AUTOWIRED_ANNOTATION =
       annotations(AT_LEAST_ONE, isType("org.springframework.beans.factory.annotation.Autowired"));
 
-  /** Instantiates the default {@link AutowiredConstructor}. */
+  /** Instantiates a new {@link AutowiredConstructor} instance. */
   public AutowiredConstructor() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
@@ -46,6 +46,9 @@ public final class CanonicalAnnotationSyntax extends BugChecker implements Annot
               CanonicalAnnotationSyntax::dropRedundantValueAttribute,
               CanonicalAnnotationSyntax::dropRedundantCurlies);
 
+  /** Instantiates the default {@link CanonicalAnnotationSyntax}. */
+  public CanonicalAnnotationSyntax() {}
+
   @Override
   public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
     return FIX_FACTORIES.stream()

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
@@ -46,7 +46,7 @@ public final class CanonicalAnnotationSyntax extends BugChecker implements Annot
               CanonicalAnnotationSyntax::dropRedundantValueAttribute,
               CanonicalAnnotationSyntax::dropRedundantCurlies);
 
-  /** Instantiates the default {@link CanonicalAnnotationSyntax}. */
+  /** Instantiates a new {@link CanonicalAnnotationSyntax} instance. */
   public CanonicalAnnotationSyntax() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
@@ -45,6 +45,9 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
   private static final Matcher<ExpressionTree> SET_COLLECTOR =
       staticMethod().anyClass().named("toSet");
 
+  /** Instantiates the default {@link CollectorMutability}. */
+  public CollectorMutability() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!COLLECTOR_METHOD.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
@@ -45,7 +45,7 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
   private static final Matcher<ExpressionTree> SET_COLLECTOR =
       staticMethod().anyClass().named("toSet");
 
-  /** Instantiates the default {@link CollectorMutability}. */
+  /** Instantiates a new {@link CollectorMutability} instance. */
   public CollectorMutability() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/EmptyMethod.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/EmptyMethod.java
@@ -38,7 +38,7 @@ public final class EmptyMethod extends BugChecker implements MethodTreeMatcher {
           AT_LEAST_ONE,
           anyOf(isType("java.lang.Override"), isType("org.aspectj.lang.annotation.Pointcut")));
 
-  /** Instantiates the default {@link EmptyMethod}. */
+  /** Instantiates a new {@link EmptyMethod} instance. */
   public EmptyMethod() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/EmptyMethod.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/EmptyMethod.java
@@ -38,6 +38,9 @@ public final class EmptyMethod extends BugChecker implements MethodTreeMatcher {
           AT_LEAST_ONE,
           anyOf(isType("java.lang.Override"), isType("org.aspectj.lang.annotation.Pointcut")));
 
+  /** Instantiates the default {@link EmptyMethod}. */
+  public EmptyMethod() {}
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     if (tree.getBody() == null

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ErrorProneTestHelperSourceFormat.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ErrorProneTestHelperSourceFormat.java
@@ -72,7 +72,7 @@ public final class ErrorProneTestHelperSourceFormat extends BugChecker
           .onDescendantOf("com.google.errorprone.BugCheckerRefactoringTestHelper.ExpectOutput")
           .named("addOutputLines");
 
-  /** Instantiates the default {@link ErrorProneTestHelperSourceFormat}. */
+  /** Instantiates a new {@link ErrorProneTestHelperSourceFormat} instance. */
   public ErrorProneTestHelperSourceFormat() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ErrorProneTestHelperSourceFormat.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ErrorProneTestHelperSourceFormat.java
@@ -72,6 +72,9 @@ public final class ErrorProneTestHelperSourceFormat extends BugChecker
           .onDescendantOf("com.google.errorprone.BugCheckerRefactoringTestHelper.ExpectOutput")
           .named("addOutputLines");
 
+  /** Instantiates the default {@link ErrorProneTestHelperSourceFormat}. */
+  public ErrorProneTestHelperSourceFormat() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     boolean isOutputSource = OUTPUT_SOURCE_ACCEPTING_METHOD.matches(tree, state);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrdering.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrdering.java
@@ -46,6 +46,9 @@ public final class ExplicitEnumOrdering extends BugChecker implements MethodInvo
   private static final Matcher<ExpressionTree> EXPLICIT_ORDERING =
       staticMethod().onClass(Ordering.class.getName()).named("explicit");
 
+  /** Instantiates the default {@link ExplicitEnumOrdering}. */
+  public ExplicitEnumOrdering() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!EXPLICIT_ORDERING.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrdering.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrdering.java
@@ -46,7 +46,7 @@ public final class ExplicitEnumOrdering extends BugChecker implements MethodInvo
   private static final Matcher<ExpressionTree> EXPLICIT_ORDERING =
       staticMethod().onClass(Ordering.class.getName()).named("explicit");
 
-  /** Instantiates the default {@link ExplicitEnumOrdering}. */
+  /** Instantiates a new {@link ExplicitEnumOrdering} instance. */
   public ExplicitEnumOrdering() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FluxFlatMapUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FluxFlatMapUsage.java
@@ -58,7 +58,7 @@ public final class FluxFlatMapUsage extends BugChecker
           .namedAnyOf("flatMap", "flatMapSequential")
           .withParameters(Function.class.getName());
 
-  /** Instantiates the default {@link FluxFlatMapUsage}. */
+  /** Instantiates a new {@link FluxFlatMapUsage} instance. */
   public FluxFlatMapUsage() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FluxFlatMapUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FluxFlatMapUsage.java
@@ -58,6 +58,9 @@ public final class FluxFlatMapUsage extends BugChecker
           .namedAnyOf("flatMap", "flatMapSequential")
           .withParameters(Function.class.getName());
 
+  /** Instantiates the default {@link FluxFlatMapUsage}. */
+  public FluxFlatMapUsage() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!FLUX_FLATMAP.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FormatStringConcatenation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FormatStringConcatenation.java
@@ -129,6 +129,9 @@ public final class FormatStringConcatenation extends BugChecker
           .onDescendantOf("org.slf4j.Logger")
           .namedAnyOf("debug", "error", "info", "trace", "warn");
 
+  /** Instantiates the default {@link FormatStringConcatenation}. */
+  public FormatStringConcatenation() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (hasNonConstantStringConcatenationArgument(tree, 0, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FormatStringConcatenation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/FormatStringConcatenation.java
@@ -129,7 +129,7 @@ public final class FormatStringConcatenation extends BugChecker
           .onDescendantOf("org.slf4j.Logger")
           .namedAnyOf("debug", "error", "info", "trace", "warn");
 
-  /** Instantiates the default {@link FormatStringConcatenation}. */
+  /** Instantiates a new {@link FormatStringConcatenation} instance. */
   public FormatStringConcatenation() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
@@ -72,7 +72,7 @@ public final class IdentityConversion extends BugChecker implements MethodInvoca
               .namedAnyOf("concat", "firstWithSignal", "from", "merge"),
           staticMethod().onClass("reactor.core.publisher.Mono").namedAnyOf("from", "fromDirect"));
 
-  /** Instantiates the default {@link IdentityConversion}. */
+  /** Instantiates a new {@link IdentityConversion} instance. */
   public IdentityConversion() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
@@ -72,6 +72,9 @@ public final class IdentityConversion extends BugChecker implements MethodInvoca
               .namedAnyOf("concat", "firstWithSignal", "from", "merge"),
           staticMethod().onClass("reactor.core.publisher.Mono").namedAnyOf("from", "fromDirect"));
 
+  /** Instantiates the default {@link IdentityConversion}. */
+  public IdentityConversion() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     List<? extends ExpressionTree> arguments = tree.getArguments();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ImmutablesSortedSetComparator.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ImmutablesSortedSetComparator.java
@@ -67,6 +67,9 @@ public final class ImmutablesSortedSetComparator extends BugChecker implements M
                   hasAnnotation("org.immutables.value.Value.NaturalOrder"),
                   hasAnnotation("org.immutables.value.Value.ReverseOrder"))));
 
+  /** Instantiates the default {@link ImmutablesSortedSetComparator}. */
+  public ImmutablesSortedSetComparator() {}
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     if (!METHOD_LACKS_ANNOTATION.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ImmutablesSortedSetComparator.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ImmutablesSortedSetComparator.java
@@ -67,7 +67,7 @@ public final class ImmutablesSortedSetComparator extends BugChecker implements M
                   hasAnnotation("org.immutables.value.Value.NaturalOrder"),
                   hasAnnotation("org.immutables.value.Value.ReverseOrder"))));
 
-  /** Instantiates the default {@link ImmutablesSortedSetComparator}. */
+  /** Instantiates a new {@link ImmutablesSortedSetComparator} instance. */
   public ImmutablesSortedSetComparator() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/JUnitMethodDeclaration.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/JUnitMethodDeclaration.java
@@ -79,7 +79,7 @@ public final class JUnitMethodDeclaration extends BugChecker implements MethodTr
               isType("org.junit.jupiter.api.BeforeAll"),
               isType("org.junit.jupiter.api.BeforeEach")));
 
-  /** Instantiates the default {@link JUnitMethodDeclaration}. */
+  /** Instantiates a new {@link JUnitMethodDeclaration} instance. */
   public JUnitMethodDeclaration() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/JUnitMethodDeclaration.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/JUnitMethodDeclaration.java
@@ -79,6 +79,9 @@ public final class JUnitMethodDeclaration extends BugChecker implements MethodTr
               isType("org.junit.jupiter.api.BeforeAll"),
               isType("org.junit.jupiter.api.BeforeEach")));
 
+  /** Instantiates the default {@link JUnitMethodDeclaration}. */
+  public JUnitMethodDeclaration() {}
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     if (HAS_UNMODIFIABLE_SIGNATURE.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
@@ -82,7 +82,7 @@ public final class LexicographicalAnnotationAttributeListing extends BugChecker
 
   private final AnnotationAttributeMatcher matcher;
 
-  /** Instantiates the default {@link LexicographicalAnnotationAttributeListing}. */
+  /** Instantiates a default {@link LexicographicalAnnotationAttributeListing} instance. */
   public LexicographicalAnnotationAttributeListing() {
     this(ErrorProneFlags.empty());
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationListing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationListing.java
@@ -40,6 +40,9 @@ public final class LexicographicalAnnotationListing extends BugChecker
     implements MethodTreeMatcher {
   private static final long serialVersionUID = 1L;
 
+  /** Instantiates the default {@link LexicographicalAnnotationListing}. */
+  public LexicographicalAnnotationListing() {}
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     List<? extends AnnotationTree> originalOrdering = tree.getModifiers().getAnnotations();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationListing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationListing.java
@@ -40,7 +40,7 @@ public final class LexicographicalAnnotationListing extends BugChecker
     implements MethodTreeMatcher {
   private static final long serialVersionUID = 1L;
 
-  /** Instantiates the default {@link LexicographicalAnnotationListing}. */
+  /** Instantiates a new {@link LexicographicalAnnotationListing} instance. */
   public LexicographicalAnnotationListing() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MethodReferenceUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MethodReferenceUsage.java
@@ -60,7 +60,7 @@ import javax.lang.model.element.Name;
 public final class MethodReferenceUsage extends BugChecker implements LambdaExpressionTreeMatcher {
   private static final long serialVersionUID = 1L;
 
-  /** Instantiates the default {@link MethodReferenceUsage}. */
+  /** Instantiates a new {@link MethodReferenceUsage} instance. */
   public MethodReferenceUsage() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MethodReferenceUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MethodReferenceUsage.java
@@ -60,6 +60,9 @@ import javax.lang.model.element.Name;
 public final class MethodReferenceUsage extends BugChecker implements LambdaExpressionTreeMatcher {
   private static final long serialVersionUID = 1L;
 
+  /** Instantiates the default {@link MethodReferenceUsage}. */
+  public MethodReferenceUsage() {}
+
   @Override
   public Description matchLambdaExpression(LambdaExpressionTree tree, VisitorState state) {
     /*

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MissingRefasterAnnotation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MissingRefasterAnnotation.java
@@ -40,6 +40,9 @@ public final class MissingRefasterAnnotation extends BugChecker implements Class
               isType("com.google.errorprone.refaster.annotation.BeforeTemplate"),
               isType("com.google.errorprone.refaster.annotation.AfterTemplate")));
 
+  /** Instantiates the default {@link MissingRefasterAnnotation}. */
+  public MissingRefasterAnnotation() {}
+
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {
     long methodTypes =

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MissingRefasterAnnotation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MissingRefasterAnnotation.java
@@ -40,7 +40,7 @@ public final class MissingRefasterAnnotation extends BugChecker implements Class
               isType("com.google.errorprone.refaster.annotation.BeforeTemplate"),
               isType("com.google.errorprone.refaster.annotation.AfterTemplate")));
 
-  /** Instantiates the default {@link MissingRefasterAnnotation}. */
+  /** Instantiates a new {@link MissingRefasterAnnotation} instance. */
   public MissingRefasterAnnotation() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MockitoStubbing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MockitoStubbing.java
@@ -36,7 +36,7 @@ public final class MockitoStubbing extends BugChecker implements MethodInvocatio
   private static final Matcher<ExpressionTree> MOCKITO_EQ_METHOD =
       staticMethod().onClass("org.mockito.ArgumentMatchers").named("eq");
 
-  /** Instantiates the default {@link MockitoStubbing}. */
+  /** Instantiates a new {@link MockitoStubbing} instance. */
   public MockitoStubbing() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MockitoStubbing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/MockitoStubbing.java
@@ -36,6 +36,9 @@ public final class MockitoStubbing extends BugChecker implements MethodInvocatio
   private static final Matcher<ExpressionTree> MOCKITO_EQ_METHOD =
       staticMethod().onClass("org.mockito.ArgumentMatchers").named("eq");
 
+  /** Instantiates the default {@link MockitoStubbing}. */
+  public MockitoStubbing() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     List<? extends ExpressionTree> arguments = tree.getArguments();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
@@ -34,7 +34,7 @@ public final class NestedOptionals extends BugChecker implements MethodInvocatio
   private static final long serialVersionUID = 1L;
   private static final Supplier<Type> OPTIONAL = Suppliers.typeFromClass(Optional.class);
 
-  /** Instantiates the default {@link NestedOptionals}. */
+  /** Instantiates a new {@link NestedOptionals} instance. */
   public NestedOptionals() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
@@ -34,6 +34,9 @@ public final class NestedOptionals extends BugChecker implements MethodInvocatio
   private static final long serialVersionUID = 1L;
   private static final Supplier<Type> OPTIONAL = Suppliers.typeFromClass(Optional.class);
 
+  /** Instantiates the default {@link NestedOptionals}. */
+  public NestedOptionals() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     return isOptionalOfOptional(tree, state) ? describeMatch(tree) : Description.NO_MATCH;

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonEmptyMono.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonEmptyMono.java
@@ -76,6 +76,9 @@ public final class NonEmptyMono extends BugChecker implements MethodInvocationTr
               .onDescendantOf("reactor.core.publisher.Mono")
               .namedAnyOf("defaultIfEmpty", "hasElement", "single"));
 
+  /** Instantiates the default {@link NonEmptyMono}. */
+  public NonEmptyMono() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!MONO_SIZE_CHECK.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonEmptyMono.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonEmptyMono.java
@@ -76,7 +76,7 @@ public final class NonEmptyMono extends BugChecker implements MethodInvocationTr
               .onDescendantOf("reactor.core.publisher.Mono")
               .namedAnyOf("defaultIfEmpty", "hasElement", "single"));
 
-  /** Instantiates the default {@link NonEmptyMono}. */
+  /** Instantiates a new {@link NonEmptyMono} instance. */
   public NonEmptyMono() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparison.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparison.java
@@ -70,6 +70,9 @@ public final class PrimitiveComparison extends BugChecker implements MethodInvoc
               .named("thenComparing")
               .withParameters(Function.class.getName()));
 
+  /** Instantiates the default {@link PrimitiveComparison}. */
+  public PrimitiveComparison() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     boolean isStatic = STATIC_COMPARISON_METHOD.matches(tree, state);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparison.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparison.java
@@ -70,7 +70,7 @@ public final class PrimitiveComparison extends BugChecker implements MethodInvoc
               .named("thenComparing")
               .withParameters(Function.class.getName()));
 
-  /** Instantiates the default {@link PrimitiveComparison}. */
+  /** Instantiates a new {@link PrimitiveComparison} instance. */
   public PrimitiveComparison() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RedundantStringConversion.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RedundantStringConversion.java
@@ -141,7 +141,7 @@ public final class RedundantStringConversion extends BugChecker
 
   private final Matcher<MethodInvocationTree> conversionMethodMatcher;
 
-  /** Instantiates the default {@link RedundantStringConversion}. */
+  /** Instantiates a default {@link RedundantStringConversion} instance. */
   public RedundantStringConversion() {
     this(ErrorProneFlags.empty());
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterAnyOfUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterAnyOfUsage.java
@@ -37,7 +37,7 @@ public final class RefasterAnyOfUsage extends BugChecker implements MethodInvoca
   private static final Matcher<ExpressionTree> REFASTER_ANY_OF =
       staticMethod().onClass(Refaster.class.getName()).named("anyOf");
 
-  /** Instantiates the default {@link RefasterAnyOfUsage}. */
+  /** Instantiates a new {@link RefasterAnyOfUsage} instance. */
   public RefasterAnyOfUsage() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterAnyOfUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterAnyOfUsage.java
@@ -37,6 +37,9 @@ public final class RefasterAnyOfUsage extends BugChecker implements MethodInvoca
   private static final Matcher<ExpressionTree> REFASTER_ANY_OF =
       staticMethod().onClass(Refaster.class.getName()).named("anyOf");
 
+  /** Instantiates the default {@link RefasterAnyOfUsage}. */
+  public RefasterAnyOfUsage() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (REFASTER_ANY_OF.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterRuleModifiers.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterRuleModifiers.java
@@ -48,7 +48,7 @@ public final class RefasterRuleModifiers extends BugChecker
   private static final Matcher<Tree> REFASTER_METHOD =
       anyOf(BEFORE_TEMPLATE_METHOD, AFTER_TEMPLATE_METHOD, PLACEHOLDER_METHOD);
 
-  /** Instantiates the default {@link RefasterRuleModifiers}. */
+  /** Instantiates a new {@link RefasterRuleModifiers} instance. */
   public RefasterRuleModifiers() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterRuleModifiers.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RefasterRuleModifiers.java
@@ -48,6 +48,9 @@ public final class RefasterRuleModifiers extends BugChecker
   private static final Matcher<Tree> REFASTER_METHOD =
       anyOf(BEFORE_TEMPLATE_METHOD, AFTER_TEMPLATE_METHOD, PLACEHOLDER_METHOD);
 
+  /** Instantiates the default {@link RefasterRuleModifiers}. */
+  public RefasterRuleModifiers() {}
+
   @Override
   public Description matchClass(ClassTree tree, VisitorState state) {
     if (!hasMatchingMember(tree, BEFORE_TEMPLATE_METHOD, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotation.java
@@ -83,7 +83,7 @@ public final class RequestMappingAnnotation extends BugChecker implements Method
                   isSameType("org.springframework.web.util.UriBuilder"),
                   isSameType("org.springframework.web.util.UriComponentsBuilder"))));
 
-  /** Instantiates the default {@link RequestMappingAnnotation}. */
+  /** Instantiates a new {@link RequestMappingAnnotation} instance. */
   public RequestMappingAnnotation() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestMappingAnnotation.java
@@ -83,6 +83,9 @@ public final class RequestMappingAnnotation extends BugChecker implements Method
                   isSameType("org.springframework.web.util.UriBuilder"),
                   isSameType("org.springframework.web.util.UriComponentsBuilder"))));
 
+  /** Instantiates the default {@link RequestMappingAnnotation}. */
+  public RequestMappingAnnotation() {}
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     // XXX: Auto-add `@RequestParam` where applicable.

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestParamType.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestParamType.java
@@ -37,7 +37,7 @@ public final class RequestParamType extends BugChecker implements VariableTreeMa
           annotations(AT_LEAST_ONE, isType("org.springframework.web.bind.annotation.RequestParam")),
           anyOf(isSubtypeOf(ImmutableCollection.class), isSubtypeOf(ImmutableMap.class)));
 
-  /** Instantiates the default {@link RequestParamType}. */
+  /** Instantiates a new {@link RequestParamType} instance. */
   public RequestParamType() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestParamType.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RequestParamType.java
@@ -37,6 +37,9 @@ public final class RequestParamType extends BugChecker implements VariableTreeMa
           annotations(AT_LEAST_ONE, isType("org.springframework.web.bind.annotation.RequestParam")),
           anyOf(isSubtypeOf(ImmutableCollection.class), isSubtypeOf(ImmutableMap.class)));
 
+  /** Instantiates the default {@link RequestParamType}. */
+  public RequestParamType() {}
+
   @Override
   public Description matchVariable(VariableTree tree, VisitorState state) {
     return HAS_UNSUPPORTED_REQUEST_PARAM.matches(tree, state)

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
@@ -46,7 +46,7 @@ public final class ScheduledTransactionTrace extends BugChecker implements Metho
   private static final MultiMatcher<Tree, AnnotationTree> TRACE_ANNOTATION =
       annotations(AT_LEAST_ONE, isType(TRACE_ANNOTATION_FQCN));
 
-  /** Instantiates the default {@link ScheduledTransactionTrace}. */
+  /** Instantiates a new {@link ScheduledTransactionTrace} instance. */
   public ScheduledTransactionTrace() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
@@ -46,6 +46,9 @@ public final class ScheduledTransactionTrace extends BugChecker implements Metho
   private static final MultiMatcher<Tree, AnnotationTree> TRACE_ANNOTATION =
       annotations(AT_LEAST_ONE, isType(TRACE_ANNOTATION_FQCN));
 
+  /** Instantiates the default {@link ScheduledTransactionTrace}. */
+  public ScheduledTransactionTrace() {}
+
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
     if (!IS_SCHEDULED.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/Slf4jLogStatement.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/Slf4jLogStatement.java
@@ -48,6 +48,9 @@ public final class Slf4jLogStatement extends BugChecker implements MethodInvocat
           .onDescendantOf("org.slf4j.Logger")
           .namedAnyOf("trace", "debug", "info", "warn", "error");
 
+  /** Instantiates the default {@link Slf4jLogStatement}. */
+  public Slf4jLogStatement() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!SLF4J_LOGGER_INVOCATION.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/Slf4jLogStatement.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/Slf4jLogStatement.java
@@ -48,7 +48,7 @@ public final class Slf4jLogStatement extends BugChecker implements MethodInvocat
           .onDescendantOf("org.slf4j.Logger")
           .namedAnyOf("trace", "debug", "info", "warn", "error");
 
-  /** Instantiates the default {@link Slf4jLogStatement}. */
+  /** Instantiates a new {@link Slf4jLogStatement} instance. */
   public Slf4jLogStatement() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/SpringMvcAnnotation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/SpringMvcAnnotation.java
@@ -57,6 +57,9 @@ public final class SpringMvcAnnotation extends BugChecker implements AnnotationT
           .put("PUT", "PutMapping")
           .build();
 
+  /** Instantiates the default {@link SpringMvcAnnotation}. */
+  public SpringMvcAnnotation() {}
+
   @Override
   public Description matchAnnotation(AnnotationTree tree, VisitorState state) {
     // XXX: We could remove the `@RequestMapping` import if not other usages remain.

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/SpringMvcAnnotation.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/SpringMvcAnnotation.java
@@ -57,7 +57,7 @@ public final class SpringMvcAnnotation extends BugChecker implements AnnotationT
           .put("PUT", "PutMapping")
           .build();
 
-  /** Instantiates the default {@link SpringMvcAnnotation}. */
+  /** Instantiates a new {@link SpringMvcAnnotation} instance. */
   public SpringMvcAnnotation() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -190,7 +190,7 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
           "of",
           "valueOf");
 
-  /** Instantiates the default {@link StaticImport}. */
+  /** Instantiates a new {@link StaticImport} instance. */
   public StaticImport() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -190,6 +190,9 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
           "of",
           "valueOf");
 
+  /** Instantiates the default {@link StaticImport}. */
+  public StaticImport() {}
+
   @Override
   public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
     if (!isCandidateContext(state) || !isCandidate(tree)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
@@ -52,7 +52,7 @@ public final class StringJoin extends BugChecker implements MethodInvocationTree
       Suppliers.typeFromClass(CharSequence.class);
   private static final Supplier<Type> FORMATTABLE_TYPE = Suppliers.typeFromClass(Formattable.class);
 
-  /** Instantiates the default {@link StringJoin}. */
+  /** Instantiates a new {@link StringJoin} instance. */
   public StringJoin() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
@@ -52,6 +52,9 @@ public final class StringJoin extends BugChecker implements MethodInvocationTree
       Suppliers.typeFromClass(CharSequence.class);
   private static final Supplier<Type> FORMATTABLE_TYPE = Suppliers.typeFromClass(Formattable.class);
 
+  /** Instantiates the default {@link StringJoin}. */
+  public StringJoin() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     if (!STRING_FORMAT_INVOCATION.matches(tree, state)) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/TimeZoneUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/TimeZoneUsage.java
@@ -62,6 +62,9 @@ public final class TimeZoneUsage extends BugChecker implements MethodInvocationT
               .named("now"),
           staticMethod().onClassAny(Instant.class.getName()).named("now").withNoParameters());
 
+  /** Instantiates the default {@link TimeZoneUsage}. */
+  public TimeZoneUsage() {}
+
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
     return BANNED_TIME_METHOD.matches(tree, state)

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/TimeZoneUsage.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/TimeZoneUsage.java
@@ -62,7 +62,7 @@ public final class TimeZoneUsage extends BugChecker implements MethodInvocationT
               .named("now"),
           staticMethod().onClassAny(Instant.class.getName()).named("now").withNoParameters());
 
-  /** Instantiates the default {@link TimeZoneUsage}. */
+  /** Instantiates a new {@link TimeZoneUsage} instance. */
   public TimeZoneUsage() {}
 
   @Override

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MethodMatcherFactory.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MethodMatcherFactory.java
@@ -21,7 +21,7 @@ public final class MethodMatcherFactory {
   private static final Pattern METHOD_SIGNATURE =
       Pattern.compile("([^\\s#(,)]+)#([^\\s#(,)]+)\\(((?:[^\\s#(,)]+(?:,[^\\s#(,)]+)*)?)\\)");
 
-  /** Instantiates the default {@link MethodMatcherFactory}. */
+  /** Instantiates a new {@link MethodMatcherFactory} instance. */
   public MethodMatcherFactory() {}
 
   /**

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MethodMatcherFactory.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MethodMatcherFactory.java
@@ -21,6 +21,9 @@ public final class MethodMatcherFactory {
   private static final Pattern METHOD_SIGNATURE =
       Pattern.compile("([^\\s#(,)]+)#([^\\s#(,)]+)\\(((?:[^\\s#(,)]+(?:,[^\\s#(,)]+)*)?)\\)");
 
+  /** Instantiates the default {@link MethodMatcherFactory}. */
+  public MethodMatcherFactory() {}
+
   /**
    * Creates a {@link Matcher} of methods with any of the given signatures.
    *

--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompiler.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompiler.java
@@ -12,6 +12,9 @@ import com.sun.tools.javac.api.BasicJavacTask;
  */
 @AutoService(Plugin.class)
 public final class RefasterRuleCompiler implements Plugin {
+  /** Instantiates the default {@link RefasterRuleCompiler}. */
+  public RefasterRuleCompiler() {}
+
   @Override
   public String getName() {
     return getClass().getSimpleName();

--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompiler.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompiler.java
@@ -12,7 +12,7 @@ import com.sun.tools.javac.api.BasicJavacTask;
  */
 @AutoService(Plugin.class)
 public final class RefasterRuleCompiler implements Plugin {
-  /** Instantiates the default {@link RefasterRuleCompiler}. */
+  /** Instantiates a new {@link RefasterRuleCompiler} instance. */
   public RefasterRuleCompiler() {}
 
   @Override

--- a/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
+++ b/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
@@ -61,6 +61,8 @@ public final class Refaster extends BugChecker implements CompilationUnitTreeMat
 
   private static final long serialVersionUID = 1L;
 
+  // For more details, see https://bugs.openjdk.org/browse/JDK-8274336.
+  @SuppressWarnings("serial")
   private final CodeTransformer codeTransformer;
 
   /** Instantiates the default {@link Refaster}. */

--- a/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
+++ b/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
@@ -61,11 +61,10 @@ public final class Refaster extends BugChecker implements CompilationUnitTreeMat
 
   private static final long serialVersionUID = 1L;
 
-  // For more details, see https://bugs.openjdk.org/browse/JDK-8274336.
-  @SuppressWarnings("serial")
+  @SuppressWarnings("serial" /* Concrete instance will be `Serializable`. */)
   private final CodeTransformer codeTransformer;
 
-  /** Instantiates the default {@link Refaster}. */
+  /** Instantiates a default {@link Refaster} instance. */
   public Refaster() {
     this(ErrorProneFlags.empty());
   }

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/AnnotatedCompositeCodeTransformer.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/AnnotatedCompositeCodeTransformer.java
@@ -42,6 +42,8 @@ public abstract class AnnotatedCompositeCodeTransformer implements CodeTransform
   private static final long serialVersionUID = 1L;
   private static final Splitter CLASS_NAME_SPLITTER = Splitter.on('.').limit(2);
 
+  AnnotatedCompositeCodeTransformer() {}
+
   abstract String packageName();
 
   abstract ImmutableList<CodeTransformer> transformers();

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsArray.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsArray.java
@@ -11,6 +11,9 @@ public final class IsArray implements Matcher<ExpressionTree> {
   private static final long serialVersionUID = 1L;
   private static final Matcher<ExpressionTree> DELEGATE = isArrayType();
 
+  /** Instantiates the default {@link IsArray}. */
+  public IsArray() {}
+
   @Override
   public boolean matches(ExpressionTree tree, VisitorState state) {
     return DELEGATE.matches(tree, state);

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsArray.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsArray.java
@@ -11,7 +11,7 @@ public final class IsArray implements Matcher<ExpressionTree> {
   private static final long serialVersionUID = 1L;
   private static final Matcher<ExpressionTree> DELEGATE = isArrayType();
 
-  /** Instantiates the default {@link IsArray}. */
+  /** Instantiates a new {@link IsArray} instance. */
   public IsArray() {}
 
   @Override

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsCharacter.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsCharacter.java
@@ -14,6 +14,9 @@ public final class IsCharacter implements Matcher<ExpressionTree> {
   private static final Matcher<ExpressionTree> DELEGATE =
       anyOf(isSameType(CHAR_TYPE), isSameType(Character.class));
 
+  /** Instantiates the default {@link IsCharacter}. */
+  public IsCharacter() {}
+
   @Override
   public boolean matches(ExpressionTree tree, VisitorState state) {
     return DELEGATE.matches(tree, state);

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsCharacter.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/IsCharacter.java
@@ -14,7 +14,7 @@ public final class IsCharacter implements Matcher<ExpressionTree> {
   private static final Matcher<ExpressionTree> DELEGATE =
       anyOf(isSameType(CHAR_TYPE), isSameType(Character.class));
 
-  /** Instantiates the default {@link IsCharacter}. */
+  /** Instantiates a new {@link IsCharacter} instance. */
   public IsCharacter() {}
 
   @Override

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedException.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedException.java
@@ -19,7 +19,7 @@ import java.util.Collection;
 public final class ThrowsCheckedException implements Matcher<ExpressionTree> {
   private static final long serialVersionUID = 1L;
 
-  /** Instantiates the default {@link ThrowsCheckedException}. */
+  /** Instantiates a new {@link ThrowsCheckedException} instance. */
   public ThrowsCheckedException() {}
 
   @Override

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedException.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/matchers/ThrowsCheckedException.java
@@ -19,6 +19,9 @@ import java.util.Collection;
 public final class ThrowsCheckedException implements Matcher<ExpressionTree> {
   private static final long serialVersionUID = 1L;
 
+  /** Instantiates the default {@link ThrowsCheckedException}. */
+  public ThrowsCheckedException() {}
+
   @Override
   public boolean matches(ExpressionTree tree, VisitorState state) {
     return containsCheckedException(getThrownTypes(tree, state), state);


### PR DESCRIPTION
 @werli reported that he got some errors when running Error Prone Support with JDK 18.0.2. 
 After some investigation I found these two JDK bug reports:
- https://bugs.openjdk.org/browse/JDK-8249634
- https://bugs.openjdk.org/browse/JDK-8160675

The first one flagged quite some violations. To resolve these violations, the default non-arg constructors are added _with_ Javadoc. This solution is not ideal. However by looking at the [docs of the javadoc](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html) command, and more specifically the [options](https://docs.oracle.com/javase/8/docs/technotes/tools/windows/javadoc.html#CHDFDACB), I don't see a way to configure the check to go around this... 

For me, this check flags a lot of missing Javadocs during development. Therefore, it'd be a good idea to not disable this check and use this PR to make the code compatible with JDK 18.

```
$ java -version
openjdk version "18.0.2" 2022-07-19
IBM Semeru Runtime Open Edition 18.0.2.0 (build 18.0.2+9)
```