### PR TITLE
Introduce `Optional{Filter,Map}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -355,6 +355,41 @@ final class OptionalRules {
     }
   }
 
+  /**
+   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when filtering that ultimately
+   * returns the same result.
+   */
+  static final class OptionalStreamFilter<T> {
+    @BeforeTemplate
+    Optional<T> before(Optional<T> optional, Predicate<? super T> predicate) {
+      return Refaster.anyOf(
+          optional.stream().filter(predicate).findAny(),
+          optional.stream().filter(predicate).findFirst());
+    }
+
+    @AfterTemplate
+    Optional<T> after(Optional<T> optional, Predicate<? super T> predicate) {
+      return optional.filter(predicate);
+    }
+  }
+
+  /**
+   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when mapping that ultimately
+   * returns the same result.
+   */
+  static final class OptionalStreamMap<S, T> {
+    @BeforeTemplate
+    Optional<? extends T> before(Optional<S> optional, Function<? super S, ? extends T> function) {
+      return Refaster.anyOf(
+          optional.stream().map(function).findAny(), optional.stream().map(function).findFirst());
+    }
+
+    @AfterTemplate
+    Optional<? extends T> after(Optional<S> optional, Function<? super S, ? extends T> function) {
+      return optional.map(function);
+    }
+  }
+
   // XXX: Add a rule for:
   // `optional.flatMap(x -> pred(x) ? Optional.empty() : Optional.of(x))` and variants.
   // (Maybe canonicalize the inner expression. Maybe we rewrite already.)

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -356,15 +356,15 @@ final class OptionalRules {
   }
 
   /**
-   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when filtering that ultimately
-   * returns the same result.
+   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when filtering a value of the
+   * former type.
    */
-  static final class OptionalStreamFilter<T> {
+  static final class OptionalFilter<T> {
     @BeforeTemplate
     Optional<T> before(Optional<T> optional, Predicate<? super T> predicate) {
       return Refaster.anyOf(
-          optional.stream().filter(predicate).findAny(),
-          optional.stream().filter(predicate).findFirst());
+          optional.stream().filter(predicate).findFirst(),
+          optional.stream().filter(predicate).findAny());
     }
 
     @AfterTemplate
@@ -374,14 +374,15 @@ final class OptionalRules {
   }
 
   /**
-   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when mapping that ultimately
-   * returns the same result.
+   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when mapping a value of the
+   * former type.
    */
-  static final class OptionalStreamMap<S, T> {
+  // XXX: If `StreamMapFirst` also simplifies `.findAny()` expressions, then this rule can be
+  // dropped in favour of `StreamMapFirst` and `OptionalIdentity`.
+  static final class OptionalMap<S, T> {
     @BeforeTemplate
     Optional<? extends T> before(Optional<S> optional, Function<? super S, ? extends T> function) {
-      return Refaster.anyOf(
-          optional.stream().map(function).findAny(), optional.stream().map(function).findFirst());
+      return optional.stream().map(function).findAny();
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -168,8 +168,9 @@ final class StreamRules {
    * Where possible, clarify that a mapping operation will be applied only to a single stream
    * element.
    */
-  // XXX: Consider whether to have a similar rule for `.findAny()`. For parallel streams it
-  // wouldn't be quite the same....
+  // XXX: Implement a similar rule for `.findAny()`. For parallel streams this wouldn't be quite the
+  // same, so such a rule requires a `Matcher` that heuristically identifies `Stream` expressions
+  // with deterministic order.
   // XXX: This change is not equivalent for `null`-returning functions, as the original code throws
   // an NPE if the first element is `null`, while the latter yields an empty `Optional`.
   static final class StreamMapFirst<T, S> {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
@@ -110,15 +110,13 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("qux").stream().max(String::compareTo));
   }
 
-  ImmutableSet<Optional<String>> testOptionalStreamFilter() {
+  ImmutableSet<Optional<String>> testOptionalFilter() {
     return ImmutableSet.of(
         Optional.of("foo").stream().filter(String::isEmpty).findFirst(),
         Optional.of("bar").stream().filter(String::isEmpty).findAny());
   }
 
-  ImmutableSet<Optional<String>> testOptionalStreamMap() {
-    return ImmutableSet.of(
-        Optional.of(1).stream().map(String::valueOf).findFirst(),
-        Optional.of(2).stream().map(String::valueOf).findAny());
+  Optional<String> testOptionalMap() {
+    return Optional.of(1).stream().map(String::valueOf).findAny();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
@@ -109,4 +109,16 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("baz").stream().min(String::compareTo),
         Optional.of("qux").stream().max(String::compareTo));
   }
+
+  ImmutableSet<Optional<String>> testOptionalStreamFilter() {
+    return ImmutableSet.of(
+        Optional.of("foo").stream().filter(String::isEmpty).findFirst(),
+        Optional.of("bar").stream().filter(String::isEmpty).findAny());
+  }
+
+  ImmutableSet<Optional<String>> testOptionalStreamMap() {
+    return ImmutableSet.of(
+        Optional.of(1).stream().map(String::valueOf).findFirst(),
+        Optional.of(2).stream().map(String::valueOf).findAny());
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
@@ -103,4 +103,14 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Optional.of("foo"), Optional.of("bar"), Optional.of("baz"), Optional.of("qux"));
   }
+
+  ImmutableSet<Optional<String>> testOptionalStreamFilter() {
+    return ImmutableSet.of(
+        Optional.of("foo").filter(String::isEmpty), Optional.of("bar").filter(String::isEmpty));
+  }
+
+  ImmutableSet<Optional<String>> testOptionalStreamMap() {
+    return ImmutableSet.of(
+        Optional.of(1).map(String::valueOf), Optional.of(2).map(String::valueOf));
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
@@ -104,13 +104,12 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("foo"), Optional.of("bar"), Optional.of("baz"), Optional.of("qux"));
   }
 
-  ImmutableSet<Optional<String>> testOptionalStreamFilter() {
+  ImmutableSet<Optional<String>> testOptionalFilter() {
     return ImmutableSet.of(
         Optional.of("foo").filter(String::isEmpty), Optional.of("bar").filter(String::isEmpty));
   }
 
-  ImmutableSet<Optional<String>> testOptionalStreamMap() {
-    return ImmutableSet.of(
-        Optional.of(1).map(String::valueOf), Optional.of(2).map(String::valueOf));
+  Optional<String> testOptionalMap() {
+    return Optional.of(1).map(String::valueOf);
   }
 }


### PR DESCRIPTION
After I had found this construct during code review.

A mixture of `Optional#map()` and `Optional#filter()` is however not supported with these rules. At this point it seems that Refaster won't be enough, I suspect?
```java
optional.stream().map(x -> x).filter(x -> true).find{Any,First}
```


Suggested commit message
```
Introduce `OptionalStream{Filter,Map}` Refaster rules (#327)
```