### PR TITLE
Upgrade Error Prone 2.16 -> 2.17.0

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,11 +22,10 @@ jobs:
             jdk: 17.0.4
             distribution: temurin
             experimental: false
-          # XXX: Re-enable this build after upgrading to Error Prone 2.17.
-          #- os: ubuntu-22.04
-          #  jdk: 20-ea
-          #  distribution: zulu
-          #  experimental: true
+          - os: ubuntu-22.04
+            jdk: 20-ea
+            distribution: zulu
+            experimental: true
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/pom.xml
+++ b/pom.xml
@@ -1591,7 +1591,7 @@
                                     -XepOpt:NullAway:CheckOptionalEmptiness=true
                                     -XepOpt:Nullness:Conservative=false
                                     <!-- XXX: Enable once this check respects
-                                    the compilation target version. See
+                                    the compilation source version. See
                                     https://github.com/google/error-prone/pull/3646.
                                     -XepOpt:StatementSwitchToExpressionSwitch:EnableDirectConversion=true -->
                                     <!-- Append additional custom arguments. -->

--- a/pom.xml
+++ b/pom.xml
@@ -148,8 +148,8 @@
         <version.auto-service>1.0.1</version.auto-service>
         <version.auto-value>1.10.1</version.auto-value>
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
-        <version.error-prone-fork>v${version.error-prone-orig}-picnic-2</version.error-prone-fork>
-        <version.error-prone-orig>2.16</version.error-prone-orig>
+        <version.error-prone-fork>v${version.error-prone-orig}-picnic-1</version.error-prone-fork>
+        <version.error-prone-orig>2.17.0</version.error-prone-orig>
         <version.error-prone-slf4j>0.1.17</version.error-prone-slf4j>
         <version.guava-beta-checker>1.0</version.guava-beta-checker>
         <version.jdk>11</version.jdk>
@@ -1590,6 +1590,10 @@
                                     -XepOpt:NullAway:AssertsEnabled=true
                                     -XepOpt:NullAway:CheckOptionalEmptiness=true
                                     -XepOpt:Nullness:Conservative=false
+                                    <!-- XXX: Enable once this check respects
+                                    the compilation target version. See
+                                    https://github.com/google/error-prone/pull/3646.
+                                    -XepOpt:StatementSwitchToExpressionSwitch:EnableDirectConversion=true -->
                                     <!-- Append additional custom arguments. -->
                                     ${error-prone.patch-args}
                                     ${error-prone.self-check-args}


### PR DESCRIPTION
Not sure why Renovate didn't open a PR (and didn't investigate), but here it is.

Suggested commit message:
```
Upgrade Error Prone 2.16 -> 2.17.0 (#432)

See:
- https://github.com/google/error-prone/releases/tag/v2.17.0
- https://github.com/google/error-prone/compare/v2.16...v2.17.0
- https://github.com/PicnicSupermarket/error-prone/compare/v2.16-picnic-2...v2.17.0-picnic-1
```