### PR TITLE
Extend `MonoFlux` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -559,7 +559,7 @@ final class ReactorRules {
   static final class MonoFlux<T> {
     @BeforeTemplate
     Flux<T> before(Mono<T> mono) {
-      return Flux.concat(mono);
+      return Refaster.anyOf(Flux.concat(mono), mono.flatMapMany(Flux::just));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -559,7 +559,8 @@ final class ReactorRules {
   static final class MonoFlux<T> {
     @BeforeTemplate
     Flux<T> before(Mono<T> mono) {
-      return Refaster.anyOf(mono.flatMapMany(Flux::just), Flux.concat(mono));
+      return Refaster.anyOf(
+          mono.flatMapMany(Mono::just), mono.flatMapMany(Flux::just), Flux.concat(mono));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -559,7 +559,7 @@ final class ReactorRules {
   static final class MonoFlux<T> {
     @BeforeTemplate
     Flux<T> before(Mono<T> mono) {
-      return Refaster.anyOf(Flux.concat(mono), mono.flatMapMany(Flux::just));
+      return Refaster.anyOf(mono.flatMapMany(Flux::just), Flux.concat(mono));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -179,7 +179,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Flux<String>> testMonoFlux() {
-    return ImmutableSet.of(Mono.just("foo").flatMapMany(Flux::just), Flux.concat(Mono.just("bar")));
+    return ImmutableSet.of(
+        Mono.just("foo").flatMapMany(Mono::just),
+        Mono.just("bar").flatMapMany(Flux::just),
+        Flux.concat(Mono.just("baz")));
   }
 
   ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -178,8 +178,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).switchMap(n -> Mono.fromSupplier(() -> n * 2)));
   }
 
-  Flux<String> testMonoFlux() {
-    return Flux.concat(Mono.just("foo"));
+  ImmutableSet<Flux<String>> testMonoFlux() {
+    return ImmutableSet.of(Flux.concat(Mono.just("foo")), Mono.just("bar").flatMapMany(Flux::just));
   }
 
   ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -179,7 +179,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Flux<String>> testMonoFlux() {
-    return ImmutableSet.of(Flux.concat(Mono.just("foo")), Mono.just("bar").flatMapMany(Flux::just));
+    return ImmutableSet.of(Mono.just("foo").flatMapMany(Flux::just), Flux.concat(Mono.just("bar")));
   }
 
   ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -180,8 +180,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).mapNotNull(n -> n * 2));
   }
 
-  Flux<String> testMonoFlux() {
-    return Mono.just("foo").flux();
+  ImmutableSet<Flux<String>> testMonoFlux() {
+    return ImmutableSet.of(Mono.just("foo").flux(), Mono.just("bar").flux());
   }
 
   ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -181,7 +181,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Flux<String>> testMonoFlux() {
-    return ImmutableSet.of(Mono.just("foo").flux(), Mono.just("bar").flux());
+    return ImmutableSet.of(
+        Mono.just("foo").flux(), Mono.just("bar").flux(), Mono.just("baz").flux());
   }
 
   ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {


### PR DESCRIPTION
As I had noticed during code review. :+1: 

Suggested commit message
```
Extend `MonoFlux` Refaster rule (#358)
```