### PR TITLE
Introduce ResultQueryFetchStream Refaster rule

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -147,6 +147,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.jooq</groupId>
+            <artifactId>jooq</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.jspecify</groupId>
             <artifactId>jspecify</artifactId>
             <scope>provided</scope>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JooqRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JooqRules.java
@@ -1,0 +1,29 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.stream.Stream;
+import org.jooq.Record;
+import org.jooq.ResultQuery;
+import tech.picnic.errorprone.refaster.annotation.Description;
+import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
+
+@OnlineDocumentation
+final class JooqRules {
+  private JooqRules() {}
+
+  /** Prefer eagerly fetching data over (lazy) streaming to avoid potentially leaking resources. */
+  @Description(
+      "Prefer eagerly fetching data over (lazy) streaming to avoid potentially leaking resources.")
+  static final class ResultQueryFetchStream {
+    @BeforeTemplate
+    Stream<?> before(ResultQuery<? extends Record> resultQuery) {
+      return resultQuery.stream();
+    }
+
+    @AfterTemplate
+    Stream<?> after(ResultQuery<? extends Record> resultQuery) {
+      return resultQuery.fetch().stream();
+    }
+  }
+}

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -49,6 +49,7 @@ final class RefasterRulesTest {
           ImmutableSortedMultisetRules.class,
           ImmutableSortedSetRules.class,
           IntStreamRules.class,
+          JooqRules.class,
           JUnitRules.class,
           JUnitToAssertJRules.class,
           LongStreamRules.class,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JooqRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JooqRulesTestInput.java
@@ -1,0 +1,11 @@
+package tech.picnic.errorprone.refasterrules;
+
+import java.util.stream.Stream;
+import org.jooq.impl.DSL;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class JooqRulesTest implements RefasterRuleCollectionTestCase {
+  Stream<?> testResultQueryFetchStream() {
+    return DSL.select().stream();
+  }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JooqRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JooqRulesTestOutput.java
@@ -1,0 +1,11 @@
+package tech.picnic.errorprone.refasterrules;
+
+import java.util.stream.Stream;
+import org.jooq.impl.DSL;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class JooqRulesTest implements RefasterRuleCollectionTestCase {
+  Stream<?> testResultQueryFetchStream() {
+    return DSL.select().fetch().stream();
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -369,6 +369,11 @@
                 <version>2.9.3</version>
             </dependency>
             <dependency>
+                <groupId>org.jooq</groupId>
+                <artifactId>jooq</artifactId>
+                <version>3.16.14</version>
+            </dependency>
+            <dependency>
                 <groupId>org.jspecify</groupId>
                 <artifactId>jspecify</artifactId>
                 <version>0.3.0</version>
@@ -1178,6 +1183,8 @@
                                 | BSD 3-clause
                                 | BSD License 3
                                 | Eclipse Distribution License (New BSD License)
+                                | Eclipse Distribution License - v 1.0
+                                | EDL 1.0
                                 | New BSD License
                             </licenseMerge>
                             <licenseMerge>


### PR DESCRIPTION
When using the jOOQ SQL library for querying a database, you can either fetch the result set of your query into memory and proceed with application code, or you can return a lazy stream from the database and process the results as a stream. [See here for examples and explanations of fetching with jOOQ](https://blog.jooq.org/the-many-different-ways-to-fetch-data-in-jooq/). A common issue with the `.stream()` approach is that it is usually used unintentionally. This is dangerous as the stream returned here is not managed and not auto-closed, leaving applications potentially at risk to resource leaking. 

A less opinionated version of this rule may be to only make this replacement when the `.stream()` is invoked _outside of a try_with_resources_ block. 