### PR TITLE
Disable failing JDK 20-ea build for now

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,10 +22,11 @@ jobs:
             jdk: 17.0.4
             distribution: temurin
             experimental: false
-          - os: ubuntu-22.04
-            jdk: 20-ea
-            distribution: zulu
-            experimental: true
+          # XXX: Reenable this build after upgrading to Error Prone 2.17.
+          #- os: ubuntu-22.04
+          #  jdk: 20-ea
+          #  distribution: zulu
+          #  experimental: true
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,7 +22,7 @@ jobs:
             jdk: 17.0.4
             distribution: temurin
             experimental: false
-          # XXX: Reenable this build after upgrading to Error Prone 2.17.
+          # XXX: Re-enable this build after upgrading to Error Prone 2.17.
           #- os: ubuntu-22.04
           #  jdk: 20-ea
           #  distribution: zulu


### PR DESCRIPTION
See the analysis in #418 for context.

Suggested commit message:
```
Disable failing JDK 20-ea build for now (#419)

The build fails due to
openjdk/jdk20@2cb64a75578ccc15a1dfc8c2843aa11d05ca8aa7; the upcoming
Error Prone release includes a workaround for this:
google/error-prone@df033f03cb55c3f26221660ac5ea49bbaeeab289.
```