### PR TITLE
Have `ReverseOrder` rule flag `Collections.reverseOrder(String::compareTo)`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -58,6 +58,7 @@ final class ComparatorRules {
     Comparator<T> before() {
       return Refaster.anyOf(
           Collections.reverseOrder(),
+          Collections.reverseOrder(T::compareTo),
           Collections.<T>reverseOrder(naturalOrder()),
           Comparator.<T>naturalOrder().reversed());
     }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
@@ -38,6 +38,7 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Comparator<String>> testReverseOrder() {
     return ImmutableSet.of(
         Collections.reverseOrder(),
+        Collections.reverseOrder(String::compareTo),
         Collections.<String>reverseOrder(naturalOrder()),
         Comparator.<String>naturalOrder().reversed());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
@@ -33,7 +33,10 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Comparator<String>> testReverseOrder() {
     return ImmutableSet.of(
-        Comparator.reverseOrder(), Comparator.reverseOrder(), Comparator.reverseOrder());
+        Comparator.reverseOrder(),
+        Comparator.reverseOrder(),
+        Comparator.reverseOrder(),
+        Comparator.reverseOrder());
   }
 
   ImmutableSet<Comparator<String>> testCustomComparator() {


### PR DESCRIPTION
Encountered this problem when testing downstream.

Without this rule this:
```
Collections.reverseOrder(String::compareTo)
```
Would be replaced with:
```
Collections.reverseOrder(Comparator.naturalOrder())
```
Which is incompatible so it would lead to non compilable code.