### PR TITLE
Upgrade JDKs used by GitHub Actions builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,9 +42,9 @@ Please replace this sentence with log output, if applicable.
 <!-- Please complete the following information: -->
 
 - Operating system (e.g. MacOS Monterey).
-- Java version (i.e. `java --version`, e.g. `17.0.3`).
-- Error Prone version (e.g. `2.15.0`).
-- Error Prone Support version (e.g. `0.3.0`).
+- Java version (i.e. `java --version`, e.g. `17.0.6`).
+- Error Prone version (e.g. `2.18.0`).
+- Error Prone Support version (e.g. `0.8.0`).
 
 ### Additional context
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,16 +10,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        jdk: [ 11.0.16, 17.0.4, 19 ]
+        jdk: [ 11.0.18, 17.0.6, 19.0.2 ]
         distribution: [ temurin ]
         experimental: [ false ]
         include:
           - os: macos-12
-            jdk: 17.0.4
+            jdk: 17.0.6
             distribution: temurin
             experimental: false
           - os: windows-2022
-            jdk: 17.0.4
+            jdk: 17.0.6
             distribution: temurin
             experimental: false
           - os: ubuntu-22.04

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:
-          java-version: 17.0.4
+          java-version: 17.0.6
           distribution: temurin
           cache: maven
       - name: Run Pitest

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:
-          java-version: 17.0.4
+          java-version: 17.0.6
           distribution: temurin
           cache: maven
       - name: Download Pitest analysis artifact

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/SourceCodeTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/SourceCodeTest.java
@@ -31,7 +31,6 @@ final class SourceCodeTest {
         .expectUnchanged()
         .addInputLines(
             "AnnotationDeletions.java",
-            "",
             "interface AnnotationDeletions {",
             "  class SoleAnnotation {",
             "    @AnnotationToBeDeleted",
@@ -66,7 +65,6 @@ final class SourceCodeTest {
             "}")
         .addOutputLines(
             "AnnotationDeletions.java",
-            "",
             "interface AnnotationDeletions {",
             "  class SoleAnnotation {",
             "    void m() {}",
@@ -101,7 +99,6 @@ final class SourceCodeTest {
     refactoringTestHelper
         .addInputLines(
             "MethodDeletions.java",
-            "",
             "interface MethodDeletions {",
             "  class SoleMethod {",
             "    void methodToBeDeleted() {}",
@@ -141,7 +138,6 @@ final class SourceCodeTest {
             "}")
         .addOutputLines(
             "MethodDeletions.java",
-            "",
             "interface MethodDeletions {",
             "  class SoleMethod {}",
             "",

--- a/pom.xml
+++ b/pom.xml
@@ -862,8 +862,8 @@
                         </annotationProcessorPaths>
                         <compilerArgs>
                             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+                            <arg>--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
                             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
                             <arg>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>


### PR DESCRIPTION
Suggested commit message:
```
Upgrade JDKs used by GitHub Actions builds (#521)

Additionally:
- Update the example version numbers mentioned in the issue template.
- Drop some redundant whitespace from `SourceCodeTest` test code.
- Sort some compiler arguments.

See:
- https://www.oracle.com/java/technologies/javase/11-0-17-relnotes.html
- https://www.oracle.com/java/technologies/javase/11-0-18-relnotes.html
- https://www.oracle.com/java/technologies/javase/17-0-5-relnotes.html
- https://www.oracle.com/java/technologies/javase/17-0-6-relnotes.html
- https://www.oracle.com/java/technologies/javase/19-0-1-relnotes.html
- https://www.oracle.com/java/technologies/javase/19-0-2-relnotes.html
```