### PR TITLE
Introduce OpenSSF Scorecard GitHub action

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -36,6 +36,8 @@ jobs:
         # Error Prone checks available only from other artifact repositories.
       - name: Check out code
         uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -29,11 +29,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
-        # We run the build twice for each supported JDK: once against the
-        # original Error Prone release, using only Error Prone checks available
-        # on Maven Central, and once against the Picnic Error Prone fork,
-        # additionally enabling all checks defined in this project and any
-        # Error Prone checks available only from other artifact repositories.
+      # We run the build twice for each supported JDK: once against the
+      # original Error Prone release, using only Error Prone checks available
+      # on Maven Central, and once against the Picnic Error Prone fork,
+      # additionally enabling all checks defined in this project and any Error
+      # Prone checks available only from other artifact repositories.
       - name: Check out code
         uses: actions/checkout@v3.1.0
         with:

--- a/.github/workflows/deploy-website.yaml
+++ b/.github/workflows/deploy-website.yaml
@@ -3,16 +3,18 @@ on:
   pull_request:
   push:
     branches: [ master, website ]
+permissions:
+  contents: read
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
 jobs:
   build:
-    permissions:
-      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
       - uses: ruby/setup-ruby@v1.126.0
         with:
           working-directory: ./website

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -18,7 +18,6 @@ jobs:
     steps:
       - name: Check out code
         uses: actions/checkout@v3.1.0
-        # XXX: Also apply elsewhere?
         with:
           persist-credentials: false
       - name: Run OpenSSF Scorecard analysis

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,0 +1,32 @@
+name: OpenSSF Scorecard update
+on:
+  # XXX: Drop PR builds after testing.
+  pull_request:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '0 4 * * 1'
+permissions:
+  contents: read
+  id-token: write
+  security-events: write
+jobs:
+  analyze:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v3.1.0
+        # XXX: Also apply elsewhere?
+        with:
+          persist-credentials: false
+      - name: Run OpenSSF Scorecard analysis
+        uses: ossf/scorecard-action@v2.1.3
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+      - name: Update GitHub's code scanning dashboard
+        uses: github/codeql-action/upload-sarif@v2.2.11
+        with:
+          sarif_file: results.sarif
+

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,6 +1,5 @@
 name: OpenSSF Scorecard update
 on:
-  # XXX: Drop PR builds after testing.
   pull_request:
   push:
     branches: [ master ]
@@ -25,7 +24,7 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
-          publish_results: true
+          publish_results: ${{ github.ref == 'refs/heads/master' }}
       - name: Update GitHub's code scanning dashboard
         uses: github/codeql-action/upload-sarif@v2.2.11
         with:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -6,11 +6,14 @@ on:
     branches: [ master ]
   schedule:
     - cron: '0 4 * * 1'
+permissions:
+  contents: read
 jobs:
   analyze:
     permissions:
       contents: read
       security-events: write
+      id-token: write
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -34,4 +34,3 @@ jobs:
         uses: github/codeql-action/upload-sarif@v2.2.11
         with:
           sarif_file: results.sarif
-

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -6,12 +6,10 @@ on:
     branches: [ master ]
   schedule:
     - cron: '0 4 * * 1'
-permissions:
-  contents: read
-  id-token: write
-  security-events: write
 jobs:
   analyze:
+    permissions:
+      contents: read
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
@@ -25,6 +23,11 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
+  submit:
+    permissions:
+      security-events: write
+    runs-on: ubuntu-22.04
+    steps:
       - name: Update GitHub's code scanning dashboard
         uses: github/codeql-action/upload-sarif@v2.2.11
         with:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -1,3 +1,8 @@
+# Analyzes the code base and GitHub project configuration for adherence to
+# security best practices for open source software. Identified issues are
+# registered with GitHub's code scanning dashboard. When a pull request is
+# analyzed, any offending lines are annotated. See
+# https://securityscorecards.dev for details.
 name: OpenSSF Scorecard update
 on:
   pull_request:

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -10,6 +10,7 @@ jobs:
   analyze:
     permissions:
       contents: read
+      security-events: write
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
@@ -23,11 +24,6 @@ jobs:
           results_file: results.sarif
           results_format: sarif
           publish_results: true
-  submit:
-    permissions:
-      security-events: write
-    runs-on: ubuntu-22.04
-    steps:
       - name: Update GitHub's code scanning dashboard
         uses: github/codeql-action/upload-sarif@v2.2.11
         with:

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -15,6 +15,7 @@ jobs:
         uses: actions/checkout@v3.1.0
         with:
           fetch-depth: 2
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -9,16 +9,20 @@ on:
       - completed
 permissions:
   actions: read
-  checks: write
-  contents: read
-  pull-requests: write
 jobs:
   update-pr:
     if: ${{ github.event.workflow_run.conclusion == 'success' }}
+    permissions:
+      actions: read
+      checks: write
+      contents: read
+      pull-requests: write
     runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v3.1.0
+        with:
+          persist-credentials: false
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:


### PR DESCRIPTION
Suggested commit message:
```
Introduce OpenSSF Scorecard GitHub action (#574)

And resolve some of the issues it identified.

See https://securityscorecards.dev
```

For the output, see [this view](https://github.com/PicnicSupermarket/error-prone-support/security/code-scanning?query=is%3Aopen+pr%3A574). Only warnings about non-pinned dependencies remain. Those can be resolved using [Renovate](https://docs.renovatebot.com/modules/manager/github-actions/#additional-information), IIUC, so I propose we address that separately.