### PR TITLE
Introduce `MonoJustOrEmptyOptional` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -106,7 +106,7 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Mono#justOrEmpty(Optional)} over more verbose alternatives. */
+  /** Prefer {@code () -> Mono#justOrEmpty(Optional)} over more verbose alternatives. */
   // XXX: If `optional` is a constant and effectively-final expression then the `Mono.defer` can be
   // dropped. Should look into Refaster support for identifying this.
   static final class MonoFromOptional<T> {
@@ -122,6 +122,19 @@ final class ReactorRules {
     @AfterTemplate
     Mono<T> after(Optional<T> optional) {
       return Mono.defer(() -> Mono.justOrEmpty(optional));
+    }
+  }
+
+  /** Prefer {@link Mono#justOrEmpty(Optional)} over more verbose alternatives. */
+  static final class MonoJustOptional<T> {
+    @BeforeTemplate
+    Mono<T> before(Optional<T> optional) {
+      return Mono.just(optional).filter(Optional::isPresent).map(Optional::orElseThrow);
+    }
+
+    @AfterTemplate
+    Mono<T> after(Optional<T> optional) {
+      return Mono.justOrEmpty(optional);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -94,7 +94,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Mono#justOrEmpty(Object)} over more contrived alternatives. */
-  static final class MonoJustOrEmpty<@Nullable T> {
+  static final class MonoJustOrEmptyObject<@Nullable T> {
     @BeforeTemplate
     Mono<T> before(T value) {
       return Mono.justOrEmpty(Optional.ofNullable(value));
@@ -106,10 +106,26 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@code () -> Mono#justOrEmpty(Optional)} over more verbose alternatives. */
+  /** Prefer {@link Mono#justOrEmpty(Optional)} over more verbose alternatives. */
+  static final class MonoJustOrEmptyOptional<T> {
+    @BeforeTemplate
+    Mono<T> before(Optional<T> optional) {
+      return Mono.just(optional).filter(Optional::isPresent).map(Optional::orElseThrow);
+    }
+
+    @AfterTemplate
+    Mono<T> after(Optional<T> optional) {
+      return Mono.justOrEmpty(optional);
+    }
+  }
+
+  /**
+   * Prefer {@link Mono#defer(Supplier) deferring} {@link Mono#justOrEmpty(Optional)} over more
+   * verbose alternatives.
+   */
   // XXX: If `optional` is a constant and effectively-final expression then the `Mono.defer` can be
   // dropped. Should look into Refaster support for identifying this.
-  static final class MonoFromOptional<T> {
+  static final class MonoDeferMonoJustOrEmpty<T> {
     @BeforeTemplate
     @SuppressWarnings(
         "MonoFromSupplier" /* `optional` may match a checked exception-throwing expression. */)
@@ -122,19 +138,6 @@ final class ReactorRules {
     @AfterTemplate
     Mono<T> after(Optional<T> optional) {
       return Mono.defer(() -> Mono.justOrEmpty(optional));
-    }
-  }
-
-  /** Prefer {@link Mono#justOrEmpty(Optional)} over more verbose alternatives. */
-  static final class MonoJustOptional<T> {
-    @BeforeTemplate
-    Mono<T> before(Optional<T> optional) {
-      return Mono.just(optional).filter(Optional::isPresent).map(Optional::orElseThrow);
-    }
-
-    @AfterTemplate
-    Mono<T> after(Optional<T> optional) {
-      return Mono.justOrEmpty(optional);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -60,18 +60,18 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.justOrEmpty(Optional.of(1));
   }
 
-  Mono<Integer> testMonoJustOrEmpty() {
+  Mono<Integer> testMonoJustOrEmptyObject() {
     return Mono.justOrEmpty(Optional.ofNullable(1));
   }
 
-  ImmutableSet<Mono<Integer>> testMonoFromOptional() {
+  Mono<Integer> testMonoJustOrEmptyOptional() {
+    return Mono.just(Optional.of(1)).filter(Optional::isPresent).map(Optional::orElseThrow);
+  }
+
+  ImmutableSet<Mono<Integer>> testMonoDeferMonoJustOrEmpty() {
     return ImmutableSet.of(
         Mono.fromCallable(() -> Optional.of(1).orElse(null)),
         Mono.fromSupplier(() -> Optional.of(2).orElse(null)));
-  }
-
-  Mono<Integer> testMonoJustOptional() {
-    return Mono.just(Optional.of(1)).filter(Optional::isPresent).map(Optional::orElseThrow);
   }
 
   Optional<Mono<String>> testOptionalMapMonoJust() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -70,6 +70,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.fromSupplier(() -> Optional.of(2).orElse(null)));
   }
 
+  Mono<Integer> testMonoJustOptional() {
+    return Mono.just(Optional.of(1)).filter(Optional::isPresent).map(Optional::orElseThrow);
+  }
+
   Optional<Mono<String>> testOptionalMapMonoJust() {
     return Optional.of("foo").map(Mono::justOrEmpty);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -62,18 +62,18 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just(1);
   }
 
-  Mono<Integer> testMonoJustOrEmpty() {
+  Mono<Integer> testMonoJustOrEmptyObject() {
     return Mono.justOrEmpty(1);
   }
 
-  ImmutableSet<Mono<Integer>> testMonoFromOptional() {
+  Mono<Integer> testMonoJustOrEmptyOptional() {
+    return Mono.justOrEmpty(Optional.of(1));
+  }
+
+  ImmutableSet<Mono<Integer>> testMonoDeferMonoJustOrEmpty() {
     return ImmutableSet.of(
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(1))),
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(2))));
-  }
-
-  Mono<Integer> testMonoJustOptional() {
-    return Mono.justOrEmpty(Optional.of(1));
   }
 
   Optional<Mono<String>> testOptionalMapMonoJust() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -72,6 +72,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.defer(() -> Mono.justOrEmpty(Optional.of(2))));
   }
 
+  Mono<Integer> testMonoJustOptional() {
+    return Mono.justOrEmpty(Optional.of(1));
+  }
+
   Optional<Mono<String>> testOptionalMapMonoJust() {
     return Optional.of("foo").map(Mono::just);
   }


### PR DESCRIPTION
Following [this suggestion](https://github.com/PicnicSupermarket/picnic-store/pull/2403#discussion_r1155845343).

Suggested commit message
```
Introduce `MonoJustOrEmptyOptional` Refaster rule (#563)

While there, rename two other rules.
```

