### PR TITLE
Don't update `project.build.outputTimestamp` on `mvn versions:set`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1223,6 +1223,9 @@
                     <groupId>org.codehaus.mojo</groupId>
                     <artifactId>versions-maven-plugin</artifactId>
                     <version>2.13.0</version>
+                    <configuration>
+                        <updateBuildOutputTimestampPolicy>never</updateBuildOutputTimestampPolicy>
+                    </configuration>
                 </plugin>
                 <plugin>
                     <groupId>org.gaul</groupId>


### PR DESCRIPTION
Noticed while testing #309. Suggested commit message:
```
Don't update `project.build.outputTimestamp` on `mvn versions:set` (#310)

As we rely on the value of `git.commit.time` instead.
```