### PR TITLE
Introduce `{Mono,Flux}DefaultIfEmpty` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -265,7 +265,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Mono#defaultIfEmpty(Object)} over more contrived alternatives. */
-  static final class MonoSwitchIfEmptyOfMonoJust<T> {
+  static final class MonoDefaultIfEmpty<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono, T object) {
       return mono.switchIfEmpty(Mono.just(object));
@@ -278,7 +278,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Flux#defaultIfEmpty(Object)} over more contrived alternatives. */
-  static final class FluxSwitchIfEmptyOfMonoOrFluxJust<T> {
+  static final class FluxDefaultIfEmpty<T> {
     @BeforeTemplate
     Flux<T> before(Flux<T> flux, T object) {
       return flux.switchIfEmpty(Refaster.anyOf(Mono.just(object), Flux.just(object)));

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -277,6 +277,19 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link Flux#defaultIfEmpty(Object)} over more contrived alternatives. */
+  static final class FluxSwitchIfEmptyOfMonoOrFluxJust<T> {
+    @BeforeTemplate
+    Flux<T> before(Flux<T> flux, T object) {
+      return flux.switchIfEmpty(Refaster.anyOf(Mono.just(object), Flux.just(object)));
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flux<T> flux, T object) {
+      return flux.defaultIfEmpty(object);
+    }
+  }
+
   /** Don't unnecessarily pass an empty publisher to {@link Mono#switchIfEmpty(Mono)}. */
   static final class MonoSwitchIfEmptyOfEmptyPublisher<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -603,9 +603,7 @@ final class ReactorRules {
   static final class MonoCollectToOptional<T> {
     @BeforeTemplate
     Mono<Optional<T>> before(Mono<T> mono) {
-      return Refaster.anyOf(
-          mono.map(Optional::of).defaultIfEmpty(Optional.empty()),
-          mono.map(Optional::of).switchIfEmpty(Mono.just(Optional.empty())));
+      return mono.map(Optional::of).defaultIfEmpty(Optional.empty());
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -264,6 +264,19 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link Mono#defaultIfEmpty(Object)} over more contrived alternatives. */
+  static final class MonoSwitchIfEmptyOfMonoJust<T> {
+    @BeforeTemplate
+    Mono<T> before(Mono<T> mono, T object) {
+      return mono.switchIfEmpty(Mono.just(object));
+    }
+
+    @AfterTemplate
+    Mono<T> after(Mono<T> mono, T object) {
+      return mono.defaultIfEmpty(object);
+    }
+  }
+
   /** Don't unnecessarily pass an empty publisher to {@link Mono#switchIfEmpty(Mono)}. */
   static final class MonoSwitchIfEmptyOfEmptyPublisher<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -195,10 +195,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.concat(Mono.just("baz")));
   }
 
-  ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {
-    return ImmutableSet.of(
-        Mono.just("foo").map(Optional::of).defaultIfEmpty(Optional.empty()),
-        Mono.just("bar").map(Optional::of).switchIfEmpty(Mono.just(Optional.empty())));
+  Mono<Optional<String>> testMonoCollectToOptional() {
+    return Mono.just("foo").map(Optional::of).defaultIfEmpty(Optional.empty());
   }
 
   Mono<Number> testMonoCast() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -83,6 +83,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 2, 3).take(1);
   }
 
+  Mono<String> testMonoSwitchIfEmptyOfMonoJust() {
+    return Mono.just("foo").switchIfEmpty(Mono.just("bar"));
+  }
+
   Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {
     return Mono.just(1).switchIfEmpty(Mono.empty());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -87,6 +87,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").switchIfEmpty(Mono.just("bar"));
   }
 
+  ImmutableSet<Flux<String>> testFluxSwitchIfEmptyOfMonoOrFluxJust() {
+    return ImmutableSet.of(
+        Flux.just("foo").switchIfEmpty(Mono.just("bar")),
+        Flux.just("bar").switchIfEmpty(Flux.just("baz")));
+  }
+
   Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {
     return Mono.just(1).switchIfEmpty(Mono.empty());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -83,14 +83,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 2, 3).take(1);
   }
 
-  Mono<String> testMonoSwitchIfEmptyOfMonoJust() {
+  Mono<String> testMonoDefaultIfEmpty() {
     return Mono.just("foo").switchIfEmpty(Mono.just("bar"));
   }
 
-  ImmutableSet<Flux<String>> testFluxSwitchIfEmptyOfMonoOrFluxJust() {
+  ImmutableSet<Flux<String>> testFluxDefaultIfEmpty() {
     return ImmutableSet.of(
         Flux.just("foo").switchIfEmpty(Mono.just("bar")),
-        Flux.just("bar").switchIfEmpty(Flux.just("baz")));
+        Flux.just("baz").switchIfEmpty(Flux.just("qux")));
   }
 
   Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -96,8 +96,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Flux<String>> testFluxSwitchIfEmptyOfMonoOrFluxJust() {
     return ImmutableSet.of(
-        Flux.just("foo").defaultIfEmpty("bar"),
-        Flux.just("bar").defaultIfEmpty("baz"));
+        Flux.just("foo").defaultIfEmpty("bar"), Flux.just("bar").defaultIfEmpty("baz"));
   }
 
   Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -90,13 +90,13 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 2, 3).take(1, true);
   }
 
-  Mono<String> testMonoSwitchIfEmptyOfMonoJust() {
+  Mono<String> testMonoDefaultIfEmpty() {
     return Mono.just("foo").defaultIfEmpty("bar");
   }
 
-  ImmutableSet<Flux<String>> testFluxSwitchIfEmptyOfMonoOrFluxJust() {
+  ImmutableSet<Flux<String>> testFluxDefaultIfEmpty() {
     return ImmutableSet.of(
-        Flux.just("foo").defaultIfEmpty("bar"), Flux.just("bar").defaultIfEmpty("baz"));
+        Flux.just("foo").defaultIfEmpty("bar"), Flux.just("baz").defaultIfEmpty("qux"));
   }
 
   Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -194,10 +194,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").flux(), Mono.just("bar").flux(), Mono.just("baz").flux());
   }
 
-  ImmutableSet<Mono<Optional<String>>> testMonoCollectToOptional() {
-    return ImmutableSet.of(
-        Mono.just("foo").flux().collect(toOptional()),
-        Mono.just("bar").flux().collect(toOptional()));
+  Mono<Optional<String>> testMonoCollectToOptional() {
+    return Mono.just("foo").flux().collect(toOptional());
   }
 
   Mono<Number> testMonoCast() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -94,6 +94,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").defaultIfEmpty("bar");
   }
 
+  ImmutableSet<Flux<String>> testFluxSwitchIfEmptyOfMonoOrFluxJust() {
+    return ImmutableSet.of(
+        Flux.just("foo").defaultIfEmpty("bar"),
+        Flux.just("bar").defaultIfEmpty("baz"));
+  }
+
   Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {
     return Mono.just(1);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -90,6 +90,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 2, 3).take(1, true);
   }
 
+  Mono<String> testMonoSwitchIfEmptyOfMonoJust() {
+    return Mono.just("foo").defaultIfEmpty("bar");
+  }
+
   Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {
     return Mono.just(1);
   }


### PR DESCRIPTION
Saw "good first issue" and could not help myself 😄 

Issue: https://github.com/PicnicSupermarket/error-prone-support/issues/363

Would like some suggestions on the rule names, not too happy with `FluxSwitchIfEmptyOfMonoOrFluxJust` especially.