### PR TITLE
Introduce `MonoIdentity` and `MonoThen` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -675,6 +675,34 @@ final class ReactorRules {
     }
   }
 
+  /** Don't unnecessarily convert {@link Mono} to {@link Flux}. */
+  @SuppressWarnings("VoidMissingNullable")
+  static final class MonoFluxThen<T> {
+    @BeforeTemplate
+    Mono<Void> before(Mono<T> mono) {
+      return mono.flux().then();
+    }
+
+    @AfterTemplate
+    Mono<Void> after(Mono<T> mono) {
+      return mono.then();
+    }
+  }
+
+  /** Don't unnecessarily call {@link Mono#then()} on a {@code Mono<Void>} . */
+  @SuppressWarnings("VoidMissingNullable")
+  static final class MonoVoidThen {
+    @BeforeTemplate
+    Mono<Void> before(Mono<Void> mono) {
+      return mono.then();
+    }
+
+    @AfterTemplate
+    Mono<Void> after(Mono<Void> mono) {
+      return mono;
+    }
+  }
+
   /**
    * Prefer a collection using {@link MoreCollectors#toOptional()} over more contrived alternatives.
    */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -365,11 +365,19 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily pass an empty publisher to {@link Mono#switchIfEmpty(Mono)}. */
-  static final class MonoSwitchIfEmptyOfEmptyPublisher<T> {
+  /** Don't unnecessarily transform a {@link Mono} to an equivalent instance. */
+  static final class MonoIdentity<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono) {
       return mono.switchIfEmpty(Mono.empty());
+    }
+
+    // XXX: Review the suppression once NullAway has better support for generics. Keep an eye on
+    // https://github.com/uber/NullAway/issues?q=is%3Aopen+generics.
+    @BeforeTemplate
+    @SuppressWarnings("NullAway" /* False positive. */)
+    Mono<@Nullable Void> before2(Mono<@Nullable Void> mono) {
+      return mono.then();
     }
 
     @AfterTemplate
@@ -675,31 +683,16 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily convert {@link Mono} to {@link Flux}. */
-  @SuppressWarnings("VoidMissingNullable")
-  static final class MonoFluxThen<T> {
+  /** Prefer direct invocation of {@link Mono#then()}} over more contrived alternatives. */
+  static final class MonoThen<T> {
     @BeforeTemplate
-    Mono<Void> before(Mono<T> mono) {
+    Mono<@Nullable Void> before(Mono<T> mono) {
       return mono.flux().then();
     }
 
     @AfterTemplate
-    Mono<Void> after(Mono<T> mono) {
+    Mono<@Nullable Void> after(Mono<T> mono) {
       return mono.then();
-    }
-  }
-
-  /** Don't unnecessarily call {@link Mono#then()} on a {@code Mono<Void>} . */
-  @SuppressWarnings("VoidMissingNullable")
-  static final class MonoVoidThen {
-    @BeforeTemplate
-    Mono<Void> before(Mono<Void> mono) {
-      return mono.then();
-    }
-
-    @AfterTemplate
-    Mono<Void> after(Mono<Void> mono) {
-      return mono;
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -221,6 +221,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.concat(Mono.just("baz")));
   }
 
+  Mono<Void> testMonoFluxThen() {
+    return Mono.just("foo").flux().then();
+  }
+
+  Mono<Void> testMonoVoidThen() {
+    return Mono.just("foo").then().then();
+  }
+
   Mono<Optional<String>> testMonoCollectToOptional() {
     return Mono.just("foo").map(Optional::of).defaultIfEmpty(Optional.empty());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -115,8 +115,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("baz").switchIfEmpty(Flux.just("qux")));
   }
 
-  Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {
-    return Mono.just(1).switchIfEmpty(Mono.empty());
+  ImmutableSet<Mono<?>> testMonoIdentity() {
+    return ImmutableSet.of(Mono.just(1).switchIfEmpty(Mono.empty()), Mono.<Void>empty().then());
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
@@ -221,12 +221,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.concat(Mono.just("baz")));
   }
 
-  Mono<Void> testMonoFluxThen() {
+  Mono<Void> testMonoThen() {
     return Mono.just("foo").flux().then();
-  }
-
-  Mono<Void> testMonoVoidThen() {
-    return Mono.just("foo").then().then();
   }
 
   Mono<Optional<String>> testMonoCollectToOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -220,6 +220,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").flux(), Mono.just("bar").flux(), Mono.just("baz").flux());
   }
 
+  Mono<Void> testMonoFluxThen() {
+    return Mono.just("foo").then();
+  }
+
+  Mono<Void> testMonoVoidThen() {
+    return Mono.just("foo").then();
+  }
+
   Mono<Optional<String>> testMonoCollectToOptional() {
     return Mono.just("foo").flux().collect(toOptional());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -120,8 +120,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("foo").defaultIfEmpty("bar"), Flux.just("baz").defaultIfEmpty("qux"));
   }
 
-  Mono<Integer> testMonoSwitchIfEmptyOfEmptyPublisher() {
-    return Mono.just(1);
+  ImmutableSet<Mono<?>> testMonoIdentity() {
+    return ImmutableSet.of(Mono.just(1), Mono.<Void>empty());
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
@@ -220,11 +220,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").flux(), Mono.just("bar").flux(), Mono.just("baz").flux());
   }
 
-  Mono<Void> testMonoFluxThen() {
-    return Mono.just("foo").then();
-  }
-
-  Mono<Void> testMonoVoidThen() {
+  Mono<Void> testMonoThen() {
     return Mono.just("foo").then();
   }
 


### PR DESCRIPTION
We came across this pattern in our code base after some (automatic) refactorings.

```java
mono
    .flatMap(operationReturningMonoVoid)
    .flux()
    .then();
```

`.flux().then()` doesn't add anything, similarly to calling `.then` on a `Mono<Void>`.

Introduced two rules for both steps

---
Suggested commit message:
```
Introduce `MonoFluxThen` and `MonoVoidThen` Refaster rules (#405)
```