### PR TITLE
Enable Checkstyle's `JavadocStyle` module

### DIFF
--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparisonTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparisonTest.java
@@ -12,6 +12,8 @@ import org.junit.jupiter.api.Test;
 // XXX: Can we perhaps work-around this by describing the fixes in reverse order?
 final class PrimitiveComparisonTest {
   /**
+   * Identification test for primitive {@code byte} comparisons.
+   *
    * @implNote The logic for {@code char} and {@code short} is exactly analogous to the {@code byte}
    *     case.
    */

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparisonTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparisonTest.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.Test;
 // XXX: Can we perhaps work-around this by describing the fixes in reverse order?
 final class PrimitiveComparisonTest {
   /**
-   * Identification test for primitive {@code byte} comparisons.
+   * Tests the identification of {@code byte} comparisons for which boxing can be avoided.
    *
    * @implNote The logic for {@code char} and {@code short} is exactly analogous to the {@code byte}
    *     case.

--- a/pom.xml
+++ b/pom.xml
@@ -710,7 +710,9 @@
                                     <module name="InnerAssignment" />
                                     <module name="InvalidJavadocPosition" />
                                     <module name="JavadocBlockTagLocation" />
-                                    <module name="JavadocStyle"/>
+                                    <module name="JavadocStyle">
+                                        <property name="checkEmptyJavadoc" value="true"/>
+                                    </module>
                                     <module name="LocalVariableName" />
                                     <module name="MatchXpath">
                                         <property name="query" value="//BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[contains(@text, '@author')]]" />

--- a/pom.xml
+++ b/pom.xml
@@ -710,6 +710,7 @@
                                     <module name="InnerAssignment" />
                                     <module name="InvalidJavadocPosition" />
                                     <module name="JavadocBlockTagLocation" />
+                                    <module name="JavadocStyle"/>
                                     <module name="LocalVariableName" />
                                     <module name="MatchXpath">
                                         <property name="query" value="//BLOCK_COMMENT_BEGIN[./COMMENT_CONTENT[contains(@text, '@author')]]" />


### PR DESCRIPTION
Suggested commit message:
```
Enable Checkstyle's `JavadocStyle` module (#451)

See: 
- https://checkstyle.org/config_javadoc.html#JavadocStyle
- https://checkstyle.org/apidocs/com/puppycrawl/tools/checkstyle/checks/javadoc/JavadocStyleCheck.html
```