### PR TITLE
Downgrade actions/setup-java v3.7.0 -> v3.6.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -37,7 +37,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           java-version: ${{ matrix.jdk }}
           distribution: ${{ matrix.distribution }}

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           fetch-depth: 2
       - name: Set up JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           java-version: 17.0.4
           distribution: temurin

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Check out code
         uses: actions/checkout@v3.1.0
       - name: Set up JDK
-        uses: actions/setup-java@v3.7.0
+        uses: actions/setup-java@v3.6.0
         with:
           java-version: 17.0.4
           distribution: temurin


### PR DESCRIPTION
This reverts commit 5afa7e1878453f97996ed73c36847844e07074cb. The v3.7.0 release got deleted, for context see
 https://github.com/actions/setup-java/issues/422.