### PR TITLE
Introduce `StringIs{,Not}EmptyPredicate` Refaster rules

### DIFF
--- a/error-prone-contrib/README.md
+++ b/error-prone-contrib/README.md
@@ -199,9 +199,6 @@ be fully closed, there are some ways in which Refaster's scope of utility could
 be extended. The following is a non-exhaustive list of ideas on how to extend
 Refaster's expressiveness:
 
-- Allow more control over _which_ methods are statically imported by
-  `@UseImportPolicy`. Sometimes the `@AfterTemplate` contains more than one
-  static method invocation, and only a subset should be statically imported.
 - Provide a way to express that a lambda expression should also match an
   equivalent method reference and/or vice versa.
 - Provide a way to express that certain method invocations should also be

--- a/error-prone-contrib/README.md
+++ b/error-prone-contrib/README.md
@@ -199,6 +199,9 @@ be fully closed, there are some ways in which Refaster's scope of utility could
 be extended. The following is a non-exhaustive list of ideas on how to extend
 Refaster's expressiveness:
 
+- Allow more control over _which_ methods are statically imported by
+  `@UseImportPolicy`. Sometimes the `@AfterTemplate` contains more than one
+  static method invocation, and only a subset should be statically imported.
 - Provide a way to express that a lambda expression should also match an
   equivalent method reference and/or vice versa.
 - Provide a way to express that certain method invocations should also be

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -1,6 +1,8 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Joiner;
@@ -11,6 +13,7 @@ import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Objects;
@@ -20,7 +23,6 @@ import org.jspecify.annotations.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to expressions dealing with {@link String}s. */
-// XXX: Should we prefer `s -> !s.isEmpty()` or `not(String::isEmpty)`?
 @OnlineDocumentation
 final class StringRules {
   private StringRules() {}
@@ -65,19 +67,20 @@ final class StringRules {
 
     @AfterTemplate
     Optional<String> after(String str) {
-      return Optional.ofNullable(str).filter(s -> !s.isEmpty());
+      return Optional.ofNullable(str).filter(not(String::isEmpty));
     }
   }
 
   static final class FilterEmptyString {
     @BeforeTemplate
     Optional<String> before(Optional<String> optional) {
-      return optional.map(Strings::emptyToNull);
+      return Refaster.anyOf(optional.map(Strings::emptyToNull), optional.filter(s -> !s.isEmpty()));
     }
 
     @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     Optional<String> after(Optional<String> optional) {
-      return optional.filter(s -> !s.isEmpty());
+      return optional.filter(not(String::isEmpty));
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -39,6 +39,8 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         getClass().getName() != null && !getClass().getName().isEmpty());
   }
 
+  // XXX: Consider updating qualifier `Predicate#not` if/when conditional `ImportPolicy` is
+  // introduced.
   ImmutableSet<Optional<String>> testOptionalNonEmptyString() {
     return ImmutableSet.of(
         Strings.isNullOrEmpty(toString()) ? Optional.empty() : Optional.of(toString()),
@@ -47,8 +49,9 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         !Strings.isNullOrEmpty(toString()) ? Optional.ofNullable(toString()) : Optional.empty());
   }
 
-  Optional<String> testFilterEmptyString() {
-    return Optional.of("foo").map(Strings::emptyToNull);
+  ImmutableSet<Optional<String>> testFilterEmptyString() {
+    return ImmutableSet.of(
+        Optional.of("foo").map(Strings::emptyToNull), Optional.of("foo").filter(s -> !s.isEmpty()));
   }
 
   ImmutableSet<String> testJoinStrings() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -33,14 +33,20 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         "baz".length() >= 1);
   }
 
+  boolean testStringIsEmptyPredicate() {
+    return Stream.of("foo").anyMatch(s -> s.isEmpty());
+  }
+
+  boolean testStringIsNotEmptyPredicate() {
+    return Stream.of("foo").anyMatch(s -> !s.isEmpty());
+  }
+
   ImmutableSet<Boolean> testStringIsNullOrEmpty() {
     return ImmutableSet.of(
         getClass().getName() == null || getClass().getName().isEmpty(),
         getClass().getName() != null && !getClass().getName().isEmpty());
   }
 
-  // XXX: Consider updating qualifier `Predicate#not` if/when conditional `ImportPolicy` is
-  // introduced.
   ImmutableSet<Optional<String>> testOptionalNonEmptyString() {
     return ImmutableSet.of(
         Strings.isNullOrEmpty(toString()) ? Optional.empty() : Optional.of(toString()),
@@ -49,9 +55,8 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         !Strings.isNullOrEmpty(toString()) ? Optional.ofNullable(toString()) : Optional.empty());
   }
 
-  ImmutableSet<Optional<String>> testFilterEmptyString() {
-    return ImmutableSet.of(
-        Optional.of("foo").map(Strings::emptyToNull), Optional.of("foo").filter(s -> !s.isEmpty()));
+  Optional<String> testFilterEmptyString() {
+    return Optional.of("foo").map(Strings::emptyToNull);
   }
 
   ImmutableSet<String> testJoinStrings() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -36,13 +36,19 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         !"baz".isEmpty());
   }
 
+  boolean testStringIsEmptyPredicate() {
+    return Stream.of("foo").anyMatch(String::isEmpty);
+  }
+
+  boolean testStringIsNotEmptyPredicate() {
+    return Stream.of("foo").anyMatch(not(String::isEmpty));
+  }
+
   ImmutableSet<Boolean> testStringIsNullOrEmpty() {
     return ImmutableSet.of(
         Strings.isNullOrEmpty(getClass().getName()), !Strings.isNullOrEmpty(getClass().getName()));
   }
 
-  // XXX: Consider updating qualifier `Predicate#not` if/when conditional `ImportPolicy` is
-  // introduced.
   ImmutableSet<Optional<String>> testOptionalNonEmptyString() {
     return ImmutableSet.of(
         Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)),
@@ -51,10 +57,8 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)));
   }
 
-  ImmutableSet<Optional<String>> testFilterEmptyString() {
-    return ImmutableSet.of(
-        Optional.of("foo").filter(not(String::isEmpty)),
-        Optional.of("foo").filter(not(String::isEmpty)));
+  Optional<String> testFilterEmptyString() {
+    return Optional.of("foo").filter(not(String::isEmpty));
   }
 
   ImmutableSet<String> testJoinStrings() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static java.util.function.Predicate.not;
 import static java.util.stream.Collectors.joining;
 
 import com.google.common.base.Joiner;
@@ -14,6 +15,7 @@ import java.util.Arrays;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
@@ -39,16 +41,20 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         Strings.isNullOrEmpty(getClass().getName()), !Strings.isNullOrEmpty(getClass().getName()));
   }
 
+  // XXX: Consider updating qualifier `Predicate#not` if/when conditional `ImportPolicy` is
+  // introduced.
   ImmutableSet<Optional<String>> testOptionalNonEmptyString() {
     return ImmutableSet.of(
-        Optional.ofNullable(toString()).filter(s -> !s.isEmpty()),
-        Optional.ofNullable(toString()).filter(s -> !s.isEmpty()),
-        Optional.ofNullable(toString()).filter(s -> !s.isEmpty()),
-        Optional.ofNullable(toString()).filter(s -> !s.isEmpty()));
+        Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)),
+        Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)),
+        Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)),
+        Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)));
   }
 
-  Optional<String> testFilterEmptyString() {
-    return Optional.of("foo").filter(s -> !s.isEmpty());
+  ImmutableSet<Optional<String>> testFilterEmptyString() {
+    return ImmutableSet.of(
+        Optional.of("foo").filter(not(String::isEmpty)),
+        Optional.of("foo").filter(not(String::isEmpty)));
   }
 
   ImmutableSet<String> testJoinStrings() {


### PR DESCRIPTION
Original suggestion [here](https://github.com/PicnicSupermarket/picnic-platform/pull/10073#discussion_r1156033284).

Suggested commit message:
```
Prefer `not(String::isEmpty) over `s -> !s.isEmpty()` for Predicates
```