### PR TITLE
Introduce `JUnitToAssertJRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -146,7 +146,7 @@
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-api</artifactId>
-            <scope>test</scope>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -73,157 +73,157 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatIsTrue {
     @BeforeTemplate
-    void before(boolean condition) {
-      assertTrue(condition);
+    void before(boolean actual) {
+      assertTrue(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition) {
-      assertThat(condition).isTrue();
+    void after(boolean actual) {
+      assertThat(actual).isTrue();
     }
   }
 
   static final class AssertThatWithFailMessageStringIsTrue {
     @BeforeTemplate
-    void before(boolean condition, String message) {
-      assertTrue(condition, message);
+    void before(boolean actual, String message) {
+      assertTrue(actual, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, String message) {
-      assertThat(condition).withFailMessage(message).isTrue();
+    void after(boolean actual, String message) {
+      assertThat(actual).withFailMessage(message).isTrue();
     }
   }
 
   static final class AssertThatWithFailMessageSupplierIsTrue {
     @BeforeTemplate
-    void before(boolean condition, Supplier<String> supplier) {
-      assertTrue(condition, supplier);
+    void before(boolean actual, Supplier<String> supplier) {
+      assertTrue(actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, Supplier<String> supplier) {
-      assertThat(condition).withFailMessage(supplier).isTrue();
+    void after(boolean actual, Supplier<String> supplier) {
+      assertThat(actual).withFailMessage(supplier).isTrue();
     }
   }
 
   static final class AssertThatIsFalse {
     @BeforeTemplate
-    void before(boolean condition) {
-      assertFalse(condition);
+    void before(boolean actual) {
+      assertFalse(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition) {
-      assertThat(condition).isFalse();
+    void after(boolean actual) {
+      assertThat(actual).isFalse();
     }
   }
 
   static final class AssertThatWithFailMessageStringIsFalse {
     @BeforeTemplate
-    void before(boolean condition, String message) {
-      assertFalse(condition, message);
+    void before(boolean actual, String message) {
+      assertFalse(actual, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, String message) {
-      assertThat(condition).withFailMessage(message).isFalse();
+    void after(boolean actual, String message) {
+      assertThat(actual).withFailMessage(message).isFalse();
     }
   }
 
   static final class AssertThatWithFailMessageSupplierIsFalse {
     @BeforeTemplate
-    void before(boolean condition, Supplier<String> supplier) {
-      assertFalse(condition, supplier);
+    void before(boolean actual, Supplier<String> supplier) {
+      assertFalse(actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, Supplier<String> supplier) {
-      assertThat(condition).withFailMessage(supplier).isFalse();
+    void after(boolean actual, Supplier<String> supplier) {
+      assertThat(actual).withFailMessage(supplier).isFalse();
     }
   }
 
   static final class AssertThatIsNull {
     @BeforeTemplate
-    void before(Object object) {
-      assertNull(object);
+    void before(Object actual) {
+      assertNull(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object) {
-      assertThat(object).isNull();
+    void after(Object actual) {
+      assertThat(actual).isNull();
     }
   }
 
   static final class AssertThatWithFailMessageStringIsNull {
     @BeforeTemplate
-    void before(Object object, String message) {
-      assertNull(object, message);
+    void before(Object actual, String message) {
+      assertNull(actual, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, String message) {
-      assertThat(object).withFailMessage(message).isNull();
+    void after(Object actual, String message) {
+      assertThat(actual).withFailMessage(message).isNull();
     }
   }
 
   static final class AssertThatWithFailMessageSupplierIsNull {
     @BeforeTemplate
-    void before(Object object, Supplier<String> supplier) {
-      assertNull(object, supplier);
+    void before(Object actual, Supplier<String> supplier) {
+      assertNull(actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Supplier<String> supplier) {
-      assertThat(object).withFailMessage(supplier).isNull();
+    void after(Object actual, Supplier<String> supplier) {
+      assertThat(actual).withFailMessage(supplier).isNull();
     }
   }
 
   static final class AssertThatIsNotNull {
     @BeforeTemplate
-    void before(Object object) {
-      assertNotNull(object);
+    void before(Object actual) {
+      assertNotNull(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object) {
-      assertThat(object).isNotNull();
+    void after(Object actual) {
+      assertThat(actual).isNotNull();
     }
   }
 
   static final class AssertThatWithFailMessageStringIsNotNull {
     @BeforeTemplate
-    void before(Object object, String message) {
-      assertNotNull(object, message);
+    void before(Object actual, String message) {
+      assertNotNull(actual, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, String message) {
-      assertThat(object).withFailMessage(message).isNotNull();
+    void after(Object actual, String message) {
+      assertThat(actual).withFailMessage(message).isNotNull();
     }
   }
 
   static final class AssertThatWithFailMessageSupplierIsNotNull {
     @BeforeTemplate
-    void before(Object object, Supplier<String> supplier) {
-      assertNotNull(object, supplier);
+    void before(Object actual, Supplier<String> supplier) {
+      assertNotNull(actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Supplier<String> supplier) {
-      assertThat(object).withFailMessage(supplier).isNotNull();
+    void after(Object actual, Supplier<String> supplier) {
+      assertThat(actual).withFailMessage(supplier).isNotNull();
     }
   }
 
@@ -452,40 +452,40 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatIsInstanceOf<T> {
     @BeforeTemplate
-    void before(Object object, Class<T> clazz) {
-      assertInstanceOf(clazz, object);
+    void before(Object actual, Class<T> clazz) {
+      assertInstanceOf(clazz, actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Class<T> clazz) {
-      assertThat(object).isInstanceOf(clazz);
+    void after(Object actual, Class<T> clazz) {
+      assertThat(actual).isInstanceOf(clazz);
     }
   }
 
   static final class AssertThatWithFailMessageStringIsInstanceOf<T> {
     @BeforeTemplate
-    void before(Object object, Class<T> clazz, String message) {
-      assertInstanceOf(clazz, object, message);
+    void before(Object actual, Class<T> clazz, String message) {
+      assertInstanceOf(clazz, actual, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Class<T> clazz, String message) {
-      assertThat(object).withFailMessage(message).isInstanceOf(clazz);
+    void after(Object actual, Class<T> clazz, String message) {
+      assertThat(actual).withFailMessage(message).isInstanceOf(clazz);
     }
   }
 
   static final class AssertThatWithFailMessageSupplierIsInstanceOf<T> {
     @BeforeTemplate
-    void before(Object object, Class<T> clazz, Supplier<String> supplier) {
-      assertInstanceOf(clazz, object, supplier);
+    void before(Object actual, Class<T> clazz, Supplier<String> supplier) {
+      assertInstanceOf(clazz, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Class<T> clazz, Supplier<String> supplier) {
-      assertThat(object).withFailMessage(supplier).isInstanceOf(clazz);
+    void after(Object actual, Class<T> clazz, Supplier<String> supplier) {
+      assertThat(actual).withFailMessage(supplier).isInstanceOf(clazz);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -7,6 +7,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -29,422 +30,460 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 /** Refaster rules to replace JUnit assertions with AssertJ equivalents. */
 @OnlineDocumentation
 final class JUnitToAssertJRules {
-    private JUnitToAssertJRules() {}
+  private JUnitToAssertJRules() {}
 
-    static final class Fail {
-        @BeforeTemplate
-        void before() {
-            Assertions.fail();
-        }
-
-        @AfterTemplate
-        @DoNotCall
-        void after() {
-            throw new AssertionError();
-        }
+  static final class Fail {
+    @BeforeTemplate
+    void before() {
+      Assertions.fail();
     }
 
-    static final class FailWithMessage {
-        @BeforeTemplate
-        void before(String message) {
-            Assertions.fail(message);
-        }
+    @AfterTemplate
+    @DoNotCall
+    void after() {
+      throw new AssertionError();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(String message) {
-            fail(message);
-        }
+  static final class FailWithMessage {
+    @BeforeTemplate
+    void before(String message) {
+      Assertions.fail(message);
     }
 
-    static final class FailWithMessageAndThrowable {
-        @BeforeTemplate
-        void before(String message, Throwable throwable) {
-            Assertions.fail(message, throwable);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(String message) {
+      fail(message);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(String message, Throwable throwable) {
-            fail(message, throwable);
-        }
+  static final class FailWithMessageAndThrowable {
+    @BeforeTemplate
+    void before(String message, Throwable throwable) {
+      Assertions.fail(message, throwable);
     }
 
-    static final class AssertTrue {
-        @BeforeTemplate
-        void before(boolean condition) {
-            assertTrue(condition);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(String message, Throwable throwable) {
+      fail(message, throwable);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(boolean condition) {
-            assertThat(condition).isTrue();
-        }
+  static final class AssertTrue {
+    @BeforeTemplate
+    void before(boolean condition) {
+      assertTrue(condition);
     }
 
-    static final class AssertTrueWithMessage {
-        @BeforeTemplate
-        void before(boolean condition, String message) {
-            assertTrue(condition, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition) {
+      assertThat(condition).isTrue();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(boolean condition, String message) {
-            assertThat(condition).withFailMessage(message).isTrue();
-        }
+  static final class AssertTrueWithMessage {
+    @BeforeTemplate
+    void before(boolean condition, String message) {
+      assertTrue(condition, message);
     }
 
-    static final class AssertTrueWithMessageSupplier {
-        @BeforeTemplate
-        void before(boolean condition, Supplier<String> messageSupplier) {
-            assertTrue(condition, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition, String message) {
+      assertThat(condition).withFailMessage(message).isTrue();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(boolean condition, Supplier<String> messageSupplier) {
-            assertThat(condition).withFailMessage(messageSupplier).isTrue();
-        }
+  static final class AssertTrueWithMessageSupplier {
+    @BeforeTemplate
+    void before(boolean condition, Supplier<String> messageSupplier) {
+      assertTrue(condition, messageSupplier);
     }
 
-    static final class AssertFalse {
-        @BeforeTemplate
-        void before(boolean condition) {
-            assertFalse(condition);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition, Supplier<String> messageSupplier) {
+      assertThat(condition).withFailMessage(messageSupplier).isTrue();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(boolean condition) {
-            assertThat(condition).isFalse();
-        }
+  static final class AssertFalse {
+    @BeforeTemplate
+    void before(boolean condition) {
+      assertFalse(condition);
     }
 
-    static final class AssertFalseWithMessage {
-        @BeforeTemplate
-        void before(boolean condition, String message) {
-            assertFalse(condition, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition) {
+      assertThat(condition).isFalse();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(boolean condition, String message) {
-            assertThat(condition).withFailMessage(message).isFalse();
-        }
+  static final class AssertFalseWithMessage {
+    @BeforeTemplate
+    void before(boolean condition, String message) {
+      assertFalse(condition, message);
     }
 
-    static final class AssertFalseWithMessageSupplier {
-        @BeforeTemplate
-        void before(boolean condition, Supplier<String> messageSupplier) {
-            assertFalse(condition, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition, String message) {
+      assertThat(condition).withFailMessage(message).isFalse();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(boolean condition, Supplier<String> messageSupplier) {
-            assertThat(condition).withFailMessage(messageSupplier).isFalse();
-        }
+  static final class AssertFalseWithMessageSupplier {
+    @BeforeTemplate
+    void before(boolean condition, Supplier<String> messageSupplier) {
+      assertFalse(condition, messageSupplier);
     }
 
-    static final class AssertNull {
-        @BeforeTemplate
-        void before(Object object) {
-            assertNull(object);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition, Supplier<String> messageSupplier) {
+      assertThat(condition).withFailMessage(messageSupplier).isFalse();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object object) {
-            assertThat(object).isNull();
-        }
+  static final class AssertNull {
+    @BeforeTemplate
+    void before(Object object) {
+      assertNull(object);
     }
 
-    static final class AssertNullWithMessage {
-        @BeforeTemplate
-        void before(Object object, String message) {
-            assertNull(object, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object) {
+      assertThat(object).isNull();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object object, String message) {
-            assertThat(object).withFailMessage(message).isNull();
-        }
+  static final class AssertNullWithMessage {
+    @BeforeTemplate
+    void before(Object object, String message) {
+      assertNull(object, message);
     }
 
-    static final class AssertNullWithMessageSupplier {
-        @BeforeTemplate
-        void before(Object object, Supplier<String> messageSupplier) {
-            assertNull(object, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object, String message) {
+      assertThat(object).withFailMessage(message).isNull();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object object, Supplier<String> messageSupplier) {
-            assertThat(object).withFailMessage(messageSupplier).isNull();
-        }
+  static final class AssertNullWithMessageSupplier {
+    @BeforeTemplate
+    void before(Object object, Supplier<String> messageSupplier) {
+      assertNull(object, messageSupplier);
     }
 
-    static final class AssertNotNull {
-        @BeforeTemplate
-        void before(Object object) {
-            assertNotNull(object);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object, Supplier<String> messageSupplier) {
+      assertThat(object).withFailMessage(messageSupplier).isNull();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object object) {
-            assertThat(object).isNotNull();
-        }
+  static final class AssertNotNull {
+    @BeforeTemplate
+    void before(Object object) {
+      assertNotNull(object);
     }
 
-    static final class AssertNotNullWithMessage {
-        @BeforeTemplate
-        void before(Object object, String message) {
-            assertNotNull(object, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object) {
+      assertThat(object).isNotNull();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object object, String message) {
-            assertThat(object).withFailMessage(message).isNotNull();
-        }
+  static final class AssertNotNullWithMessage {
+    @BeforeTemplate
+    void before(Object object, String message) {
+      assertNotNull(object, message);
     }
 
-    static final class AssertNotNullWithMessageSupplier {
-        @BeforeTemplate
-        void before(Object object, Supplier<String> messageSupplier) {
-            assertNotNull(object, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object, String message) {
+      assertThat(object).withFailMessage(message).isNotNull();
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object object, Supplier<String> messageSupplier) {
-            assertThat(object).withFailMessage(messageSupplier).isNotNull();
-        }
+  static final class AssertNotNullWithMessageSupplier {
+    @BeforeTemplate
+    void before(Object object, Supplier<String> messageSupplier) {
+      assertNotNull(object, messageSupplier);
     }
 
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertEquals
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertArrayEquals
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertIterableEquals
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertLinesMatch
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotEquals
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object, Supplier<String> messageSupplier) {
+      assertThat(object).withFailMessage(messageSupplier).isNotNull();
+    }
+  }
 
-    static final class AssertSame {
-        @BeforeTemplate
-        void before(Object actual, Object expected) {
-            assertSame(expected, actual);
-        }
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertEquals
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertArrayEquals
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertIterableEquals
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertLinesMatch
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotEquals
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object actual, Object expected) {
-            assertThat(actual).isSameAs(expected);
-        }
+  static final class AssertSame {
+    @BeforeTemplate
+    void before(Object actual, Object expected) {
+      assertSame(expected, actual);
     }
 
-    static final class AssertSameWithMessage {
-        @BeforeTemplate
-        void before(Object actual, Object expected, String message) {
-            assertSame(expected, actual, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object actual, Object expected) {
+      assertThat(actual).isSameAs(expected);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object actual, Object expected, String message) {
-            assertThat(actual).withFailMessage(message).isSameAs(expected);
-        }
+  static final class AssertSameWithMessage {
+    @BeforeTemplate
+    void before(Object actual, Object expected, String message) {
+      assertSame(expected, actual, message);
     }
 
-    static final class AssertSameWithMessageSupplier {
-        @BeforeTemplate
-        void before(Object actual, Object expected, Supplier<String> messageSupplier) {
-            assertSame(expected, actual, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object actual, Object expected, String message) {
+      assertThat(actual).withFailMessage(message).isSameAs(expected);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object actual, Object expected, Supplier<String> messageSupplier) {
-            assertThat(actual).withFailMessage(messageSupplier).isSameAs(expected);
-        }
+  static final class AssertSameWithMessageSupplier {
+    @BeforeTemplate
+    void before(Object actual, Object expected, Supplier<String> messageSupplier) {
+      assertSame(expected, actual, messageSupplier);
     }
 
-    static final class AssertNotSame {
-        @BeforeTemplate
-        void before(Object actual, Object expected) {
-            assertNotSame(expected, actual);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object actual, Object expected, Supplier<String> messageSupplier) {
+      assertThat(actual).withFailMessage(messageSupplier).isSameAs(expected);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object actual, Object expected) {
-            assertThat(actual).isNotSameAs(expected);
-        }
+  static final class AssertNotSame {
+    @BeforeTemplate
+    void before(Object actual, Object expected) {
+      assertNotSame(expected, actual);
     }
 
-    static final class AssertNotSameWithMessage {
-        @BeforeTemplate
-        void before(Object actual, Object expected, String message) {
-            assertNotSame(expected, actual, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object actual, Object expected) {
+      assertThat(actual).isNotSameAs(expected);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object actual, Object expected, String message) {
-            assertThat(actual).withFailMessage(message).isNotSameAs(expected);
-        }
+  static final class AssertNotSameWithMessage {
+    @BeforeTemplate
+    void before(Object actual, Object expected, String message) {
+      assertNotSame(expected, actual, message);
     }
 
-    static final class AssertNotSameWithMessageSupplier {
-        @BeforeTemplate
-        void before(Object actual, Object expected, Supplier<String> messageSupplier) {
-            assertNotSame(expected, actual, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object actual, Object expected, String message) {
+      assertThat(actual).withFailMessage(message).isNotSameAs(expected);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(Object actual, Object expected, Supplier<String> messageSupplier) {
-            assertThat(actual).withFailMessage(messageSupplier).isNotSameAs(expected);
-        }
+  static final class AssertNotSameWithMessageSupplier {
+    @BeforeTemplate
+    void before(Object actual, Object expected, Supplier<String> messageSupplier) {
+      assertNotSame(expected, actual, messageSupplier);
     }
 
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertAll
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object actual, Object expected, Supplier<String> messageSupplier) {
+      assertThat(actual).withFailMessage(messageSupplier).isNotSameAs(expected);
+    }
+  }
 
-    static final class AssertThrowsExactly<T extends Throwable> {
-        @BeforeTemplate
-        void before(Executable runnable, Class<T> clazz) {
-            assertThrowsExactly(clazz, runnable);
-        }
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertAll
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, Class<T> clazz) {
-            assertThatThrownBy(runnable).isExactlyInstanceOf(clazz);
-        }
+  static final class AssertThrowsExactly<T extends Throwable> {
+    @BeforeTemplate
+    void before(Executable runnable, Class<T> clazz) {
+      assertThrowsExactly(clazz, runnable);
     }
 
-    static final class AssertThrowsExactlyWithMessage<T extends Throwable> {
-        @BeforeTemplate
-        void before(Executable runnable, Class<T> clazz, String message) {
-            assertThrowsExactly(clazz, runnable, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, Class<T> clazz) {
+      assertThatThrownBy(runnable).isExactlyInstanceOf(clazz);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, Class<T> clazz, String message) {
-            assertThatThrownBy(runnable).withFailMessage(message).isExactlyInstanceOf(clazz);
-        }
+  static final class AssertThrowsExactlyWithMessage<T extends Throwable> {
+    @BeforeTemplate
+    void before(Executable runnable, Class<T> clazz, String message) {
+      assertThrowsExactly(clazz, runnable, message);
     }
 
-    static final class AssertThrowsExactlyWithMessageSupplier<T extends Throwable> {
-        @BeforeTemplate
-        void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-            assertThrowsExactly(clazz, runnable, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, Class<T> clazz, String message) {
+      assertThatThrownBy(runnable).withFailMessage(message).isExactlyInstanceOf(clazz);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-            assertThatThrownBy(runnable).withFailMessage(messageSupplier).isExactlyInstanceOf(clazz);
-        }
+  static final class AssertThrowsExactlyWithMessageSupplier<T extends Throwable> {
+    @BeforeTemplate
+    void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+      assertThrowsExactly(clazz, runnable, messageSupplier);
     }
 
-    static final class AssertThrows<T extends Throwable> {
-        @BeforeTemplate
-        void before(Executable runnable, Class<T> clazz) {
-            assertThrows(clazz, runnable);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+      assertThatThrownBy(runnable).withFailMessage(messageSupplier).isExactlyInstanceOf(clazz);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, Class<T> clazz) {
-            assertThatThrownBy(runnable).isInstanceOf(clazz);
-        }
+  static final class AssertThrows<T extends Throwable> {
+    @BeforeTemplate
+    void before(Executable runnable, Class<T> clazz) {
+      assertThrows(clazz, runnable);
     }
 
-    static final class AssertThrowsWithMessage<T extends Throwable> {
-        @BeforeTemplate
-        void before(Executable runnable, Class<T> clazz, String message) {
-            assertThrows(clazz, runnable, message);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, Class<T> clazz) {
+      assertThatThrownBy(runnable).isInstanceOf(clazz);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, Class<T> clazz, String message) {
-            assertThatThrownBy(runnable).withFailMessage(message).isInstanceOf(clazz);
-        }
+  static final class AssertThrowsWithMessage<T extends Throwable> {
+    @BeforeTemplate
+    void before(Executable runnable, Class<T> clazz, String message) {
+      assertThrows(clazz, runnable, message);
     }
 
-    static final class AssertThrowsWithMessageSupplier<T extends Throwable> {
-        @BeforeTemplate
-        void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-            assertThrows(clazz, runnable, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, Class<T> clazz, String message) {
+      assertThatThrownBy(runnable).withFailMessage(message).isInstanceOf(clazz);
+    }
+  }
 
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-            assertThatThrownBy(runnable).withFailMessage(messageSupplier).isInstanceOf(clazz);
-        }
+  static final class AssertThrowsWithMessageSupplier<T extends Throwable> {
+    @BeforeTemplate
+    void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+      assertThrows(clazz, runnable, messageSupplier);
     }
 
-    static final class AssertDoesNotThrow {
-        @BeforeTemplate
-        void before(Executable runnable) {
-            assertDoesNotThrow(runnable);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+      assertThatThrownBy(runnable).withFailMessage(messageSupplier).isInstanceOf(clazz);
+    }
+  }
 
-        @BeforeTemplate
-        void before(ThrowingSupplier<?> runnable) {
-            assertDoesNotThrow(runnable);
-        }
-
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable) {
-            assertThatCode(runnable).doesNotThrowAnyException();
-        }
+  static final class AssertDoesNotThrow {
+    @BeforeTemplate
+    void before(Executable runnable) {
+      assertDoesNotThrow(runnable);
     }
 
-    static final class AssertDoesNotThrowWithMessage {
-        @BeforeTemplate
-        void before(Executable runnable, String message) {
-            assertDoesNotThrow(runnable, message);
-        }
-
-        @BeforeTemplate
-        void before(ThrowingSupplier<?> runnable, String message) {
-            assertDoesNotThrow(runnable, message);
-        }
-
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, String message) {
-            assertThatCode(runnable).withFailMessage(message).doesNotThrowAnyException();
-        }
+    @BeforeTemplate
+    void before(ThrowingSupplier<?> runnable) {
+      assertDoesNotThrow(runnable);
     }
 
-    static final class AssertDoesNotThrowWithMessageSupplier {
-        @BeforeTemplate
-        void before(Executable runnable, Supplier<String> messageSupplier) {
-            assertDoesNotThrow(runnable, messageSupplier);
-        }
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable) {
+      assertThatCode(runnable).doesNotThrowAnyException();
+    }
+  }
 
-        @BeforeTemplate
-        void before(ThrowingSupplier<?> runnable, Supplier<String> messageSupplier) {
-            assertDoesNotThrow(runnable, messageSupplier);
-        }
-
-        @AfterTemplate
-        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-        void after(ThrowingCallable runnable, Supplier<String> messageSupplier) {
-            assertThatCode(runnable).withFailMessage(messageSupplier).doesNotThrowAnyException();
-        }
+  static final class AssertDoesNotThrowWithMessage {
+    @BeforeTemplate
+    void before(Executable runnable, String message) {
+      assertDoesNotThrow(runnable, message);
     }
 
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeout
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertInstanceOf
+    @BeforeTemplate
+    void before(ThrowingSupplier<?> runnable, String message) {
+      assertDoesNotThrow(runnable, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, String message) {
+      assertThatCode(runnable).withFailMessage(message).doesNotThrowAnyException();
+    }
+  }
+
+  static final class AssertDoesNotThrowWithMessageSupplier {
+    @BeforeTemplate
+    void before(Executable runnable, Supplier<String> messageSupplier) {
+      assertDoesNotThrow(runnable, messageSupplier);
+    }
+
+    @BeforeTemplate
+    void before(ThrowingSupplier<?> runnable, Supplier<String> messageSupplier) {
+      assertDoesNotThrow(runnable, messageSupplier);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(ThrowingCallable runnable, Supplier<String> messageSupplier) {
+      assertThatCode(runnable).withFailMessage(messageSupplier).doesNotThrowAnyException();
+    }
+  }
+
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeout
+  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
+
+  static final class AssertInstanceOf<T> {
+    @BeforeTemplate
+    void before(Object object, Class<T> clazz) {
+      assertInstanceOf(clazz, object);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object, Class<T> clazz) {
+      assertThat(object).isInstanceOf(clazz);
+    }
+  }
+
+  static final class AssertInstanceOfWithMessage<T> {
+    @BeforeTemplate
+    void before(Object object, Class<T> clazz, String message) {
+      assertInstanceOf(clazz, object, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object, Class<T> clazz, String message) {
+      assertThat(object).withFailMessage(message).isInstanceOf(clazz);
+    }
+  }
+
+  static final class AssertInstanceOfWithMessageSupplier<T> {
+    @BeforeTemplate
+    void before(Object object, Class<T> clazz, Supplier<String> messageSupplier) {
+      assertInstanceOf(clazz, object, messageSupplier);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object object, Class<T> clazz, Supplier<String> messageSupplier) {
+      assertThat(object).withFailMessage(messageSupplier).isInstanceOf(clazz);
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -2,20 +2,61 @@ package tech.picnic.errorprone.refasterrules;
 
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.errorprone.annotations.DoNotCall;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.function.Supplier;
+import org.junit.jupiter.api.Assertions;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules to replace JUnit assertions with AssertJ equivalents. */
 @OnlineDocumentation
 final class JUnitToAssertJRules {
     private JUnitToAssertJRules() {}
-    
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.fail
+
+    static final class Fail {
+        @BeforeTemplate
+        void before() {
+            Assertions.fail();
+        }
+
+        @AfterTemplate
+        @DoNotCall
+        void after() {
+            throw new AssertionError();
+        }
+    }
+
+    static final class FailWithMessage {
+        @BeforeTemplate
+        void before(String message) {
+            Assertions.fail(message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(String message) {
+            fail(message);
+        }
+    }
+
+    static final class FailWithMessageAndThrowable {
+        @BeforeTemplate
+        void before(String message, Throwable throwable) {
+            Assertions.fail(message, throwable);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(String message, Throwable throwable) {
+            fail(message, throwable);
+        }
+    }
 
     static final class AssertTrue {
         @BeforeTemplate
@@ -56,7 +97,45 @@ final class JUnitToAssertJRules {
         }
     }
 
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertFalse
+    static final class AssertFalse {
+        @BeforeTemplate
+        void before(boolean condition) {
+            assertFalse(condition);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(boolean condition) {
+            assertThat(condition).isFalse();
+        }
+    }
+
+    static final class AssertFalseWithMessage {
+        @BeforeTemplate
+        void before(boolean condition, String message) {
+            assertFalse(condition, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(boolean condition, String message) {
+            assertThat(condition).withFailMessage(message).isFalse();
+        }
+    }
+
+    static final class AssertFalseWithMessageSupplier {
+        @BeforeTemplate
+        void before(boolean condition, Supplier<String> messageSupplier) {
+            assertFalse(condition, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(boolean condition, Supplier<String> messageSupplier) {
+            assertThat(condition).withFailMessage(messageSupplier).isFalse();
+        }
+    }
+
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNull
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotNull
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertEquals

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -4,6 +4,8 @@ import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.errorprone.annotations.DoNotCall;
@@ -136,8 +138,84 @@ final class JUnitToAssertJRules {
         }
     }
 
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNull
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotNull
+    static final class AssertNull {
+        @BeforeTemplate
+        void before(Object object) {
+            assertNull(object);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object object) {
+            assertThat(object).isNull();
+        }
+    }
+
+    static final class AssertNullWithMessage {
+        @BeforeTemplate
+        void before(Object object, String message) {
+            assertNull(object, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object object, String message) {
+            assertThat(object).withFailMessage(message).isNull();
+        }
+    }
+
+    static final class AssertNullWithMessageSupplier {
+        @BeforeTemplate
+        void before(Object object, Supplier<String> messageSupplier) {
+            assertNull(object, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object object, Supplier<String> messageSupplier) {
+            assertThat(object).withFailMessage(messageSupplier).isNull();
+        }
+    }
+
+    static final class AssertNotNull {
+        @BeforeTemplate
+        void before(Object object) {
+            assertNotNull(object);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object object) {
+            assertThat(object).isNotNull();
+        }
+    }
+
+    static final class AssertNotNullWithMessage {
+        @BeforeTemplate
+        void before(Object object, String message) {
+            assertNotNull(object, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object object, String message) {
+            assertThat(object).withFailMessage(message).isNotNull();
+        }
+    }
+
+    static final class AssertNotNullWithMessageSupplier {
+        @BeforeTemplate
+        void before(Object object, Supplier<String> messageSupplier) {
+            assertNotNull(object, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object object, Supplier<String> messageSupplier) {
+            assertThat(object).withFailMessage(messageSupplier).isNotNull();
+        }
+    }
+
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertEquals
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertArrayEquals
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertIterableEquals

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -99,14 +99,14 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatWithFailMessageSupplierIsTrue {
     @BeforeTemplate
-    void before(boolean condition, Supplier<String> messageSupplier) {
-      assertTrue(condition, messageSupplier);
+    void before(boolean condition, Supplier<String> supplier) {
+      assertTrue(condition, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, Supplier<String> messageSupplier) {
-      assertThat(condition).withFailMessage(messageSupplier).isTrue();
+    void after(boolean condition, Supplier<String> supplier) {
+      assertThat(condition).withFailMessage(supplier).isTrue();
     }
   }
 
@@ -138,14 +138,14 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatWithFailMessageSupplierIsFalse {
     @BeforeTemplate
-    void before(boolean condition, Supplier<String> messageSupplier) {
-      assertFalse(condition, messageSupplier);
+    void before(boolean condition, Supplier<String> supplier) {
+      assertFalse(condition, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, Supplier<String> messageSupplier) {
-      assertThat(condition).withFailMessage(messageSupplier).isFalse();
+    void after(boolean condition, Supplier<String> supplier) {
+      assertThat(condition).withFailMessage(supplier).isFalse();
     }
   }
 
@@ -261,14 +261,14 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatWithFailMessageSupplierIsSameAs {
     @BeforeTemplate
-    void before(Object actual, Object expected, Supplier<String> messageSupplier) {
-      assertSame(expected, actual, messageSupplier);
+    void before(Object actual, Object expected, Supplier<String> supplier) {
+      assertSame(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Object expected, Supplier<String> messageSupplier) {
-      assertThat(actual).withFailMessage(messageSupplier).isSameAs(expected);
+    void after(Object actual, Object expected, Supplier<String> supplier) {
+      assertThat(actual).withFailMessage(supplier).isSameAs(expected);
     }
   }
 
@@ -300,14 +300,14 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatWithFailMessageSupplierIsNotSameAs {
     @BeforeTemplate
-    void before(Object actual, Object expected, Supplier<String> messageSupplier) {
-      assertNotSame(expected, actual, messageSupplier);
+    void before(Object actual, Object expected, Supplier<String> supplier) {
+      assertNotSame(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Object expected, Supplier<String> messageSupplier) {
-      assertThat(actual).withFailMessage(messageSupplier).isNotSameAs(expected);
+    void after(Object actual, Object expected, Supplier<String> supplier) {
+      assertThat(actual).withFailMessage(supplier).isNotSameAs(expected);
     }
   }
 
@@ -344,14 +344,14 @@ final class JUnitToAssertJRules {
   static final class AssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf<
       T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-      assertThrowsExactly(clazz, runnable, messageSupplier);
+    void before(Executable runnable, Class<T> clazz, Supplier<String> supplier) {
+      assertThrowsExactly(clazz, runnable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-      assertThatThrownBy(runnable).withFailMessage(messageSupplier).isExactlyInstanceOf(clazz);
+    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> supplier) {
+      assertThatThrownBy(runnable).withFailMessage(supplier).isExactlyInstanceOf(clazz);
     }
   }
 
@@ -383,14 +383,14 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatThrownByWithFailMessageSupplierIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-      assertThrows(clazz, runnable, messageSupplier);
+    void before(Executable runnable, Class<T> clazz, Supplier<String> supplier) {
+      assertThrows(clazz, runnable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
-      assertThatThrownBy(runnable).withFailMessage(messageSupplier).isInstanceOf(clazz);
+    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> supplier) {
+      assertThatThrownBy(runnable).withFailMessage(supplier).isInstanceOf(clazz);
     }
   }
 
@@ -432,19 +432,19 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException {
     @BeforeTemplate
-    void before(Executable runnable, Supplier<String> messageSupplier) {
-      assertDoesNotThrow(runnable, messageSupplier);
+    void before(Executable runnable, Supplier<String> supplier) {
+      assertDoesNotThrow(runnable, supplier);
     }
 
     @BeforeTemplate
-    void before(ThrowingSupplier<?> runnable, Supplier<String> messageSupplier) {
-      assertDoesNotThrow(runnable, messageSupplier);
+    void before(ThrowingSupplier<?> runnable, Supplier<String> supplier) {
+      assertDoesNotThrow(runnable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Supplier<String> messageSupplier) {
-      assertThatCode(runnable).withFailMessage(messageSupplier).doesNotThrowAnyException();
+    void after(ThrowingCallable runnable, Supplier<String> supplier) {
+      assertThatCode(runnable).withFailMessage(supplier).doesNotThrowAnyException();
     }
   }
 
@@ -479,14 +479,14 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatWithFailMessageSupplierIsInstanceOf<T> {
     @BeforeTemplate
-    void before(Object object, Class<T> clazz, Supplier<String> messageSupplier) {
-      assertInstanceOf(clazz, object, messageSupplier);
+    void before(Object object, Class<T> clazz, Supplier<String> supplier) {
+      assertInstanceOf(clazz, object, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Class<T> clazz, Supplier<String> messageSupplier) {
-      assertThat(object).withFailMessage(messageSupplier).isInstanceOf(clazz);
+    void after(Object object, Class<T> clazz, Supplier<String> supplier) {
+      assertThat(object).withFailMessage(supplier).isInstanceOf(clazz);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -32,7 +32,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class JUnitToAssertJRules {
   private JUnitToAssertJRules() {}
 
-  static final class Fail {
+  static final class ThrowNewAssertionError {
     @BeforeTemplate
     void before() {
       Assertions.fail();
@@ -71,7 +71,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertTrue {
+  static final class AssertThatIsTrue {
     @BeforeTemplate
     void before(boolean condition) {
       assertTrue(condition);
@@ -84,7 +84,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertTrueWithMessage {
+  static final class AssertThatWithFailMessageStringIsTrue {
     @BeforeTemplate
     void before(boolean condition, String message) {
       assertTrue(condition, message);
@@ -97,7 +97,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertTrueWithMessageSupplier {
+  static final class AssertThatWithFailMessageSupplierIsTrue {
     @BeforeTemplate
     void before(boolean condition, Supplier<String> messageSupplier) {
       assertTrue(condition, messageSupplier);
@@ -110,7 +110,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertFalse {
+  static final class AssertThatIsFalse {
     @BeforeTemplate
     void before(boolean condition) {
       assertFalse(condition);
@@ -123,7 +123,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertFalseWithMessage {
+  static final class AssertThatWithFailMessageStringIsFalse {
     @BeforeTemplate
     void before(boolean condition, String message) {
       assertFalse(condition, message);
@@ -136,7 +136,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertFalseWithMessageSupplier {
+  static final class AssertThatWithFailMessageSupplierIsFalse {
     @BeforeTemplate
     void before(boolean condition, Supplier<String> messageSupplier) {
       assertFalse(condition, messageSupplier);
@@ -149,7 +149,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNull {
+  static final class AssertThatIsNull {
     @BeforeTemplate
     void before(Object object) {
       assertNull(object);
@@ -162,7 +162,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNullWithMessage {
+  static final class AssertThatWithFailMessageStringIsNull {
     @BeforeTemplate
     void before(Object object, String message) {
       assertNull(object, message);
@@ -175,20 +175,20 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNullWithMessageSupplier {
+  static final class AssertThatWithFailMessageSupplierIsNull {
     @BeforeTemplate
-    void before(Object object, Supplier<String> messageSupplier) {
-      assertNull(object, messageSupplier);
+    void before(Object object, Supplier<String> supplier) {
+      assertNull(object, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Supplier<String> messageSupplier) {
-      assertThat(object).withFailMessage(messageSupplier).isNull();
+    void after(Object object, Supplier<String> supplier) {
+      assertThat(object).withFailMessage(supplier).isNull();
     }
   }
 
-  static final class AssertNotNull {
+  static final class AssertThatIsNotNull {
     @BeforeTemplate
     void before(Object object) {
       assertNotNull(object);
@@ -201,7 +201,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNotNullWithMessage {
+  static final class AssertThatWithFailMessageStringIsNotNull {
     @BeforeTemplate
     void before(Object object, String message) {
       assertNotNull(object, message);
@@ -214,26 +214,26 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNotNullWithMessageSupplier {
+  static final class AssertThatWithFailMessageSupplierIsNotNull {
     @BeforeTemplate
-    void before(Object object, Supplier<String> messageSupplier) {
-      assertNotNull(object, messageSupplier);
+    void before(Object object, Supplier<String> supplier) {
+      assertNotNull(object, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, Supplier<String> messageSupplier) {
-      assertThat(object).withFailMessage(messageSupplier).isNotNull();
+    void after(Object object, Supplier<String> supplier) {
+      assertThat(object).withFailMessage(supplier).isNotNull();
     }
   }
 
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertEquals
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertArrayEquals
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertIterableEquals
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertLinesMatch
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotEquals
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertEquals`.
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertArrayEquals`.
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertIterableEquals`.
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertLinesMatch`.
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertNotEquals`.
 
-  static final class AssertSame {
+  static final class AssertThatIsSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected) {
       assertSame(expected, actual);
@@ -246,7 +246,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertSameWithMessage {
+  static final class AssertThatWithFailMessageStringIsSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected, String message) {
       assertSame(expected, actual, message);
@@ -259,7 +259,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertSameWithMessageSupplier {
+  static final class AssertThatWithFailMessageSupplierIsSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected, Supplier<String> messageSupplier) {
       assertSame(expected, actual, messageSupplier);
@@ -272,7 +272,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNotSame {
+  static final class AssertThatIsNotSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected) {
       assertNotSame(expected, actual);
@@ -285,7 +285,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNotSameWithMessage {
+  static final class AssertThatWithFailMessageStringIsNotSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected, String message) {
       assertNotSame(expected, actual, message);
@@ -298,7 +298,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertNotSameWithMessageSupplier {
+  static final class AssertThatWithFailMessageSupplierIsNotSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected, Supplier<String> messageSupplier) {
       assertNotSame(expected, actual, messageSupplier);
@@ -311,9 +311,10 @@ final class JUnitToAssertJRules {
     }
   }
 
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertAll
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertAll`.
 
-  static final class AssertThrowsExactly<T extends Throwable> {
+  // XXX: Switch params?
+  static final class AssertThatThrownByIsExactlyInstanceOf<T extends Throwable> {
     @BeforeTemplate
     void before(Executable runnable, Class<T> clazz) {
       assertThrowsExactly(clazz, runnable);
@@ -326,7 +327,8 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThrowsExactlyWithMessage<T extends Throwable> {
+  static final class AssertThatThrownByWithFailMessageStringIsExactlyInstanceOf<
+      T extends Throwable> {
     @BeforeTemplate
     void before(Executable runnable, Class<T> clazz, String message) {
       assertThrowsExactly(clazz, runnable, message);
@@ -339,7 +341,8 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThrowsExactlyWithMessageSupplier<T extends Throwable> {
+  static final class AssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf<
+      T extends Throwable> {
     @BeforeTemplate
     void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
       assertThrowsExactly(clazz, runnable, messageSupplier);
@@ -352,7 +355,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThrows<T extends Throwable> {
+  static final class AssertThatThrownByIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
     void before(Executable runnable, Class<T> clazz) {
       assertThrows(clazz, runnable);
@@ -365,7 +368,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThrowsWithMessage<T extends Throwable> {
+  static final class AssertThatThrownByWithFailMessageStringIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
     void before(Executable runnable, Class<T> clazz, String message) {
       assertThrows(clazz, runnable, message);
@@ -378,7 +381,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThrowsWithMessageSupplier<T extends Throwable> {
+  static final class AssertThatThrownByWithFailMessageSupplierIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
     void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
       assertThrows(clazz, runnable, messageSupplier);
@@ -391,7 +394,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertDoesNotThrow {
+  static final class AssertThatCodeDoesNotThrowAnyException {
     @BeforeTemplate
     void before(Executable runnable) {
       assertDoesNotThrow(runnable);
@@ -409,7 +412,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertDoesNotThrowWithMessage {
+  static final class AssertThatCodeWithFailMessageStringDoesNotThrowAnyException {
     @BeforeTemplate
     void before(Executable runnable, String message) {
       assertDoesNotThrow(runnable, message);
@@ -427,7 +430,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertDoesNotThrowWithMessageSupplier {
+  static final class AssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException {
     @BeforeTemplate
     void before(Executable runnable, Supplier<String> messageSupplier) {
       assertDoesNotThrow(runnable, messageSupplier);
@@ -445,10 +448,10 @@ final class JUnitToAssertJRules {
     }
   }
 
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeout
-  // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertTimeout`.
+  // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertTimeoutPreemptively`.
 
-  static final class AssertInstanceOf<T> {
+  static final class AssertThatIsInstanceOf<T> {
     @BeforeTemplate
     void before(Object object, Class<T> clazz) {
       assertInstanceOf(clazz, object);
@@ -461,7 +464,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertInstanceOfWithMessage<T> {
+  static final class AssertThatWithFailMessageStringIsInstanceOf<T> {
     @BeforeTemplate
     void before(Object object, Class<T> clazz, String message) {
       assertInstanceOf(clazz, object, message);
@@ -474,7 +477,7 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertInstanceOfWithMessageSupplier<T> {
+  static final class AssertThatWithFailMessageSupplierIsInstanceOf<T> {
     @BeforeTemplate
     void before(Object object, Class<T> clazz, Supplier<String> messageSupplier) {
       assertInstanceOf(clazz, object, messageSupplier);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -5,7 +5,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.errorprone.annotations.DoNotCall;
@@ -221,8 +223,85 @@ final class JUnitToAssertJRules {
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertIterableEquals
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertLinesMatch
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotEquals
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertSame
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotSame
+
+    static final class AssertSame {
+        @BeforeTemplate
+        void before(Object actual, Object expected) {
+            assertSame(expected, actual);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object actual, Object expected) {
+            assertThat(actual).isSameAs(expected);
+        }
+    }
+
+    static final class AssertSameWithMessage {
+        @BeforeTemplate
+        void before(Object actual, Object expected, String message) {
+            assertSame(expected, actual, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object actual, Object expected, String message) {
+            assertThat(actual).withFailMessage(message).isSameAs(expected);
+        }
+    }
+
+    static final class AssertSameWithMessageSupplier {
+        @BeforeTemplate
+        void before(Object actual, Object expected, Supplier<String> messageSupplier) {
+            assertSame(expected, actual, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object actual, Object expected, Supplier<String> messageSupplier) {
+            assertThat(actual).withFailMessage(messageSupplier).isSameAs(expected);
+        }
+    }
+
+    static final class AssertNotSame {
+        @BeforeTemplate
+        void before(Object actual, Object expected) {
+            assertNotSame(expected, actual);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object actual, Object expected) {
+            assertThat(actual).isNotSameAs(expected);
+        }
+    }
+
+    static final class AssertNotSameWithMessage {
+        @BeforeTemplate
+        void before(Object actual, Object expected, String message) {
+            assertNotSame(expected, actual, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object actual, Object expected, String message) {
+            assertThat(actual).withFailMessage(message).isNotSameAs(expected);
+        }
+    }
+
+    static final class AssertNotSameWithMessageSupplier {
+        @BeforeTemplate
+        void before(Object actual, Object expected, Supplier<String> messageSupplier) {
+            assertNotSame(expected, actual, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(Object actual, Object expected, Supplier<String> messageSupplier) {
+            assertThat(actual).withFailMessage(messageSupplier).isNotSameAs(expected);
+        }
+    }
+
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertAll
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertThrowsExactly
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertThrows

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -313,7 +313,6 @@ final class JUnitToAssertJRules {
 
   // XXX: Rewrite `org.junit.jupiter.api.Assertions.assertAll`.
 
-  // XXX: Switch params?
   static final class AssertThatThrownByIsExactlyInstanceOf<T extends Throwable> {
     @BeforeTemplate
     void before(Executable runnable, Class<T> clazz) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -1,0 +1,76 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.function.Supplier;
+import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
+
+/** Refaster rules to replace JUnit assertions with AssertJ equivalents. */
+@OnlineDocumentation
+final class JUnitToAssertJRules {
+    private JUnitToAssertJRules() {}
+    
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.fail
+
+    static final class AssertTrue {
+        @BeforeTemplate
+        void before(boolean condition) {
+            assertTrue(condition);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(boolean condition) {
+            assertThat(condition).isTrue();
+        }
+    }
+
+    static final class AssertTrueWithMessage {
+        @BeforeTemplate
+        void before(boolean condition, String message) {
+            assertTrue(condition, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(boolean condition, String message) {
+            assertThat(condition).withFailMessage(message).isTrue();
+        }
+    }
+
+    static final class AssertTrueWithMessageSupplier {
+        @BeforeTemplate
+        void before(boolean condition, Supplier<String> messageSupplier) {
+            assertTrue(condition, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(boolean condition, Supplier<String> messageSupplier) {
+            assertThat(condition).withFailMessage(messageSupplier).isTrue();
+        }
+    }
+
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertFalse
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNull
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotNull
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertEquals
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertArrayEquals
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertIterableEquals
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertLinesMatch
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotEquals
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertSame
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertNotSame
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertAll
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertThrowsExactly
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertThrows
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertDoesNotThrow
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeout
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
+    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertInstanceOf
+}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -2,12 +2,17 @@ package tech.picnic.errorprone.refasterrules;
 
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.errorprone.annotations.DoNotCall;
@@ -15,7 +20,10 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.function.Supplier;
+import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules to replace JUnit assertions with AssertJ equivalents. */
@@ -303,9 +311,139 @@ final class JUnitToAssertJRules {
     }
 
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertAll
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertThrowsExactly
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertThrows
-    // XXX: Rewrite org.junit.jupiter.api.Assertions.assertDoesNotThrow
+
+    static final class AssertThrowsExactly<T extends Throwable> {
+        @BeforeTemplate
+        void before(Executable runnable, Class<T> clazz) {
+            assertThrowsExactly(clazz, runnable);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, Class<T> clazz) {
+            assertThatThrownBy(runnable).isExactlyInstanceOf(clazz);
+        }
+    }
+
+    static final class AssertThrowsExactlyWithMessage<T extends Throwable> {
+        @BeforeTemplate
+        void before(Executable runnable, Class<T> clazz, String message) {
+            assertThrowsExactly(clazz, runnable, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, Class<T> clazz, String message) {
+            assertThatThrownBy(runnable).withFailMessage(message).isExactlyInstanceOf(clazz);
+        }
+    }
+
+    static final class AssertThrowsExactlyWithMessageSupplier<T extends Throwable> {
+        @BeforeTemplate
+        void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+            assertThrowsExactly(clazz, runnable, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+            assertThatThrownBy(runnable).withFailMessage(messageSupplier).isExactlyInstanceOf(clazz);
+        }
+    }
+
+    static final class AssertThrows<T extends Throwable> {
+        @BeforeTemplate
+        void before(Executable runnable, Class<T> clazz) {
+            assertThrows(clazz, runnable);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, Class<T> clazz) {
+            assertThatThrownBy(runnable).isInstanceOf(clazz);
+        }
+    }
+
+    static final class AssertThrowsWithMessage<T extends Throwable> {
+        @BeforeTemplate
+        void before(Executable runnable, Class<T> clazz, String message) {
+            assertThrows(clazz, runnable, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, Class<T> clazz, String message) {
+            assertThatThrownBy(runnable).withFailMessage(message).isInstanceOf(clazz);
+        }
+    }
+
+    static final class AssertThrowsWithMessageSupplier<T extends Throwable> {
+        @BeforeTemplate
+        void before(Executable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+            assertThrows(clazz, runnable, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> messageSupplier) {
+            assertThatThrownBy(runnable).withFailMessage(messageSupplier).isInstanceOf(clazz);
+        }
+    }
+
+    static final class AssertDoesNotThrow {
+        @BeforeTemplate
+        void before(Executable runnable) {
+            assertDoesNotThrow(runnable);
+        }
+
+        @BeforeTemplate
+        void before(ThrowingSupplier<?> runnable) {
+            assertDoesNotThrow(runnable);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable) {
+            assertThatCode(runnable).doesNotThrowAnyException();
+        }
+    }
+
+    static final class AssertDoesNotThrowWithMessage {
+        @BeforeTemplate
+        void before(Executable runnable, String message) {
+            assertDoesNotThrow(runnable, message);
+        }
+
+        @BeforeTemplate
+        void before(ThrowingSupplier<?> runnable, String message) {
+            assertDoesNotThrow(runnable, message);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, String message) {
+            assertThatCode(runnable).withFailMessage(message).doesNotThrowAnyException();
+        }
+    }
+
+    static final class AssertDoesNotThrowWithMessageSupplier {
+        @BeforeTemplate
+        void before(Executable runnable, Supplier<String> messageSupplier) {
+            assertDoesNotThrow(runnable, messageSupplier);
+        }
+
+        @BeforeTemplate
+        void before(ThrowingSupplier<?> runnable, Supplier<String> messageSupplier) {
+            assertDoesNotThrow(runnable, messageSupplier);
+        }
+
+        @AfterTemplate
+        @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+        void after(ThrowingCallable runnable, Supplier<String> messageSupplier) {
+            assertThatCode(runnable).withFailMessage(messageSupplier).doesNotThrowAnyException();
+        }
+    }
+
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeout
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertTimeoutPreemptively
     // XXX: Rewrite org.junit.jupiter.api.Assertions.assertInstanceOf

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -315,135 +315,135 @@ final class JUnitToAssertJRules {
 
   static final class AssertThatThrownByIsExactlyInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz) {
-      assertThrowsExactly(clazz, runnable);
+    void before(Executable throwingCallable, Class<T> clazz) {
+      assertThrowsExactly(clazz, throwingCallable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz) {
-      assertThatThrownBy(runnable).isExactlyInstanceOf(clazz);
+    void after(ThrowingCallable throwingCallable, Class<T> clazz) {
+      assertThatThrownBy(throwingCallable).isExactlyInstanceOf(clazz);
     }
   }
 
   static final class AssertThatThrownByWithFailMessageStringIsExactlyInstanceOf<
       T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz, String message) {
-      assertThrowsExactly(clazz, runnable, message);
+    void before(Executable throwingCallable, Class<T> clazz, String message) {
+      assertThrowsExactly(clazz, throwingCallable, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz, String message) {
-      assertThatThrownBy(runnable).withFailMessage(message).isExactlyInstanceOf(clazz);
+    void after(ThrowingCallable throwingCallable, Class<T> clazz, String message) {
+      assertThatThrownBy(throwingCallable).withFailMessage(message).isExactlyInstanceOf(clazz);
     }
   }
 
   static final class AssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf<
       T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz, Supplier<String> supplier) {
-      assertThrowsExactly(clazz, runnable, supplier);
+    void before(Executable throwingCallable, Class<T> clazz, Supplier<String> supplier) {
+      assertThrowsExactly(clazz, throwingCallable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> supplier) {
-      assertThatThrownBy(runnable).withFailMessage(supplier).isExactlyInstanceOf(clazz);
+    void after(ThrowingCallable throwingCallable, Class<T> clazz, Supplier<String> supplier) {
+      assertThatThrownBy(throwingCallable).withFailMessage(supplier).isExactlyInstanceOf(clazz);
     }
   }
 
   static final class AssertThatThrownByIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz) {
-      assertThrows(clazz, runnable);
+    void before(Executable throwingCallable, Class<T> clazz) {
+      assertThrows(clazz, throwingCallable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz) {
-      assertThatThrownBy(runnable).isInstanceOf(clazz);
+    void after(ThrowingCallable throwingCallable, Class<T> clazz) {
+      assertThatThrownBy(throwingCallable).isInstanceOf(clazz);
     }
   }
 
   static final class AssertThatThrownByWithFailMessageStringIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz, String message) {
-      assertThrows(clazz, runnable, message);
+    void before(Executable throwingCallable, Class<T> clazz, String message) {
+      assertThrows(clazz, throwingCallable, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz, String message) {
-      assertThatThrownBy(runnable).withFailMessage(message).isInstanceOf(clazz);
+    void after(ThrowingCallable throwingCallable, Class<T> clazz, String message) {
+      assertThatThrownBy(throwingCallable).withFailMessage(message).isInstanceOf(clazz);
     }
   }
 
   static final class AssertThatThrownByWithFailMessageSupplierIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable runnable, Class<T> clazz, Supplier<String> supplier) {
-      assertThrows(clazz, runnable, supplier);
+    void before(Executable throwingCallable, Class<T> clazz, Supplier<String> supplier) {
+      assertThrows(clazz, throwingCallable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz, Supplier<String> supplier) {
-      assertThatThrownBy(runnable).withFailMessage(supplier).isInstanceOf(clazz);
+    void after(ThrowingCallable throwingCallable, Class<T> clazz, Supplier<String> supplier) {
+      assertThatThrownBy(throwingCallable).withFailMessage(supplier).isInstanceOf(clazz);
     }
   }
 
   static final class AssertThatCodeDoesNotThrowAnyException {
     @BeforeTemplate
-    void before(Executable runnable) {
-      assertDoesNotThrow(runnable);
+    void before(Executable throwingCallable) {
+      assertDoesNotThrow(throwingCallable);
     }
 
     @BeforeTemplate
-    void before(ThrowingSupplier<?> runnable) {
-      assertDoesNotThrow(runnable);
+    void before(ThrowingSupplier<?> throwingCallable) {
+      assertDoesNotThrow(throwingCallable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable) {
-      assertThatCode(runnable).doesNotThrowAnyException();
+    void after(ThrowingCallable throwingCallable) {
+      assertThatCode(throwingCallable).doesNotThrowAnyException();
     }
   }
 
   static final class AssertThatCodeWithFailMessageStringDoesNotThrowAnyException {
     @BeforeTemplate
-    void before(Executable runnable, String message) {
-      assertDoesNotThrow(runnable, message);
+    void before(Executable throwingCallable, String message) {
+      assertDoesNotThrow(throwingCallable, message);
     }
 
     @BeforeTemplate
-    void before(ThrowingSupplier<?> runnable, String message) {
-      assertDoesNotThrow(runnable, message);
+    void before(ThrowingSupplier<?> throwingCallable, String message) {
+      assertDoesNotThrow(throwingCallable, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, String message) {
-      assertThatCode(runnable).withFailMessage(message).doesNotThrowAnyException();
+    void after(ThrowingCallable throwingCallable, String message) {
+      assertThatCode(throwingCallable).withFailMessage(message).doesNotThrowAnyException();
     }
   }
 
   static final class AssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException {
     @BeforeTemplate
-    void before(Executable runnable, Supplier<String> supplier) {
-      assertDoesNotThrow(runnable, supplier);
+    void before(Executable throwingCallable, Supplier<String> supplier) {
+      assertDoesNotThrow(throwingCallable, supplier);
     }
 
     @BeforeTemplate
-    void before(ThrowingSupplier<?> runnable, Supplier<String> supplier) {
-      assertDoesNotThrow(runnable, supplier);
+    void before(ThrowingSupplier<?> throwingCallable, Supplier<String> supplier) {
+      assertDoesNotThrow(throwingCallable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Supplier<String> supplier) {
-      assertThatCode(runnable).withFailMessage(supplier).doesNotThrowAnyException();
+    void after(ThrowingCallable throwingCallable, Supplier<String> supplier) {
+      assertThatCode(throwingCallable).withFailMessage(supplier).doesNotThrowAnyException();
     }
   }
 

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -50,6 +50,7 @@ final class RefasterRulesTest {
           ImmutableSortedSetRules.class,
           IntStreamRules.class,
           JUnitRules.class,
+          JUnitToAssertJRules.class,
           LongStreamRules.class,
           MapEntryRules.class,
           MapRules.class,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -16,135 +16,163 @@ import org.junit.jupiter.api.Assertions;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
-    void testFail() {
-        Assertions.fail();
-    }
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(
+        (Runnable) () -> assertDoesNotThrow(() -> null),
+        (Runnable) () -> assertFalse(true),
+        (Runnable) () -> assertInstanceOf(null, null),
+        (Runnable) () -> assertNotNull(null),
+        (Runnable) () -> assertNotSame(null, null),
+        (Runnable) () -> assertNull(null),
+        (Runnable) () -> assertSame(null, null),
+        (Runnable) () -> assertThrows(null, null),
+        (Runnable) () -> assertThrowsExactly(null, null),
+        (Runnable) () -> assertTrue(true),
+        (Runnable) () -> Assertions.fail());
+  }
 
-    void testFailWithMessage() {
-        Assertions.fail("foo");
-    }
+  void testFail() {
+    Assertions.fail();
+  }
 
-    void testFailWithMessageAndThrowable() {
-        Assertions.fail("foo", new IllegalStateException());
-    }
+  void testFailWithMessage() {
+    Assertions.fail("foo");
+  }
 
-    void testAssertTrue() {
-        assertTrue(true);
-    }
+  void testFailWithMessageAndThrowable() {
+    Assertions.fail("foo", new IllegalStateException());
+  }
 
-    void testAssertTrueWithMessage() {
-        assertTrue(true, "foo");
-    }
+  void testAssertTrue() {
+    assertTrue(true);
+  }
 
-    void testAssertTrueWithMessageSupplier() {
-        assertTrue(true, () -> "foo");
-    }
+  void testAssertTrueWithMessage() {
+    assertTrue(true, "foo");
+  }
 
-    void testAssertFalse() {
-        assertFalse(true);
-    }
+  void testAssertTrueWithMessageSupplier() {
+    assertTrue(true, () -> "foo");
+  }
 
-    void testAssertFalseWithMessage() {
-        assertFalse(true, "foo");
-    }
+  void testAssertFalse() {
+    assertFalse(true);
+  }
 
-    void testAssertFalseWithMessageSupplier() {
-        assertFalse(true, () -> "foo");
-    }
+  void testAssertFalseWithMessage() {
+    assertFalse(true, "foo");
+  }
 
-    void testAssertNull() {
-        assertNull(new Object());
-    }
+  void testAssertFalseWithMessageSupplier() {
+    assertFalse(true, () -> "foo");
+  }
 
-    void testAssertNullWithMessage() {
-        assertNull(new Object(), "foo");
-    }
+  void testAssertNull() {
+    assertNull(new Object());
+  }
 
-    void testAssertNullWithMessageSupplier() {
-        assertNull(new Object(), () -> "foo");
-    }
+  void testAssertNullWithMessage() {
+    assertNull(new Object(), "foo");
+  }
 
-    void testAssertNotNull() {
-        assertNotNull(new Object());
-    }
+  void testAssertNullWithMessageSupplier() {
+    assertNull(new Object(), () -> "foo");
+  }
 
-    void testAssertNotNullWithMessage() {
-        assertNotNull(new Object(), "foo");
-    }
+  void testAssertNotNull() {
+    assertNotNull(new Object());
+  }
 
-    void testAssertNotNullWithMessageSupplier() {
-        assertNotNull(new Object(), () -> "foo");
-    }
+  void testAssertNotNullWithMessage() {
+    assertNotNull(new Object(), "foo");
+  }
 
-    void testAssertSame() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertSame(expected, actual);
-    }
+  void testAssertNotNullWithMessageSupplier() {
+    assertNotNull(new Object(), () -> "foo");
+  }
 
-    void testAssertSameWithMessage() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertSame(expected, actual, "foo");
-    }
+  void testAssertSame() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertSame(expected, actual);
+  }
 
-    void testAssertSameWithMessageSupplier() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertSame(expected, actual, () -> "foo");
-    }
+  void testAssertSameWithMessage() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertSame(expected, actual, "foo");
+  }
 
-    void testAssertNotSame() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertNotSame(expected, actual);
-    }
+  void testAssertSameWithMessageSupplier() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertSame(expected, actual, () -> "foo");
+  }
 
-    void testAssertNotSameWithMessage() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertNotSame(expected, actual, "foo");
-    }
+  void testAssertNotSame() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertNotSame(expected, actual);
+  }
 
-    void testAssertNotSameWithMessageSupplier() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertNotSame(expected, actual, () -> "foo");
-    }
+  void testAssertNotSameWithMessage() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertNotSame(expected, actual, "foo");
+  }
 
-    void testAssertThrowsExactly() {
-        assertThrowsExactly(IllegalStateException.class, () -> {});
-    }
+  void testAssertNotSameWithMessageSupplier() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertNotSame(expected, actual, () -> "foo");
+  }
 
-    void testAssertThrowsExactlyWithMessage() {
-        assertThrowsExactly(IllegalStateException.class, () -> {}, "foo");
-    }
+  void testAssertThrowsExactly() {
+    assertThrowsExactly(IllegalStateException.class, () -> {});
+  }
 
-    void testAssertThrowsExactlyWithMessageSupplier() {
-        assertThrowsExactly(IllegalStateException.class, () -> {}, () -> "foo");
-    }
+  void testAssertThrowsExactlyWithMessage() {
+    assertThrowsExactly(IllegalStateException.class, () -> {}, "foo");
+  }
 
-    void testAssertThrows() {
-        assertThrows(IllegalStateException.class, () -> {});
-    }
+  void testAssertThrowsExactlyWithMessageSupplier() {
+    assertThrowsExactly(IllegalStateException.class, () -> {}, () -> "foo");
+  }
 
-    void testAssertThrowsWithMessage() {
-        assertThrows(IllegalStateException.class, () -> {}, "foo");
-    }
+  void testAssertThrows() {
+    assertThrows(IllegalStateException.class, () -> {});
+  }
 
-    void testAssertThrowsWithMessageSupplier() {
-        assertThrows(IllegalStateException.class, () -> {}, () -> "foo");
-    }
+  void testAssertThrowsWithMessage() {
+    assertThrows(IllegalStateException.class, () -> {}, "foo");
+  }
 
-    void testAssertDoesNotThrow() {
-        assertDoesNotThrow(() -> {});
-    }
+  void testAssertThrowsWithMessageSupplier() {
+    assertThrows(IllegalStateException.class, () -> {}, () -> "foo");
+  }
 
-    void testAssertDoesNotThrowWithMessage() {
-        assertDoesNotThrow(() -> {}, "foo");
-    }
+  void testAssertDoesNotThrow() {
+    assertDoesNotThrow(() -> {});
+  }
 
-    void testAssertDoesNotThrowWithMessageSupplier() {
-        assertDoesNotThrow(() -> {}, () -> "foo");
-    }
+  void testAssertDoesNotThrowWithMessage() {
+    assertDoesNotThrow(() -> {}, "foo");
+  }
+
+  void testAssertDoesNotThrowWithMessageSupplier() {
+    assertDoesNotThrow(() -> {}, () -> "foo");
+  }
+
+  void testAssertInstanceOf() {
+    assertInstanceOf(Object.class, new Object());
+  }
+
+  void testAssertInstanceOfWithMessage() {
+    assertInstanceOf(Object.class, new Object(), "foo");
+  }
+
+  void testAssertInstanceOfWithMessageSupplier() {
+    assertInstanceOf(Object.class, new Object(), () -> "foo");
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -32,7 +32,7 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         (Runnable) () -> Assertions.fail());
   }
 
-  void testFail() {
+  void testThrowNewAssertionError() {
     Assertions.fail();
   }
 
@@ -44,135 +44,135 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     Assertions.fail("foo", new IllegalStateException());
   }
 
-  void testAssertTrue() {
+  void testAssertThatIsTrue() {
     assertTrue(true);
   }
 
-  void testAssertTrueWithMessage() {
+  void testAssertThatWithFailMessageStringIsTrue() {
     assertTrue(true, "foo");
   }
 
-  void testAssertTrueWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsTrue() {
     assertTrue(true, () -> "foo");
   }
 
-  void testAssertFalse() {
+  void testAssertThatIsFalse() {
     assertFalse(true);
   }
 
-  void testAssertFalseWithMessage() {
+  void testAssertThatWithFailMessageStringIsFalse() {
     assertFalse(true, "foo");
   }
 
-  void testAssertFalseWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsFalse() {
     assertFalse(true, () -> "foo");
   }
 
-  void testAssertNull() {
+  void testAssertThatIsNull() {
     assertNull(new Object());
   }
 
-  void testAssertNullWithMessage() {
+  void testAssertThatWithFailMessageStringIsNull() {
     assertNull(new Object(), "foo");
   }
 
-  void testAssertNullWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsNull() {
     assertNull(new Object(), () -> "foo");
   }
 
-  void testAssertNotNull() {
+  void testAssertThatIsNotNull() {
     assertNotNull(new Object());
   }
 
-  void testAssertNotNullWithMessage() {
+  void testAssertThatWithFailMessageStringIsNotNull() {
     assertNotNull(new Object(), "foo");
   }
 
-  void testAssertNotNullWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsNotNull() {
     assertNotNull(new Object(), () -> "foo");
   }
 
-  void testAssertSame() {
+  void testAssertThatIsSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertSame(expected, actual);
   }
 
-  void testAssertSameWithMessage() {
+  void testAssertThatWithFailMessageStringIsSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertSame(expected, actual, "foo");
   }
 
-  void testAssertSameWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertSame(expected, actual, () -> "foo");
   }
 
-  void testAssertNotSame() {
+  void testAssertThatIsNotSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertNotSame(expected, actual);
   }
 
-  void testAssertNotSameWithMessage() {
+  void testAssertThatWithFailMessageStringIsNotSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertNotSame(expected, actual, "foo");
   }
 
-  void testAssertNotSameWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsNotSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertNotSame(expected, actual, () -> "foo");
   }
 
-  void testAssertThrowsExactly() {
+  void testAssertThatThrownByIsExactlyInstanceOf() {
     assertThrowsExactly(IllegalStateException.class, () -> {});
   }
 
-  void testAssertThrowsExactlyWithMessage() {
+  void testAssertThatThrownByWithFailMessageStringIsExactlyInstanceOf() {
     assertThrowsExactly(IllegalStateException.class, () -> {}, "foo");
   }
 
-  void testAssertThrowsExactlyWithMessageSupplier() {
+  void testAssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf() {
     assertThrowsExactly(IllegalStateException.class, () -> {}, () -> "foo");
   }
 
-  void testAssertThrows() {
+  void testAssertThatThrownByIsInstanceOf() {
     assertThrows(IllegalStateException.class, () -> {});
   }
 
-  void testAssertThrowsWithMessage() {
+  void testAssertThatThrownByWithFailMessageStringIsInstanceOf() {
     assertThrows(IllegalStateException.class, () -> {}, "foo");
   }
 
-  void testAssertThrowsWithMessageSupplier() {
+  void testAssertThatThrownByWithFailMessageSupplierIsInstanceOf() {
     assertThrows(IllegalStateException.class, () -> {}, () -> "foo");
   }
 
-  void testAssertDoesNotThrow() {
+  void testAssertThatCodeDoesNotThrowAnyException() {
     assertDoesNotThrow(() -> {});
   }
 
-  void testAssertDoesNotThrowWithMessage() {
+  void testAssertThatCodeWithFailMessageStringDoesNotThrowAnyException() {
     assertDoesNotThrow(() -> {}, "foo");
   }
 
-  void testAssertDoesNotThrowWithMessageSupplier() {
+  void testAssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException() {
     assertDoesNotThrow(() -> {}, () -> "foo");
   }
 
-  void testAssertInstanceOf() {
+  void testAssertThatIsInstanceOf() {
     assertInstanceOf(Object.class, new Object());
   }
 
-  void testAssertInstanceOfWithMessage() {
+  void testAssertThatWithFailMessageStringIsInstanceOf() {
     assertInstanceOf(Object.class, new Object(), "foo");
   }
 
-  void testAssertInstanceOfWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsInstanceOf() {
     assertInstanceOf(Object.class, new Object(), () -> "foo");
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -20,16 +20,16 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
         (Runnable) () -> assertDoesNotThrow(() -> null),
-        (Runnable) () -> assertFalse(true),
-        (Runnable) () -> assertInstanceOf(null, null),
-        (Runnable) () -> assertNotNull(null),
-        (Runnable) () -> assertNotSame(null, null),
-        (Runnable) () -> assertNull(null),
-        (Runnable) () -> assertSame(null, null),
-        (Runnable) () -> assertThrows(null, null),
-        (Runnable) () -> assertThrowsExactly(null, null),
-        (Runnable) () -> assertTrue(true),
-        (Runnable) () -> Assertions.fail());
+        () -> assertFalse(true),
+        () -> assertInstanceOf(null, null),
+        () -> assertNotNull(null),
+        () -> assertNotSame(null, null),
+        () -> assertNull(null),
+        () -> assertSame(null, null),
+        () -> assertThrows(null, null),
+        () -> assertThrowsExactly(null, null),
+        () -> assertTrue(true),
+        () -> Assertions.fail());
   }
 
   void testThrowNewAssertionError() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -19,29 +19,33 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        (Runnable) () -> assertDoesNotThrow(() -> null),
-        () -> assertFalse(true),
-        () -> assertInstanceOf(null, null),
-        () -> assertNotNull(null),
-        () -> assertNotSame(null, null),
-        () -> assertNull(null),
-        () -> assertSame(null, null),
-        () -> assertThrows(null, null),
-        () -> assertThrowsExactly(null, null),
-        () -> assertTrue(true),
-        () -> Assertions.fail());
+        Assertions.class,
+        assertDoesNotThrow(() -> null),
+        assertInstanceOf(null, null),
+        assertThrows(null, null),
+        assertThrowsExactly(null, null),
+        (Runnable) () -> assertFalse(true),
+        (Runnable) () -> assertNotNull(null),
+        (Runnable) () -> assertNotSame(null, null),
+        (Runnable) () -> assertNull(null),
+        (Runnable) () -> assertSame(null, null),
+        (Runnable) () -> assertTrue(true));
   }
 
   void testThrowNewAssertionError() {
     Assertions.fail();
   }
 
-  void testFailWithMessage() {
-    Assertions.fail("foo");
+  Object testFailWithMessage() {
+    return Assertions.fail("foo");
   }
 
-  void testFailWithMessageAndThrowable() {
-    Assertions.fail("foo", new IllegalStateException());
+  Object testFailWithMessageAndThrowable() {
+    return Assertions.fail("foo", new IllegalStateException());
+  }
+
+  void testFailWithThrowable() {
+    Assertions.fail(new IllegalStateException());
   }
 
   void testAssertThatIsTrue() {
@@ -93,39 +97,27 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAssertThatIsSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertSame(expected, actual);
+    assertSame("foo", "bar");
   }
 
   void testAssertThatWithFailMessageStringIsSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertSame(expected, actual, "foo");
+    assertSame("foo", "bar", "baz");
   }
 
   void testAssertThatWithFailMessageSupplierIsSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertSame(expected, actual, () -> "foo");
+    assertSame("foo", "bar", () -> "baz");
   }
 
   void testAssertThatIsNotSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertNotSame(expected, actual);
+    assertNotSame("foo", "bar");
   }
 
   void testAssertThatWithFailMessageStringIsNotSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertNotSame(expected, actual, "foo");
+    assertNotSame("foo", "bar", "baz");
   }
 
   void testAssertThatWithFailMessageSupplierIsNotSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertNotSame(expected, actual, () -> "foo");
+    assertNotSame("foo", "bar", () -> "baz");
   }
 
   void testAssertThatThrownByIsExactlyInstanceOf() {
@@ -154,14 +146,17 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
   void testAssertThatCodeDoesNotThrowAnyException() {
     assertDoesNotThrow(() -> {});
+    assertDoesNotThrow(() -> toString());
   }
 
   void testAssertThatCodeWithFailMessageStringDoesNotThrowAnyException() {
     assertDoesNotThrow(() -> {}, "foo");
+    assertDoesNotThrow(() -> toString(), "bar");
   }
 
   void testAssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException() {
     assertDoesNotThrow(() -> {}, () -> "foo");
+    assertDoesNotThrow(() -> toString(), () -> "bar");
   }
 
   void testAssertThatIsInstanceOf() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -2,7 +2,9 @@ package tech.picnic.errorprone.refasterrules;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
@@ -68,5 +70,41 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
     void testAssertNotNullWithMessageSupplier() {
         assertNotNull(new Object(), () -> "foo");
+    }
+
+    void testAssertSame() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertSame(expected, actual);
+    }
+
+    void testAssertSameWithMessage() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertSame(expected, actual, "foo");
+    }
+
+    void testAssertSameWithMessageSupplier() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertSame(expected, actual, () -> "foo");
+    }
+
+    void testAssertNotSame() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertNotSame(expected, actual);
+    }
+
+    void testAssertNotSameWithMessage() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertNotSame(expected, actual, "foo");
+    }
+
+    void testAssertNotSameWithMessageSupplier() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertNotSame(expected, actual, () -> "foo");
     }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -1,6 +1,8 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
@@ -42,5 +44,29 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
     void testAssertFalseWithMessageSupplier() {
         assertFalse(true, () -> "foo");
+    }
+
+    void testAssertNull() {
+        assertNull(new Object());
+    }
+
+    void testAssertNullWithMessage() {
+        assertNull(new Object(), "foo");
+    }
+
+    void testAssertNullWithMessageSupplier() {
+        assertNull(new Object(), () -> "foo");
+    }
+
+    void testAssertNotNull() {
+        assertNotNull(new Object());
+    }
+
+    void testAssertNotNullWithMessage() {
+        assertNotNull(new Object(), "foo");
+    }
+
+    void testAssertNotNullWithMessageSupplier() {
+        assertNotNull(new Object(), () -> "foo");
     }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -1,10 +1,25 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Assertions;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
+    void testFail() {
+        Assertions.fail();
+    }
+
+    void testFailWithMessage() {
+        Assertions.fail("foo");
+    }
+
+    void testFailWithMessageAndThrowable() {
+        Assertions.fail("foo", new IllegalStateException());
+    }
+
     void testAssertTrue() {
         assertTrue(true);
     }
@@ -15,5 +30,17 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
     void testAssertTrueWithMessageSupplier() {
         assertTrue(true, () -> "foo");
+    }
+
+    void testAssertFalse() {
+        assertFalse(true);
+    }
+
+    void testAssertFalseWithMessage() {
+        assertFalse(true, "foo");
+    }
+
+    void testAssertFalseWithMessageSupplier() {
+        assertFalse(true, () -> "foo");
     }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -1,10 +1,14 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
@@ -106,5 +110,41 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         Object actual = new Object();
         Object expected = new Object();
         assertNotSame(expected, actual, () -> "foo");
+    }
+
+    void testAssertThrowsExactly() {
+        assertThrowsExactly(IllegalStateException.class, () -> {});
+    }
+
+    void testAssertThrowsExactlyWithMessage() {
+        assertThrowsExactly(IllegalStateException.class, () -> {}, "foo");
+    }
+
+    void testAssertThrowsExactlyWithMessageSupplier() {
+        assertThrowsExactly(IllegalStateException.class, () -> {}, () -> "foo");
+    }
+
+    void testAssertThrows() {
+        assertThrows(IllegalStateException.class, () -> {});
+    }
+
+    void testAssertThrowsWithMessage() {
+        assertThrows(IllegalStateException.class, () -> {}, "foo");
+    }
+
+    void testAssertThrowsWithMessageSupplier() {
+        assertThrows(IllegalStateException.class, () -> {}, () -> "foo");
+    }
+
+    void testAssertDoesNotThrow() {
+        assertDoesNotThrow(() -> {});
+    }
+
+    void testAssertDoesNotThrowWithMessage() {
+        assertDoesNotThrow(() -> {}, "foo");
+    }
+
+    void testAssertDoesNotThrowWithMessageSupplier() {
+        assertDoesNotThrow(() -> {}, () -> "foo");
     }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -1,0 +1,19 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
+    void testAssertTrue() {
+        assertTrue(true);
+    }
+
+    void testAssertTrueWithMessage() {
+        assertTrue(true, "foo");
+    }
+
+    void testAssertTrueWithMessageSupplier() {
+        assertTrue(true, () -> "foo");
+    }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -1,12 +1,18 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
@@ -108,5 +114,43 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         Object actual = new Object();
         Object expected = new Object();
         assertThat(actual).withFailMessage(() -> "foo").isNotSameAs(expected);
+    }
+
+    void testAssertThrowsExactly() {
+        assertThatThrownBy(() -> {}).isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    void testAssertThrowsExactlyWithMessage() {
+        assertThatThrownBy(() -> {}).withFailMessage("foo")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    void testAssertThrowsExactlyWithMessageSupplier() {
+        assertThatThrownBy(() -> {}).withFailMessage(() -> "foo")
+                .isExactlyInstanceOf(IllegalStateException.class);
+    }
+
+    void testAssertThrows() {
+        assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class);
+    }
+
+    void testAssertThrowsWithMessage() {
+        assertThatThrownBy(() -> {}).withFailMessage("foo").isInstanceOf(IllegalStateException.class);
+    }
+
+    void testAssertThrowsWithMessageSupplier() {
+        assertThatThrownBy(() -> {}).withFailMessage(() -> "foo").isInstanceOf(IllegalStateException.class);
+    }
+
+    void testAssertDoesNotThrow() {
+        assertThatCode(() -> {}).doesNotThrowAnyException();
+    }
+
+    void testAssertDoesNotThrowWithMessage() {
+        assertThatCode(() -> {}).withFailMessage("foo").doesNotThrowAnyException();
+    }
+
+    void testAssertDoesNotThrowWithMessageSupplier() {
+        assertThatCode(() -> {}).withFailMessage(() -> "foo").doesNotThrowAnyException();
     }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -24,16 +24,16 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
         (Runnable) () -> assertDoesNotThrow(() -> null),
-        (Runnable) () -> assertFalse(true),
-        (Runnable) () -> assertInstanceOf(null, null),
-        (Runnable) () -> assertNotNull(null),
-        (Runnable) () -> assertNotSame(null, null),
-        (Runnable) () -> assertNull(null),
-        (Runnable) () -> assertSame(null, null),
-        (Runnable) () -> assertThrows(null, null),
-        (Runnable) () -> assertThrowsExactly(null, null),
-        (Runnable) () -> assertTrue(true),
-        (Runnable) () -> Assertions.fail());
+        () -> assertFalse(true),
+        () -> assertInstanceOf(null, null),
+        () -> assertNotNull(null),
+        () -> assertNotSame(null, null),
+        () -> assertNull(null),
+        () -> assertSame(null, null),
+        () -> assertThrows(null, null),
+        () -> assertThrowsExactly(null, null),
+        () -> assertTrue(true),
+        () -> Assertions.fail());
   }
 
   void testThrowNewAssertionError() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -3,6 +3,8 @@ package tech.picnic.errorprone.refasterrules;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
@@ -44,5 +46,29 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
     void testAssertFalseWithMessageSupplier() {
         assertThat(true).withFailMessage(() -> "foo").isFalse();
+    }
+
+    void testAssertNull() {
+        assertThat(new Object()).isNull();
+    }
+
+    void testAssertNullWithMessage() {
+        assertThat(new Object()).withFailMessage("foo").isNull();
+    }
+
+    void testAssertNullWithMessageSupplier() {
+        assertThat(new Object()).withFailMessage(() -> "foo").isNull();
+    }
+
+    void testAssertNotNull() {
+        assertThat(new Object()).isNotNull();
+    }
+
+    void testAssertNotNullWithMessage() {
+        assertThat(new Object()).withFailMessage("foo").isNotNull();
+    }
+
+    void testAssertNotNullWithMessageSupplier() {
+        assertThat(new Object()).withFailMessage(() -> "foo").isNotNull();
     }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -1,11 +1,27 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import com.google.common.collect.ImmutableSet;
+import org.junit.jupiter.api.Assertions;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
+    void testFail() {
+        throw new AssertionError();
+    }
+
+    void testFailWithMessage() {
+        fail("foo");
+    }
+
+    void testFailWithMessageAndThrowable() {
+        fail("foo", new IllegalStateException());
+    }
+
     void testAssertTrue() {
         assertThat(true).isTrue();
     }
@@ -16,5 +32,17 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
     void testAssertTrueWithMessageSupplier() {
         assertThat(true).withFailMessage(() -> "foo").isTrue();
+    }
+
+    void testAssertFalse() {
+        assertThat(true).isFalse();
+    }
+
+    void testAssertFalseWithMessage() {
+        assertThat(true).withFailMessage("foo").isFalse();
+    }
+
+    void testAssertFalseWithMessageSupplier() {
+        assertThat(true).withFailMessage(() -> "foo").isFalse();
     }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -1,0 +1,20 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
+    void testAssertTrue() {
+        assertThat(true).isTrue();
+    }
+
+    void testAssertTrueWithMessage() {
+        assertThat(true).withFailMessage("foo").isTrue();
+    }
+
+    void testAssertTrueWithMessageSupplier() {
+        assertThat(true).withFailMessage(() -> "foo").isTrue();
+    }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -23,29 +23,33 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        (Runnable) () -> assertDoesNotThrow(() -> null),
-        () -> assertFalse(true),
-        () -> assertInstanceOf(null, null),
-        () -> assertNotNull(null),
-        () -> assertNotSame(null, null),
-        () -> assertNull(null),
-        () -> assertSame(null, null),
-        () -> assertThrows(null, null),
-        () -> assertThrowsExactly(null, null),
-        () -> assertTrue(true),
-        () -> Assertions.fail());
+        Assertions.class,
+        assertDoesNotThrow(() -> null),
+        assertInstanceOf(null, null),
+        assertThrows(null, null),
+        assertThrowsExactly(null, null),
+        (Runnable) () -> assertFalse(true),
+        (Runnable) () -> assertNotNull(null),
+        (Runnable) () -> assertNotSame(null, null),
+        (Runnable) () -> assertNull(null),
+        (Runnable) () -> assertSame(null, null),
+        (Runnable) () -> assertTrue(true));
   }
 
   void testThrowNewAssertionError() {
     throw new AssertionError();
   }
 
-  void testFailWithMessage() {
-    fail("foo");
+  Object testFailWithMessage() {
+    return fail("foo");
   }
 
-  void testFailWithMessageAndThrowable() {
-    fail("foo", new IllegalStateException());
+  Object testFailWithMessageAndThrowable() {
+    return fail("foo", new IllegalStateException());
+  }
+
+  void testFailWithThrowable() {
+    throw new AssertionError(new IllegalStateException());
   }
 
   void testAssertThatIsTrue() {
@@ -97,39 +101,27 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAssertThatIsSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertThat(actual).isSameAs(expected);
+    assertThat("bar").isSameAs("foo");
   }
 
   void testAssertThatWithFailMessageStringIsSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertThat(actual).withFailMessage("foo").isSameAs(expected);
+    assertThat("bar").withFailMessage("baz").isSameAs("foo");
   }
 
   void testAssertThatWithFailMessageSupplierIsSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertThat(actual).withFailMessage(() -> "foo").isSameAs(expected);
+    assertThat("bar").withFailMessage(() -> "baz").isSameAs("foo");
   }
 
   void testAssertThatIsNotSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertThat(actual).isNotSameAs(expected);
+    assertThat("bar").isNotSameAs("foo");
   }
 
   void testAssertThatWithFailMessageStringIsNotSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertThat(actual).withFailMessage("foo").isNotSameAs(expected);
+    assertThat("bar").withFailMessage("baz").isNotSameAs("foo");
   }
 
   void testAssertThatWithFailMessageSupplierIsNotSameAs() {
-    Object actual = new Object();
-    Object expected = new Object();
-    assertThat(actual).withFailMessage(() -> "foo").isNotSameAs(expected);
+    assertThat("bar").withFailMessage(() -> "baz").isNotSameAs("foo");
   }
 
   void testAssertThatThrownByIsExactlyInstanceOf() {
@@ -164,14 +156,17 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
   void testAssertThatCodeDoesNotThrowAnyException() {
     assertThatCode(() -> {}).doesNotThrowAnyException();
+    assertThatCode(() -> toString()).doesNotThrowAnyException();
   }
 
   void testAssertThatCodeWithFailMessageStringDoesNotThrowAnyException() {
     assertThatCode(() -> {}).withFailMessage("foo").doesNotThrowAnyException();
+    assertThatCode(() -> toString()).withFailMessage("bar").doesNotThrowAnyException();
   }
 
   void testAssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException() {
     assertThatCode(() -> {}).withFailMessage(() -> "foo").doesNotThrowAnyException();
+    assertThatCode(() -> toString()).withFailMessage(() -> "bar").doesNotThrowAnyException();
   }
 
   void testAssertThatIsInstanceOf() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -36,7 +36,7 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         (Runnable) () -> Assertions.fail());
   }
 
-  void testFail() {
+  void testThrowNewAssertionError() {
     throw new AssertionError();
   }
 
@@ -48,141 +48,141 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     fail("foo", new IllegalStateException());
   }
 
-  void testAssertTrue() {
+  void testAssertThatIsTrue() {
     assertThat(true).isTrue();
   }
 
-  void testAssertTrueWithMessage() {
+  void testAssertThatWithFailMessageStringIsTrue() {
     assertThat(true).withFailMessage("foo").isTrue();
   }
 
-  void testAssertTrueWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsTrue() {
     assertThat(true).withFailMessage(() -> "foo").isTrue();
   }
 
-  void testAssertFalse() {
+  void testAssertThatIsFalse() {
     assertThat(true).isFalse();
   }
 
-  void testAssertFalseWithMessage() {
+  void testAssertThatWithFailMessageStringIsFalse() {
     assertThat(true).withFailMessage("foo").isFalse();
   }
 
-  void testAssertFalseWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsFalse() {
     assertThat(true).withFailMessage(() -> "foo").isFalse();
   }
 
-  void testAssertNull() {
+  void testAssertThatIsNull() {
     assertThat(new Object()).isNull();
   }
 
-  void testAssertNullWithMessage() {
+  void testAssertThatWithFailMessageStringIsNull() {
     assertThat(new Object()).withFailMessage("foo").isNull();
   }
 
-  void testAssertNullWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsNull() {
     assertThat(new Object()).withFailMessage(() -> "foo").isNull();
   }
 
-  void testAssertNotNull() {
+  void testAssertThatIsNotNull() {
     assertThat(new Object()).isNotNull();
   }
 
-  void testAssertNotNullWithMessage() {
+  void testAssertThatWithFailMessageStringIsNotNull() {
     assertThat(new Object()).withFailMessage("foo").isNotNull();
   }
 
-  void testAssertNotNullWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsNotNull() {
     assertThat(new Object()).withFailMessage(() -> "foo").isNotNull();
   }
 
-  void testAssertSame() {
+  void testAssertThatIsSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertThat(actual).isSameAs(expected);
   }
 
-  void testAssertSameWithMessage() {
+  void testAssertThatWithFailMessageStringIsSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertThat(actual).withFailMessage("foo").isSameAs(expected);
   }
 
-  void testAssertSameWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertThat(actual).withFailMessage(() -> "foo").isSameAs(expected);
   }
 
-  void testAssertNotSame() {
+  void testAssertThatIsNotSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertThat(actual).isNotSameAs(expected);
   }
 
-  void testAssertNotSameWithMessage() {
+  void testAssertThatWithFailMessageStringIsNotSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertThat(actual).withFailMessage("foo").isNotSameAs(expected);
   }
 
-  void testAssertNotSameWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsNotSameAs() {
     Object actual = new Object();
     Object expected = new Object();
     assertThat(actual).withFailMessage(() -> "foo").isNotSameAs(expected);
   }
 
-  void testAssertThrowsExactly() {
+  void testAssertThatThrownByIsExactlyInstanceOf() {
     assertThatThrownBy(() -> {}).isExactlyInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThrowsExactlyWithMessage() {
+  void testAssertThatThrownByWithFailMessageStringIsExactlyInstanceOf() {
     assertThatThrownBy(() -> {})
         .withFailMessage("foo")
         .isExactlyInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThrowsExactlyWithMessageSupplier() {
+  void testAssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf() {
     assertThatThrownBy(() -> {})
         .withFailMessage(() -> "foo")
         .isExactlyInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThrows() {
+  void testAssertThatThrownByIsInstanceOf() {
     assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThrowsWithMessage() {
+  void testAssertThatThrownByWithFailMessageStringIsInstanceOf() {
     assertThatThrownBy(() -> {}).withFailMessage("foo").isInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThrowsWithMessageSupplier() {
+  void testAssertThatThrownByWithFailMessageSupplierIsInstanceOf() {
     assertThatThrownBy(() -> {})
         .withFailMessage(() -> "foo")
         .isInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertDoesNotThrow() {
+  void testAssertThatCodeDoesNotThrowAnyException() {
     assertThatCode(() -> {}).doesNotThrowAnyException();
   }
 
-  void testAssertDoesNotThrowWithMessage() {
+  void testAssertThatCodeWithFailMessageStringDoesNotThrowAnyException() {
     assertThatCode(() -> {}).withFailMessage("foo").doesNotThrowAnyException();
   }
 
-  void testAssertDoesNotThrowWithMessageSupplier() {
+  void testAssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException() {
     assertThatCode(() -> {}).withFailMessage(() -> "foo").doesNotThrowAnyException();
   }
 
-  void testAssertInstanceOf() {
+  void testAssertThatIsInstanceOf() {
     assertThat(new Object()).isInstanceOf(Object.class);
   }
 
-  void testAssertInstanceOfWithMessage() {
+  void testAssertThatWithFailMessageStringIsInstanceOf() {
     assertThat(new Object()).withFailMessage("foo").isInstanceOf(Object.class);
   }
 
-  void testAssertInstanceOfWithMessageSupplier() {
+  void testAssertThatWithFailMessageSupplierIsInstanceOf() {
     assertThat(new Object()).withFailMessage(() -> "foo").isInstanceOf(Object.class);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -20,137 +20,169 @@ import org.junit.jupiter.api.Assertions;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
-    void testFail() {
-        throw new AssertionError();
-    }
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(
+        (Runnable) () -> assertDoesNotThrow(() -> null),
+        (Runnable) () -> assertFalse(true),
+        (Runnable) () -> assertInstanceOf(null, null),
+        (Runnable) () -> assertNotNull(null),
+        (Runnable) () -> assertNotSame(null, null),
+        (Runnable) () -> assertNull(null),
+        (Runnable) () -> assertSame(null, null),
+        (Runnable) () -> assertThrows(null, null),
+        (Runnable) () -> assertThrowsExactly(null, null),
+        (Runnable) () -> assertTrue(true),
+        (Runnable) () -> Assertions.fail());
+  }
 
-    void testFailWithMessage() {
-        fail("foo");
-    }
+  void testFail() {
+    throw new AssertionError();
+  }
 
-    void testFailWithMessageAndThrowable() {
-        fail("foo", new IllegalStateException());
-    }
+  void testFailWithMessage() {
+    fail("foo");
+  }
 
-    void testAssertTrue() {
-        assertThat(true).isTrue();
-    }
+  void testFailWithMessageAndThrowable() {
+    fail("foo", new IllegalStateException());
+  }
 
-    void testAssertTrueWithMessage() {
-        assertThat(true).withFailMessage("foo").isTrue();
-    }
+  void testAssertTrue() {
+    assertThat(true).isTrue();
+  }
 
-    void testAssertTrueWithMessageSupplier() {
-        assertThat(true).withFailMessage(() -> "foo").isTrue();
-    }
+  void testAssertTrueWithMessage() {
+    assertThat(true).withFailMessage("foo").isTrue();
+  }
 
-    void testAssertFalse() {
-        assertThat(true).isFalse();
-    }
+  void testAssertTrueWithMessageSupplier() {
+    assertThat(true).withFailMessage(() -> "foo").isTrue();
+  }
 
-    void testAssertFalseWithMessage() {
-        assertThat(true).withFailMessage("foo").isFalse();
-    }
+  void testAssertFalse() {
+    assertThat(true).isFalse();
+  }
 
-    void testAssertFalseWithMessageSupplier() {
-        assertThat(true).withFailMessage(() -> "foo").isFalse();
-    }
+  void testAssertFalseWithMessage() {
+    assertThat(true).withFailMessage("foo").isFalse();
+  }
 
-    void testAssertNull() {
-        assertThat(new Object()).isNull();
-    }
+  void testAssertFalseWithMessageSupplier() {
+    assertThat(true).withFailMessage(() -> "foo").isFalse();
+  }
 
-    void testAssertNullWithMessage() {
-        assertThat(new Object()).withFailMessage("foo").isNull();
-    }
+  void testAssertNull() {
+    assertThat(new Object()).isNull();
+  }
 
-    void testAssertNullWithMessageSupplier() {
-        assertThat(new Object()).withFailMessage(() -> "foo").isNull();
-    }
+  void testAssertNullWithMessage() {
+    assertThat(new Object()).withFailMessage("foo").isNull();
+  }
 
-    void testAssertNotNull() {
-        assertThat(new Object()).isNotNull();
-    }
+  void testAssertNullWithMessageSupplier() {
+    assertThat(new Object()).withFailMessage(() -> "foo").isNull();
+  }
 
-    void testAssertNotNullWithMessage() {
-        assertThat(new Object()).withFailMessage("foo").isNotNull();
-    }
+  void testAssertNotNull() {
+    assertThat(new Object()).isNotNull();
+  }
 
-    void testAssertNotNullWithMessageSupplier() {
-        assertThat(new Object()).withFailMessage(() -> "foo").isNotNull();
-    }
+  void testAssertNotNullWithMessage() {
+    assertThat(new Object()).withFailMessage("foo").isNotNull();
+  }
 
-    void testAssertSame() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertThat(actual).isSameAs(expected);
-    }
+  void testAssertNotNullWithMessageSupplier() {
+    assertThat(new Object()).withFailMessage(() -> "foo").isNotNull();
+  }
 
-    void testAssertSameWithMessage() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertThat(actual).withFailMessage("foo").isSameAs(expected);
-    }
+  void testAssertSame() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertThat(actual).isSameAs(expected);
+  }
 
-    void testAssertSameWithMessageSupplier() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertThat(actual).withFailMessage(() -> "foo").isSameAs(expected);
-    }
+  void testAssertSameWithMessage() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertThat(actual).withFailMessage("foo").isSameAs(expected);
+  }
 
-    void testAssertNotSame() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertThat(actual).isNotSameAs(expected);
-    }
+  void testAssertSameWithMessageSupplier() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertThat(actual).withFailMessage(() -> "foo").isSameAs(expected);
+  }
 
-    void testAssertNotSameWithMessage() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertThat(actual).withFailMessage("foo").isNotSameAs(expected);
-    }
+  void testAssertNotSame() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertThat(actual).isNotSameAs(expected);
+  }
 
-    void testAssertNotSameWithMessageSupplier() {
-        Object actual = new Object();
-        Object expected = new Object();
-        assertThat(actual).withFailMessage(() -> "foo").isNotSameAs(expected);
-    }
+  void testAssertNotSameWithMessage() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertThat(actual).withFailMessage("foo").isNotSameAs(expected);
+  }
 
-    void testAssertThrowsExactly() {
-        assertThatThrownBy(() -> {}).isExactlyInstanceOf(IllegalStateException.class);
-    }
+  void testAssertNotSameWithMessageSupplier() {
+    Object actual = new Object();
+    Object expected = new Object();
+    assertThat(actual).withFailMessage(() -> "foo").isNotSameAs(expected);
+  }
 
-    void testAssertThrowsExactlyWithMessage() {
-        assertThatThrownBy(() -> {}).withFailMessage("foo")
-                .isExactlyInstanceOf(IllegalStateException.class);
-    }
+  void testAssertThrowsExactly() {
+    assertThatThrownBy(() -> {}).isExactlyInstanceOf(IllegalStateException.class);
+  }
 
-    void testAssertThrowsExactlyWithMessageSupplier() {
-        assertThatThrownBy(() -> {}).withFailMessage(() -> "foo")
-                .isExactlyInstanceOf(IllegalStateException.class);
-    }
+  void testAssertThrowsExactlyWithMessage() {
+    assertThatThrownBy(() -> {})
+        .withFailMessage("foo")
+        .isExactlyInstanceOf(IllegalStateException.class);
+  }
 
-    void testAssertThrows() {
-        assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class);
-    }
+  void testAssertThrowsExactlyWithMessageSupplier() {
+    assertThatThrownBy(() -> {})
+        .withFailMessage(() -> "foo")
+        .isExactlyInstanceOf(IllegalStateException.class);
+  }
 
-    void testAssertThrowsWithMessage() {
-        assertThatThrownBy(() -> {}).withFailMessage("foo").isInstanceOf(IllegalStateException.class);
-    }
+  void testAssertThrows() {
+    assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class);
+  }
 
-    void testAssertThrowsWithMessageSupplier() {
-        assertThatThrownBy(() -> {}).withFailMessage(() -> "foo").isInstanceOf(IllegalStateException.class);
-    }
+  void testAssertThrowsWithMessage() {
+    assertThatThrownBy(() -> {}).withFailMessage("foo").isInstanceOf(IllegalStateException.class);
+  }
 
-    void testAssertDoesNotThrow() {
-        assertThatCode(() -> {}).doesNotThrowAnyException();
-    }
+  void testAssertThrowsWithMessageSupplier() {
+    assertThatThrownBy(() -> {})
+        .withFailMessage(() -> "foo")
+        .isInstanceOf(IllegalStateException.class);
+  }
 
-    void testAssertDoesNotThrowWithMessage() {
-        assertThatCode(() -> {}).withFailMessage("foo").doesNotThrowAnyException();
-    }
+  void testAssertDoesNotThrow() {
+    assertThatCode(() -> {}).doesNotThrowAnyException();
+  }
 
-    void testAssertDoesNotThrowWithMessageSupplier() {
-        assertThatCode(() -> {}).withFailMessage(() -> "foo").doesNotThrowAnyException();
-    }
+  void testAssertDoesNotThrowWithMessage() {
+    assertThatCode(() -> {}).withFailMessage("foo").doesNotThrowAnyException();
+  }
+
+  void testAssertDoesNotThrowWithMessageSupplier() {
+    assertThatCode(() -> {}).withFailMessage(() -> "foo").doesNotThrowAnyException();
+  }
+
+  void testAssertInstanceOf() {
+    assertThat(new Object()).isInstanceOf(Object.class);
+  }
+
+  void testAssertInstanceOfWithMessage() {
+    assertThat(new Object()).withFailMessage("foo").isInstanceOf(Object.class);
+  }
+
+  void testAssertInstanceOfWithMessageSupplier() {
+    assertThat(new Object()).withFailMessage(() -> "foo").isInstanceOf(Object.class);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -4,7 +4,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
@@ -70,5 +72,41 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
 
     void testAssertNotNullWithMessageSupplier() {
         assertThat(new Object()).withFailMessage(() -> "foo").isNotNull();
+    }
+
+    void testAssertSame() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertThat(actual).isSameAs(expected);
+    }
+
+    void testAssertSameWithMessage() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertThat(actual).withFailMessage("foo").isSameAs(expected);
+    }
+
+    void testAssertSameWithMessageSupplier() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertThat(actual).withFailMessage(() -> "foo").isSameAs(expected);
+    }
+
+    void testAssertNotSame() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertThat(actual).isNotSameAs(expected);
+    }
+
+    void testAssertNotSameWithMessage() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertThat(actual).withFailMessage("foo").isNotSameAs(expected);
+    }
+
+    void testAssertNotSameWithMessageSupplier() {
+        Object actual = new Object();
+        Object expected = new Object();
+        assertThat(actual).withFailMessage(() -> "foo").isNotSameAs(expected);
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -686,10 +686,6 @@
                                             <!-- Instead, please use
                                             `com.google.common.collect.Streams`. -->
                                         </property>
-                                        <property name="illegalClasses" value="org\.junit\.jupiter\.api\.Assertions(\..*?)?">
-                                            <!-- Instead, please use
-                                            `org.assertj.core.api.Assertions`. -->
-                                        </property>
                                         <property name="illegalClasses" value="org\.springframework\.stereotype\.(Component|Controller|Service)">
                                             <!-- We don't use Spring's
                                             component scanning, so `@Component`


### PR DESCRIPTION
Related issue: https://github.com/PicnicSupermarket/error-prone-support/issues/402

Left `XXX` comments on `org.junit.jupiter.api.Assertions` methods that do not (yet) have rules.

Decided to leave the equality-related ones for a follow-up PR to reduce the scope a little bit, as those also need a bit more work (equality with deltas, etc.).
* `assertEquals`
* `assertArrayEquals`
* `assertIterableEquals`
* `assertNotEquals`

The following methods don't seem to have direct AssertJ equivalents, but could also be handled later.
* `assertLinesMatch`
* `assertAll`
* `assertTimeout`
* `assertTimeoutPreemptively`