### PR TITLE
Introduce `Mono{Empty,Just,JustOrEmpty}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -64,7 +64,7 @@ final class ReactorRules {
   static final class MonoEmpty<T> {
     @BeforeTemplate
     Mono<T> before() {
-      return Refaster.anyOf(Mono.just(null), Mono.justOrEmpty(null));
+      return Refaster.anyOf(Mono.justOrEmpty(null), Mono.justOrEmpty(Optional.empty()));
     }
 
     @AfterTemplate
@@ -73,16 +73,28 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Mono#justOrEmpty(Optional)} over more contrived alternatives. */
-  static final class MonoJustOrEmpty<T> {
+  /** Prefer {@link Mono#just(Object)} over more contrived alternatives. */
+  static final class MonoJust<T> {
     @BeforeTemplate
-    @SuppressWarnings("NullAway")
-    Mono<T> before(@Nullable T value) {
-      return Mono.justOrEmpty(Refaster.anyOf(Optional.of(value), Optional.ofNullable(value)));
+    Mono<T> before(T value) {
+      return Mono.justOrEmpty(Optional.of(value));
     }
 
     @AfterTemplate
-    Mono<T> after(@Nullable T value) {
+    Mono<T> after(T value) {
+      return Mono.just(value);
+    }
+  }
+
+  /** Prefer {@link Mono#justOrEmpty(Object)} over more contrived alternatives. */
+  static final class MonoJustOrEmpty<@Nullable T> {
+    @BeforeTemplate
+    Mono<T> before(T value) {
+      return Mono.justOrEmpty(Optional.ofNullable(value));
+    }
+
+    @AfterTemplate
+    Mono<T> after(T value) {
       return Mono.justOrEmpty(value);
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -64,7 +64,7 @@ final class ReactorRules {
   static final class MonoEmpty<T> {
     @BeforeTemplate
     Mono<T> before() {
-      return Mono.justOrEmpty(null);
+      return Refaster.anyOf(Mono.just(null), Mono.justOrEmpty(null));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -26,6 +26,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import org.jspecify.nullness.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -56,6 +57,33 @@ final class ReactorRules {
     @AfterTemplate
     Mono<T> after(Supplier<? extends T> supplier) {
       return Mono.fromSupplier(supplier);
+    }
+  }
+
+  /** Prefer {@link Mono#empty()} over more contrived alternatives. */
+  static final class MonoEmpty<T> {
+    @BeforeTemplate
+    Mono<T> before() {
+      return Mono.justOrEmpty(null);
+    }
+
+    @AfterTemplate
+    Mono<T> after() {
+      return Mono.empty();
+    }
+  }
+
+  /** Prefer {@link Mono#justOrEmpty(Optional)} over more contrived alternatives. */
+  static final class MonoJustOrEmpty<T> {
+    @BeforeTemplate
+    @SuppressWarnings("NullAway")
+    Mono<T> before(@Nullable T value) {
+      return Mono.justOrEmpty(Refaster.anyOf(Optional.of(value), Optional.ofNullable(value)));
+    }
+
+    @AfterTemplate
+    Mono<T> after(@Nullable T value) {
+      return Mono.justOrEmpty(value);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -35,12 +35,15 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<String>> testMonoEmpty() {
-    return ImmutableSet.of(Mono.just(null), Mono.justOrEmpty(null));
+    return ImmutableSet.of(Mono.justOrEmpty(null), Mono.justOrEmpty(Optional.empty()));
   }
 
-  ImmutableSet<Mono<Integer>> testMonoJustOrEmpty() {
-    return ImmutableSet.of(
-        Mono.justOrEmpty(Optional.of(1)), Mono.justOrEmpty(Optional.ofNullable(2)));
+  Mono<Integer> testMonoJust() {
+    return Mono.justOrEmpty(Optional.of(1));
+  }
+
+  Mono<Integer> testMonoJustOrEmpty() {
+    return Mono.justOrEmpty(Optional.ofNullable(1));
   }
 
   ImmutableSet<Mono<Integer>> testMonoFromOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -34,8 +34,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.fromCallable(this::toString));
   }
 
-  Mono<String> testMonoEmpty() {
-    return Mono.justOrEmpty(null);
+  ImmutableSet<Mono<String>> testMonoEmpty() {
+    return ImmutableSet.of(Mono.just(null), Mono.justOrEmpty(null));
   }
 
   ImmutableSet<Mono<Integer>> testMonoJustOrEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -34,6 +34,15 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.fromCallable(this::toString));
   }
 
+  Mono<String> testMonoEmpty() {
+    return Mono.justOrEmpty(null);
+  }
+
+  ImmutableSet<Mono<Integer>> testMonoJustOrEmpty() {
+    return ImmutableSet.of(
+        Mono.justOrEmpty(Optional.of(1)), Mono.justOrEmpty(Optional.ofNullable(2)));
+  }
+
   ImmutableSet<Mono<Integer>> testMonoFromOptional() {
     return ImmutableSet.of(
         Mono.fromCallable(() -> Optional.of(1).orElse(null)),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -41,8 +41,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Mono.empty(), Mono.empty());
   }
 
-  ImmutableSet<Mono<Integer>> testMonoJustOrEmpty() {
-    return ImmutableSet.of(Mono.justOrEmpty(1), Mono.justOrEmpty(2));
+  Mono<Integer> testMonoJust() {
+    return Mono.just(1);
+  }
+
+  Mono<Integer> testMonoJustOrEmpty() {
+    return Mono.justOrEmpty(1);
   }
 
   ImmutableSet<Mono<Integer>> testMonoFromOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -37,6 +37,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.fromSupplier(this::toString));
   }
 
+  Mono<String> testMonoEmpty() {
+    return Mono.empty();
+  }
+
+  ImmutableSet<Mono<Integer>> testMonoJustOrEmpty() {
+    return ImmutableSet.of(Mono.justOrEmpty(1), Mono.justOrEmpty(2));
+  }
+
   ImmutableSet<Mono<Integer>> testMonoFromOptional() {
     return ImmutableSet.of(
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(1))),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -37,8 +37,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.fromSupplier(this::toString));
   }
 
-  Mono<String> testMonoEmpty() {
-    return Mono.empty();
+  ImmutableSet<Mono<String>> testMonoEmpty() {
+    return ImmutableSet.of(Mono.empty(), Mono.empty());
   }
 
   ImmutableSet<Mono<Integer>> testMonoJustOrEmpty() {


### PR DESCRIPTION
After https://github.com/PicnicSupermarket/error-prone-support/pull/384 I noticed a few more interactions between the Optional and Mono API we can simplify.

Pretty simple cases, but why not cover them?

---
Suggested commit message:
```
Introduce `Mono{Empty,Just,JustOrEmpty}` Refaster rules (#385)
```