### PR TITLE
Fix Gradle installation guide link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,9 @@ definition. -->
 
 #### Gradle
 
-1. First, follow the [installation guide]
-   [error-prone-gradle-installation-guide] of the `gradle-errorprone-plugin`.
+1. First, follow the [installation
+   guide][error-prone-gradle-installation-guide] of the
+   `gradle-errorprone-plugin`.
 2. Next, edit your `build.gradle` file to add one or more Error Prone Support
    modules:
 


### PR DESCRIPTION
Suggested commit message:
```
Fix Gradle installation guide link in README (#606)
```

Without this the rendering is [incorrect](https://github.com/PicnicSupermarket/error-prone-support#gradle). Wrapped after 79 chars as usual.