### PR TITLE
Introduce `ImmutableMapCopyOfMapsFilter{Keys,Values}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
@@ -366,9 +366,4 @@ final class ImmutableMapRules {
   // map.entrySet().stream().filter(keyPred).forEach(mapBuilder::put)
   // ->
   // mapBuilder.putAll(Maps.filterKeys(map, pred))
-  //
-  // map.entrySet().stream().filter(entry ->
-  // pred(entry.getKey())).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue))
-  // ->
-  // ImmutableMap.copyOf(Maps.filterKeys(map, pred))
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
@@ -127,8 +127,8 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Don't map a stream's elements to map entries, only to subsequently collect them into an
-   * {@link ImmutableMap}. The collection can be performed directly.
+   * Don't map a stream's elements to map entries, only to subsequently collect them into an {@link
+   * ImmutableMap}. The collection can be performed directly.
    */
   abstract static class StreamOfMapEntriesToImmutableMap<E, K, V> {
     @Placeholder(allowsIdentity = true)

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
@@ -127,7 +127,7 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Don't map a a stream's elements to map entries, only to subsequently collect them into an
+   * Don't map a stream's elements to map entries, only to subsequently collect them into an
    * {@link ImmutableMap}. The collection can be performed directly.
    */
   abstract static class StreamOfMapEntriesToImmutableMap<E, K, V> {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
@@ -317,44 +317,44 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Prefer {@link Maps#filterKeys(Map, Predicate)} over streaming entries of a map and filtering
-   * the keys.
+   * Prefer creation of an immutable submap using {@link Maps#filterKeys(Map, Predicate)} over more
+   * contrived alternatives.
    */
-  abstract static class ImmutableMapFilterKeys<K, V> {
+  abstract static class ImmutableMapCopyOfMapsFilterKeys<K, V> {
     @Placeholder(allowsIdentity = true)
-    abstract boolean keyFilter(@MayOptionallyUse K element);
+    abstract boolean keyFilter(@MayOptionallyUse K key);
 
     @BeforeTemplate
-    ImmutableMap<K, V> before(ImmutableMap<K, V> input) {
-      return input.entrySet().stream()
-          .filter(entry -> keyFilter(entry.getKey()))
+    ImmutableMap<K, V> before(ImmutableMap<K, V> map) {
+      return map.entrySet().stream()
+          .filter(e -> keyFilter(e.getKey()))
           .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @AfterTemplate
-    ImmutableMap<K, V> after(ImmutableMap<K, V> input) {
-      return ImmutableMap.copyOf(Maps.filterKeys(input, k -> keyFilter(k)));
+    ImmutableMap<K, V> after(ImmutableMap<K, V> map) {
+      return ImmutableMap.copyOf(Maps.filterKeys(map, k -> keyFilter(k)));
     }
   }
 
   /**
-   * Prefer {@link Maps#filterValues(Map, Predicate)} over streaming entries of a map and filtering
-   * the values.
+   * Prefer creation of an immutable submap using {@link Maps#filterValues(Map, Predicate)} over
+   * more contrived alternatives.
    */
-  abstract static class ImmutableMapFilterValues<K, V> {
+  abstract static class ImmutableMapCopyOfMapsFilterValues<K, V> {
     @Placeholder(allowsIdentity = true)
-    abstract boolean valueFilter(@MayOptionallyUse V element);
+    abstract boolean valueFilter(@MayOptionallyUse V value);
 
     @BeforeTemplate
-    ImmutableMap<K, V> before(ImmutableMap<K, V> input) {
-      return input.entrySet().stream()
-          .filter(entry -> valueFilter(entry.getValue()))
+    ImmutableMap<K, V> before(ImmutableMap<K, V> map) {
+      return map.entrySet().stream()
+          .filter(e -> valueFilter(e.getValue()))
           .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @AfterTemplate
-    ImmutableMap<K, V> after(ImmutableMap<K, V> input) {
-      return ImmutableMap.copyOf(Maps.filterValues(input, v -> valueFilter(v)));
+    ImmutableMap<K, V> after(ImmutableMap<K, V> map) {
+      return ImmutableMap.copyOf(Maps.filterValues(map, v -> valueFilter(v)));
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestInput.java
@@ -107,4 +107,16 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
   Map<String, String> testImmutableMapOf5() {
     return Map.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4", "k5", "v5");
   }
+
+  ImmutableMap<String, String> testImmutableMapFilterKeys() {
+    return ImmutableMap.of("k1", "v1", "k2", "v2").entrySet().stream()
+        .filter(entry -> entry.getKey().equals("k1"))
+        .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
+
+  ImmutableMap<String, String> testImmutableMapFilterValues() {
+    return ImmutableMap.of("k1", "v1", "k2", "v2").entrySet().stream()
+        .filter(entry -> entry.getValue().equals("v1"))
+        .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestInput.java
@@ -108,15 +108,15 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
     return Map.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4", "k5", "v5");
   }
 
-  ImmutableMap<String, String> testImmutableMapFilterKeys() {
-    return ImmutableMap.of("k1", "v1", "k2", "v2").entrySet().stream()
-        .filter(entry -> entry.getKey().equals("k1"))
+  ImmutableMap<String, Integer> testImmutableMapCopyOfMapsFilterKeys() {
+    return ImmutableMap.of("foo", 1).entrySet().stream()
+        .filter(entry -> entry.getKey().length() > 1)
         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  ImmutableMap<String, String> testImmutableMapFilterValues() {
-    return ImmutableMap.of("k1", "v1", "k2", "v2").entrySet().stream()
-        .filter(entry -> entry.getValue().equals("v1"))
+  ImmutableMap<String, Integer> testImmutableMapCopyOfMapsFilterValues() {
+    return ImmutableMap.of("foo", 1).entrySet().stream()
+        .filter(entry -> entry.getValue() > 0)
         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestOutput.java
@@ -91,13 +91,11 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4", "k5", "v5");
   }
 
-  ImmutableMap<String, String> testImmutableMapFilterKeys() {
-    return ImmutableMap.copyOf(
-        Maps.filterKeys(ImmutableMap.of("k1", "v1", "k2", "v2"), k -> k.equals("k1")));
+  ImmutableMap<String, Integer> testImmutableMapCopyOfMapsFilterKeys() {
+    return ImmutableMap.copyOf(Maps.filterKeys(ImmutableMap.of("foo", 1), k -> k.length() > 1));
   }
 
-  ImmutableMap<String, String> testImmutableMapFilterValues() {
-    return ImmutableMap.copyOf(
-        Maps.filterValues(ImmutableMap.of("k1", "v1", "k2", "v2"), v -> v.equals("v1")));
+  ImmutableMap<String, Integer> testImmutableMapCopyOfMapsFilterValues() {
+    return ImmutableMap.copyOf(Maps.filterValues(ImmutableMap.of("foo", 1), v -> v > 0));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestOutput.java
@@ -90,4 +90,14 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
   Map<String, String> testImmutableMapOf5() {
     return ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4", "k5", "v5");
   }
+
+  ImmutableMap<String, String> testImmutableMapFilterKeys() {
+    return ImmutableMap.copyOf(
+        Maps.filterKeys(ImmutableMap.of("k1", "v1", "k2", "v2"), k -> k.equals("k1")));
+  }
+
+  ImmutableMap<String, String> testImmutableMapFilterValues() {
+    return ImmutableMap.copyOf(
+        Maps.filterValues(ImmutableMap.of("k1", "v1", "k2", "v2"), v -> v.equals("v1")));
+  }
 }


### PR DESCRIPTION
Hesitated for a sec to also cover `FilterEntries`, but I reckon this has less usages and will somehow conflict with `FilterValues` and `FilterKeys`, so I left it out. 

Suggested commit message:
```
Introduce `ImmutableMapFilter{Keys,Values}` Refaster rules (#517)
```