### PR TITLE
Expand AssertJ enumerable templates with Map support

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
@@ -1,10 +1,12 @@
 package tech.picnic.errorprone.refasterrules;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.Iterables;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.util.Collection;
+import java.util.Map;
 import org.assertj.core.api.EnumerableAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
@@ -59,6 +61,18 @@ final class AssertJEnumerableRules {
     @AfterTemplate
     EnumerableAssert<?, S> after(EnumerableAssert<?, S> enumAssert, Iterable<T> iterable) {
       return enumAssert.hasSameSizeAs(iterable);
+    }
+  }
+
+  static final class EnumerableAssertMapHasSameSizeAs<S, T, U> {
+    @BeforeTemplate
+    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumAssert, Map<T, U> map) {
+      return enumAssert.hasSize(map.size());
+    }
+
+    @AfterTemplate
+    EnumerableAssert<?, S> after(EnumerableAssert<?, S> enumAssert, Map<T, U> map) {
+      return enumAssert.hasSameSizeAs(map.entrySet());
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
@@ -2,6 +2,7 @@ package tech.picnic.errorprone.refasterrules;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.assertj.core.api.EnumerableAssert;
@@ -29,5 +30,9 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
         assertThat(ImmutableSet.of(1)).hasSize(Iterables.size(ImmutableSet.of(2))),
         assertThat(ImmutableSet.of(3)).hasSize(ImmutableSet.of(4).size()),
         assertThat(ImmutableSet.of(5)).hasSize(new Integer[0].length));
+  }
+
+  ImmutableSet<EnumerableAssert<?, Integer>> testEnumerableAssertMapHasSameSizeAs() {
+    return ImmutableSet.of(assertThat(ImmutableSet.of(1)).hasSize(ImmutableMap.of(2, 3).size()));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
@@ -2,6 +2,7 @@ package tech.picnic.errorprone.refasterrules;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import org.assertj.core.api.EnumerableAssert;
@@ -28,5 +29,10 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
         assertThat(ImmutableSet.of(1)).hasSameSizeAs(ImmutableSet.of(2)),
         assertThat(ImmutableSet.of(3)).hasSameSizeAs(ImmutableSet.of(4)),
         assertThat(ImmutableSet.of(5)).hasSameSizeAs(new Integer[0]));
+  }
+
+  ImmutableSet<EnumerableAssert<?, Integer>> testEnumerableAssertMapHasSameSizeAs() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).hasSameSizeAs(ImmutableMap.of(2, 3).entrySet()));
   }
 }


### PR DESCRIPTION
Opening as draft as this is not clearly an improvement.
The question is then, should we go this way or actually push to go the opposite direction and actually rewrite `hasSameSize(Map.entrySet())` to `hasSize(Map.size())`? 
I'm tempted to say the latter personally, will open a thread below to ease discussions 👌 