### PR TITLE
Prevent `NestedOptionals` from throwing an NPE

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
@@ -41,8 +41,11 @@ public final class NestedOptionals extends BugChecker implements MethodInvocatio
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    return state.getTypes().isSubtype(ASTHelpers.getType(tree), OPTIONAL_OF_OPTIONAL.get(state))
-        ? describeMatch(tree)
-        : Description.NO_MATCH;
+    Type stateType = OPTIONAL_OF_OPTIONAL.get(state);
+    if (stateType != null && state.getTypes().isSubtype(ASTHelpers.getType(tree), stateType)) {
+      return describeMatch(tree);
+    } else {
+      return Description.NO_MATCH;
+    }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NestedOptionals.java
@@ -41,11 +41,11 @@ public final class NestedOptionals extends BugChecker implements MethodInvocatio
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    Type stateType = OPTIONAL_OF_OPTIONAL.get(state);
-    if (stateType != null && state.getTypes().isSubtype(ASTHelpers.getType(tree), stateType)) {
-      return describeMatch(tree);
-    } else {
+    Type type = OPTIONAL_OF_OPTIONAL.get(state);
+    if (type == null || !state.getTypes().isSubtype(ASTHelpers.getType(tree), type)) {
       return Description.NO_MATCH;
     }
+
+    return describeMatch(tree);
   }
 }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NestedOptionalsTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NestedOptionalsTest.java
@@ -39,4 +39,19 @@ final class NestedOptionalsTest {
             "}")
         .doTest();
   }
+
+  @Test
+  void failingTypeCheck() {
+    compilationTestHelper
+        .addSourceLines(
+            "B.java",
+            "import java.time.temporal.ChronoUnit;",
+            "",
+            "class B {",
+            "  void m() {",
+            "    java.time.Duration.of(1, ChronoUnit.YEARS);",
+            "  }",
+            "}")
+        .doTest();
+  }
 }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NestedOptionalsTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NestedOptionalsTest.java
@@ -41,15 +41,15 @@ final class NestedOptionalsTest {
   }
 
   @Test
-  void failingTypeCheck() {
+  void identificationOptionalTypeNotLoaded() {
     compilationTestHelper
         .addSourceLines(
-            "B.java",
-            "import java.time.temporal.ChronoUnit;",
+            "A.java",
+            "import java.time.Duration;",
             "",
-            "class B {",
+            "class A {",
             "  void m() {",
-            "    java.time.Duration.of(1, ChronoUnit.YEARS);",
+            "    Duration.ofSeconds(1);",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
While testing version 0.6.0 I encountered a `NullPointerException` thrown by `NestedOptinal` when analysing this code (please don't judge, it's a bug sample!):

```
void m() {
    java.time.Duration.of(1, ChronoUnit.YEARS);
}
```

This PR adds a unit test reproducing the problem and a proposed fix.
Thanks a lot for providing this project!