### PR TITLE
Extend `StreamRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -280,6 +280,7 @@ final class StreamRules {
 
   static final class StreamMin<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     Optional<T> before(Stream<T> stream, Comparator<? super T> comparator) {
       return Refaster.anyOf(
           stream.max(comparator.reversed()),

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -280,7 +280,7 @@ final class StreamRules {
 
   static final class StreamMin<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     Optional<T> before(Stream<T> stream, Comparator<? super T> comparator) {
       return Refaster.anyOf(
           stream.max(comparator.reversed()),
@@ -309,7 +309,7 @@ final class StreamRules {
 
   static final class StreamMax<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     Optional<T> before(Stream<T> stream, Comparator<? super T> comparator) {
       return Refaster.anyOf(
           stream.min(comparator.reversed()),
@@ -412,7 +412,7 @@ final class StreamRules {
 
   static final class StreamMapToIntSum<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     long before(Stream<T> stream, ToIntFunction<T> mapper) {
       return stream.collect(summingInt(mapper));
     }
@@ -432,7 +432,7 @@ final class StreamRules {
 
   static final class StreamMapToDoubleSum<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     double before(Stream<T> stream, ToDoubleFunction<T> mapper) {
       return stream.collect(summingDouble(mapper));
     }
@@ -452,7 +452,7 @@ final class StreamRules {
 
   static final class StreamMapToLongSum<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     long before(Stream<T> stream, ToLongFunction<T> mapper) {
       return stream.collect(summingLong(mapper));
     }
@@ -508,7 +508,7 @@ final class StreamRules {
 
   static final class StreamCount<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     long before(Stream<T> stream) {
       return stream.collect(counting());
     }
@@ -521,7 +521,7 @@ final class StreamRules {
 
   static final class StreamReduce<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     Optional<T> before(Stream<T> stream, BinaryOperator<T> accumulator) {
       return stream.collect(reducing(accumulator));
     }
@@ -534,7 +534,7 @@ final class StreamRules {
 
   static final class StreamReduceWithIdentity<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     T before(Stream<T> stream, T identity, BinaryOperator<T> accumulator) {
       return stream.collect(reducing(identity, accumulator));
     }
@@ -561,7 +561,7 @@ final class StreamRules {
 
   static final class StreamMapCollect<T, U, R> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
     R before(
         Stream<T> stream,
         Function<? super T, ? extends U> mapper,

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -308,6 +308,7 @@ final class StreamRules {
 
   static final class StreamMax<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     Optional<T> before(Stream<T> stream, Comparator<? super T> comparator) {
       return Refaster.anyOf(
           stream.min(comparator.reversed()),
@@ -410,6 +411,7 @@ final class StreamRules {
 
   static final class StreamMapToIntSum<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     long before(Stream<T> stream, ToIntFunction<T> mapper) {
       return stream.collect(summingInt(mapper));
     }
@@ -429,6 +431,7 @@ final class StreamRules {
 
   static final class StreamMapToDoubleSum<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     double before(Stream<T> stream, ToDoubleFunction<T> mapper) {
       return stream.collect(summingDouble(mapper));
     }
@@ -448,6 +451,7 @@ final class StreamRules {
 
   static final class StreamMapToLongSum<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     long before(Stream<T> stream, ToLongFunction<T> mapper) {
       return stream.collect(summingLong(mapper));
     }
@@ -503,6 +507,7 @@ final class StreamRules {
 
   static final class StreamCount<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     long before(Stream<T> stream) {
       return stream.collect(counting());
     }
@@ -515,6 +520,7 @@ final class StreamRules {
 
   static final class StreamReduce<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     Optional<T> before(Stream<T> stream, BinaryOperator<T> accumulator) {
       return stream.collect(reducing(accumulator));
     }
@@ -527,6 +533,7 @@ final class StreamRules {
 
   static final class StreamReduceWithIdentity<T> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     T before(Stream<T> stream, T identity, BinaryOperator<T> accumulator) {
       return stream.collect(reducing(identity, accumulator));
     }
@@ -553,6 +560,7 @@ final class StreamRules {
 
   static final class StreamMapCollect<T, U, R> {
     @BeforeTemplate
+    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
     R before(
         Stream<T> stream,
         Function<? super T, ? extends U> mapper,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -4,15 +4,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Comparator.comparingInt;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Predicate.not;
-import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.joining;
-import static java.util.stream.Collectors.mapping;
-import static java.util.stream.Collectors.maxBy;
-import static java.util.stream.Collectors.minBy;
-import static java.util.stream.Collectors.reducing;
-import static java.util.stream.Collectors.summingDouble;
-import static java.util.stream.Collectors.summingInt;
-import static java.util.stream.Collectors.summingLong;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
@@ -100,7 +92,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Stream.of("foo").max(comparingInt(String::length).reversed()),
         Stream.of("bar").sorted(comparingInt(String::length)).findFirst(),
-        Stream.of("baz").collect(minBy(comparingInt(String::length))));
+        Stream.of("baz").collect(java.util.stream.Collectors.minBy(comparingInt(String::length))));
   }
 
   ImmutableSet<Optional<String>> testStreamMinNaturalOrder() {
@@ -112,7 +104,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Stream.of("foo").min(comparingInt(String::length).reversed()),
         Streams.findLast(Stream.of("bar").sorted(comparingInt(String::length))),
-        Stream.of("baz").collect(maxBy(comparingInt(String::length))));
+        Stream.of("baz").collect(java.util.stream.Collectors.maxBy(comparingInt(String::length))));
   }
 
   ImmutableSet<Optional<String>> testStreamMaxNaturalOrder() {
@@ -160,7 +152,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Integer testStreamCollectSummingInt() {
-    return Stream.of("1").collect(summingInt(Integer::parseInt));
+    return Stream.of("1").collect(java.util.stream.Collectors.summingInt(Integer::parseInt));
   }
 
   ImmutableSet<Double> testStreamMapToDoubleSum() {
@@ -172,7 +164,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Double testStreamCollectSummingDouble() {
-    return Stream.of("1").collect(summingDouble(Double::parseDouble));
+    return Stream.of("1").collect(java.util.stream.Collectors.summingDouble(Double::parseDouble));
   }
 
   ImmutableSet<Long> testStreamMapToLongSum() {
@@ -184,22 +176,23 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Long testStreamCollectSummingLong() {
-    return Stream.of("1").collect(summingLong(Long::parseLong));
+    return Stream.of("1").collect(java.util.stream.Collectors.summingLong(Long::parseLong));
   }
 
   Long testStreamCount() {
-    return Stream.of(1).collect(counting());
+    return Stream.of(1).collect(java.util.stream.Collectors.counting());
   }
 
   Integer testStreamReduce() {
-    return Stream.of(1).collect(reducing(0, Integer::sum));
+    return Stream.of(1).collect(java.util.stream.Collectors.reducing(0, Integer::sum));
   }
 
   Optional<Integer> testStreamReduceOptional() {
-    return Stream.of(1).collect(reducing(Integer::sum));
+    return Stream.of(1).collect(java.util.stream.Collectors.reducing(Integer::sum));
   }
 
   ImmutableSet<Integer> testStreamMap() {
-    return Stream.of("1").collect(mapping(Integer::parseInt, toImmutableSet()));
+    return Stream.of("1")
+        .collect(java.util.stream.Collectors.mapping(Integer::parseInt, toImmutableSet()));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -1,9 +1,18 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Comparator.comparingInt;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.maxBy;
+import static java.util.stream.Collectors.minBy;
+import static java.util.stream.Collectors.reducing;
+import static java.util.stream.Collectors.summingDouble;
+import static java.util.stream.Collectors.summingInt;
+import static java.util.stream.Collectors.summingLong;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
@@ -90,7 +99,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Optional<String>> testStreamMin() {
     return ImmutableSet.of(
         Stream.of("foo").max(comparingInt(String::length).reversed()),
-        Stream.of("bar").sorted(comparingInt(String::length)).findFirst());
+        Stream.of("bar").sorted(comparingInt(String::length)).findFirst(),
+        Stream.of("baz").collect(minBy(comparingInt(String::length))));
   }
 
   ImmutableSet<Optional<String>> testStreamMinNaturalOrder() {
@@ -101,7 +111,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Optional<String>> testStreamMax() {
     return ImmutableSet.of(
         Stream.of("foo").min(comparingInt(String::length).reversed()),
-        Streams.findLast(Stream.of("bar").sorted(comparingInt(String::length))));
+        Streams.findLast(Stream.of("bar").sorted(comparingInt(String::length))),
+        Stream.of("baz").collect(maxBy(comparingInt(String::length))));
   }
 
   ImmutableSet<Optional<String>> testStreamMaxNaturalOrder() {
@@ -148,6 +159,10 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("3").map(parseIntFunction).reduce(0, Integer::sum));
   }
 
+  Integer testStreamCollectSummingInt() {
+    return Stream.of("1").collect(summingInt(Integer::parseInt));
+  }
+
   ImmutableSet<Double> testStreamMapToDoubleSum() {
     Function<String, Double> parseDoubleFunction = Double::parseDouble;
     return ImmutableSet.of(
@@ -156,11 +171,35 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("3").map(parseDoubleFunction).reduce(0.0, Double::sum));
   }
 
+  Double testStreamCollectSummingDouble() {
+    return Stream.of("1").collect(summingDouble(Double::parseDouble));
+  }
+
   ImmutableSet<Long> testStreamMapToLongSum() {
     Function<String, Long> parseLongFunction = Long::parseLong;
     return ImmutableSet.of(
         Stream.of(1).map(i -> i * 2L).reduce(0L, Long::sum),
         Stream.of("2").map(Long::parseLong).reduce(0L, Long::sum),
         Stream.of("3").map(parseLongFunction).reduce(0L, Long::sum));
+  }
+
+  Long testStreamCollectSummingLong() {
+    return Stream.of("1").collect(summingLong(Long::parseLong));
+  }
+
+  Long testStreamCount() {
+    return Stream.of(1).collect(counting());
+  }
+
+  Integer testStreamReduce() {
+    return Stream.of(1).collect(reducing(0, Integer::sum));
+  }
+
+  Optional<Integer> testStreamReduceOptional() {
+    return Stream.of(1).collect(reducing(Integer::sum));
+  }
+
+  ImmutableSet<Integer> testStreamMap() {
+    return Stream.of("1").collect(mapping(Integer::parseInt, toImmutableSet()));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -4,10 +4,26 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Comparator.comparingInt;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.filtering;
+import static java.util.stream.Collectors.flatMapping;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.maxBy;
+import static java.util.stream.Collectors.minBy;
+import static java.util.stream.Collectors.reducing;
+import static java.util.stream.Collectors.summarizingDouble;
+import static java.util.stream.Collectors.summarizingInt;
+import static java.util.stream.Collectors.summarizingLong;
+import static java.util.stream.Collectors.summingDouble;
+import static java.util.stream.Collectors.summingInt;
+import static java.util.stream.Collectors.summingLong;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
+import java.util.DoubleSummaryStatistics;
+import java.util.IntSummaryStatistics;
+import java.util.LongSummaryStatistics;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -18,7 +34,23 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Objects.class, Streams.class, not(null));
+    return ImmutableSet.of(
+        Objects.class,
+        Streams.class,
+        counting(),
+        filtering(null, null),
+        flatMapping(null, null),
+        mapping(null, null),
+        maxBy(null),
+        minBy(null),
+        not(null),
+        reducing(null),
+        summarizingDouble(null),
+        summarizingInt(null),
+        summarizingLong(null),
+        summingDouble(null),
+        summingInt(null),
+        summingLong(null));
   }
 
   String testJoining() {
@@ -92,7 +124,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Stream.of("foo").max(comparingInt(String::length).reversed()),
         Stream.of("bar").sorted(comparingInt(String::length)).findFirst(),
-        Stream.of("baz").collect(java.util.stream.Collectors.minBy(comparingInt(String::length))));
+        Stream.of("baz").collect(minBy(comparingInt(String::length))));
   }
 
   ImmutableSet<Optional<String>> testStreamMinNaturalOrder() {
@@ -104,7 +136,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Stream.of("foo").min(comparingInt(String::length).reversed()),
         Streams.findLast(Stream.of("bar").sorted(comparingInt(String::length))),
-        Stream.of("baz").collect(java.util.stream.Collectors.maxBy(comparingInt(String::length))));
+        Stream.of("baz").collect(maxBy(comparingInt(String::length))));
   }
 
   ImmutableSet<Optional<String>> testStreamMaxNaturalOrder() {
@@ -146,53 +178,63 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Integer> testStreamMapToIntSum() {
     Function<String, Integer> parseIntFunction = Integer::parseInt;
     return ImmutableSet.of(
-        Stream.of(1).map(i -> i * 2).reduce(0, Integer::sum),
-        Stream.of("2").map(Integer::parseInt).reduce(0, Integer::sum),
-        Stream.of("3").map(parseIntFunction).reduce(0, Integer::sum));
-  }
-
-  Integer testStreamCollectSummingInt() {
-    return Stream.of("1").collect(java.util.stream.Collectors.summingInt(Integer::parseInt));
+        Stream.of("1").collect(summingInt(Integer::parseInt)),
+        Stream.of(2).map(i -> i * 2).reduce(0, Integer::sum),
+        Stream.of("3").map(Integer::parseInt).reduce(0, Integer::sum),
+        Stream.of("4").map(parseIntFunction).reduce(0, Integer::sum));
   }
 
   ImmutableSet<Double> testStreamMapToDoubleSum() {
     Function<String, Double> parseDoubleFunction = Double::parseDouble;
     return ImmutableSet.of(
-        Stream.of(1).map(i -> i * 2.0).reduce(0.0, Double::sum),
-        Stream.of("2").map(Double::parseDouble).reduce(0.0, Double::sum),
-        Stream.of("3").map(parseDoubleFunction).reduce(0.0, Double::sum));
-  }
-
-  Double testStreamCollectSummingDouble() {
-    return Stream.of("1").collect(java.util.stream.Collectors.summingDouble(Double::parseDouble));
+        Stream.of("1").collect(summingDouble(Double::parseDouble)),
+        Stream.of(2).map(i -> i * 2.0).reduce(0.0, Double::sum),
+        Stream.of("3").map(Double::parseDouble).reduce(0.0, Double::sum),
+        Stream.of("4").map(parseDoubleFunction).reduce(0.0, Double::sum));
   }
 
   ImmutableSet<Long> testStreamMapToLongSum() {
     Function<String, Long> parseLongFunction = Long::parseLong;
     return ImmutableSet.of(
-        Stream.of(1).map(i -> i * 2L).reduce(0L, Long::sum),
-        Stream.of("2").map(Long::parseLong).reduce(0L, Long::sum),
-        Stream.of("3").map(parseLongFunction).reduce(0L, Long::sum));
+        Stream.of("1").collect(summingLong(Long::parseLong)),
+        Stream.of(2).map(i -> i * 2L).reduce(0L, Long::sum),
+        Stream.of("3").map(Long::parseLong).reduce(0L, Long::sum),
+        Stream.of("4").map(parseLongFunction).reduce(0L, Long::sum));
   }
 
-  Long testStreamCollectSummingLong() {
-    return Stream.of("1").collect(java.util.stream.Collectors.summingLong(Long::parseLong));
+  IntSummaryStatistics testStreamMapToIntSummaryStatistics() {
+    return Stream.of("1").collect(summarizingInt(Integer::parseInt));
+  }
+
+  DoubleSummaryStatistics testStreamMapToDoubleSummaryStatistics() {
+    return Stream.of("1").collect(summarizingDouble(Double::parseDouble));
+  }
+
+  LongSummaryStatistics testStreamMapToLongSummaryStatistics() {
+    return Stream.of("1").collect(summarizingLong(Long::parseLong));
   }
 
   Long testStreamCount() {
-    return Stream.of(1).collect(java.util.stream.Collectors.counting());
+    return Stream.of(1).collect(counting());
   }
 
-  Integer testStreamReduce() {
-    return Stream.of(1).collect(java.util.stream.Collectors.reducing(0, Integer::sum));
+  Optional<Integer> testStreamReduce() {
+    return Stream.of(1).collect(reducing(Integer::sum));
   }
 
-  Optional<Integer> testStreamReduceOptional() {
-    return Stream.of(1).collect(java.util.stream.Collectors.reducing(Integer::sum));
+  Integer testStreamReduceWithIdentity() {
+    return Stream.of(1).collect(reducing(0, Integer::sum));
   }
 
-  ImmutableSet<Integer> testStreamMap() {
-    return Stream.of("1")
-        .collect(java.util.stream.Collectors.mapping(Integer::parseInt, toImmutableSet()));
+  ImmutableSet<String> testStreamFilterCollect() {
+    return Stream.of("1").collect(filtering(String::isEmpty, toImmutableSet()));
+  }
+
+  ImmutableSet<Integer> testStreamMapCollect() {
+    return Stream.of("1").collect(mapping(Integer::parseInt, toImmutableSet()));
+  }
+
+  ImmutableSet<Integer> testStreamFlatMapCollect() {
+    return Stream.of(1).collect(flatMapping(n -> Stream.of(n, n), toImmutableSet()));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -5,11 +5,27 @@ import static java.util.Comparator.comparingInt;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.counting;
+import static java.util.stream.Collectors.filtering;
+import static java.util.stream.Collectors.flatMapping;
 import static java.util.stream.Collectors.joining;
+import static java.util.stream.Collectors.mapping;
+import static java.util.stream.Collectors.maxBy;
+import static java.util.stream.Collectors.minBy;
+import static java.util.stream.Collectors.reducing;
+import static java.util.stream.Collectors.summarizingDouble;
+import static java.util.stream.Collectors.summarizingInt;
+import static java.util.stream.Collectors.summarizingLong;
+import static java.util.stream.Collectors.summingDouble;
+import static java.util.stream.Collectors.summingInt;
+import static java.util.stream.Collectors.summingLong;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
+import java.util.DoubleSummaryStatistics;
+import java.util.IntSummaryStatistics;
+import java.util.LongSummaryStatistics;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -20,7 +36,23 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Objects.class, Streams.class, not(null));
+    return ImmutableSet.of(
+        Objects.class,
+        Streams.class,
+        counting(),
+        filtering(null, null),
+        flatMapping(null, null),
+        mapping(null, null),
+        maxBy(null),
+        minBy(null),
+        not(null),
+        reducing(null),
+        summarizingDouble(null),
+        summarizingInt(null),
+        summarizingLong(null),
+        summingDouble(null),
+        summingInt(null),
+        summingLong(null));
   }
 
   String testJoining() {
@@ -145,52 +177,63 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Integer> testStreamMapToIntSum() {
     Function<String, Integer> parseIntFunction = Integer::parseInt;
     return ImmutableSet.of(
-        Stream.of(1).mapToInt(i -> i * 2).sum(),
-        Stream.of("2").mapToInt(Integer::parseInt).sum(),
-        Stream.of("3").map(parseIntFunction).reduce(0, Integer::sum));
-  }
-
-  Integer testStreamCollectSummingInt() {
-    return Stream.of("1").mapToInt(Integer::parseInt).sum();
+        Stream.of("1").mapToInt(Integer::parseInt).sum(),
+        Stream.of(2).mapToInt(i -> i * 2).sum(),
+        Stream.of("3").mapToInt(Integer::parseInt).sum(),
+        Stream.of("4").map(parseIntFunction).reduce(0, Integer::sum));
   }
 
   ImmutableSet<Double> testStreamMapToDoubleSum() {
     Function<String, Double> parseDoubleFunction = Double::parseDouble;
     return ImmutableSet.of(
-        Stream.of(1).mapToDouble(i -> i * 2.0).sum(),
-        Stream.of("2").mapToDouble(Double::parseDouble).sum(),
-        Stream.of("3").map(parseDoubleFunction).reduce(0.0, Double::sum));
-  }
-
-  Double testStreamCollectSummingDouble() {
-    return Stream.of("1").mapToDouble(Double::parseDouble).sum();
+        Stream.of("1").mapToDouble(Double::parseDouble).sum(),
+        Stream.of(2).mapToDouble(i -> i * 2.0).sum(),
+        Stream.of("3").mapToDouble(Double::parseDouble).sum(),
+        Stream.of("4").map(parseDoubleFunction).reduce(0.0, Double::sum));
   }
 
   ImmutableSet<Long> testStreamMapToLongSum() {
     Function<String, Long> parseLongFunction = Long::parseLong;
     return ImmutableSet.of(
-        Stream.of(1).mapToLong(i -> i * 2L).sum(),
-        Stream.of("2").mapToLong(Long::parseLong).sum(),
-        Stream.of("3").map(parseLongFunction).reduce(0L, Long::sum));
+        Stream.of("1").mapToLong(Long::parseLong).sum(),
+        Stream.of(2).mapToLong(i -> i * 2L).sum(),
+        Stream.of("3").mapToLong(Long::parseLong).sum(),
+        Stream.of("4").map(parseLongFunction).reduce(0L, Long::sum));
   }
 
-  Long testStreamCollectSummingLong() {
-    return Stream.of("1").mapToLong(Long::parseLong).sum();
+  IntSummaryStatistics testStreamMapToIntSummaryStatistics() {
+    return Stream.of("1").mapToInt(Integer::parseInt).summaryStatistics();
+  }
+
+  DoubleSummaryStatistics testStreamMapToDoubleSummaryStatistics() {
+    return Stream.of("1").mapToDouble(Double::parseDouble).summaryStatistics();
+  }
+
+  LongSummaryStatistics testStreamMapToLongSummaryStatistics() {
+    return Stream.of("1").mapToLong(Long::parseLong).summaryStatistics();
   }
 
   Long testStreamCount() {
     return Stream.of(1).count();
   }
 
-  Integer testStreamReduce() {
-    return Stream.of(1).reduce(0, Integer::sum);
-  }
-
-  Optional<Integer> testStreamReduceOptional() {
+  Optional<Integer> testStreamReduce() {
     return Stream.of(1).reduce(Integer::sum);
   }
 
-  ImmutableSet<Integer> testStreamMap() {
+  Integer testStreamReduceWithIdentity() {
+    return Stream.of(1).reduce(0, Integer::sum);
+  }
+
+  ImmutableSet<String> testStreamFilterCollect() {
+    return Stream.of("1").filter(String::isEmpty).collect(toImmutableSet());
+  }
+
+  ImmutableSet<Integer> testStreamMapCollect() {
     return Stream.of("1").map(Integer::parseInt).collect(toImmutableSet());
+  }
+
+  ImmutableSet<Integer> testStreamFlatMapCollect() {
+    return Stream.of(1).flatMap(n -> Stream.of(n, n)).collect(toImmutableSet());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -1,5 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Comparator.comparingInt;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
@@ -91,7 +92,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Optional<String>> testStreamMin() {
     return ImmutableSet.of(
         Stream.of("foo").min(comparingInt(String::length)),
-        Stream.of("bar").min(comparingInt(String::length)));
+        Stream.of("bar").min(comparingInt(String::length)),
+        Stream.of("baz").min(comparingInt(String::length)));
   }
 
   ImmutableSet<Optional<String>> testStreamMinNaturalOrder() {
@@ -102,7 +104,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Optional<String>> testStreamMax() {
     return ImmutableSet.of(
         Stream.of("foo").max(comparingInt(String::length)),
-        Stream.of("bar").max(comparingInt(String::length)));
+        Stream.of("bar").max(comparingInt(String::length)),
+        Stream.of("baz").max(comparingInt(String::length)));
   }
 
   ImmutableSet<Optional<String>> testStreamMaxNaturalOrder() {
@@ -147,6 +150,10 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("3").map(parseIntFunction).reduce(0, Integer::sum));
   }
 
+  Integer testStreamCollectSummingInt() {
+    return Stream.of("1").mapToInt(Integer::parseInt).sum();
+  }
+
   ImmutableSet<Double> testStreamMapToDoubleSum() {
     Function<String, Double> parseDoubleFunction = Double::parseDouble;
     return ImmutableSet.of(
@@ -155,11 +162,35 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("3").map(parseDoubleFunction).reduce(0.0, Double::sum));
   }
 
+  Double testStreamCollectSummingDouble() {
+    return Stream.of("1").mapToDouble(Double::parseDouble).sum();
+  }
+
   ImmutableSet<Long> testStreamMapToLongSum() {
     Function<String, Long> parseLongFunction = Long::parseLong;
     return ImmutableSet.of(
         Stream.of(1).mapToLong(i -> i * 2L).sum(),
         Stream.of("2").mapToLong(Long::parseLong).sum(),
         Stream.of("3").map(parseLongFunction).reduce(0L, Long::sum));
+  }
+
+  Long testStreamCollectSummingLong() {
+    return Stream.of("1").mapToLong(Long::parseLong).sum();
+  }
+
+  Long testStreamCount() {
+    return Stream.of(1).count();
+  }
+
+  Integer testStreamReduce() {
+    return Stream.of(1).reduce(0, Integer::sum);
+  }
+
+  Optional<Integer> testStreamReduceOptional() {
+    return Stream.of(1).reduce(Integer::sum);
+  }
+
+  ImmutableSet<Integer> testStreamMap() {
+    return Stream.of("1").map(Integer::parseInt).collect(toImmutableSet());
   }
 }


### PR DESCRIPTION
https://github.com/PicnicSupermarket/error-prone-support/issues/578

* Replace redundant `stream#collect` calls.

[Suggested commit message:](https://github.com/PicnicSupermarket/error-prone-support/pull/593#pullrequestreview-1397175353)
```
Extend `StreamRules` Refaster rule collection (#593)

All changes suggested by SonarCloud's java:S4266 rule are now covered.

See https://sonarcloud.io/organizations/picnic-technologies/rules?open=java%3AS4266&rule_key=java%3AS4266

Fixes #578.
```

1. `stream.collect(minBy(comparator))` -> `stream.min(comparator)`
2. `stream.collect(maxBy(comparator))` -> `stream.max(comparator)`
3. `stream.collect(summingInt(mapper))` -> `stream.mapToInt(mapper).sum()`
4. `stream.collect(summingDouble(mapper))` -> `stream.mapToDouble(mapper).sum()`
5. `stream.collect(summingLong(mapper))` -> `stream.mapToLong(mapper).sum()`
6. `stream.collect(counting())` -> `stream.count()`
7. `stream.collect(reducing(identity, accumulator))` -> `stream.reduce(identity, accumulator)`
8. `stream.collect(reducing(accumulator))` -> `stream.reduce(accumulator)`
9. `stream.collect(mapping(mapper, collector))` -> `stream.map(mapper).collect(collector)`

**Fun fact:** Most of this list was suggested by co-pilot 🧠 :
<img width="903" alt="Screenshot 2023-04-22 at 19 35 42" src="https://user-images.githubusercontent.com/110535847/233867730-85b9c78f-7e6d-48e5-847c-ca199c353c12.png">
