### PR TITLE
Introduce/extend `RequireNonNullElse{,Get}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
@@ -2,13 +2,17 @@ package tech.picnic.errorprone.refasterrules;
 
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
 
 import com.google.common.base.MoreObjects;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Matches;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Predicate;
+import java.util.function.Supplier;
 import org.jspecify.annotations.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
@@ -43,19 +47,47 @@ final class NullRules {
     }
   }
 
-  /** Prefer {@link Objects#requireNonNullElse(Object, Object)} over the Guava alternative. */
-  // XXX: This rule is not valid in case `second` is `@Nullable`: in that case the Guava variant
-  // will return `null`, while the JDK variant will throw an NPE.
+  /**
+   * Prefer {@link Objects#requireNonNullElse(Object, Object)} over the Guava and Optional
+   * alternatives.
+   */
+  // XXX: This rule is not valid in case `second` is `@Nullable`: in that case the Guava and
+  // Optional variants
+  // will return `null`, while the Objects.requireNonNullElse variant will throw an NPE.
   static final class RequireNonNullElse<T> {
     @BeforeTemplate
     T before(T first, T second) {
       return MoreObjects.firstNonNull(first, second);
     }
 
+    @BeforeTemplate
+    T beforeOptional(T first, T second) {
+      return Optional.ofNullable(first).orElse(second);
+    }
+
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     T after(T first, T second) {
       return requireNonNullElse(first, second);
+    }
+  }
+
+  /**
+   * Prefer {@link Objects#requireNonNullElseGet(Object, Supplier)} over {@link Optional}{@code
+   * .ofNullable(Object).orElseGet(Supplier)}
+   */
+  // XXX: This rule is not valid in case `supplier` may return `null`: Optional will return `null`,
+  // while the `requireNonNullElseGet` replacement will throw an NPE.
+  static final class RequireNonNullElseGet<T, S extends Supplier<T>> {
+    @BeforeTemplate
+    T before(T object, S defaultSupplier) {
+      return Optional.ofNullable(object).orElseGet(defaultSupplier);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    T after(T object, S defaultSupplier) {
+      return requireNonNullElseGet(object, defaultSupplier);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
@@ -3,13 +3,14 @@ package tech.picnic.errorprone.refasterrules;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class NullRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(MoreObjects.class);
+    return ImmutableSet.of(MoreObjects.class, Optional.class);
   }
 
   boolean testIsNull() {
@@ -22,11 +23,11 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<String> testRequireNonNullElse() {
     return ImmutableSet.of(
-        MoreObjects.firstNonNull("foo", "bar"), java.util.Optional.ofNullable("foo").orElse("bar"));
+        MoreObjects.firstNonNull("foo", "bar"), Optional.ofNullable("baz").orElse("qux"));
   }
 
   String testRequireNonNullElseGet() {
-    return java.util.Optional.ofNullable("foo").orElseGet(() -> "bar");
+    return Optional.ofNullable("foo").orElseGet(() -> "bar");
   }
 
   long testIsNullFunction() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
@@ -20,8 +20,13 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return Objects.nonNull("foo");
   }
 
-  String testRequireNonNullElse() {
-    return MoreObjects.firstNonNull("foo", "bar");
+  ImmutableSet<String> testRequireNonNullElse() {
+    return ImmutableSet.of(
+        MoreObjects.firstNonNull("foo", "bar"), java.util.Optional.ofNullable("foo").orElse("bar"));
+  }
+
+  String testRequireNonNullElseGet() {
+    return java.util.Optional.ofNullable("foo").orElseGet(() -> "bar");
   }
 
   long testIsNullFunction() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static java.util.Objects.requireNonNullElse;
+import static java.util.Objects.requireNonNullElseGet;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
@@ -22,8 +23,12 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return "foo" != null;
   }
 
-  String testRequireNonNullElse() {
-    return requireNonNullElse("foo", "bar");
+  ImmutableSet<String> testRequireNonNullElse() {
+    return ImmutableSet.of(requireNonNullElse("foo", "bar"), requireNonNullElse("foo", "bar"));
+  }
+
+  String testRequireNonNullElseGet() {
+    return requireNonNullElseGet("foo", () -> "bar");
   }
 
   long testIsNullFunction() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
@@ -6,13 +6,14 @@ import static java.util.Objects.requireNonNullElseGet;
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class NullRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(MoreObjects.class);
+    return ImmutableSet.of(MoreObjects.class, Optional.class);
   }
 
   boolean testIsNull() {
@@ -24,7 +25,7 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<String> testRequireNonNullElse() {
-    return ImmutableSet.of(requireNonNullElse("foo", "bar"), requireNonNullElse("foo", "bar"));
+    return ImmutableSet.of(requireNonNullElse("foo", "bar"), requireNonNullElse("baz", "qux"));
   }
 
   String testRequireNonNullElseGet() {


### PR DESCRIPTION
Related issue: #364

Added Rules:
 - prefer `requireNonNullElse(A, B)` over `Optional.ofNullable(A).orElse(B)`
 - prefer `requireNonNullElseGet(A, () -> B)` over `Optional.ofNullable(A).orElseGet(() -> B)`

 Wrote test inputs and outputs.

**Potential problems:**

In the tests, referenced `Optional` by it's fully qualified name to avoid breaking `RefasterRulesTest` or leaving unused imports in the code. - this seems hacky but didn't came up with better solution.

Neither the new or already existing rules are not dealing with potential NPE when the second argument can be or produce null. - this seems to be a larger or at least a separated issue.

