### PR TITLE
Prevent `ReverseOrder` Refaster rule from introducing a static import

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -62,8 +62,9 @@ final class ComparatorRules {
           Comparator.<T>naturalOrder().reversed());
     }
 
+    // XXX: Add `@UseImportPolicy(STATIC_IMPORT_ALWAYS)` if/when
+    // https://github.com/google/error-prone/pull/3584 is merged and released.
     @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     Comparator<T> after() {
       return reverseOrder();
     }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
@@ -32,7 +32,8 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Comparator<String>> testReverseOrder() {
-    return ImmutableSet.of(reverseOrder(), reverseOrder(), reverseOrder());
+    return ImmutableSet.of(
+        Comparator.reverseOrder(), Comparator.reverseOrder(), Comparator.reverseOrder());
   }
 
   ImmutableSet<Comparator<String>> testCustomComparator() {


### PR DESCRIPTION
This is a workaround for google/error-prone#3584.

Suggested commit message:
```
Prevent `ReverseOrder` Refaster rule from introducing a static import (#397)

This is a workaround for the issue resolved by google/error-prone#3584.

After application of this Refaster rule, any static imports of
`java.util.Collections.reverseOrder` are obsolete. These can be removed by
running Google Java Format or Error Prone's `RemoveUnusedImports` check.

Where possible, subsequent application of the `StaticImport` check will
statically import `java.util.Comparator.reverseOrder`.
```