### PR TITLE
Introduce `MapGetOrDefault` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -45,10 +45,10 @@ final class MapRules {
     }
   }
 
-  /**
-   * Prefer {@link Map#getOrDefault(Object, Object)} over more contrived alternatives. Note that
-   * this method may return null instead of throwing a NPE.
-   */
+  /** Prefer {@link Map#getOrDefault(Object, Object)} over more contrived alternatives. */
+  // Note that
+  // XXX: `requireNonNullElse` throws an NPE if the second argument is `null`, while the alternative
+  // does not.
   static final class MapGetOrDefault<K, V, T> {
     @BeforeTemplate
     V before(Map<K, V> map, T key, V defaultValue) {
@@ -56,7 +56,6 @@ final class MapRules {
     }
 
     @AfterTemplate
-    @Nullable
     V after(Map<K, V> map, T key, V defaultValue) {
       return map.getOrDefault(key, defaultValue);
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -46,9 +46,8 @@ final class MapRules {
   }
 
   /** Prefer {@link Map#getOrDefault(Object, Object)} over more contrived alternatives. */
-  // Note that
-  // XXX: `requireNonNullElse` throws an NPE if the second argument is `null`, while the alternative
-  // does not.
+  // XXX: Note that `requireNonNullElse` throws an NPE if the second argument is `null`, while the
+  // alternative does not.
   static final class MapGetOrDefault<K, V, T> {
     @BeforeTemplate
     V before(Map<K, V> map, T key, V defaultValue) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -1,5 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static java.util.Objects.requireNonNullElse;
+
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
@@ -40,6 +42,23 @@ final class MapRules {
     @Nullable
     V after(Map<K, V> map, T key) {
       return map.get(key);
+    }
+  }
+
+  /**
+   * Prefer {@link Map#getOrDefault(Object, Object)} over more contrived alternatives. Note that
+   * this method may return null instead of throwing a NPE.
+   */
+  static final class MapGetOrDefault<K, V, T> {
+    @BeforeTemplate
+    V before(Map<K, V> map, T key, V defaultValue) {
+      return requireNonNullElse(map.get(key), defaultValue);
+    }
+
+    @AfterTemplate
+    @Nullable
+    V after(Map<K, V> map, T key, V defaultValue) {
+      return map.getOrDefault(key, defaultValue);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
@@ -1,5 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static java.util.Objects.requireNonNullElse;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.math.RoundingMode;
@@ -11,7 +13,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class MapRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(HashMap.class);
+    return ImmutableSet.of(HashMap.class, requireNonNullElse("foo", "bar"));
   }
 
   Map<RoundingMode, String> testCreateEnumMap() {
@@ -20,6 +22,10 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
 
   String testMapGetOrNull() {
     return ImmutableMap.of(1, "foo").getOrDefault("bar", null);
+  }
+
+  String testMapGetOrDefault() {
+    return requireNonNullElse(ImmutableMap.of(1, "foo").get("bar"), "baz");
   }
 
   ImmutableSet<Boolean> testMapIsEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
@@ -13,7 +13,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class MapRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(HashMap.class, requireNonNullElse("foo", "bar"));
+    return ImmutableSet.of(HashMap.class, requireNonNullElse(null, null));
   }
 
   Map<RoundingMode, String> testCreateEnumMap() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
@@ -1,5 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static java.util.Objects.requireNonNullElse;
+
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.math.RoundingMode;
@@ -12,7 +14,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class MapRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(HashMap.class);
+    return ImmutableSet.of(HashMap.class, requireNonNullElse("foo", "bar"));
   }
 
   Map<RoundingMode, String> testCreateEnumMap() {
@@ -21,6 +23,10 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
 
   String testMapGetOrNull() {
     return ImmutableMap.of(1, "foo").get("bar");
+  }
+
+  String testMapGetOrDefault() {
+    return ImmutableMap.of(1, "foo").getOrDefault("bar", "baz");
   }
 
   ImmutableSet<Boolean> testMapIsEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
@@ -14,7 +14,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class MapRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<?> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(HashMap.class, requireNonNullElse("foo", "bar"));
+    return ImmutableSet.of(HashMap.class, requireNonNullElse(null, null));
   }
 
   Map<RoundingMode, String> testCreateEnumMap() {


### PR DESCRIPTION
adds rules to fix #431.

Added Rules:
-  prefer `map.getOrDefault(k, defaultValue)` over `requireNonNullElse(map.get(k), defaultValue)`

Wrote test inputs and outputs.

Could be a problem that when `defaultValue` is null, `Objects#requireNonNullElse` throws a NPE while `Map#getOrDefault` does not.