### PR TITLE
Prefer Sets#intersection over more contrived alternatives.

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
@@ -314,4 +314,17 @@ final class ImmutableSetRules {
       return Sets.intersection(set, multimap.keySet()).immutableCopy();
     }
   }
+
+  /** Prefer an immutable copy of {@link Sets#union(Set, Set)} over more contrived alternatives. */
+  static final class SetsUnion<S, T extends S, U extends S> {
+    @BeforeTemplate
+    ImmutableSet<S> before(Set<T> set1, Set<U> set2) {
+      return Stream.concat(set1.stream(), set2.stream()).collect(toImmutableSet());
+    }
+
+    @AfterTemplate
+    ImmutableSet<S> after(Set<T> set1, Set<U> set2) {
+      return Sets.union(set1, set2).immutableCopy();
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
@@ -4,6 +4,7 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
+import static java.util.function.Predicate.not;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Multimap;
@@ -215,41 +216,101 @@ final class ImmutableSetRules {
     }
   }
 
-  /** Prefer {@link Sets#intersection(Set, Set)} over more contrived alternatives. */
-  static final class SetsIntersection<T> {
+  /**
+   * Prefer an immutable copy of {@link Sets#difference(Set, Set)} over more contrived alternatives.
+   */
+  static final class SetsDifference<S, T> {
     @BeforeTemplate
-    ImmutableSet<T> before(Set<T> set1, Set<T> set2) {
-      return set1.stream().filter(set2::contains).collect(toImmutableSet());
+    ImmutableSet<S> before(Set<S> set1, Set<T> set2) {
+      return set1.stream()
+          .filter(Refaster.anyOf(not(set2::contains), e -> !set2.contains(e)))
+          .collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<T> after(Set<T> set1, Set<T> set2) {
-      return Sets.intersection(set1, set2).immutableCopy();
+    ImmutableSet<S> after(Set<S> set1, Set<T> set2) {
+      return Sets.difference(set1, set2).immutableCopy();
     }
   }
 
-  /** Prefer {@link Sets#intersection(Set, Set)} over more contrived alternatives. */
-  static final class SetsIntersectionMap<K, V> {
+  /**
+   * Prefer an immutable copy of {@link Sets#difference(Set, Set)} over more contrived alternatives.
+   */
+  static final class SetsDifferenceMap<T, K, V> {
     @BeforeTemplate
-    ImmutableSet<K> before(Set<K> set, Map<K, V> map) {
-      return set.stream().filter(map::containsKey).collect(toImmutableSet());
+    ImmutableSet<T> before(Set<T> set, Map<K, V> map) {
+      return set.stream()
+          .filter(Refaster.anyOf(not(map::containsKey), e -> !map.containsKey(e)))
+          .collect(toImmutableSet());
     }
 
     @AfterTemplate
     ImmutableSet<K> after(Set<K> set, Map<K, V> map) {
+      return Sets.difference(set, map.keySet()).immutableCopy();
+    }
+  }
+
+  /**
+   * Prefer an immutable copy of {@link Sets#difference(Set, Set)} over more contrived alternatives.
+   */
+  static final class SetsDifferenceMultimap<T, K, V> {
+    @BeforeTemplate
+    ImmutableSet<T> before(Set<T> set, Multimap<K, V> multimap) {
+      return set.stream()
+          .filter(Refaster.anyOf(not(multimap::containsKey), e -> !multimap.containsKey(e)))
+          .collect(toImmutableSet());
+    }
+
+    @AfterTemplate
+    ImmutableSet<T> after(Set<T> set, Multimap<K, V> multimap) {
+      return Sets.difference(set, multimap.keySet()).immutableCopy();
+    }
+  }
+
+  /**
+   * Prefer an immutable copy of {@link Sets#intersection(Set, Set)} over more contrived
+   * alternatives.
+   */
+  static final class SetsIntersection<S, T> {
+    @BeforeTemplate
+    ImmutableSet<S> before(Set<S> set1, Set<T> set2) {
+      return set1.stream().filter(set2::contains).collect(toImmutableSet());
+    }
+
+    @AfterTemplate
+    ImmutableSet<S> after(Set<S> set1, Set<T> set2) {
+      return Sets.intersection(set1, set2).immutableCopy();
+    }
+  }
+
+  /**
+   * Prefer an immutable copy of {@link Sets#intersection(Set, Set)} over more contrived
+   * alternatives.
+   */
+  static final class SetsIntersectionMap<T, K, V> {
+    @BeforeTemplate
+    ImmutableSet<T> before(Set<T> set, Map<K, V> map) {
+      return set.stream().filter(map::containsKey).collect(toImmutableSet());
+    }
+
+    @AfterTemplate
+    ImmutableSet<T> after(Set<T> set, Map<K, V> map) {
       return Sets.intersection(set, map.keySet()).immutableCopy();
     }
   }
 
-  /** Prefer {@link Sets#intersection(Set, Set)} over more contrived alternatives. */
-  static final class SetsIntersectionMultimap<K, V> {
+  /**
+   * Prefer an immutable copy of {@link Sets#intersection(Set, Set)} over more contrived
+   * alternatives.
+   */
+  static final class SetsIntersectionMultimap<T, K, V> {
     @BeforeTemplate
-    ImmutableSet<K> before(Set<K> set, Multimap<K, V> multimap) {
+    ImmutableSet<T> before(Set<T> set, Multimap<K, V> multimap) {
       return set.stream().filter(multimap::containsKey).collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<K> after(Set<K> set, Multimap<K, V> multimap) {
+    ImmutableSet<T> after(Set<T> set, Multimap<K, V> multimap) {
       return Sets.intersection(set, multimap.keySet()).immutableCopy();
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
@@ -6,6 +6,8 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.common.collect.Streams;
 import com.google.errorprone.refaster.Refaster;
@@ -15,6 +17,7 @@ import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -209,6 +212,45 @@ final class ImmutableSetRules {
     @AfterTemplate
     ImmutableSet<T> after(T e1, T e2, T e3, T e4, T e5) {
       return ImmutableSet.of(e1, e2, e3, e4, e5);
+    }
+  }
+
+  /** Prefer {@link Sets#intersection(Set, Set)} ()} over more contrived alternatives. */
+  static final class SetsIntersection<T> {
+    @BeforeTemplate
+    ImmutableSet<T> before(Set<T> set1, Set<T> set2) {
+      return set1.stream().filter(set2::contains).collect(toImmutableSet());
+    }
+
+    @AfterTemplate
+    ImmutableSet<T> after(Set<T> set1, Set<T> set2) {
+      return Sets.intersection(set1, set2).immutableCopy();
+    }
+  }
+
+  /** Prefer {@link Sets#intersection(Set, Set)} ()} over more contrived alternatives. */
+  static final class MapKeySetIntersection<K, V> {
+    @BeforeTemplate
+    ImmutableSet<K> before(Set<K> set, Map<K, V> map) {
+      return set.stream().filter(map::containsKey).collect(toImmutableSet());
+    }
+
+    @AfterTemplate
+    ImmutableSet<K> after(Set<K> set, Map<K, V> map) {
+      return Sets.intersection(set, map.keySet()).immutableCopy();
+    }
+  }
+
+  /** Prefer {@link Sets#intersection(Set, Set)} ()} over more contrived alternatives. */
+  static final class SetMultimapKeySetIntersection<K, V> {
+    @BeforeTemplate
+    ImmutableSet<K> before(Set<K> set, SetMultimap<K, V> setMultimap) {
+      return set.stream().filter(setMultimap::containsKey).collect(toImmutableSet());
+    }
+
+    @AfterTemplate
+    ImmutableSet<K> after(Set<K> set, SetMultimap<K, V> setMultimap) {
+      return Sets.intersection(set, setMultimap.keySet()).immutableCopy();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
@@ -6,7 +6,7 @@ import static java.util.Collections.emptySet;
 import static java.util.Collections.singleton;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.SetMultimap;
+import com.google.common.collect.Multimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.common.collect.Streams;
@@ -215,7 +215,7 @@ final class ImmutableSetRules {
     }
   }
 
-  /** Prefer {@link Sets#intersection(Set, Set)} ()} over more contrived alternatives. */
+  /** Prefer {@link Sets#intersection(Set, Set)} over more contrived alternatives. */
   static final class SetsIntersection<T> {
     @BeforeTemplate
     ImmutableSet<T> before(Set<T> set1, Set<T> set2) {
@@ -228,8 +228,8 @@ final class ImmutableSetRules {
     }
   }
 
-  /** Prefer {@link Sets#intersection(Set, Set)} ()} over more contrived alternatives. */
-  static final class MapKeySetIntersection<K, V> {
+  /** Prefer {@link Sets#intersection(Set, Set)} over more contrived alternatives. */
+  static final class SetsIntersectionMap<K, V> {
     @BeforeTemplate
     ImmutableSet<K> before(Set<K> set, Map<K, V> map) {
       return set.stream().filter(map::containsKey).collect(toImmutableSet());
@@ -241,16 +241,16 @@ final class ImmutableSetRules {
     }
   }
 
-  /** Prefer {@link Sets#intersection(Set, Set)} ()} over more contrived alternatives. */
-  static final class SetMultimapKeySetIntersection<K, V> {
+  /** Prefer {@link Sets#intersection(Set, Set)} over more contrived alternatives. */
+  static final class SetsIntersectionMultimap<K, V> {
     @BeforeTemplate
-    ImmutableSet<K> before(Set<K> set, SetMultimap<K, V> setMultimap) {
-      return set.stream().filter(setMultimap::containsKey).collect(toImmutableSet());
+    ImmutableSet<K> before(Set<K> set, Multimap<K, V> multimap) {
+      return set.stream().filter(multimap::containsKey).collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<K> after(Set<K> set, SetMultimap<K, V> setMultimap) {
-      return Sets.intersection(set, setMultimap.keySet()).immutableCopy();
+    ImmutableSet<K> after(Set<K> set, Multimap<K, V> multimap) {
+      return Sets.intersection(set, multimap.keySet()).immutableCopy();
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
@@ -4,8 +4,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
@@ -77,18 +77,16 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Integer> testSetsIntersection() {
     ImmutableSet<Integer> set = ImmutableSet.of(1);
-    return ImmutableSet.of(1, 2, 3).stream().filter(set::contains).collect(toImmutableSet());
+    return ImmutableSet.of(2).stream().filter(set::contains).collect(toImmutableSet());
   }
 
-  ImmutableSet<Integer> testMapKeySetIntersection() {
-    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 4);
-    return ImmutableSet.of(1, 2, 3).stream().filter(map::containsKey).collect(toImmutableSet());
+  ImmutableSet<Integer> testSetsIntersectionMap() {
+    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 2);
+    return ImmutableSet.of(3).stream().filter(map::containsKey).collect(toImmutableSet());
   }
 
-  ImmutableSet<Integer> testSetMultimapKeySetIntersection() {
-    ImmutableSetMultimap<Integer, Integer> setMultiMap = ImmutableSetMultimap.of(1, 4);
-    return ImmutableSet.of(1, 2, 3).stream()
-        .filter(setMultiMap::containsKey)
-        .collect(toImmutableSet());
+  ImmutableSet<Integer> testSetsIntersectionMultimap() {
+    ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 2);
+    return ImmutableSet.of(3).stream().filter(multimap::containsKey).collect(toImmutableSet());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
@@ -3,7 +3,9 @@ package tech.picnic.errorprone.refasterrules;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
@@ -71,5 +73,22 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
 
   Set<Integer> testImmutableSetOf5() {
     return Set.of(1, 2, 3, 4, 5);
+  }
+
+  ImmutableSet<Integer> testSetsIntersection() {
+    ImmutableSet<Integer> set = ImmutableSet.of(1);
+    return ImmutableSet.of(1, 2, 3).stream().filter(set::contains).collect(toImmutableSet());
+  }
+
+  ImmutableSet<Integer> testMapKeySetIntersection() {
+    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 4);
+    return ImmutableSet.of(1, 2, 3).stream().filter(map::containsKey).collect(toImmutableSet());
+  }
+
+  ImmutableSet<Integer> testSetMultimapKeySetIntersection() {
+    ImmutableSetMultimap<Integer, Integer> setMultiMap = ImmutableSetMultimap.of(1, 4);
+    return ImmutableSet.of(1, 2, 3).stream()
+        .filter(setMultiMap::containsKey)
+        .collect(toImmutableSet());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
@@ -123,4 +123,9 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
         .filter(ImmutableSetMultimap.of(2, 3)::containsKey)
         .collect(toImmutableSet());
   }
+
+  ImmutableSet<Integer> testSetsUnion() {
+    return Stream.concat(ImmutableSet.of(1).stream(), ImmutableSet.of(2).stream())
+        .collect(toImmutableSet());
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
@@ -1,11 +1,12 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.function.Predicate.not;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
@@ -17,7 +18,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Arrays.class, Collections.class, Streams.class);
+    return ImmutableSet.of(Arrays.class, Collections.class, Streams.class, not(null));
   }
 
   ImmutableSet.Builder<String> testImmutableSetBuilder() {
@@ -75,18 +76,51 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
     return Set.of(1, 2, 3, 4, 5);
   }
 
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifference() {
+    return ImmutableSet.of(
+        ImmutableSet.of(1).stream()
+            .filter(not(ImmutableSet.of(2)::contains))
+            .collect(toImmutableSet()),
+        ImmutableSet.of(3).stream()
+            .filter(v -> !ImmutableSet.of(4).contains(v))
+            .collect(toImmutableSet()));
+  }
+
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMap() {
+    return ImmutableSet.of(
+        ImmutableSet.of(1).stream()
+            .filter(not(ImmutableMap.of(2, 3)::containsKey))
+            .collect(toImmutableSet()),
+        ImmutableSet.of(4).stream()
+            .filter(v -> !ImmutableMap.of(5, 6).containsKey(v))
+            .collect(toImmutableSet()));
+  }
+
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMultimap() {
+    return ImmutableSet.of(
+        ImmutableSet.of(1).stream()
+            .filter(not(ImmutableSetMultimap.of(2, 3)::containsKey))
+            .collect(toImmutableSet()),
+        ImmutableSet.of(4).stream()
+            .filter(v -> !ImmutableSetMultimap.of(5, 6).containsKey(v))
+            .collect(toImmutableSet()));
+  }
+
   ImmutableSet<Integer> testSetsIntersection() {
-    ImmutableSet<Integer> set = ImmutableSet.of(1);
-    return ImmutableSet.of(2).stream().filter(set::contains).collect(toImmutableSet());
+    return ImmutableSet.of(1).stream()
+        .filter(ImmutableSet.of(2)::contains)
+        .collect(toImmutableSet());
   }
 
   ImmutableSet<Integer> testSetsIntersectionMap() {
-    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 2);
-    return ImmutableSet.of(3).stream().filter(map::containsKey).collect(toImmutableSet());
+    return ImmutableSet.of(1).stream()
+        .filter(ImmutableMap.of(2, 3)::containsKey)
+        .collect(toImmutableSet());
   }
 
   ImmutableSet<Integer> testSetsIntersectionMultimap() {
-    ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 2);
-    return ImmutableSet.of(3).stream().filter(multimap::containsKey).collect(toImmutableSet());
+    return ImmutableSet.of(1).stream()
+        .filter(ImmutableSetMultimap.of(2, 3)::containsKey)
+        .collect(toImmutableSet());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
@@ -4,8 +4,8 @@ import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
@@ -72,16 +72,16 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Integer> testSetsIntersection() {
     ImmutableSet<Integer> set = ImmutableSet.of(1);
-    return Sets.intersection(ImmutableSet.of(1, 2, 3), set).immutableCopy();
+    return Sets.intersection(ImmutableSet.of(2), set).immutableCopy();
   }
 
-  ImmutableSet<Integer> testMapKeySetIntersection() {
-    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 4);
-    return Sets.intersection(ImmutableSet.of(1, 2, 3), map.keySet()).immutableCopy();
+  ImmutableSet<Integer> testSetsIntersectionMap() {
+    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 2);
+    return Sets.intersection(ImmutableSet.of(3), map.keySet()).immutableCopy();
   }
 
-  ImmutableSet<Integer> testSetMultimapKeySetIntersection() {
-    ImmutableSetMultimap<Integer, Integer> setMultiMap = ImmutableSetMultimap.of(1, 4);
-    return Sets.intersection(ImmutableSet.of(1, 2, 3), setMultiMap.keySet()).immutableCopy();
+  ImmutableSet<Integer> testSetsIntersectionMultimap() {
+    ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 2);
+    return Sets.intersection(ImmutableSet.of(3), multimap.keySet()).immutableCopy();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
@@ -102,4 +102,8 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
     return Sets.intersection(ImmutableSet.of(1), ImmutableSetMultimap.of(2, 3).keySet())
         .immutableCopy();
   }
+
+  ImmutableSet<Integer> testSetsUnion() {
+    return Sets.union(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy();
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
@@ -1,11 +1,12 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
+import static java.util.function.Predicate.not;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultimap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
@@ -17,7 +18,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Arrays.class, Collections.class, Streams.class);
+    return ImmutableSet.of(Arrays.class, Collections.class, Streams.class, not(null));
   }
 
   ImmutableSet.Builder<String> testImmutableSetBuilder() {
@@ -70,18 +71,35 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1, 2, 3, 4, 5);
   }
 
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifference() {
+    return ImmutableSet.of(
+        Sets.difference(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy(),
+        Sets.difference(ImmutableSet.of(3), ImmutableSet.of(4)).immutableCopy());
+  }
+
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMap() {
+    return ImmutableSet.of(
+        Sets.difference(ImmutableSet.of(1), ImmutableMap.of(2, 3).keySet()).immutableCopy(),
+        Sets.difference(ImmutableSet.of(4), ImmutableMap.of(5, 6).keySet()).immutableCopy());
+  }
+
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMultimap() {
+    return ImmutableSet.of(
+        Sets.difference(ImmutableSet.of(1), ImmutableSetMultimap.of(2, 3).keySet()).immutableCopy(),
+        Sets.difference(ImmutableSet.of(4), ImmutableSetMultimap.of(5, 6).keySet())
+            .immutableCopy());
+  }
+
   ImmutableSet<Integer> testSetsIntersection() {
-    ImmutableSet<Integer> set = ImmutableSet.of(1);
-    return Sets.intersection(ImmutableSet.of(2), set).immutableCopy();
+    return Sets.intersection(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy();
   }
 
   ImmutableSet<Integer> testSetsIntersectionMap() {
-    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 2);
-    return Sets.intersection(ImmutableSet.of(3), map.keySet()).immutableCopy();
+    return Sets.intersection(ImmutableSet.of(1), ImmutableMap.of(2, 3).keySet()).immutableCopy();
   }
 
   ImmutableSet<Integer> testSetsIntersectionMultimap() {
-    ImmutableMultimap<Integer, Integer> multimap = ImmutableMultimap.of(1, 2);
-    return Sets.intersection(ImmutableSet.of(3), multimap.keySet()).immutableCopy();
+    return Sets.intersection(ImmutableSet.of(1), ImmutableSetMultimap.of(2, 3).keySet())
+        .immutableCopy();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
@@ -3,7 +3,9 @@ package tech.picnic.errorprone.refasterrules;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
@@ -66,5 +68,20 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
 
   Set<Integer> testImmutableSetOf5() {
     return ImmutableSet.of(1, 2, 3, 4, 5);
+  }
+
+  ImmutableSet<Integer> testSetsIntersection() {
+    ImmutableSet<Integer> set = ImmutableSet.of(1);
+    return Sets.intersection(ImmutableSet.of(1, 2, 3), set).immutableCopy();
+  }
+
+  ImmutableSet<Integer> testMapKeySetIntersection() {
+    ImmutableMap<Integer, Integer> map = ImmutableMap.of(1, 4);
+    return Sets.intersection(ImmutableSet.of(1, 2, 3), map.keySet()).immutableCopy();
+  }
+
+  ImmutableSet<Integer> testSetMultimapKeySetIntersection() {
+    ImmutableSetMultimap<Integer, Integer> setMultiMap = ImmutableSetMultimap.of(1, 4);
+    return Sets.intersection(ImmutableSet.of(1, 2, 3), setMultiMap.keySet()).immutableCopy();
   }
 }


### PR DESCRIPTION
~~Original discussion.~~

Suggested commit message:
```
Introduce `Sets{Difference,Intersection}{,Map,Multimap}` and `SetsUnion` Refaster rules (#607)
```