### PR TITLE
Introduce `FluxCollectToImmutableSet` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1170,7 +1170,7 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableSet#toImmutableSet()} over
+   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableSet#toImmutableSet()} over more
    * contrived alternatives.
    */
   static final class FluxCollectToImmutableSet<T> {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static com.google.errorprone.BugPattern.SeverityLevel.WARNING;
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
@@ -12,6 +13,7 @@ import static reactor.function.TupleUtils.function;
 import com.google.common.collect.ImmutableCollection;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
@@ -33,6 +35,7 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
+import java.util.stream.Collector;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -1163,6 +1166,23 @@ final class ReactorRules {
     @AfterTemplate
     Flux<T> after(Flux<T> flux, Predicate<? super T> predicate, Comparator<? super T> comparator) {
       return flux.filter(predicate).sort(comparator);
+    }
+  }
+
+  /**
+   * Prefer {@link Flux#collect(Collector)} with {@link ImmutableSet#toImmutableSet()} over
+   * contrived alternatives.
+   */
+  static final class FluxCollectToImmutableSet<T> {
+    @BeforeTemplate
+    Mono<ImmutableSet<T>> before(Flux<T> flux) {
+      return flux.collect(toImmutableList()).map(ImmutableSet::copyOf);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    Mono<ImmutableSet<T>> after(Flux<T> flux) {
+      return flux.collect(toImmutableSet());
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -378,7 +378,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
-    return Flux.just(1, 4, 3, 2).collect(toImmutableList()).map(ImmutableSet::copyOf);
+    return Flux.just(1, 2).collect(toImmutableList()).map(ImmutableSet::copyOf);
   }
 
   ImmutableSet<Context> testContextEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -378,7 +378,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
-    return Flux.just(1, 2).collect(toImmutableList()).map(ImmutableSet::copyOf);
+    return Flux.just(1).collect(toImmutableList()).map(ImmutableSet::copyOf);
   }
 
   ImmutableSet<Context> testContextEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -377,6 +377,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).sort(reverseOrder()).filter(i -> i % 2 == 0);
   }
 
+  Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
+    return Flux.just(1, 4, 3, 2).collect(toImmutableList()).map(ImmutableSet::copyOf);
+  }
+
   ImmutableSet<Context> testContextEmpty() {
     return ImmutableSet.of(Context.of(new HashMap<>()), Context.of(ImmutableMap.of()));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -367,7 +367,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
-    return Flux.just(1, 2).collect(toImmutableSet());
+    return Flux.just(1).collect(toImmutableSet());
   }
 
   ImmutableSet<Context> testContextEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Function.identity;
@@ -363,6 +364,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Flux<Integer> testFluxFilterSortWithComparator() {
     return Flux.just(1, 4, 3, 2).filter(i -> i % 2 == 0).sort(reverseOrder());
+  }
+
+  Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
+    return Flux.just(1, 4, 3, 2).collect(toImmutableSet());
   }
 
   ImmutableSet<Context> testContextEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -367,7 +367,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Mono<ImmutableSet<Integer>> testFluxCollectToImmutableSet() {
-    return Flux.just(1, 4, 3, 2).collect(toImmutableSet());
+    return Flux.just(1, 2).collect(toImmutableSet());
   }
 
   ImmutableSet<Context> testContextEmpty() {


### PR DESCRIPTION
Idea is based on an internal GH thread.

Suggested commit message:
```
Introduce `FluxCollectToImmutableSet` Refaster rule (#571)
```
