### PR TITLE
By default, prevent `BugChecker`s from introducing new dependencies

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -175,6 +175,11 @@
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
             <artifactId>spring-test</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -176,7 +176,7 @@
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
-            <scope>provided</scope>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.springframework</groupId>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
@@ -18,6 +18,7 @@ import com.google.errorprone.matchers.Matcher;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
 import java.util.stream.Collector;
+import tech.picnic.errorprone.bugpatterns.util.ThirdPartyLibrary;
 
 /**
  * A {@link BugChecker} that flags {@link Collector Collectors} that don't clearly express
@@ -50,7 +51,7 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (!COLLECTOR_METHOD.matches(tree, state)) {
+    if (!ThirdPartyLibrary.GUAVA.canUse(state) || !COLLECTOR_METHOD.matches(tree, state)) {
       return Description.NO_MATCH;
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
@@ -51,7 +51,8 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (!ThirdPartyLibrary.GUAVA.canUse(state) || !COLLECTOR_METHOD.matches(tree, state)) {
+    if (!ThirdPartyLibrary.GUAVA.isIntroductionAllowed(state)
+        || !COLLECTOR_METHOD.matches(tree, state)) {
       return Description.NO_MATCH;
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
@@ -52,7 +52,7 @@ public final class ScheduledTransactionTrace extends BugChecker implements Metho
 
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
-    if (!ThirdPartyLibrary.NEW_RELIC_AGENT_API.canUse(state)
+    if (!ThirdPartyLibrary.NEW_RELIC_AGENT_API.isIntroductionAllowed(state)
         || !IS_SCHEDULED.matches(tree, state)) {
       return Description.NO_MATCH;
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTrace.java
@@ -26,6 +26,7 @@ import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
+import tech.picnic.errorprone.bugpatterns.util.ThirdPartyLibrary;
 
 /**
  * A {@link BugChecker} that flags methods with Spring's {@code @Scheduled} annotation that lack New
@@ -51,7 +52,8 @@ public final class ScheduledTransactionTrace extends BugChecker implements Metho
 
   @Override
   public Description matchMethod(MethodTree tree, VisitorState state) {
-    if (!IS_SCHEDULED.matches(tree, state)) {
+    if (!ThirdPartyLibrary.NEW_RELIC_AGENT_API.canUse(state)
+        || !IS_SCHEDULED.matches(tree, state)) {
       return Description.NO_MATCH;
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -189,8 +189,7 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
           "INSTANCE",
           "newBuilder",
           "of",
-          "valueOf",
-          "values");
+          "valueOf");
 
   /** Instantiates a new {@link StaticImport} instance. */
   public StaticImport() {}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -102,7 +102,8 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
           "org.springframework.http.MediaType",
           "org.testng.Assert",
           "reactor.function.TupleUtils",
-          "tech.picnic.errorprone.bugpatterns.util.MoreTypes");
+          "tech.picnic.errorprone.bugpatterns.util.MoreTypes",
+          "tech.picnic.errorprone.bugpatterns.util.ThirdPartyLibrary");
 
   /** Type members that should be statically imported. */
   @VisibleForTesting
@@ -189,7 +190,8 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
           "INSTANCE",
           "newBuilder",
           "of",
-          "valueOf");
+          "valueOf",
+          "values");
 
   /** Instantiates a new {@link StaticImport} instance. */
   public StaticImport() {}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -102,8 +102,7 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
           "org.springframework.http.MediaType",
           "org.testng.Assert",
           "reactor.function.TupleUtils",
-          "tech.picnic.errorprone.bugpatterns.util.MoreTypes",
-          "tech.picnic.errorprone.bugpatterns.util.ThirdPartyLibrary");
+          "tech.picnic.errorprone.bugpatterns.util.MoreTypes");
 
   /** Type members that should be statically imported. */
   @VisibleForTesting

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
@@ -1,0 +1,98 @@
+package tech.picnic.errorprone.bugpatterns.util;
+
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.suppliers.Supplier;
+import com.sun.tools.javac.code.ClassFinder;
+import com.sun.tools.javac.code.Symbol.CompletionFailure;
+import com.sun.tools.javac.util.Name;
+
+/**
+ * Utility class that helps decide whether it is appropriate to introduce references to (well-known)
+ * third-party libraries.
+ *
+ * <p>This class should be used by bug checkers that may otherwise suggest the introduction of code
+ * that depends on possibly-not-present third-party libraries.
+ */
+// XXX: Consider giving users more fine-grained control. This would be beneficial in cases where a
+// dependency is on the classpath, but new usages are undesirable.
+public enum ThirdPartyLibrary {
+  /**
+   * AssertJ.
+   *
+   * @see <a href="https://assertj.github.io/doc">AssertJ documentation</a>
+   */
+  ASSERTJ("org.assertj.core.api.Assertions"),
+  /**
+   * Google's Guava.
+   *
+   * @see <a href="https://github.com/google/guava">Guava on Github</a>
+   */
+  GUAVA("com.google.common.collect.ImmutableList"),
+  /**
+   * New Relic's Java agent API.
+   *
+   * @see <a href="https://github.com/newrelic/newrelic-java-agent/tree/main/newrelic-api">New Relic
+   *     Java agent API on Github</a>
+   */
+  NEW_RELIC_AGENT_API("com.newrelic.api.agent.Agent"),
+  /**
+   * VMWare's Project Reactor.
+   *
+   * @see <a href="https://projectreactor.io">Home page</a>
+   */
+  REACTOR("reactor.core.publisher.Flux");
+
+  private static final String IGNORE_CLASSPATH_COMPAT_FLAG =
+      "ErrorProneSupport:IgnoreClasspathCompat";
+
+  @SuppressWarnings("ImmutableEnumChecker" /* Supplier is deterministic. */)
+  private final Supplier<Boolean> canUse;
+
+  ThirdPartyLibrary(String witnessFqcn) {
+    this.canUse = VisitorState.memoize(state -> canIntroduceUsage(witnessFqcn, state));
+  }
+
+  /**
+   * Tells whether it is okay to introduce a dependency on this well-known third party library in
+   * the given context.
+   *
+   * @param state The context under consideration.
+   * @return {@code true} iff if it is okay to assume or create a dependency on this library.
+   */
+  public boolean canUse(VisitorState state) {
+    return canUse.get(state);
+  }
+
+  private static boolean canIntroduceUsage(String className, VisitorState state) {
+    return shouldIgnoreClasspath(state) || isKnownClass(className, state);
+  }
+
+  /**
+   * Attempts to determine whether a class with the given FQCN is on the classpath.
+   *
+   * <p>The {@link VisitorState}'s symbol table is consulted first. If the type has not yet been
+   * loaded, then an attempt is made to do so.
+   */
+  private static boolean isKnownClass(String className, VisitorState state) {
+    return state.getTypeFromString(className) != null || canLoadClass(className, state);
+  }
+
+  private static boolean canLoadClass(String className, VisitorState state) {
+    ClassFinder classFinder = ClassFinder.instance(state.context);
+    Name binaryName = state.binaryNameFromClassname(className);
+    try {
+      classFinder.loadClass(state.getSymtab().unnamedModule, binaryName);
+      return true;
+    } catch (CompletionFailure e) {
+      return false;
+    }
+  }
+
+  private static boolean shouldIgnoreClasspath(VisitorState state) {
+    return state
+        .errorProneOptions()
+        .getFlags()
+        .getBoolean(IGNORE_CLASSPATH_COMPAT_FLAG)
+        .orElse(Boolean.FALSE);
+  }
+}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.bugpatterns.util;
 
 import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.suppliers.Supplier;
 import com.sun.tools.javac.code.ClassFinder;
 import com.sun.tools.javac.code.Symbol.CompletionFailure;
@@ -10,8 +11,8 @@ import com.sun.tools.javac.util.Name;
  * Utility class that helps decide whether it is appropriate to introduce references to (well-known)
  * third-party libraries.
  *
- * <p>This class should be used by bug checkers that may otherwise suggest the introduction of code
- * that depends on possibly-not-present third-party libraries.
+ * <p>This class should be used by {@link BugChecker}s that may otherwise suggest the introduction
+ * of code that depends on possibly-not-present third-party libraries.
  */
 // XXX: Consider giving users more fine-grained control. This would be beneficial in cases where a
 // dependency is on the classpath, but new usages are undesirable.
@@ -25,14 +26,14 @@ public enum ThirdPartyLibrary {
   /**
    * Google's Guava.
    *
-   * @see <a href="https://github.com/google/guava">Guava on Github</a>
+   * @see <a href="https://github.com/google/guava">Guava on GitHub</a>
    */
   GUAVA("com.google.common.collect.ImmutableList"),
   /**
    * New Relic's Java agent API.
    *
    * @see <a href="https://github.com/newrelic/newrelic-java-agent/tree/main/newrelic-api">New Relic
-   *     Java agent API on Github</a>
+   *     Java agent API on GitHub</a>
    */
   NEW_RELIC_AGENT_API("com.newrelic.api.agent.Agent"),
   /**
@@ -57,7 +58,7 @@ public enum ThirdPartyLibrary {
    * the given context.
    *
    * @param state The context under consideration.
-   * @return {@code true} iff if it is okay to assume or create a dependency on this library.
+   * @return {@code true} iff it is okay to assume or create a dependency on this library.
    */
   public boolean canUse(VisitorState state) {
     return canUse.get(state);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
@@ -49,6 +49,12 @@ public enum ThirdPartyLibrary {
   @SuppressWarnings("ImmutableEnumChecker" /* Supplier is deterministic. */)
   private final Supplier<Boolean> canUse;
 
+  /**
+   * Instantiates a {@link ThirdPartyLibrary} enum value.
+   *
+   * @param witnessFqcn The fully-qualified class name of a type that is expected to be on the
+   *     classpath iff the associated third-party library is on the classpath.
+   */
   ThirdPartyLibrary(String witnessFqcn) {
     this.canUse = VisitorState.memoize(state -> canIntroduceUsage(witnessFqcn, state));
   }
@@ -60,7 +66,7 @@ public enum ThirdPartyLibrary {
    * @param state The context under consideration.
    * @return {@code true} iff it is okay to assume or create a dependency on this library.
    */
-  public boolean canUse(VisitorState state) {
+  public boolean isIntroductionAllowed(VisitorState state) {
     return canUse.get(state);
   }
 

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/CollectorMutabilityTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/CollectorMutabilityTest.java
@@ -66,6 +66,23 @@ final class CollectorMutabilityTest {
   }
 
   @Test
+  void identificationWithoutGuavaOnClasspath() {
+    compilationTestHelper
+        .withClasspath()
+        .addSourceLines(
+            "A.java",
+            "import java.util.stream.Collectors;",
+            "import java.util.stream.Stream;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    Stream.empty().collect(Collectors.toList());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   void replacementFirstSuggestedFix() {
     refactoringTestHelper
         .addInputLines(

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTraceTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ScheduledTransactionTraceTest.java
@@ -4,6 +4,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Scheduled;
 
 final class ScheduledTransactionTraceTest {
   private final CompilationTestHelper compilationTestHelper =
@@ -39,6 +40,21 @@ final class ScheduledTransactionTraceTest {
             "  @Scheduled(fixedDelay = 1)",
             "  @Trace(dispatcher = true)",
             "  void scheduledAndProperlyTraced() {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void identificationWithoutNewRelicAgentApiOnClasspath() {
+    compilationTestHelper
+        .withClasspath(Scheduled.class)
+        .addSourceLines(
+            "A.java",
+            "import org.springframework.scheduling.annotation.Scheduled;",
+            "",
+            "class A {",
+            "  @Scheduled(fixedDelay = 1)",
+            "  void scheduledButNotTraced() {}",
             "}")
         .doTest();
   }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibraryTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibraryTest.java
@@ -22,7 +22,7 @@ final class ThirdPartyLibraryTest {
       CompilationTestHelper.newInstance(TestChecker.class, getClass());
 
   @Test
-  void canUse() {
+  void isIntroductionAllowed() {
     compilationTestHelper
         .addSourceLines(
             "A.java",
@@ -32,7 +32,7 @@ final class ThirdPartyLibraryTest {
   }
 
   @Test
-  void canUseWitnessClassesInSymtab() {
+  void isIntroductionAllowedWitnessClassesInSymtab() {
     compilationTestHelper
         .addSourceLines(
             "A.java",
@@ -54,7 +54,7 @@ final class ThirdPartyLibraryTest {
   }
 
   @Test
-  void canUseWitnessClassesPartiallyOnClassPath() {
+  void isIntroductionAllowedWitnessClassesPartiallyOnClassPath() {
     compilationTestHelper
         .withClasspath(ImmutableList.class, Flux.class)
         .addSourceLines(
@@ -65,7 +65,7 @@ final class ThirdPartyLibraryTest {
   }
 
   @Test
-  void canUseWitnessClassesNotOnClassPath() {
+  void isIntroductionAllowedWitnessClassesNotOnClassPath() {
     compilationTestHelper
         .withClasspath()
         .addSourceLines(
@@ -78,7 +78,7 @@ final class ThirdPartyLibraryTest {
 
   @ParameterizedTest
   @ValueSource(booleans = {true, false})
-  void canUseIgnoreClasspathCompat(boolean ignoreClassPath) {
+  void isIntroductionAllowedIgnoreClasspathCompat(boolean ignoreClassPath) {
     compilationTestHelper
         .setArgs("-XepOpt:ErrorProneSupport:IgnoreClasspathCompat=" + ignoreClassPath)
         .withClasspath(ImmutableList.class, Flux.class)
@@ -104,7 +104,10 @@ final class ThirdPartyLibraryTest {
       return buildDescription(tree)
           .setMessage(
               Arrays.stream(ThirdPartyLibrary.values())
-                  .map(lib -> String.join(": ", lib.name(), String.valueOf(lib.canUse(state))))
+                  .map(
+                      lib ->
+                          String.join(
+                              ": ", lib.name(), String.valueOf(lib.isIntroductionAllowed(state))))
                   .collect(joining(", ")))
           .build();
     }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibraryTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibraryTest.java
@@ -1,0 +1,112 @@
+package tech.picnic.errorprone.bugpatterns.util;
+
+import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
+import static java.util.stream.Collectors.joining;
+
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
+import com.google.errorprone.matchers.Description;
+import com.sun.source.tree.ClassTree;
+import java.util.Arrays;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import reactor.core.publisher.Flux;
+
+final class ThirdPartyLibraryTest {
+  private final CompilationTestHelper compilationTestHelper =
+      CompilationTestHelper.newInstance(TestChecker.class, getClass());
+
+  @Test
+  void canUse() {
+    compilationTestHelper
+        .addSourceLines(
+            "A.java",
+            "// BUG: Diagnostic contains: ASSERTJ: true, GUAVA: true, NEW_RELIC_AGENT_API: true, REACTOR: true",
+            "class A {}")
+        .doTest();
+  }
+
+  @Test
+  void canUseWitnessClassesInSymtab() {
+    compilationTestHelper
+        .addSourceLines(
+            "A.java",
+            "import com.google.common.collect.ImmutableList;",
+            "import com.newrelic.api.agent.Agent;",
+            "import org.assertj.core.api.Assertions;",
+            "import reactor.core.publisher.Flux;",
+            "",
+            "// BUG: Diagnostic contains: ASSERTJ: true, GUAVA: true, NEW_RELIC_AGENT_API: true, REACTOR: true",
+            "class A {",
+            "  void m(Class<?> clazz) {",
+            "    m(Assertions.class);",
+            "    m(ImmutableList.class);",
+            "    m(Agent.class);",
+            "    m(Flux.class);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void canUseWitnessClassesPartiallyOnClassPath() {
+    compilationTestHelper
+        .withClasspath(ImmutableList.class, Flux.class)
+        .addSourceLines(
+            "A.java",
+            "// BUG: Diagnostic contains: ASSERTJ: false, GUAVA: true, NEW_RELIC_AGENT_API: false, REACTOR: true",
+            "class A {}")
+        .doTest();
+  }
+
+  @Test
+  void canUseWitnessClassesNotOnClassPath() {
+    compilationTestHelper
+        .withClasspath()
+        .addSourceLines(
+            "A.java",
+            "// BUG: Diagnostic contains: ASSERTJ: false, GUAVA: false, NEW_RELIC_AGENT_API: false, REACTOR:",
+            "// false",
+            "class A {}")
+        .doTest();
+  }
+
+  @ParameterizedTest
+  @ValueSource(booleans = {true, false})
+  void canUseIgnoreClasspathCompat(boolean ignoreClassPath) {
+    compilationTestHelper
+        .setArgs("-XepOpt:ErrorProneSupport:IgnoreClasspathCompat=" + ignoreClassPath)
+        .withClasspath(ImmutableList.class, Flux.class)
+        .addSourceLines(
+            "A.java",
+            String.format(
+                "// BUG: Diagnostic contains: ASSERTJ: %s, GUAVA: true, NEW_RELIC_AGENT_API: %s, REACTOR: true",
+                ignoreClassPath, ignoreClassPath),
+            "class A {}")
+        .doTest();
+  }
+
+  /**
+   * Flags classes with a diagnostics message that indicates, for each {@link ThirdPartyLibrary}
+   * element, whether they can be used.
+   */
+  @BugPattern(severity = ERROR, summary = "Interacts with `ThirdPartyLibrary` for testing purposes")
+  public static final class TestChecker extends BugChecker implements ClassTreeMatcher {
+    private static final long serialVersionUID = 1L;
+
+    @Override
+    public Description matchClass(ClassTree tree, VisitorState state) {
+      return buildDescription(tree)
+          .setMessage(
+              Arrays.stream(ThirdPartyLibrary.values())
+                  .map(lib -> String.join(": ", lib.name(), String.valueOf(lib.canUse(state))))
+                  .collect(joining(", ")))
+          .build();
+    }
+  }
+}


### PR DESCRIPTION
As-is, this is especially relevant for users who do not use Guava or the New Relic Agent API, as mentioned [here](https://www.reddit.com/r/java/comments/y2u8tv/comment/is50d1u/?utm_source=share&utm_medium=web2x&context=3). Note that most `BugChecker`s don't need to be modified, since any third-party references in their suggestions must already be present if the check is to trigger at all.

Suggested commit message:
```
By default, prevent `BugChecker`s from introducing new dependencies (#308)
```

We should implement something similar for Refaster, but that will look quite different (and is out of scope for this PR).