### PR TITLE
Introduce `MapIsEmpty` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -110,7 +110,7 @@ final class MapRules {
   static final class MapIsEmpty<K, V> {
     @BeforeTemplate
     boolean before(Map<K, V> map) {
-      return map.keySet().isEmpty();
+      return Refaster.anyOf(map.keySet(), map.values(), map.entrySet()).isEmpty();
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -41,6 +41,19 @@ final class MapRules {
     }
   }
 
+  /** Prefer {@link Map#isEmpty()} over more contrived alternatives. */
+  static final class MapIsEmpty<K, V> {
+    @BeforeTemplate
+    boolean before(Map<K, V> map) {
+      return Refaster.anyOf(map.keySet(), map.values(), map.entrySet()).isEmpty();
+    }
+
+    @AfterTemplate
+    boolean after(Map<K, V> map) {
+      return map.isEmpty();
+    }
+  }
+
   /** Prefer {@link Map#size()} over more contrived alternatives. */
   static final class MapSize<K, V> {
     @BeforeTemplate
@@ -103,19 +116,6 @@ final class MapRules {
     @AfterTemplate
     Stream<V> after(Map<K, V> map) {
       return map.values().stream();
-    }
-  }
-
-  /** Prefer {@link Map#isEmpty()} over more contrived alternatives. */
-  static final class MapIsEmpty<K, V> {
-    @BeforeTemplate
-    boolean before(Map<K, V> map) {
-      return Refaster.anyOf(map.keySet(), map.values(), map.entrySet()).isEmpty();
-    }
-
-    @AfterTemplate
-    boolean after(Map<K, V> map) {
-      return map.isEmpty();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -105,4 +105,17 @@ final class MapRules {
       return map.values().stream();
     }
   }
+
+  /** Prefer {@link Map#isEmpty()} over more contrived alternatives. */
+  static final class MapIsEmpty<K, V> {
+    @BeforeTemplate
+    boolean before(Map<K, V> map) {
+      return map.keySet().isEmpty();
+    }
+
+    @AfterTemplate
+    boolean after(Map<K, V> map) {
+      return map.isEmpty();
+    }
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
@@ -48,4 +48,11 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
   Stream<boolean> testMapIsEmpty() {
     return ImmutableMap.of("foo", 1).entrySet().isEmpty();
   }
+
+  ImmutableSet<Boolean> testMapIsEmpty() {
+    return ImmutableSet.of(
+        ImmutableMap.of("foo", 1).keySet().isEmpty(),
+        ImmutableMap.of("bar", 2).values().isEmpty(),
+        ImmutableMap.of("baz", 3).entrySet().isEmpty());
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
@@ -22,6 +22,13 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.of(1, "foo").getOrDefault("bar", null);
   }
 
+  ImmutableSet<Boolean> testMapIsEmpty() {
+    return ImmutableSet.of(
+        ImmutableMap.of("foo", 1).keySet().isEmpty(),
+        ImmutableMap.of("bar", 2).values().isEmpty(),
+        ImmutableMap.of("baz", 3).entrySet().isEmpty());
+  }
+
   ImmutableSet<Integer> testMapSize() {
     return ImmutableSet.of(
         ImmutableMap.of("foo", 1).keySet().size(),
@@ -43,12 +50,5 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
 
   Stream<Integer> testMapValueStream() {
     return ImmutableMap.of("foo", 1).entrySet().stream().map(Map.Entry::getValue);
-  }
-
-  ImmutableSet<Boolean> testMapIsEmpty() {
-    return ImmutableSet.of(
-        ImmutableMap.of("foo", 1).keySet().isEmpty(),
-        ImmutableMap.of("bar", 2).values().isEmpty(),
-        ImmutableMap.of("baz", 3).entrySet().isEmpty());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
@@ -45,10 +45,6 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.of("foo", 1).entrySet().stream().map(Map.Entry::getValue);
   }
 
-  Stream<boolean> testMapIsEmpty() {
-    return ImmutableMap.of("foo", 1).entrySet().isEmpty();
-  }
-
   ImmutableSet<Boolean> testMapIsEmpty() {
     return ImmutableSet.of(
         ImmutableMap.of("foo", 1).keySet().isEmpty(),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
@@ -44,4 +44,8 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
   Stream<Integer> testMapValueStream() {
     return ImmutableMap.of("foo", 1).entrySet().stream().map(Map.Entry::getValue);
   }
+
+  Stream<boolean> testMapIsEmpty() {
+    return ImmutableMap.of("foo", 1).entrySet().isEmpty();
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
@@ -23,6 +23,13 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.of(1, "foo").get("bar");
   }
 
+  ImmutableSet<Boolean> testMapIsEmpty() {
+    return ImmutableSet.of(
+        ImmutableMap.of("foo", 1).isEmpty(),
+        ImmutableMap.of("bar", 2).isEmpty(),
+        ImmutableMap.of("baz", 3).isEmpty());
+  }
+
   ImmutableSet<Integer> testMapSize() {
     return ImmutableSet.of(
         ImmutableMap.of("foo", 1).size(),
@@ -44,12 +51,5 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
 
   Stream<Integer> testMapValueStream() {
     return ImmutableMap.of("foo", 1).values().stream();
-  }
-
-  ImmutableSet<Boolean> testMapIsEmpty() {
-    return ImmutableSet.of(
-        ImmutableMap.of("foo", 1).isEmpty(),
-        ImmutableMap.of("bar", 2).isEmpty(),
-        ImmutableMap.of("baz", 3).isEmpty());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
@@ -46,7 +46,10 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.of("foo", 1).values().stream();
   }
 
-  Stream<boolean> testMapIsEmpty() {
-    return ImmutableMap.of("foo", 1).isEmpty();
+  ImmutableSet<Boolean> testMapIsEmpty() {
+    return ImmutableSet.of(
+        ImmutableMap.of("foo", 1).isEmpty(),
+        ImmutableMap.of("bar", 2).isEmpty(),
+        ImmutableMap.of("baz", 3).isEmpty());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
@@ -45,4 +45,8 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
   Stream<Integer> testMapValueStream() {
     return ImmutableMap.of("foo", 1).values().stream();
   }
+
+  Stream<boolean> testMapIsEmpty() {
+    return ImmutableMap.of("foo", 1).isEmpty();
+  }
 }


### PR DESCRIPTION
Adds an additional refaster Map rule that builts on https://github.com/PicnicSupermarket/error-prone-support/pull/337

Suggested commit message:
```
Introduce `map.keySet().isEmpty()` to `map.isEmpty()` refaster rule
```