### PR TITLE
Prefer `BigDecimal.valueOf(double)` over `new BigDecimal(double)`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -54,7 +54,7 @@ final class BigDecimalRules {
   // XXX: Ideally we also rewrite `new BigDecimal("<some-integer-value>")` in cases where the
   // specified number can be represented as an `int` or `long`, but that requires a custom
   // `BugChecker`.
-  static final class BigDecimalFactoryMethod {
+  static final class BigDecimalValueOf {
     @BeforeTemplate
     BigDecimal before(double value) {
       return new BigDecimal(value);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -51,8 +51,9 @@ final class BigDecimalRules {
   }
 
   /** Prefer {@link BigDecimal#valueOf(double)} over the associated constructor. */
-  // XXX: Ideally we'd also rewrite `new BigDecimal("<some-integer-value>")`, but it doesn't
-  // appear that's currently possible with Error Prone.
+  // XXX: Ideally we also rewrite `new BigDecimal("<some-integer-value>")` in cases where the
+  // specified number can be represented as an `int` or `long`, but that requires a custom
+  // `BugChecker`.
   static final class BigDecimalFactoryMethod {
     @BeforeTemplate
     BigDecimal before(double value) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -50,17 +50,17 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer {@link BigDecimal#valueOf(long)} over the associated constructor. */
-  // XXX: Ideally we'd also rewrite `BigDecimal.valueOf("<some-integer-value>")`, but it doesn't
+  /** Prefer {@link BigDecimal#valueOf(double)} over the associated constructor. */
+  // XXX: Ideally we'd also rewrite `new BigDecimal("<some-integer-value>")`, but it doesn't
   // appear that's currently possible with Error Prone.
   static final class BigDecimalFactoryMethod {
     @BeforeTemplate
-    BigDecimal before(long value) {
+    BigDecimal before(double value) {
       return new BigDecimal(value);
     }
 
     @AfterTemplate
-    BigDecimal after(long value) {
+    BigDecimal after(double value) {
       return BigDecimal.valueOf(value);
     }
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -18,6 +18,6 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<BigDecimal> testBigDecimalFactoryMethod() {
-    return ImmutableSet.of(new BigDecimal(0), new BigDecimal(0L));
+    return ImmutableSet.of(new BigDecimal(2), new BigDecimal(2L), new BigDecimal(2.0));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -17,7 +17,7 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(BigDecimal.valueOf(10), BigDecimal.valueOf(10L), new BigDecimal("10"));
   }
 
-  ImmutableSet<BigDecimal> testBigDecimalFactoryMethod() {
+  ImmutableSet<BigDecimal> testBigDecimalValueOf() {
     return ImmutableSet.of(new BigDecimal(2), new BigDecimal(2L), new BigDecimal(2.0));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -17,7 +17,7 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(BigDecimal.TEN, BigDecimal.TEN, BigDecimal.TEN);
   }
 
-  ImmutableSet<BigDecimal> testBigDecimalFactoryMethod() {
+  ImmutableSet<BigDecimal> testBigDecimalValueOf() {
     return ImmutableSet.of(BigDecimal.valueOf(2), BigDecimal.valueOf(2L), BigDecimal.valueOf(2.0));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -18,6 +18,6 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<BigDecimal> testBigDecimalFactoryMethod() {
-    return ImmutableSet.of(BigDecimal.valueOf(0), BigDecimal.valueOf(0L));
+    return ImmutableSet.of(BigDecimal.valueOf(2), BigDecimal.valueOf(2L), BigDecimal.valueOf(2.0));
   }
 }


### PR DESCRIPTION
A very nice rule to rewrite `new BigDecimal(long/int)` to `BigDecimal.valueOf(long/int)` already existed. As using `new BigDecimal(double)` is [quite discouraged](https://rules.sonarsource.com/java/RSPEC-2111), this PR extends the existing rule to rewrite `new BigDecimal(double/long/int)` to `BigDecimal.valueOf(double/long/int)`