### PR TITLE
Introduce `FluxCollectToImmutableList` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
@@ -35,6 +35,8 @@ import tech.picnic.errorprone.bugpatterns.util.SourceCode;
 // XXX: Consider detecting cases where a flagged expression is passed to a method, and where removal
 // of the identity conversion would cause a different method overload to be selected. Depending on
 // the target method such a modification may change the code's semantics or performance.
+// XXX: Also flag `Stream#map`, `Mono#map` and `Flux#map` invocations where the given transformation
+// is effectively the identity operation.
 @AutoService(BugChecker.class)
 @BugPattern(
     summary = "Avoid or clarify identity conversions",

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1170,6 +1170,23 @@ final class ReactorRules {
   }
 
   /**
+   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableList#toImmutableList} over {@link
+   * Flux#collectList()}.
+   */
+  static final class FluxCollectListToCollectImmutableList<T> {
+    @BeforeTemplate
+    Mono<List<T>> before(Flux<T> flux) {
+      return flux.collectList();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    Mono<List<T>> after(Flux<T> flux) {
+      return flux.collect(toImmutableList());
+    }
+  }
+
+  /**
    * Prefer {@link Flux#collect(Collector)} with {@link ImmutableSet#toImmutableSet()} over more
    * contrived alternatives.
    */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1176,12 +1176,8 @@ final class ReactorRules {
   static final class FluxCollectToImmutableList<T> {
     @BeforeTemplate
     Mono<List<T>> before(Flux<T> flux) {
-      return flux.collectList();
-    }
-
-    @BeforeTemplate
-    Mono<List<T>> before2(Flux<T> flux) {
-      return flux.collect(toImmutableList()).map(ImmutableList::copyOf);
+      return Refaster.anyOf(
+          flux.collectList(), flux.collect(toImmutableList()).map(ImmutableList::copyOf));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1170,13 +1170,18 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableList#toImmutableList} over {@link
-   * Flux#collectList()}.
+   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableList#toImmutableList} over
+   * alternatives.
    */
-  static final class FluxCollectListToCollectImmutableList<T> {
+  static final class FluxCollectToImmutableList<T> {
     @BeforeTemplate
     Mono<List<T>> before(Flux<T> flux) {
       return flux.collectList();
+    }
+
+    @BeforeTemplate
+    Mono<List<T>> before2(Flux<T> flux) {
+      return flux.collect(toImmutableList()).map(ImmutableList::copyOf);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -403,6 +403,13 @@ final class ReactorRules {
       return mono.then();
     }
 
+    // XXX: Replace this rule with an extension of the `IdentityConversion` rule, supporting
+    // `Stream#map`, `Mono#map` and `Flux#map`.
+    @BeforeTemplate
+    Mono<ImmutableList<T>> before3(Mono<ImmutableList<T>> mono) {
+      return mono.map(ImmutableList::copyOf);
+    }
+
     @AfterTemplate
     Mono<T> after(Mono<T> mono) {
       return mono;
@@ -1170,19 +1177,18 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableList#toImmutableList} over
-   * alternatives.
+   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableList#toImmutableList()} over
+   * alternatives that do not explicitly return an immutable collection.
    */
   static final class FluxCollectToImmutableList<T> {
     @BeforeTemplate
     Mono<List<T>> before(Flux<T> flux) {
-      return Refaster.anyOf(
-          flux.collectList(), flux.collect(toImmutableList()).map(ImmutableList::copyOf));
+      return flux.collectList();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Mono<List<T>> after(Flux<T> flux) {
+    Mono<ImmutableList<T>> after(Flux<T> flux) {
       return flux.collect(toImmutableList());
     }
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -377,6 +377,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).sort(reverseOrder()).filter(i -> i % 2 == 0);
   }
 
+  Mono<List<Integer>> testFluxCollectListToCollectImmutableList() {
+    return Flux.just(1, 4, 3, 2).collectList();
+  }
+
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
     return Flux.just(1).collect(toImmutableList()).map(ImmutableSet::copyOf);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -141,7 +141,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just(1).switchIfEmpty(Mono.empty()),
         Mono.just(2).flux().next(),
         Mono.just(3).flux().singleOrEmpty(),
-        Mono.<Void>empty().then());
+        Mono.<Void>empty().then(),
+        Mono.<ImmutableList<String>>empty().map(ImmutableList::copyOf));
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
@@ -377,10 +378,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).sort(reverseOrder()).filter(i -> i % 2 == 0);
   }
 
-  ImmutableSet<Mono<List<Integer>>> testFluxCollectToImmutableList() {
-    return ImmutableSet.of(
-        Flux.just(1).collectList(),
-        Flux.just(2).collect(toImmutableList()).map(ImmutableList::copyOf));
+  Mono<List<Integer>> testFluxCollectToImmutableList() {
+    return Flux.just(1).collectList();
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -377,8 +377,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).sort(reverseOrder()).filter(i -> i % 2 == 0);
   }
 
-  Mono<List<Integer>> testFluxCollectListToCollectImmutableList() {
-    return Flux.just(1, 4, 3, 2).collectList();
+  ImmutableSet<Mono<List<Integer>>> testFluxCollectToImmutableList() {
+    return ImmutableSet.of(
+        Flux.just(1).collectList(),
+        Flux.just(2).collect(toImmutableList()).map(ImmutableList::copyOf));
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -366,6 +366,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).filter(i -> i % 2 == 0).sort(reverseOrder());
   }
 
+  Mono<List<Integer>> testFluxCollectListToCollectImmutableList() {
+    return Flux.just(1, 4, 3, 2).collect(toImmutableList());
+  }
+
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
     return Flux.just(1).collect(toImmutableSet());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -366,8 +366,9 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).filter(i -> i % 2 == 0).sort(reverseOrder());
   }
 
-  Mono<List<Integer>> testFluxCollectListToCollectImmutableList() {
-    return Flux.just(1, 4, 3, 2).collect(toImmutableList());
+  ImmutableSet<Mono<List<Integer>>> testFluxCollectToImmutableList() {
+    return ImmutableSet.of(
+        Flux.just(1).collect(toImmutableList()), Flux.just(2).collect(toImmutableList()));
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -142,7 +142,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<?>> testMonoIdentity() {
-    return ImmutableSet.of(Mono.just(1), Mono.just(2), Mono.just(3), Mono.<Void>empty());
+    return ImmutableSet.of(
+        Mono.just(1),
+        Mono.just(2),
+        Mono.just(3),
+        Mono.<Void>empty(),
+        Mono.<ImmutableList<String>>empty());
   }
 
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
@@ -366,9 +371,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).filter(i -> i % 2 == 0).sort(reverseOrder());
   }
 
-  ImmutableSet<Mono<List<Integer>>> testFluxCollectToImmutableList() {
-    return ImmutableSet.of(
-        Flux.just(1).collect(toImmutableList()), Flux.just(2).collect(toImmutableList()));
+  Mono<List<Integer>> testFluxCollectToImmutableList() {
+    return Flux.just(1).collect(toImmutableList());
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {


### PR DESCRIPTION
Based on internal inquiry

Suggested commit message:
```
Introduce `FluxCollectToImmutableList` Refaster rule (#570)
```