### PR TITLE
Extend `null` check Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreASTHelpers.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreASTHelpers.java
@@ -2,6 +2,7 @@ package tech.picnic.errorprone.bugpatterns.util;
 
 import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
@@ -27,7 +28,7 @@ public final class MoreASTHelpers {
    */
   public static ImmutableList<MethodTree> findMethods(CharSequence methodName, VisitorState state) {
     ClassTree clazz = state.findEnclosing(ClassTree.class);
-    checkArgument(clazz != null, "Visited node is not enclosed by a class");
+    requireNonNull(clazz, "Visited node is not enclosed by a class");
     return clazz.getMembers().stream()
         .filter(MethodTree.class::isInstance)
         .map(MethodTree.class::cast)

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreASTHelpers.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreASTHelpers.java
@@ -1,7 +1,7 @@
 package tech.picnic.errorprone.bugpatterns.util;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
@@ -27,7 +27,7 @@ public final class MoreASTHelpers {
    */
   public static ImmutableList<MethodTree> findMethods(CharSequence methodName, VisitorState state) {
     ClassTree clazz = state.findEnclosing(ClassTree.class);
-    requireNonNull(clazz, "Visited node is not enclosed by a class");
+    checkArgument(clazz != null, "Visited node is not enclosed by a class");
     return clazz.getMembers().stream()
         .filter(MethodTree.class::isInstance)
         .map(MethodTree.class::cast)

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreASTHelpers.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreASTHelpers.java
@@ -1,6 +1,5 @@
 package tech.picnic.errorprone.bugpatterns.util;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.collect.ImmutableList.toImmutableList;
 import static java.util.Objects.requireNonNull;
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
@@ -21,16 +21,14 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class NullRules {
   private NullRules() {}
 
-  /** Prefer the {@code ==} operator over {@link Objects#isNull(Object)}. */
+  /**
+   * Prefer the {@code ==} operator (with {@code null} as the second operand) over {@link
+   * Objects#isNull(Object)}.
+   */
   static final class IsNull {
     @BeforeTemplate
     boolean before(@Nullable Object object) {
-      return null == object;
-    }
-
-    @BeforeTemplate
-    boolean before2(@Nullable Object object) {
-      return Objects.isNull(object);
+      return Refaster.anyOf(null == object, Objects.isNull(object));
     }
 
     @AfterTemplate
@@ -39,16 +37,14 @@ final class NullRules {
     }
   }
 
-  /** Prefer the {@code !=} operator over {@link Objects#nonNull(Object)}. */
+  /**
+   * Prefer the {@code !=} operator (with {@code null} as the second operand) over {@link
+   * Objects#nonNull(Object)}.
+   */
   static final class IsNotNull {
     @BeforeTemplate
     boolean before(@Nullable Object object) {
-      return null != object;
-    }
-
-    @BeforeTemplate
-    boolean before2(@Nullable Object object) {
-      return Objects.nonNull(object);
+      return Refaster.anyOf(null != object, Objects.nonNull(object));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
@@ -25,6 +25,11 @@ final class NullRules {
   static final class IsNull {
     @BeforeTemplate
     boolean before(@Nullable Object object) {
+      return null == object;
+    }
+
+    @BeforeTemplate
+    boolean before2(@Nullable Object object) {
       return Objects.isNull(object);
     }
 
@@ -38,6 +43,11 @@ final class NullRules {
   static final class IsNotNull {
     @BeforeTemplate
     boolean before(@Nullable Object object) {
+      return null != object;
+    }
+
+    @BeforeTemplate
+    boolean before2(@Nullable Object object) {
       return Objects.nonNull(object);
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -74,18 +74,27 @@ final class PreconditionsRules {
     }
   }
 
-  /** Prefer {@link Objects#requireNonNull(Object)} over more verbose alternatives. */
+  /** Prefer {@link Objects#requireNonNull(Object)} over non-JDK alternatives. */
   static final class RequireNonNull<T> {
+    @BeforeTemplate
+    T before(T object) {
+      return checkNotNull(object);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    T after(T object) {
+      return requireNonNull(object);
+    }
+  }
+
+  /** Prefer {@link Objects#requireNonNull(Object)} over more verbose alternatives. */
+  static final class RequireNonNullStatement<T> {
     @BeforeTemplate
     void before(T object) {
       if (object == null) {
         throw new NullPointerException();
       }
-    }
-
-    @BeforeTemplate
-    void before2(T object) {
-      checkNotNull(object);
     }
 
     @BeforeTemplate
@@ -100,18 +109,27 @@ final class PreconditionsRules {
     }
   }
 
-  /** Prefer {@link Objects#requireNonNull(Object, String)} over more verbose alternatives. */
+  /** Prefer {@link Objects#requireNonNull(Object, String)} over non-JDK alternatives. */
   static final class RequireNonNullWithMessage<T> {
+    @BeforeTemplate
+    T before2(T object, String message) {
+      return checkNotNull(object, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    T after(T object, String message) {
+      return requireNonNull(object, message);
+    }
+  }
+
+  /** Prefer {@link Objects#requireNonNull(Object, String)} over more verbose alternatives. */
+  static final class RequireNonNullWithMessageStatement<T> {
     @BeforeTemplate
     void before(T object, String message) {
       if (object == null) {
         throw new NullPointerException(message);
       }
-    }
-
-    @BeforeTemplate
-    void before2(T object, String message) {
-      checkNotNull(object, message);
     }
 
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -88,7 +88,7 @@ final class PreconditionsRules {
     }
   }
 
-  /** Prefer {@link Objects#requireNonNull(Object)} over more verbose alternatives. */
+  /** Prefer {@link Objects#requireNonNull(Object)} over non-JDK alternatives. */
   static final class RequireNonNullStatement<T> {
     @BeforeTemplate
     void before(T object) {
@@ -98,7 +98,7 @@ final class PreconditionsRules {
     }
 
     @BeforeTemplate
-    void before3(T object) {
+    void before2(T object) {
       checkArgument(object != null);
     }
 
@@ -112,7 +112,7 @@ final class PreconditionsRules {
   /** Prefer {@link Objects#requireNonNull(Object, String)} over non-JDK alternatives. */
   static final class RequireNonNullWithMessage<T> {
     @BeforeTemplate
-    T before2(T object, String message) {
+    T before(T object, String message) {
       return checkNotNull(object, message);
     }
 
@@ -133,7 +133,7 @@ final class PreconditionsRules {
     }
 
     @BeforeTemplate
-    void before3(T object, String message) {
+    void before2(T object, String message) {
       checkArgument(object != null, message);
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -9,7 +9,6 @@ import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
-import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
@@ -79,7 +78,7 @@ final class PreconditionsRules {
   static final class RequireNonNull<T> {
     @BeforeTemplate
     void before(T object) {
-      if (Refaster.anyOf(object == null, null == object)) {
+      if (object == null) {
         throw new NullPointerException();
       }
     }
@@ -91,7 +90,7 @@ final class PreconditionsRules {
 
     @BeforeTemplate
     void before3(T object) {
-      checkArgument(Refaster.anyOf(object != null, null != object));
+      checkArgument(object != null);
     }
 
     @AfterTemplate
@@ -105,7 +104,7 @@ final class PreconditionsRules {
   static final class RequireNonNullWithMessage<T> {
     @BeforeTemplate
     void before(T object, String message) {
-      if (Refaster.anyOf(object == null, null == object)) {
+      if (object == null) {
         throw new NullPointerException(message);
       }
     }
@@ -117,7 +116,7 @@ final class PreconditionsRules {
 
     @BeforeTemplate
     void before3(T object, String message) {
-      checkArgument(Refaster.anyOf(object != null, null != object), message);
+      checkArgument(object != null, message);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -9,6 +9,7 @@ import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
+import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
@@ -78,7 +79,7 @@ final class PreconditionsRules {
   static final class RequireNonNull<T> {
     @BeforeTemplate
     void before(T object) {
-      if (object == null) {
+      if (Refaster.anyOf(object == null, null == object)) {
         throw new NullPointerException();
       }
     }
@@ -86,6 +87,11 @@ final class PreconditionsRules {
     @BeforeTemplate
     void before2(T object) {
       checkNotNull(object);
+    }
+
+    @BeforeTemplate
+    void before3(T object) {
+      checkArgument(Refaster.anyOf(object != null, null != object));
     }
 
     @AfterTemplate
@@ -99,7 +105,7 @@ final class PreconditionsRules {
   static final class RequireNonNullWithMessage<T> {
     @BeforeTemplate
     void before(T object, String message) {
-      if (object == null) {
+      if (Refaster.anyOf(object == null, null == object)) {
         throw new NullPointerException(message);
       }
     }
@@ -107,6 +113,11 @@ final class PreconditionsRules {
     @BeforeTemplate
     void before2(T object, String message) {
       checkNotNull(object, message);
+    }
+
+    @BeforeTemplate
+    void before3(T object, String message) {
+      checkArgument(Refaster.anyOf(object != null, null != object), message);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -88,18 +88,13 @@ final class PreconditionsRules {
     }
   }
 
-  /** Prefer {@link Objects#requireNonNull(Object)} over non-JDK alternatives. */
+  /** Prefer {@link Objects#requireNonNull(Object)} over more verbose alternatives. */
   static final class RequireNonNullStatement<T> {
     @BeforeTemplate
     void before(T object) {
       if (object == null) {
         throw new NullPointerException();
       }
-    }
-
-    @BeforeTemplate
-    void before2(T object) {
-      checkArgument(object != null);
     }
 
     @AfterTemplate
@@ -130,11 +125,6 @@ final class PreconditionsRules {
       if (object == null) {
         throw new NullPointerException(message);
       }
-    }
-
-    @BeforeTemplate
-    void before2(T object, String message) {
-      checkArgument(object != null, message);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -6,11 +6,13 @@ import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndex;
 import static com.google.common.base.Preconditions.checkState;
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.Objects;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster templates related to statements dealing with {@link Preconditions}. */
@@ -72,8 +74,8 @@ final class PreconditionsRules {
     }
   }
 
-  /** Prefer {@link Preconditions#checkNotNull(Object)} over more verbose alternatives. */
-  static final class CheckNotNull<T> {
+  /** Prefer {@link Objects#requireNonNull(Object)} over more verbose alternatives. */
+  static final class RequireNonNull<T> {
     @BeforeTemplate
     void before(T object) {
       if (object == null) {
@@ -81,15 +83,20 @@ final class PreconditionsRules {
       }
     }
 
+    @BeforeTemplate
+    void before2(T object) {
+      checkNotNull(object);
+    }
+
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(T object) {
-      checkNotNull(object);
+      requireNonNull(object);
     }
   }
 
-  /** Prefer {@link Preconditions#checkNotNull(Object, Object)} over more verbose alternatives. */
-  static final class CheckNotNullWithMessage<T> {
+  /** Prefer {@link Objects#requireNonNull(Object, String)} over more verbose alternatives. */
+  static final class RequireNonNullWithMessage<T> {
     @BeforeTemplate
     void before(T object, String message) {
       if (object == null) {
@@ -97,10 +104,15 @@ final class PreconditionsRules {
       }
     }
 
+    @BeforeTemplate
+    void before2(T object, String message) {
+      checkNotNull(object, message);
+    }
+
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(T object, String message) {
-      checkNotNull(object, message);
+      requireNonNull(object, message);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
@@ -13,12 +13,12 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(MoreObjects.class, Optional.class);
   }
 
-  boolean testIsNull() {
-    return Objects.isNull("foo");
+  ImmutableSet<Boolean> testIsNull() {
+    return ImmutableSet.of(null == "foo", Objects.isNull("bar"));
   }
 
-  boolean testIsNotNull() {
-    return Objects.nonNull("foo");
+  ImmutableSet<Boolean> testIsNotNull() {
+    return ImmutableSet.of(null != "foo", Objects.nonNull("bar"));
   }
 
   ImmutableSet<String> testRequireNonNullElse() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
@@ -16,12 +16,12 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(MoreObjects.class, Optional.class);
   }
 
-  boolean testIsNull() {
-    return "foo" == null;
+  ImmutableSet<Boolean> testIsNull() {
+    return ImmutableSet.of("foo" == null, "bar" == null);
   }
 
-  boolean testIsNotNull() {
-    return "foo" != null;
+  ImmutableSet<Boolean> testIsNotNull() {
+    return ImmutableSet.of("foo" != null, "bar" != null);
   }
 
   ImmutableSet<String> testRequireNonNullElse() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -34,24 +34,16 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     if ("foo" == null) {
       throw new NullPointerException();
     }
-    if (null == "bar") {
-      throw new NullPointerException();
-    }
-    checkNotNull("baz");
-    checkArgument("qux" != null);
-    checkArgument(null != "quux");
+    checkNotNull("bar");
+    checkArgument("baz" != null);
   }
 
   void testRequireNonNullWithMessage() {
     if ("foo" == null) {
       throw new NullPointerException("The string is null");
     }
-    if (null == "bar") {
-      throw new NullPointerException("The string is null");
-    }
-    checkNotNull("baz", "The string is null");
-    checkArgument("qux" != null, "The string is null");
-    checkArgument(null != "quux", "The string is null");
+    checkNotNull("bar", "The string is null");
+    checkArgument("baz" != null, "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -1,8 +1,16 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.common.base.Preconditions.checkNotNull;
+
+import com.google.common.collect.ImmutableSet;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(checkNotNull(null));
+  }
+
   void testCheckArgument() {
     if ("foo".isEmpty()) {
       throw new IllegalArgumentException();
@@ -21,16 +29,18 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
-  void testCheckNotNull() {
+  void testRequireNonNull() {
     if ("foo" == null) {
       throw new NullPointerException();
     }
+    checkNotNull("foo");
   }
 
-  void testCheckNotNullWithMessage() {
+  void testRequireNonNullWithMessage() {
     if ("foo" == null) {
       throw new NullPointerException("The string is null");
     }
+    checkNotNull("foo", "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -34,24 +34,24 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     if ("foo" == null) {
       throw new NullPointerException();
     }
-    if (null == "foo") {
+    if (null == "bar") {
       throw new NullPointerException();
     }
-    checkNotNull("foo");
-    checkArgument("foo" != null);
-    checkArgument(null != "foo");
+    checkNotNull("baz");
+    checkArgument("qux" != null);
+    checkArgument(null != "quux");
   }
 
   void testRequireNonNullWithMessage() {
     if ("foo" == null) {
       throw new NullPointerException("The string is null");
     }
-    if (null == "foo") {
+    if (null == "bar") {
       throw new NullPointerException("The string is null");
     }
-    checkNotNull("foo", "The string is null");
-    checkArgument("foo" != null, "The string is null");
-    checkArgument(null != "foo", "The string is null");
+    checkNotNull("baz", "The string is null");
+    checkArgument("qux" != null, "The string is null");
+    checkArgument(null != "quux", "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -8,6 +8,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
   @Override
+  @SuppressWarnings("RequireNonNull")
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(checkNotNull(null));
   }
@@ -30,20 +31,26 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
-  void testRequireNonNull() {
+  String testRequireNonNull() {
+    return checkNotNull("foo");
+  }
+
+  void testRequireNonNullStatement() {
     if ("foo" == null) {
       throw new NullPointerException();
     }
-    checkNotNull("bar");
-    checkArgument("baz" != null);
+    checkArgument("bar" != null);
   }
 
-  void testRequireNonNullWithMessage() {
+  String testRequireNonNullWithMessage() {
+    return checkNotNull("foo", "The string is null");
+  }
+
+  void testRequireNonNullWithMessageStatement() {
     if ("foo" == null) {
       throw new NullPointerException("The string is null");
     }
-    checkNotNull("bar", "The string is null");
-    checkArgument("baz" != null, "The string is null");
+    checkArgument("bar" != null, "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -1,5 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableSet;
@@ -33,14 +34,24 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     if ("foo" == null) {
       throw new NullPointerException();
     }
+    if (null == "foo") {
+      throw new NullPointerException();
+    }
     checkNotNull("foo");
+    checkArgument("foo" != null);
+    checkArgument(null != "foo");
   }
 
   void testRequireNonNullWithMessage() {
     if ("foo" == null) {
       throw new NullPointerException("The string is null");
     }
+    if (null == "foo") {
+      throw new NullPointerException("The string is null");
+    }
     checkNotNull("foo", "The string is null");
+    checkArgument("foo" != null, "The string is null");
+    checkArgument(null != "foo", "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -1,6 +1,5 @@
 package tech.picnic.errorprone.refasterrules;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
 
 import com.google.common.collect.ImmutableSet;
@@ -39,7 +38,6 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     if ("foo" == null) {
       throw new NullPointerException();
     }
-    checkArgument("bar" != null);
   }
 
   String testRequireNonNullWithMessage() {
@@ -50,7 +48,6 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     if ("foo" == null) {
       throw new NullPointerException("The string is null");
     }
-    checkArgument("bar" != null, "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -30,18 +30,18 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
 
   void testRequireNonNull() {
     requireNonNull("foo");
-    requireNonNull("foo");
-    requireNonNull("foo");
-    requireNonNull("foo");
-    requireNonNull("foo");
+    requireNonNull("bar");
+    requireNonNull("baz");
+    requireNonNull("qux");
+    requireNonNull("quux");
   }
 
   void testRequireNonNullWithMessage() {
     requireNonNull("foo", "The string is null");
-    requireNonNull("foo", "The string is null");
-    requireNonNull("foo", "The string is null");
-    requireNonNull("foo", "The string is null");
-    requireNonNull("foo", "The string is null");
+    requireNonNull("bar", "The string is null");
+    requireNonNull("baz", "The string is null");
+    requireNonNull("qux", "The string is null");
+    requireNonNull("quux", "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -32,16 +32,12 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     requireNonNull("foo");
     requireNonNull("bar");
     requireNonNull("baz");
-    requireNonNull("qux");
-    requireNonNull("quux");
   }
 
   void testRequireNonNullWithMessage() {
     requireNonNull("foo", "The string is null");
     requireNonNull("bar", "The string is null");
     requireNonNull("baz", "The string is null");
-    requireNonNull("qux", "The string is null");
-    requireNonNull("quux", "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -31,9 +31,15 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
   void testRequireNonNull() {
     requireNonNull("foo");
     requireNonNull("foo");
+    requireNonNull("foo");
+    requireNonNull("foo");
+    requireNonNull("foo");
   }
 
   void testRequireNonNullWithMessage() {
+    requireNonNull("foo", "The string is null");
+    requireNonNull("foo", "The string is null");
+    requireNonNull("foo", "The string is null");
     requireNonNull("foo", "The string is null");
     requireNonNull("foo", "The string is null");
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -35,7 +35,6 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
 
   void testRequireNonNullStatement() {
     requireNonNull("foo");
-    requireNonNull("bar");
   }
 
   String testRequireNonNullWithMessage() {
@@ -44,7 +43,6 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
 
   void testRequireNonNullWithMessageStatement() {
     requireNonNull("foo", "The string is null");
-    requireNonNull("bar", "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -12,6 +12,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
   @Override
+  @SuppressWarnings("RequireNonNull")
   public ImmutableSet<?> elidedTypesAndStaticImports() {
     return ImmutableSet.of(checkNotNull(null));
   }
@@ -28,16 +29,22 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     checkElementIndex(1, 2, "My index");
   }
 
-  void testRequireNonNull() {
-    requireNonNull("foo");
-    requireNonNull("bar");
-    requireNonNull("baz");
+  String testRequireNonNull() {
+    return requireNonNull("foo");
   }
 
-  void testRequireNonNullWithMessage() {
+  void testRequireNonNullStatement() {
+    requireNonNull("foo");
+    requireNonNull("bar");
+  }
+
+  String testRequireNonNullWithMessage() {
+    return requireNonNull("foo", "The string is null");
+  }
+
+  void testRequireNonNullWithMessageStatement() {
     requireNonNull("foo", "The string is null");
     requireNonNull("bar", "The string is null");
-    requireNonNull("baz", "The string is null");
   }
 
   void testCheckPositionIndex() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -5,10 +5,17 @@ import static com.google.common.base.Preconditions.checkElementIndex;
 import static com.google.common.base.Preconditions.checkNotNull;
 import static com.google.common.base.Preconditions.checkPositionIndex;
 import static com.google.common.base.Preconditions.checkState;
+import static java.util.Objects.requireNonNull;
 
+import com.google.common.collect.ImmutableSet;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(checkNotNull(null));
+  }
+
   void testCheckArgument() {
     checkArgument(!"foo".isEmpty());
   }
@@ -21,12 +28,14 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     checkElementIndex(1, 2, "My index");
   }
 
-  void testCheckNotNull() {
-    checkNotNull("foo");
+  void testRequireNonNull() {
+    requireNonNull("foo");
+    requireNonNull("foo");
   }
 
-  void testCheckNotNullWithMessage() {
-    checkNotNull("foo", "The string is null");
+  void testRequireNonNullWithMessage() {
+    requireNonNull("foo", "The string is null");
+    requireNonNull("foo", "The string is null");
   }
 
   void testCheckPositionIndex() {


### PR DESCRIPTION
Follow up of this [issue](https://github.com/PicnicSupermarket/error-prone-support/issues/437).

Suggested commit message:
```
Extend `null` check Refaster rules (#523)

Summary of changes:
- Replace `CheckNotNull` with `RequireNonNull{,WithMessage}{,Statement}`.
- Extend `Is{,Not}Null`.

Fixes #437.
```