### PR TITLE
Extend `MonoIdentity` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -377,6 +377,11 @@ final class ReactorRules {
       return mono.then();
     }
 
+    @BeforeTemplate
+    Mono<T> before3(Mono<T> mono) {
+      return mono.flux().next();
+    }
+
     @AfterTemplate
     Mono<T> after(Mono<T> mono) {
       return mono;

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -369,17 +369,12 @@ final class ReactorRules {
   static final class MonoIdentity<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono) {
-      return mono.switchIfEmpty(Mono.empty());
+      return Refaster.anyOf(mono.switchIfEmpty(Mono.empty()), mono.flux().next());
     }
 
     @BeforeTemplate
     Mono<@Nullable Void> before2(Mono<@Nullable Void> mono) {
       return mono.then();
-    }
-
-    @BeforeTemplate
-    Mono<T> before3(Mono<T> mono) {
-      return mono.flux().next();
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -116,7 +116,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<?>> testMonoIdentity() {
-    return ImmutableSet.of(Mono.just(1).switchIfEmpty(Mono.empty()), Mono.<Void>empty().then());
+    return ImmutableSet.of(
+        Mono.just(1).switchIfEmpty(Mono.empty()),
+        Mono.<Void>empty().then(),
+        Mono.just(2).flux().next());
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -118,8 +118,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Mono<?>> testMonoIdentity() {
     return ImmutableSet.of(
         Mono.just(1).switchIfEmpty(Mono.empty()),
-        Mono.<Void>empty().then(),
-        Mono.just(2).flux().next());
+        Mono.just(2).flux().next(),
+        Mono.<Void>empty().then());
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -121,7 +121,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<?>> testMonoIdentity() {
-    return ImmutableSet.of(Mono.just(1), Mono.<Void>empty());
+    return ImmutableSet.of(Mono.just(1), Mono.<Void>empty(), Mono.just(2));
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -121,7 +121,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<?>> testMonoIdentity() {
-    return ImmutableSet.of(Mono.just(1), Mono.<Void>empty(), Mono.just(2));
+    return ImmutableSet.of(Mono.just(1), Mono.just(2), Mono.<Void>empty());
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {


### PR DESCRIPTION
After applying EPS on a repository, I've noticed essentially the following interesting pattern:
```java
Mono.<Void>empty().flux().next()
```
- `Mono#flux()` converts the `Mono` to a `Flux` as-is.
- `Flux#next()` however simply takes the first element in the `Flux` or returns empty without any side-effects (contrary to `Flux#single()`).

So, this is practically a no-op.

### Suggested commit message
```
Extend `MonoIdentity` Refaster rule (#465)

By flagging expressions of the form `mono.flux().next()`.
```