### PR TITLE
Introduce `AssertThatPathContent{,Utf8}` Refaster rules

### DIFF
--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/BugPatternExtractorTest.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/BugPatternExtractorTest.java
@@ -14,7 +14,6 @@ import com.google.errorprone.bugpatterns.BugChecker.ClassTreeMatcher;
 import com.google.errorprone.matchers.Description;
 import com.sun.source.tree.ClassTree;
 import java.io.IOException;
-import java.nio.file.Files;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -120,7 +119,8 @@ final class BugPatternExtractorTest {
 
   private static void verifyFileMatchesResource(
       Path outputDirectory, String fileName, String resourceName) throws IOException {
-    assertThat(Files.readString(outputDirectory.resolve(fileName)))
+    assertThat(outputDirectory.resolve(fileName))
+        .content(UTF_8)
         .isEqualToIgnoringWhitespace(getResource(resourceName));
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
@@ -1,11 +1,16 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -87,6 +92,32 @@ final class AssertJStringRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     AbstractAssert<?, ?> after(String string, String regex) {
       return assertThat(string).doesNotMatch(regex);
+    }
+  }
+
+  static final class AssertThatPathContent {
+    @BeforeTemplate
+    AbstractStringAssert<?> before(Path path, Charset charset) throws IOException {
+      return assertThat(Files.readString(path, charset));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(Path path, Charset charset) {
+      return assertThat(path).content(charset);
+    }
+  }
+
+  static final class AssertThatPathContentUtf8 {
+    @BeforeTemplate
+    AbstractStringAssert<?> before(Path path) throws IOException {
+      return assertThat(Files.readString(path));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(Path path) {
+      return assertThat(path).content(UTF_8);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
@@ -2,11 +2,21 @@ package tech.picnic.errorprone.refasterrules;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Files.class);
+  }
+
   void testAbstractStringAssertStringIsEmpty() {
     assertThat("foo").isEqualTo("");
   }
@@ -29,5 +39,13 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
 
   AbstractAssert<?, ?> testAssertThatDoesNotMatch() {
     return assertThat("foo".matches(".*")).isFalse();
+  }
+
+  AbstractStringAssert<?> testAssertThatPathContent() throws IOException {
+    return assertThat(Files.readString(Paths.get(""), Charset.defaultCharset()));
+  }
+
+  AbstractStringAssert<?> testAssertThatPathContentUtf8() throws IOException {
+    return assertThat(Files.readString(Paths.get("")));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
@@ -1,12 +1,23 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
+import java.nio.charset.Charset;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<?> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Files.class);
+  }
+
   void testAbstractStringAssertStringIsEmpty() {
     assertThat("foo").isEmpty();
   }
@@ -29,5 +40,13 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
 
   AbstractAssert<?, ?> testAssertThatDoesNotMatch() {
     return assertThat("foo").doesNotMatch(".*");
+  }
+
+  AbstractStringAssert<?> testAssertThatPathContent() throws IOException {
+    return assertThat(Paths.get("")).content(Charset.defaultCharset());
+  }
+
+  AbstractStringAssert<?> testAssertThatPathContentUtf8() throws IOException {
+    return assertThat(Paths.get("")).content(UTF_8);
   }
 }


### PR DESCRIPTION
Identified while reviewing #494.

Suggested commit message:
```
Introduce `AssertThatPathContent{,Utf8}` Refaster rules (#530)
```