### PR TITLE
Fixed the link for ErrorProneTestHelperSourceFormat

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ErrorProneTestHelperSourceFormat.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ErrorProneTestHelperSourceFormat.java
@@ -51,7 +51,7 @@ import java.util.Optional;
 @AutoService(BugChecker.class)
 @BugPattern(
     summary = "Test code should follow the Google Java style",
-    link = BUG_PATTERNS_BASE_URL + "ErrorProneTestHelperSourceFormat",
+    link = BUG_PATTERNS_BASE_URL + "ErrorProneHelperSourceFormat",
     linkType = CUSTOM,
     severity = SUGGESTION,
     tags = STYLE)


### PR DESCRIPTION
The link for the ErrorProneTestHelperSourceFormat is broken: https://error-prone.picnic.tech/bugpatterns/ErrorProneTestHelperSourceFormat

It should be: https://error-prone.picnic.tech/bugpatterns/ErrorProneHelperSourceFormat/