### PR TITLE
Extend `StepVerifierStepIdentity` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1232,6 +1232,24 @@ final class ReactorRules {
     }
   }
 
+  /**
+   * Prefer {@link StepVerifier.LastStep#verifyComplete()} over {@code
+   * StepVerifier.Step#expectNextCount(0).verifyComplete()} or its alternatives.
+   */
+  static final class StepVerifierStepExpectNextCountZeroVerifyComplete<T> {
+    @BeforeTemplate
+    Duration before(StepVerifier.Step<T> step) {
+      return Refaster.anyOf(
+          step.expectNextCount(0L).expectComplete().verify(),
+          step.expectNextCount(0L).verifyComplete());
+    }
+
+    @AfterTemplate
+    Duration after(StepVerifier.LastStep step) {
+      return step.verifyComplete();
+    }
+  }
+
   /** Prefer {@link StepVerifier.LastStep#verifyComplete()} over more verbose alternatives. */
   static final class StepVerifierLastStepVerifyComplete {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1205,11 +1205,13 @@ final class ReactorRules {
   }
 
   /** Don't unnecessarily have {@link StepVerifier.Step} expect no elements. */
+  // XXX: Given an `IsEmpty` matcher that identifies a wide range of guaranteed-empty `Iterable`
+  // expressions, consider also simplifying `step.expectNextSequence(someEmptyIterable)`.
   static final class StepVerifierStepIdentity<T> {
     @BeforeTemplate
     @SuppressWarnings("unchecked")
     StepVerifier.Step<T> before(StepVerifier.Step<T> step) {
-      return Refaster.anyOf(step.expectNext(), step.expectNextCount(0L));
+      return Refaster.anyOf(step.expectNext(), step.expectNextCount(0));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1204,12 +1204,15 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily call {@link StepVerifier.Step#expectNext(Object[])}. */
+  /**
+   * Don't unnecessarily call {@link StepVerifier.Step#expectNext(Object[])} or {@code
+   * StepVerifier.Step#expectNextCount(0L)}.
+   */
   static final class StepVerifierStepExpectNextEmpty<T> {
     @BeforeTemplate
     @SuppressWarnings("unchecked")
     StepVerifier.Step<T> before(StepVerifier.Step<T> step) {
-      return step.expectNext();
+      return Refaster.anyOf(step.expectNext(), step.expectNextCount(0L));
     }
 
     @AfterTemplate
@@ -1229,19 +1232,6 @@ final class ReactorRules {
     @AfterTemplate
     StepVerifier.Step<T> after(StepVerifier.Step<T> step, T object) {
       return step.expectNext(object);
-    }
-  }
-
-  /** Remove redundant {@code StepVerifier.Step#expectNextCount(0)} checks. */
-  static final class StepVerifierStepExpectNextCountZero<T> {
-    @BeforeTemplate
-    StepVerifier.Step<T> before(StepVerifier.Step<T> step) {
-      return step.expectNextCount(0L);
-    }
-
-    @AfterTemplate
-    StepVerifier.Step<T> after(StepVerifier.Step<T> step) {
-      return step;
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1204,10 +1204,7 @@ final class ReactorRules {
     }
   }
 
-  /**
-   * Don't unnecessarily call {@link StepVerifier.Step#expectNext(Object[])} or {@code
-   * StepVerifier.Step#expectNextCount(0L)}.
-   */
+  /** Don't unnecessarily have {@link StepVerifier.Step} expect no elements. */
   static final class StepVerifierStepIdentity<T> {
     @BeforeTemplate
     @SuppressWarnings("unchecked")

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1232,21 +1232,16 @@ final class ReactorRules {
     }
   }
 
-  /**
-   * Prefer {@link StepVerifier.LastStep#verifyComplete()} over {@code
-   * StepVerifier.Step#expectNextCount(0).verifyComplete()} or its alternatives.
-   */
-  static final class StepVerifierStepExpectNextCountZeroVerifyComplete<T> {
+  /** Remove redundant {@code StepVerifier.Step#expectNextCount(0)} checks. */
+  static final class StepVerifierStepExpectNextCountZero<T> {
     @BeforeTemplate
-    Duration before(StepVerifier.Step<T> step) {
-      return Refaster.anyOf(
-          step.expectNextCount(0L).expectComplete().verify(),
-          step.expectNextCount(0L).verifyComplete());
+    StepVerifier.Step<T> before(StepVerifier.Step<T> step) {
+      return step.expectNextCount(0L);
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step) {
-      return step.verifyComplete();
+    StepVerifier.Step<T> after(StepVerifier.Step<T> step) {
+      return step;
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1208,7 +1208,7 @@ final class ReactorRules {
    * Don't unnecessarily call {@link StepVerifier.Step#expectNext(Object[])} or {@code
    * StepVerifier.Step#expectNextCount(0L)}.
    */
-  static final class StepVerifierStepExpectNextEmpty<T> {
+  static final class StepVerifierStepIdentity<T> {
     @BeforeTemplate
     @SuppressWarnings("unchecked")
     StepVerifier.Step<T> before(StepVerifier.Step<T> step) {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -389,18 +389,16 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return StepVerifier.create(Flux.just(1));
   }
 
-  StepVerifier.Step<Integer> testStepVerifierStepExpectNextEmpty() {
-    return StepVerifier.create(Mono.just(0)).expectNext();
+  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepExpectNextEmpty() {
+    return ImmutableSet.of(
+        StepVerifier.create(Mono.just(0)).expectNext(),
+        StepVerifier.create(Mono.just(0)).expectNextCount(0L));
   }
 
   ImmutableSet<StepVerifier.Step<String>> testStepVerifierStepExpectNext() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.just("foo")).expectNextMatches(s -> s.equals("bar")),
         StepVerifier.create(Mono.just("baz")).expectNextMatches("qux"::equals));
-  }
-
-  StepVerifier.Step<Object> testStepVerifierStepExpectNextCountZero() {
-    return StepVerifier.create(Mono.empty()).expectNextCount(0L);
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -391,8 +391,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
     return ImmutableSet.of(
-        StepVerifier.create(Mono.just(0)).expectNext(),
-        StepVerifier.create(Mono.just(0)).expectNextCount(0L));
+        StepVerifier.create(Mono.just(1)).expectNext(),
+        StepVerifier.create(Mono.just(2)).expectNextCount(0L));
   }
 
   ImmutableSet<StepVerifier.Step<String>> testStepVerifierStepExpectNext() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -399,10 +399,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNextMatches("qux"::equals));
   }
 
-  ImmutableSet<Duration> testStepVerifierStepExpectNextCountZeroVerifyComplete() {
-    return ImmutableSet.of(
-        StepVerifier.create(Mono.empty()).expectNextCount(0).expectComplete().verify(),
-        StepVerifier.create(Mono.empty()).expectNextCount(0).verifyComplete());
+  StepVerifier.Step<Object> testStepVerifierStepExpectNextCountZero() {
+    return StepVerifier.create(Mono.empty()).expectNextCount(0L);
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -389,7 +389,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return StepVerifier.create(Flux.just(1));
   }
 
-  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepExpectNextEmpty() {
+  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.just(0)).expectNext(),
         StepVerifier.create(Mono.just(0)).expectNextCount(0L));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -399,6 +399,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNextMatches("qux"::equals));
   }
 
+  ImmutableSet<Duration> testStepVerifierStepExpectNextCountZeroVerifyComplete() {
+    return ImmutableSet.of(
+        StepVerifier.create(Mono.empty()).expectNextCount(0).expectComplete().verify(),
+        StepVerifier.create(Mono.empty()).expectNextCount(0).verifyComplete());
+  }
+
   Duration testStepVerifierLastStepVerifyComplete() {
     return StepVerifier.create(Mono.empty()).expectComplete().verify();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -378,7 +378,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
-    return ImmutableSet.of(StepVerifier.create(Mono.just(0)), StepVerifier.create(Mono.just(0)));
+    return ImmutableSet.of(StepVerifier.create(Mono.just(1)), StepVerifier.create(Mono.just(2)));
   }
 
   ImmutableSet<StepVerifier.Step<String>> testStepVerifierStepExpectNext() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -377,7 +377,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).as(StepVerifier::create);
   }
 
-  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepExpectNextEmpty() {
+  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
     return ImmutableSet.of(StepVerifier.create(Mono.just(0)), StepVerifier.create(Mono.just(0)));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -387,10 +387,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNext("qux"));
   }
 
-  ImmutableSet<Duration> testStepVerifierStepExpectNextCountZeroVerifyComplete() {
-    return ImmutableSet.of(
-        StepVerifier.create(Mono.empty()).verifyComplete(),
-        StepVerifier.create(Mono.empty()).verifyComplete());
+  StepVerifier.Step<Object> testStepVerifierStepExpectNextCountZero() {
+    return StepVerifier.create(Mono.empty());
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -387,6 +387,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNext("qux"));
   }
 
+  ImmutableSet<Duration> testStepVerifierStepExpectNextCountZeroVerifyComplete() {
+    return ImmutableSet.of(
+        StepVerifier.create(Mono.empty()).verifyComplete(),
+        StepVerifier.create(Mono.empty()).verifyComplete());
+  }
+
   Duration testStepVerifierLastStepVerifyComplete() {
     return StepVerifier.create(Mono.empty()).verifyComplete();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -377,18 +377,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).as(StepVerifier::create);
   }
 
-  StepVerifier.Step<Integer> testStepVerifierStepExpectNextEmpty() {
-    return StepVerifier.create(Mono.just(0));
+  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepExpectNextEmpty() {
+    return ImmutableSet.of(StepVerifier.create(Mono.just(0)), StepVerifier.create(Mono.just(0)));
   }
 
   ImmutableSet<StepVerifier.Step<String>> testStepVerifierStepExpectNext() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.just("foo")).expectNext("bar"),
         StepVerifier.create(Mono.just("baz")).expectNext("qux"));
-  }
-
-  StepVerifier.Step<Object> testStepVerifierStepExpectNextCountZero() {
-    return StepVerifier.create(Mono.empty());
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {


### PR DESCRIPTION
Following [this suggestion](https://github.com/PicnicSupermarket/picnic-platform/pull/9982#discussion_r1133960563).

Suggested commit message
```
Drop usage of redundant `expectNextCount(0)` checks
```

