### PR TITLE
Have `apply-error-prone-suggestions.sh` download JitPack-hosted artifacts

### DIFF
--- a/apply-error-prone-suggestions.sh
+++ b/apply-error-prone-suggestions.sh
@@ -9,13 +9,14 @@
 set -e -u -o pipefail
 
 if [ "${#}" -gt 1 ]; then
-  echo "Usage: ./$(basename "${0}") [PatchChecks]"
+  echo "Usage: ${0} [PatchChecks]"
   exit 1
 fi
 
 patchChecks=${1:-}
 
 mvn clean test-compile fmt:format \
+  -s "$(dirname "${0}")/settings.xml" \
   -T 1.0C \
   -Perror-prone \
   -Perror-prone-fork \

--- a/run-mutation-tests.sh
+++ b/run-mutation-tests.sh
@@ -7,7 +7,7 @@
 set -e -u -o pipefail
 
 if [ "${#}" -gt 1 ]; then
-  echo "Usage: ./$(basename "${0}") [TargetTests]"
+  echo "Usage: ${0} [TargetTests]"
   exit 1
 fi
 


### PR DESCRIPTION
Suggested commit message:
```
Have `apply-error-prone-suggestions.sh` download JitPack-hosted artifacts (#441)

While there, tweak the usage message of both `apply-error-prone-suggestions.sh`
and `run-mutation-tests.sh`.
```