### PR TITLE
Introduce some Refaster rules that avoid nested `Publisher`s

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -639,6 +639,58 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link Mono#flatMap(Function)} over more contrived alternatives. */
+  static final class MonoFlatMapIdentity<S, T> {
+    @BeforeTemplate
+    Mono<T> before(Mono<S> mono, Function<S, Mono<T>> function) {
+      return mono.map(function).flatMap(identity());
+    }
+
+    @AfterTemplate
+    Mono<T> after(Mono<S> mono, Function<S, Mono<T>> function) {
+      return mono.flatMap(function);
+    }
+  }
+
+  /** Prefer {@link Mono#flatMapMany(Function)} over more contrived alternatives. */
+  static final class FlatMapManyIdentity<S, T> {
+    @BeforeTemplate
+    Flux<T> before(Mono<S> mono, Function<S, ? extends Publisher<T>> function) {
+      return mono.map(function).flatMapMany(identity());
+    }
+
+    @AfterTemplate
+    Flux<T> after(Mono<S> mono, Function<S, ? extends Publisher<T>> function) {
+      return mono.flatMapMany(function);
+    }
+  }
+
+  /** Prefer {@link Flux#concatMap(Function)} over more contrived alternatives. */
+  static final class ConcatMapIdentity<S, T> {
+    @BeforeTemplate
+    Flux<T> before(Flux<S> flux, Function<S, ? extends Publisher<T>> function) {
+      return flux.map(function).concatMap(identity());
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flux<S> flux, Function<S, ? extends Publisher<T>> function) {
+      return flux.concatMap(function);
+    }
+  }
+
+  /** Prefer {@link Flux#concatMap(Function, int)} over more contrived alternatives. */
+  static final class ConcatMapIdentityWithPrefetch<S, T> {
+    @BeforeTemplate
+    Flux<T> before(Flux<S> flux, Function<S, ? extends Publisher<T>> function, int prefetch) {
+      return flux.map(function).concatMap(identity(), prefetch);
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flux<S> flux, Function<S, ? extends Publisher<T>> function, int prefetch) {
+      return flux.concatMap(function, prefetch);
+    }
+  }
+
   /**
    * Prefer {@link Flux#concatMapIterable(Function)} over alternatives that require an additional
    * subscription.

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -105,12 +105,16 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Flux<Integer>> testFluxConcatMap() {
     return ImmutableSet.of(
-        Flux.just(1).flatMap(Mono::just, 1), Flux.just(2).flatMapSequential(Mono::just, 1));
+        Flux.just(1).flatMap(Mono::just, 1),
+        Flux.just(2).flatMapSequential(Mono::just, 1),
+        Flux.just(3).map(Mono::just).concatMap(identity()));
   }
 
   ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {
     return ImmutableSet.of(
-        Flux.just(1).flatMap(Mono::just, 1, 3), Flux.just(2).flatMapSequential(Mono::just, 1, 4));
+        Flux.just(1).flatMap(Mono::just, 1, 3),
+        Flux.just(2).flatMapSequential(Mono::just, 1, 4),
+        Flux.just(3).map(Mono::just).concatMap(identity(), 5));
   }
 
   Flux<Integer> testFluxConcatMapIterable() {
@@ -208,26 +212,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
-  Mono<String> testMonoFlatMapIdentity() {
+  Mono<String> testMonoFlatMap() {
     return Mono.just("foo").map(Mono::just).flatMap(identity());
   }
 
-  ImmutableSet<Flux<String>> testFlatMapManyIdentity() {
-    return ImmutableSet.of(
-        Mono.just("foo").map(Mono::just).flatMapMany(identity()),
-        Mono.just("foo").map(Flux::just).flatMapMany(identity()));
-  }
-
-  ImmutableSet<Flux<String>> testConcatMapIdentity() {
-    return ImmutableSet.of(
-        Flux.just("foo", "bar").map(Mono::just).concatMap(identity()),
-        Flux.just("foo", "bar").map(Flux::just).concatMap(identity()));
-  }
-
-  ImmutableSet<Flux<String>> testConcatMapIdentityWithPrefetch() {
-    return ImmutableSet.of(
-        Flux.just("foo", "bar").map(Mono::just).concatMap(identity(), 1),
-        Flux.just("foo", "bar").map(Flux::just).concatMap(identity(), 1));
+  Flux<String> testMonoFlatMapMany() {
+    return Mono.just("foo").map(Mono::just).flatMapMany(identity());
   }
 
   ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -1,5 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static java.util.function.Function.identity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.common.collect.ImmutableList;
@@ -205,6 +206,28 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Flux<Number> testFluxCast() {
     return Flux.just(1).map(Number.class::cast);
+  }
+
+  Mono<String> testMonoFlatMapIdentity() {
+    return Mono.just("foo").map(Mono::just).flatMap(identity());
+  }
+
+  ImmutableSet<Flux<String>> testFlatMapManyIdentity() {
+    return ImmutableSet.of(
+        Mono.just("foo").map(Mono::just).flatMapMany(identity()),
+        Mono.just("foo").map(Flux::just).flatMapMany(identity()));
+  }
+
+  ImmutableSet<Flux<String>> testConcatMapIdentity() {
+    return ImmutableSet.of(
+        Flux.just("foo", "bar").map(Mono::just).concatMap(identity()),
+        Flux.just("foo", "bar").map(Flux::just).concatMap(identity()));
+  }
+
+  ImmutableSet<Flux<String>> testConcatMapIdentityWithPrefetch() {
+    return ImmutableSet.of(
+        Flux.just("foo", "bar").map(Mono::just).concatMap(identity(), 1),
+        Flux.just("foo", "bar").map(Flux::just).concatMap(identity(), 1));
   }
 
   ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -108,12 +108,17 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Flux<Integer>> testFluxConcatMap() {
-    return ImmutableSet.of(Flux.just(1).concatMap(Mono::just), Flux.just(2).concatMap(Mono::just));
+    return ImmutableSet.of(
+        Flux.just(1).concatMap(Mono::just),
+        Flux.just(2).concatMap(Mono::just),
+        Flux.just(3).concatMap(Mono::just));
   }
 
   ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {
     return ImmutableSet.of(
-        Flux.just(1).concatMap(Mono::just, 3), Flux.just(2).concatMap(Mono::just, 4));
+        Flux.just(1).concatMap(Mono::just, 3),
+        Flux.just(2).concatMap(Mono::just, 4),
+        Flux.just(3).concatMap(Mono::just, 5));
   }
 
   Flux<Integer> testFluxConcatMapIterable() {
@@ -206,25 +211,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
-  Mono<String> testMonoFlatMapIdentity() {
+  Mono<String> testMonoFlatMap() {
     return Mono.just("foo").flatMap(Mono::just);
   }
 
-  ImmutableSet<Flux<String>> testFlatMapManyIdentity() {
-    return ImmutableSet.of(
-        Mono.just("foo").flatMapMany(Mono::just), Mono.just("foo").flatMapMany(Flux::just));
-  }
-
-  ImmutableSet<Flux<String>> testConcatMapIdentity() {
-    return ImmutableSet.of(
-        Flux.just("foo", "bar").concatMap(Mono::just),
-        Flux.just("foo", "bar").concatMap(Flux::just));
-  }
-
-  ImmutableSet<Flux<String>> testConcatMapIdentityWithPrefetch() {
-    return ImmutableSet.of(
-        Flux.just("foo", "bar").concatMap(Mono::just, 1),
-        Flux.just("foo", "bar").concatMap(Flux::just, 1));
+  Flux<String> testMonoFlatMapMany() {
+    return Mono.just("foo").flatMapMany(Mono::just);
   }
 
   ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -206,6 +206,27 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
+  Mono<String> testMonoFlatMapIdentity() {
+    return Mono.just("foo").flatMap(Mono::just);
+  }
+
+  ImmutableSet<Flux<String>> testFlatMapManyIdentity() {
+    return ImmutableSet.of(
+        Mono.just("foo").flatMapMany(Mono::just), Mono.just("foo").flatMapMany(Flux::just));
+  }
+
+  ImmutableSet<Flux<String>> testConcatMapIdentity() {
+    return ImmutableSet.of(
+        Flux.just("foo", "bar").concatMap(Mono::just),
+        Flux.just("foo", "bar").concatMap(Flux::just));
+  }
+
+  ImmutableSet<Flux<String>> testConcatMapIdentityWithPrefetch() {
+    return ImmutableSet.of(
+        Flux.just("foo", "bar").concatMap(Mono::just, 1),
+        Flux.just("foo", "bar").concatMap(Flux::just, 1));
+  }
+
   ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {
     return ImmutableSet.of(
         Flux.just(ImmutableList.of("foo")).concatMapIterable(identity()),


### PR DESCRIPTION
### Context

These proposed Refaster rules primarily aim to make Reactor code more readable as nested `Publisher`s are avoided (e.g. `Mono<Mono<String>>`).

They may result in a minor performance improvement due to the dropped `map()` calls.


### Summary

I've noticed an occurrence of the following code pattern:
```java
Mono<String> method1() {
  Mono.just("foo")
    .map(str -> method2(str))
    .flatMap(identity());
}

Mono<String> method2(String str) {
  ...
} 
```
which these changes rewrite to:
```java
Mono<String> method1() {
  Mono.just("foo")
    .flatMap(str -> method2(str));
}
```
Conceptionally, the same applies for:
- `Mono#flatMap(Function)`
- `Mono#flatMapMap(Function)`
- `Flux#concatMap(Function)`
- `Flux#concatMap(Function, int)`

and in theory also for some others (e.g. `Flux#flatMap()`), but these are already re-written by other rules IIUC.

### Suggested commit message
```
Introduce some Refaster rules that avoid nested `Publisher`s (#374)
```