### PR TITLE
Assign a proper build number for GitHub Actions builds

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Remove installed project artifacts
         run: mvn build-helper:remove-project-artifact
       - name: TEST
-        run: echo "Run ID: $GITHUB_RUN_ID"
+        run: 'echo "Run ID: $GITHUB_RUN_ID"'
 
 # XXX: Enable Codecov once we "go public".
 # XXX: Enable SonarCloud once we "go public".

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -52,6 +52,8 @@ jobs:
         run: mvn -T1C clean verify -Perror-prone-fork -Pnon-maven-central -Pself-check -s settings.xml
       - name: Remove installed project artifacts
         run: mvn build-helper:remove-project-artifact
+      - name: TEST
+        run: echo "Run ID: $GITHUB_RUN_ID"
 
 # XXX: Enable Codecov once we "go public".
 # XXX: Enable SonarCloud once we "go public".

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -53,7 +53,7 @@ jobs:
       - name: Remove installed project artifacts
         run: mvn build-helper:remove-project-artifact
       - name: TEST
-        run: 'echo "Run ID: $GITHUB_RUN_ID"'
+        run: echo "Run ID - $GITHUB_RUN_ID"
 
 # XXX: Enable Codecov once we "go public".
 # XXX: Enable SonarCloud once we "go public".

--- a/pom.xml
+++ b/pom.xml
@@ -1787,6 +1787,17 @@
             </properties>
         </profile>
         <profile>
+            <id>github-actions-build-number</id>
+            <activation>
+                <property>
+                    <name>env.GITHUB_RUN_ID</name>
+                </property>
+            </activation>
+            <properties>
+                <build.number>${env.GITHUB_RUN_ID}</build.number>
+            </properties>
+        </profile>
+        <profile>
             <id>third-party-license-tsv-export</id>
             <activation>
                 <file>


### PR DESCRIPTION
Suggested commit message:
```
Assign a proper build number for GitHub Actions builds (#592)

This prevents the `Implementation-Version` field in
`META-INF/MANIFEST.MF` from claiming that the JARs were produced by a
local build.
```

How to test:
```sh
mvn clean install -DskipTests -Dverification.skip > /dev/null
unzip -c error-prone-contrib/target/error-prone-contrib-*-SNAPSHOT.jar META-INF/MANIFEST.MF | grep Implementation-Version:
GITHUB_RUN_ID=xxx mvn clean install -DskipTests -Dverification.skip > /dev/null
unzip -c error-prone-contrib/target/error-prone-contrib-*-SNAPSHOT.jar META-INF/MANIFEST.MF | grep Implementation-Version:
```