### PR TITLE
Upgrade Error Prone 2.17.0 -> 2.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -149,7 +149,7 @@
         <version.auto-value>1.10.1</version.auto-value>
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
         <version.error-prone-fork>v${version.error-prone-orig}-picnic-1</version.error-prone-fork>
-        <version.error-prone-orig>2.17.0</version.error-prone-orig>
+        <version.error-prone-orig>2.18.0</version.error-prone-orig>
         <version.error-prone-slf4j>0.1.17</version.error-prone-slf4j>
         <version.guava-beta-checker>1.0</version.guava-beta-checker>
         <version.jdk>11</version.jdk>
@@ -1575,6 +1575,10 @@
                                     <!-- XXX: Enable this once we open-source
                                     this library. -->
                                     -Xep:BetaApi:OFF
+                                    <!-- XXX: Enable once compatible with
+                                    `UnnecessarilyVisible`. See
+                                    https://github.com/google/error-prone/issues/3706. -->
+                                    -Xep:InjectOnBugCheckers:OFF
                                     <!-- We don't target JDK 7. -->
                                     -Xep:Java7ApiChecker:OFF
                                     <!-- We don't target JDK 8. -->
@@ -1583,6 +1587,9 @@
                                     -Xep:StaticOrDefaultInterfaceMethod:OFF
                                     <!-- We generally discourage `var` use. -->
                                     -Xep:Varifier:OFF
+                                    <!-- Yoda conditions are not always more
+                                    readable than the alternative. -->
+                                    -Xep:YodaCondition:OFF
                                     -XepOpt:CheckReturnValue:CheckAllConstructors=true
                                     <!-- XXX: Enable once there are fewer
                                     false-positives.

--- a/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
+++ b/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
@@ -161,6 +161,7 @@ public final class Refaster extends BugChecker implements CompilationUnitTreeMat
    * that could cause {@link VisitorState#reportMatch(Description)}} to override the reported
    * severity).
    */
+  @SuppressWarnings("RestrictedApiChecker" /* We create a heavily customized `Description` here. */)
   private static Description augmentDescription(
       Description description, Optional<SeverityLevel> severityOverride) {
     return Description.builder(

--- a/refaster-support/src/main/java/tech/picnic/errorprone/refaster/AnnotatedCompositeCodeTransformer.java
+++ b/refaster-support/src/main/java/tech/picnic/errorprone/refaster/AnnotatedCompositeCodeTransformer.java
@@ -77,6 +77,7 @@ public abstract class AnnotatedCompositeCodeTransformer implements CodeTransform
     }
   }
 
+  @SuppressWarnings("RestrictedApiChecker" /* We create a heavily customized `Description` here. */)
   private Description augmentDescription(
       Description description, CodeTransformer delegate, Context context) {
     String shortCheckName = getShortCheckName(description.checkName);

--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/AnnotatedCompositeCodeTransformerTest.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/AnnotatedCompositeCodeTransformerTest.java
@@ -171,6 +171,7 @@ final class AnnotatedCompositeCodeTransformerTest {
     return description(name, Optional.of(""), WARNING, "");
   }
 
+  @SuppressWarnings("RestrictedApiChecker" /* We create a heavily customized `Description` here. */)
   private static Description description(
       String name, Optional<String> link, SeverityLevel severityLevel, String message) {
     return Description.builder(DUMMY_POSITION, name, link.orElse(null), severityLevel, message)

--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
@@ -35,9 +35,7 @@ abstract class AbstractMatcherTestChecker extends BugChecker implements Compilat
       @Override
       public @Nullable Void scan(Tree tree, @Nullable Void unused) {
         if (tree instanceof ExpressionTree && delegate.matches((ExpressionTree) tree, state)) {
-          state.reportMatch(
-              Description.builder(tree, canonicalName(), null, defaultSeverity(), message())
-                  .build());
+          state.reportMatch(describeMatch(tree));
         }
 
         return super.scan(tree, unused);


### PR DESCRIPTION
Suggested commit message:
```
Upgrade Error Prone 2.17.0 -> 2.18.0 (#455)

See:
- https://github.com/google/error-prone/releases/tag/v2.18.0
- https://github.com/google/error-prone/compare/v2.17.0...v2.18.0
- https://github.com/PicnicSupermarket/error-prone/compare/v2.17.0-picnic-1...v2.18.0-picnic-1
```