### PR TITLE
Introduce `MonoFromOptionalSwitchIfEmpty` and `OptionalMapMonoJust` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -119,20 +119,34 @@ final class ReactorRules {
   }
 
   /**
+   * Try to avoid expressions of type {@code Optional<Mono<T>>}, but if you must map an {@link
+   * Optional} to this type, prefer using {@link Mono#just(Object)}.
+   */
+  static final class OptionalMapMonoJust<T> {
+    @BeforeTemplate
+    Optional<Mono<T>> before(Optional<T> optional) {
+      return optional.map(Mono::justOrEmpty);
+    }
+
+    @AfterTemplate
+    Optional<Mono<T>> after(Optional<T> optional) {
+      return optional.map(Mono::just);
+    }
+  }
+
+  /**
    * Prefer a {@link Mono#justOrEmpty(Optional)} and {@link Mono#switchIfEmpty(Mono)} chain over
    * more contrived alternatives.
    */
   static final class MonoFromOptionalSwitchIfEmpty<T> {
     @BeforeTemplate
-    Mono<T> before(Optional<T> optional, Mono<T> alternative) {
-      return optional
-          .map(Refaster.<Function<T, Mono<T>>>anyOf(Mono::just, Mono::justOrEmpty))
-          .orElse(alternative);
+    Mono<T> before(Optional<T> optional, Mono<T> mono) {
+      return optional.map(Mono::just).orElse(mono);
     }
 
     @AfterTemplate
-    Mono<T> after(Optional<T> optional, Mono<T> alternative) {
-      return Mono.justOrEmpty(optional).switchIfEmpty(alternative);
+    Mono<T> after(Optional<T> optional, Mono<T> mono) {
+      return Mono.justOrEmpty(optional).switchIfEmpty(mono);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -119,6 +119,24 @@ final class ReactorRules {
   }
 
   /**
+   * Prefer a {@link Mono#justOrEmpty(Optional)} and {@link Mono#switchIfEmpty(Mono)} chain over
+   * more contrived alternatives.
+   */
+  static final class MonoFromOptionalSwitchIfEmpty<T> {
+    @BeforeTemplate
+    Mono<T> before(Optional<T> optional, Mono<T> alternative) {
+      return optional
+          .map(Refaster.<Function<T, Mono<T>>>anyOf(Mono::just, Mono::justOrEmpty))
+          .orElse(alternative);
+    }
+
+    @AfterTemplate
+    Mono<T> after(Optional<T> optional, Mono<T> alternative) {
+      return Mono.justOrEmpty(optional).switchIfEmpty(alternative);
+    }
+  }
+
+  /**
    * Prefer {@link Mono#zip(Mono, Mono)} over a chained {@link Mono#zipWith(Mono)}, as the former
    * better conveys that the {@link Mono}s may be subscribed to concurrently, and generalizes to
    * combining three or more reactive streams.

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -137,6 +137,8 @@ final class ReactorRules {
   /**
    * Prefer a {@link Mono#justOrEmpty(Optional)} and {@link Mono#switchIfEmpty(Mono)} chain over
    * more contrived alternatives.
+   *
+   * <p>In particular, avoid mixing of the {@link Optional} and {@link Mono} APIs.
    */
   static final class MonoFromOptionalSwitchIfEmpty<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -52,6 +52,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.fromSupplier(() -> Optional.of(2).orElse(null)));
   }
 
+  ImmutableSet<Mono<Integer>> testMonoFromOptionalSwitchIfEmpty() {
+    return ImmutableSet.of(
+        Optional.of(1).map(Mono::just).orElse(Mono.just(2)),
+        Optional.of(3).map(Mono::justOrEmpty).orElse(Mono.just(4)));
+  }
+
   Mono<Tuple2<String, Integer>> testMonoZip() {
     return Mono.just("foo").zipWith(Mono.just(1));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -52,10 +52,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.fromSupplier(() -> Optional.of(2).orElse(null)));
   }
 
-  ImmutableSet<Mono<Integer>> testMonoFromOptionalSwitchIfEmpty() {
-    return ImmutableSet.of(
-        Optional.of(1).map(Mono::just).orElse(Mono.just(2)),
-        Optional.of(3).map(Mono::justOrEmpty).orElse(Mono.just(4)));
+  Optional<Mono<String>> testOptionalMapMonoJust() {
+    return Optional.of("foo").map(Mono::justOrEmpty);
+  }
+
+  Mono<Integer> testMonoFromOptionalSwitchIfEmpty() {
+    return Optional.of(1).map(Mono::just).orElse(Mono.just(2));
   }
 
   Mono<Tuple2<String, Integer>> testMonoZip() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -55,10 +55,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(2))));
   }
 
-  ImmutableSet<Mono<Integer>> testMonoFromOptionalSwitchIfEmpty() {
-    return ImmutableSet.of(
-        Mono.justOrEmpty(Optional.of(1)).switchIfEmpty(Mono.just(2)),
-        Mono.justOrEmpty(Optional.of(3)).switchIfEmpty(Mono.just(4)));
+  Optional<Mono<String>> testOptionalMapMonoJust() {
+    return Optional.of("foo").map(Mono::just);
+  }
+
+  Mono<Integer> testMonoFromOptionalSwitchIfEmpty() {
+    return Mono.justOrEmpty(Optional.of(1)).switchIfEmpty(Mono.just(2));
   }
 
   Mono<Tuple2<String, Integer>> testMonoZip() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -55,6 +55,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(2))));
   }
 
+  ImmutableSet<Mono<Integer>> testMonoFromOptionalSwitchIfEmpty() {
+    return ImmutableSet.of(
+        Mono.justOrEmpty(Optional.of(1)).switchIfEmpty(Mono.just(2)),
+        Mono.justOrEmpty(Optional.of(3)).switchIfEmpty(Mono.just(4)));
+  }
+
   Mono<Tuple2<String, Integer>> testMonoZip() {
     return Mono.zip(Mono.just("foo"), Mono.just(1));
   }


### PR DESCRIPTION
I've spotted the following interesting pattern:
```java
Optional.of(someNullableValue())
  .map(Mono::just)
  .orElse(someMono());
```
The mix between `Optional` and `Mono` API is unnecessary.

These rules aim to rewrite these to:
```java
Mono.justOrEmpty(someNullableValue())
  .switchIfEmpty(someMono());
```


---
Suggested commit message:
```
Introduce `MonoFromOptionalSwitchIfEmpty` Refaster rule (#384)
```