### PR TITLE
Configure documentation URL for `StringJoin` check

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
@@ -4,6 +4,7 @@ import static com.google.errorprone.BugPattern.LinkType.NONE;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.SIMPLIFICATION;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
+import static tech.picnic.errorprone.bugpatterns.util.Documentation.BUG_PATTERNS_BASE_URL;
 
 import com.google.auto.service.AutoService;
 import com.google.common.base.Splitter;
@@ -40,7 +41,7 @@ import tech.picnic.errorprone.bugpatterns.util.SourceCode;
 @AutoService(BugChecker.class)
 @BugPattern(
     summary = "Prefer `String#join` over `String#format`",
-    linkType = NONE,
+    link = BUG_PATTERNS_BASE_URL + "StringJoin",
     severity = SUGGESTION,
     tags = SIMPLIFICATION)
 public final class StringJoin extends BugChecker implements MethodInvocationTreeMatcher {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
@@ -1,5 +1,6 @@
 package tech.picnic.errorprone.bugpatterns;
 
+import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.SIMPLIFICATION;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;
@@ -41,6 +42,7 @@ import tech.picnic.errorprone.bugpatterns.util.SourceCode;
 @BugPattern(
     summary = "Prefer `String#join` over `String#format`",
     link = BUG_PATTERNS_BASE_URL + "StringJoin",
+    linkType = CUSTOM,
     severity = SUGGESTION,
     tags = SIMPLIFICATION)
 public final class StringJoin extends BugChecker implements MethodInvocationTreeMatcher {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StringJoin.java
@@ -1,6 +1,5 @@
 package tech.picnic.errorprone.bugpatterns;
 
-import static com.google.errorprone.BugPattern.LinkType.NONE;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.SIMPLIFICATION;
 import static com.google.errorprone.matchers.method.MethodMatchers.staticMethod;


### PR DESCRIPTION
Thanks a lot for providing error-prone-support! I'm using it inside SonarQube and the links to the doc are useful.

The link for the StringJoin bug checker should be https://error-prone.picnic.tech/bugpatterns/StringJoin/