### PR TITLE
Upgrade Maven API 3.8.6 -> 3.8.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
         <version.error-prone-slf4j>0.1.18</version.error-prone-slf4j>
         <version.guava-beta-checker>1.0</version.guava-beta-checker>
         <version.jdk>11</version.jdk>
-        <version.maven>3.8.6</version.maven>
+        <version.maven>3.8.7</version.maven>
         <version.mockito>5.1.1</version.mockito>
         <version.nopen-checker>1.0.1</version.nopen-checker>
         <version.nullaway>0.10.9</version.nullaway>


### PR DESCRIPTION
Suggested commit message:
```
Upgrade Maven API 3.8.6 -> 3.8.7 (#498)

See:
- https://maven.apache.org/docs/3.8.7/release-notes.html
- https://github.com/apache/maven/releases/tag/maven-3.8.7
- https://github.com/apache/maven/compare/maven-3.8.6...maven-3.8.7
```

