### PR TITLE
Extend `MonoIdentity` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -369,7 +369,8 @@ final class ReactorRules {
   static final class MonoIdentity<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono) {
-      return Refaster.anyOf(mono.switchIfEmpty(Mono.empty()), mono.flux().next());
+      return Refaster.anyOf(
+          mono.switchIfEmpty(Mono.empty()), mono.flux().next(), mono.flux().singleOrEmpty());
     }
 
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -119,6 +119,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Mono.just(1).switchIfEmpty(Mono.empty()),
         Mono.just(2).flux().next(),
+        Mono.just(3).flux().singleOrEmpty(),
         Mono.<Void>empty().then());
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -121,7 +121,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<?>> testMonoIdentity() {
-    return ImmutableSet.of(Mono.just(1), Mono.just(2), Mono.<Void>empty());
+    return ImmutableSet.of(Mono.just(1), Mono.just(2), Mono.just(3), Mono.<Void>empty());
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {


### PR DESCRIPTION
Sorry for two bite size PRs, but I've just now noticed one more case which wasn't covered in #465.

`Mono#singleOrEmpty()` _has_ side-effects, but only if there is more than one element which by definition cannot occur after a `Mono#flux()` call.

I've checked again to see whether more expressions would qualify, however `Mono#single()` and `Mono#last()` don't qualify since they have side-effects when no element can be found.

### Suggested commit message
```
Extend `MonoIdentity` Refaster rule (#470)

By flagging expressions of the form `mono.flux().singleOrEmpty()`.
```