### PR TITLE
Introduce `CollectionForEach` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import java.util.SortedSet;
+import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -401,6 +402,19 @@ final class CollectionRules {
     @AfterTemplate
     Optional<T> after(Queue<T> queue) {
       return Optional.ofNullable(queue.poll());
+    }
+  }
+
+  /** Prefer calling {@link Collection#forEach} ()} over more contrived alternatives. */
+  static final class CollectionForEach<T> {
+    @BeforeTemplate
+    void before(Collection<T> collection, Consumer<T> consumer) {
+      collection.stream().forEach(consumer);
+    }
+
+    @AfterTemplate
+    void after(Collection<T> collection, Consumer<T> consumer) {
+      collection.forEach(consumer);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -405,15 +405,15 @@ final class CollectionRules {
     }
   }
 
-  /** Prefer calling {@link Collection#forEach} ()} over more contrived alternatives. */
+  /** Prefer {@link Collection#forEach(Consumer)} over more contrived alternatives. */
   static final class CollectionForEach<T> {
     @BeforeTemplate
-    void before(Collection<T> collection, Consumer<T> consumer) {
+    void before(Collection<T> collection, Consumer<? super T> consumer) {
       collection.stream().forEach(consumer);
     }
 
     @AfterTemplate
-    void after(Collection<T> collection, Consumer<T> consumer) {
+    void after(Collection<T> collection, Consumer<? super T> consumer) {
       collection.forEach(consumer);
     }
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
@@ -186,4 +186,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
             ? Optional.ofNullable(new LinkedList<String>().remove())
             : Optional.empty());
   }
+
+  void testCollectionForEach() {
+    ImmutableSet.of(1).stream().forEach(String::valueOf);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
@@ -136,4 +136,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         Optional.ofNullable(new LinkedList<String>().poll()),
         Optional.ofNullable(new LinkedList<String>().poll()));
   }
+
+  void testCollectionForEach() {
+    ImmutableSet.of(1).forEach(String::valueOf);
+  }
 }


### PR DESCRIPTION
Related to the issue #387, I added a new Refaster rule to rewrite the use of `forEach` when working with collections.