### PR TITLE
Upgrade JDKs used by GitHub Actions builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,9 +42,9 @@ Please replace this sentence with log output, if applicable.
 <!-- Please complete the following information: -->
 
 - Operating system (e.g. MacOS Monterey).
-- Java version (i.e. `java --version`, e.g. `17.0.6`).
+- Java version (i.e. `java --version`, e.g. `17.0.7`).
 - Error Prone version (e.g. `2.18.0`).
-- Error Prone Support version (e.g. `0.8.0`).
+- Error Prone Support version (e.g. `0.9.0`).
 
 ### Additional context
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,22 +10,18 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        jdk: [ 11.0.18, 17.0.6, 19.0.2 ]
+        jdk: [ 11.0.19, 17.0.7, 20.0.1 ]
         distribution: [ temurin ]
         experimental: [ false ]
         include:
           - os: macos-12
-            jdk: 17.0.6
+            jdk: 17.0.7
             distribution: temurin
             experimental: false
           - os: windows-2022
-            jdk: 17.0.6
+            jdk: 17.0.7
             distribution: temurin
             experimental: false
-          - os: ubuntu-22.04
-            jdk: 20-ea
-            distribution: zulu
-            experimental: true
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:
-          java-version: 17.0.6
+          java-version: 17.0.7
           distribution: temurin
           cache: maven
       - name: Initialize CodeQL

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:
-          java-version: 17.0.6
+          java-version: 17.0.7
           distribution: temurin
           cache: maven
       - name: Run Pitest

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:
-          java-version: 17.0.6
+          java-version: 17.0.7
           distribution: temurin
           cache: maven
       - name: Download Pitest analysis artifact

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@v3.8.0
         with:
-          java-version: 17.0.6
+          java-version: 17.0.7
           distribution: temurin
           cache: maven
       - name: Create missing `test` directory


### PR DESCRIPTION
Suggested commit message:
```
Upgrade JDKs used by GitHub Actions builds (#604)

Summary of changes:
- Use JDK 11.0.19 instead of 11.0.18.
- Use JDK 17.0.7 instead of 17.0.6.
- Use JDK 20.0.1 instead of 19.0.2.
- Drop the early access build, as Error Prone is currently not compatible with JDK 21-ea.

See:
- https://www.oracle.com/java/technologies/javase/11-0-19-relnotes.html
- https://www.oracle.com/java/technologies/javase/17-0-7-relnotes.html
- https://www.oracle.com/java/technologies/javase/20-relnote-issues.html
- https://www.oracle.com/java/technologies/javase/20-0-1-relnotes.html
```