### PR TITLE
Improve `AbstractMatcherTestChecker`

### DIFF
--- a/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
+++ b/refaster-support/src/test/java/tech/picnic/errorprone/refaster/matchers/AbstractMatcherTestChecker.java
@@ -8,8 +8,11 @@ import com.google.errorprone.matchers.Matcher;
 import com.sun.source.tree.CompilationUnitTree;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.ImportTree;
+import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.MethodTree;
 import com.sun.source.tree.Tree;
+import com.sun.source.tree.TypeCastTree;
+import com.sun.source.util.TreePath;
 import com.sun.source.util.TreeScanner;
 import org.jspecify.annotations.Nullable;
 
@@ -31,18 +34,27 @@ abstract class AbstractMatcherTestChecker extends BugChecker implements Compilat
 
   @Override
   public Description matchCompilationUnit(CompilationUnitTree compilationUnit, VisitorState state) {
-    new TreeScanner<@Nullable Void, @Nullable Void>() {
+    new TreeScanner<@Nullable Void, TreePath>() {
       @Override
-      public @Nullable Void scan(Tree tree, @Nullable Void unused) {
-        if (tree instanceof ExpressionTree && delegate.matches((ExpressionTree) tree, state)) {
-          state.reportMatch(describeMatch(tree));
+      public @Nullable Void scan(@Nullable Tree tree, TreePath treePath) {
+        if (tree == null) {
+          return null;
         }
 
-        return super.scan(tree, unused);
+        TreePath path = new TreePath(treePath, tree);
+        if (tree instanceof ExpressionTree) {
+          ExpressionTree expressionTree = (ExpressionTree) tree;
+          if (!isMethodSelect(expressionTree, path)
+              && delegate.matches(expressionTree, state.withPath(path))) {
+            state.reportMatch(describeMatch(tree));
+          }
+        }
+
+        return super.scan(tree, path);
       }
 
       @Override
-      public @Nullable Void visitImport(ImportTree node, @Nullable Void unused) {
+      public @Nullable Void visitImport(ImportTree tree, TreePath path) {
         /*
          * We're not interested in matching import statements. While components of these
          * can be `ExpressionTree`s, they will never be matched by Refaster.
@@ -51,15 +63,42 @@ abstract class AbstractMatcherTestChecker extends BugChecker implements Compilat
       }
 
       @Override
-      public @Nullable Void visitMethod(MethodTree node, @Nullable Void unused) {
+      public @Nullable Void visitMethod(MethodTree tree, TreePath path) {
         /*
          * We're not interested in matching e.g. parameter and return type declarations. While these
          * can be `ExpressionTree`s, they will never be matched by Refaster.
          */
-        return scan(node.getBody(), unused);
+        return scan(tree.getBody(), new TreePath(path, tree));
       }
-    }.scan(compilationUnit, null);
+
+      @Override
+      public @Nullable Void visitTypeCast(TypeCastTree tree, TreePath path) {
+        /*
+         * We're not interested in matching the parenthesized type subtree that is part of a type
+         * cast expression. While such trees can be `ExpressionTree`s, they will never be matched by
+         * Refaster.
+         */
+        return scan(tree.getExpression(), new TreePath(path, tree));
+      }
+    }.scan(compilationUnit, state.getPath());
 
     return Description.NO_MATCH;
+  }
+
+  /**
+   * Tells whether the given {@link ExpressionTree} is the {@link
+   * MethodInvocationTree#getMethodSelect() method select} portion of a method invocation.
+   *
+   * <p>Such {@link ExpressionTree}s will never be matched by Refaster.
+   */
+  private static boolean isMethodSelect(ExpressionTree tree, TreePath path) {
+    TreePath parentPath = path.getParentPath();
+    if (parentPath == null) {
+      return false;
+    }
+
+    Tree parentTree = parentPath.getLeaf();
+    return parentTree instanceof MethodInvocationTree
+        && ((MethodInvocationTree) parentTree).getMethodSelect().equals(tree);
   }
 }


### PR DESCRIPTION
I extracted these changes from [this branch](https://github.com/PicnicSupermarket/error-prone-support/compare/sschroevers/introduce-IsNullableMatcher), following the discussion in [this thread](https://github.com/PicnicSupermarket/error-prone-support/pull/527#discussion_r1173558090). There are no tests for this test code. My proposal would be to finalize #527 on top of this PR as proof that it works. (Over time we'll introduce other `Matcher`s that will rely on (and thus exercise) this code. IIRC I have one or more other branches that would benefit from these changes. I might try to open PRs for those.)

Suggested commit message:
```
Improve `AbstractMatcherTestChecker` (#599)

These changes enable testing of a wider range of `Matcher` implementations. In
a nutshell:
- The `Matcher` under test is now passed `VisitorState` instances with an
  accurate `TreePath`.
- The `Matcher` under test is no longer consulted for method select and cast
  type expressions, mirroring Refaster behavior.
```