### PR TITLE
Drop indentation in feature request issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -17,22 +17,23 @@ you'd like to be solved through Error Prone Support. -->
 
 - [ ] Support a stylistic preference.
 - [ ] Avoid a common gotcha, or potential problem.
+- [ ] Improve performance.
 
 <!--
 Here, provide a clear and concise description of the desired change.
 
 If possible, provide a simple and minimal example using the following format:
-
-  I would like to rewrite the following code:
-  ```java
-  // XXX: Write the code to match here.
-  ```
-
-  to:
-  ```java
-  // XXX: Write the desired code here.
-  ```
 -->
+
+I would like to rewrite the following code:
+```java
+// XXX: Write the code to match here.
+```
+
+to:
+```java
+// XXX: Write the desired code here.
+```
 
 ### Considerations
 


### PR DESCRIPTION
(This has no priority but a minor quality of life improvement.)

When creating a ticket it is a bit annoying that the proposed format and code indented. 
One should manually remove this which is not so nice and can be forgotten.
I also noticed others didn't always notice this indentation.

Let me know what you guys think :).

Suggested commit message:
```
Drop indentation in feature request issue template (#403)

While there, add "Improve performance" as a rewrite reason. 
```