### PR TITLE
Extend `PrimitiveRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PrimitiveRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PrimitiveRules.java
@@ -1,6 +1,13 @@
 package tech.picnic.errorprone.refasterrules;
 
+import com.google.common.primitives.Booleans;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -19,7 +26,7 @@ final class PrimitiveRules {
     }
 
     @AfterTemplate
-    boolean after(long a, long b) {
+    boolean after(double a, double b) {
       return a < b;
     }
   }
@@ -33,7 +40,7 @@ final class PrimitiveRules {
     }
 
     @AfterTemplate
-    boolean after(long a, long b) {
+    boolean after(double a, double b) {
       return a <= b;
     }
   }
@@ -47,7 +54,7 @@ final class PrimitiveRules {
     }
 
     @AfterTemplate
-    boolean after(long a, long b) {
+    boolean after(double a, double b) {
       return a > b;
     }
   }
@@ -61,7 +68,7 @@ final class PrimitiveRules {
     }
 
     @AfterTemplate
-    boolean after(long a, long b) {
+    boolean after(double a, double b) {
       return a >= b;
     }
   }
@@ -76,6 +83,305 @@ final class PrimitiveRules {
     @AfterTemplate
     int after(long a) {
       return Math.toIntExact(a);
+    }
+  }
+
+  /** Prefer {@link Boolean#hashCode(boolean)} over the Guava alternative. */
+  static final class BooleanHashCode {
+    @BeforeTemplate
+    int before(boolean b) {
+      return Booleans.hashCode(b);
+    }
+
+    @AfterTemplate
+    int after(boolean b) {
+      return Boolean.hashCode(b);
+    }
+  }
+
+  /** Prefer {@link Byte#hashCode(byte)} over the Guava alternative. */
+  static final class ByteHashCode {
+    @BeforeTemplate
+    int before(byte b) {
+      return Bytes.hashCode(b);
+    }
+
+    @AfterTemplate
+    int after(byte b) {
+      return Byte.hashCode(b);
+    }
+  }
+
+  /** Prefer {@link Character#hashCode(char)} over the Guava alternative. */
+  static final class CharacterHashCode {
+    @BeforeTemplate
+    int before(char c) {
+      return Chars.hashCode(c);
+    }
+
+    @AfterTemplate
+    int after(char c) {
+      return Character.hashCode(c);
+    }
+  }
+
+  /** Prefer {@link Short#hashCode(short)} over the Guava alternative. */
+  static final class ShortHashCode {
+    @BeforeTemplate
+    int before(short s) {
+      return Shorts.hashCode(s);
+    }
+
+    @AfterTemplate
+    int after(short s) {
+      return Short.hashCode(s);
+    }
+  }
+
+  /** Prefer {@link Integer#hashCode(int)} over the Guava alternative. */
+  static final class IntegerHashCode {
+    @BeforeTemplate
+    int before(int i) {
+      return Ints.hashCode(i);
+    }
+
+    @AfterTemplate
+    int after(int i) {
+      return Integer.hashCode(i);
+    }
+  }
+
+  /** Prefer {@link Long#hashCode(long)} over the Guava alternative. */
+  static final class LongHashCode {
+    @BeforeTemplate
+    int before(long l) {
+      return Longs.hashCode(l);
+    }
+
+    @AfterTemplate
+    int after(long l) {
+      return Long.hashCode(l);
+    }
+  }
+
+  /** Prefer {@link Float#hashCode(float)} over the Guava alternative. */
+  static final class FloatHashCode {
+    @BeforeTemplate
+    int before(float f) {
+      return Floats.hashCode(f);
+    }
+
+    @AfterTemplate
+    int after(float f) {
+      return Float.hashCode(f);
+    }
+  }
+
+  /** Prefer {@link Double#hashCode(double)} over the Guava alternative. */
+  static final class DoubleHashCode {
+    @BeforeTemplate
+    int before(double d) {
+      return Doubles.hashCode(d);
+    }
+
+    @AfterTemplate
+    int after(double d) {
+      return Double.hashCode(d);
+    }
+  }
+
+  /** Prefer {@link Boolean#compare(boolean, boolean)} over the Guava alternative. */
+  static final class BooleanCompare {
+    @BeforeTemplate
+    int before(boolean a, boolean b) {
+      return Booleans.compare(a, b);
+    }
+
+    @AfterTemplate
+    int after(boolean a, boolean b) {
+      return Boolean.compare(a, b);
+    }
+  }
+
+  /** Prefer {@link Character#compare(char, char)} over the Guava alternative. */
+  static final class CharacterCompare {
+    @BeforeTemplate
+    int before(char a, char b) {
+      return Chars.compare(a, b);
+    }
+
+    @AfterTemplate
+    int after(char a, char b) {
+      return Character.compare(a, b);
+    }
+  }
+
+  /** Prefer {@link Short#compare(short, short)} over the Guava alternative. */
+  static final class ShortCompare {
+    @BeforeTemplate
+    int before(short a, short b) {
+      return Shorts.compare(a, b);
+    }
+
+    @AfterTemplate
+    int after(short a, short b) {
+      return Short.compare(a, b);
+    }
+  }
+
+  /** Prefer {@link Integer#compare(int, int)} over the Guava alternative. */
+  static final class IntegerCompare {
+    @BeforeTemplate
+    int before(int a, int b) {
+      return Ints.compare(a, b);
+    }
+
+    @AfterTemplate
+    int after(int a, int b) {
+      return Integer.compare(a, b);
+    }
+  }
+
+  /** Prefer {@link Long#compare(long, long)} over the Guava alternative. */
+  static final class LongCompare {
+    @BeforeTemplate
+    int before(long a, long b) {
+      return Longs.compare(a, b);
+    }
+
+    @AfterTemplate
+    int after(long a, long b) {
+      return Long.compare(a, b);
+    }
+  }
+
+  /** Prefer {@link Float#compare(float, float)} over the Guava alternative. */
+  static final class FloatCompare {
+    @BeforeTemplate
+    int before(float a, float b) {
+      return Floats.compare(a, b);
+    }
+
+    @AfterTemplate
+    int after(float a, float b) {
+      return Float.compare(a, b);
+    }
+  }
+
+  /** Prefer {@link Double#compare(double, double)} over the Guava alternative. */
+  static final class DoubleCompare {
+    @BeforeTemplate
+    int before(double a, double b) {
+      return Doubles.compare(a, b);
+    }
+
+    @AfterTemplate
+    int after(double a, double b) {
+      return Double.compare(a, b);
+    }
+  }
+
+  /** Prefer {@link Character#BYTES} over the Guava alternative. */
+  static final class CharacterBytes {
+    @BeforeTemplate
+    int before() {
+      return Chars.BYTES;
+    }
+
+    @AfterTemplate
+    int after() {
+      return Character.BYTES;
+    }
+  }
+
+  /** Prefer {@link Short#BYTES} over the Guava alternative. */
+  static final class ShortBytes {
+    @BeforeTemplate
+    int before() {
+      return Shorts.BYTES;
+    }
+
+    @AfterTemplate
+    int after() {
+      return Short.BYTES;
+    }
+  }
+
+  /** Prefer {@link Integer#BYTES} over the Guava alternative. */
+  static final class IntegerBytes {
+    @BeforeTemplate
+    int before() {
+      return Ints.BYTES;
+    }
+
+    @AfterTemplate
+    int after() {
+      return Integer.BYTES;
+    }
+  }
+
+  /** Prefer {@link Long#BYTES} over the Guava alternative. */
+  static final class LongBytes {
+    @BeforeTemplate
+    int before() {
+      return Longs.BYTES;
+    }
+
+    @AfterTemplate
+    int after() {
+      return Long.BYTES;
+    }
+  }
+
+  /** Prefer {@link Float#BYTES} over the Guava alternative. */
+  static final class FloatBytes {
+    @BeforeTemplate
+    int before() {
+      return Floats.BYTES;
+    }
+
+    @AfterTemplate
+    int after() {
+      return Float.BYTES;
+    }
+  }
+
+  /** Prefer {@link Double#BYTES} over the Guava alternative. */
+  static final class DoubleBytes {
+    @BeforeTemplate
+    int before() {
+      return Doubles.BYTES;
+    }
+
+    @AfterTemplate
+    int after() {
+      return Double.BYTES;
+    }
+  }
+
+  /** Prefer {@link Float#isFinite(float)} over the Guava alternative. */
+  static final class FloatIsFinite {
+    @BeforeTemplate
+    boolean before(float f) {
+      return Floats.isFinite(f);
+    }
+
+    @AfterTemplate
+    boolean after(float f) {
+      return Float.isFinite(f);
+    }
+  }
+
+  /** Prefer {@link Double#isFinite(double)} over the Guava alternative. */
+  static final class DoubleIsFinite {
+    @BeforeTemplate
+    boolean before(double d) {
+      return Doubles.isFinite(d);
+    }
+
+    @AfterTemplate
+    boolean after(double d) {
+      return Double.isFinite(d);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PrimitiveRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PrimitiveRules.java
@@ -76,13 +76,13 @@ final class PrimitiveRules {
   /** Prefer {@link Math#toIntExact(long)} over the Guava alternative. */
   static final class LongToIntExact {
     @BeforeTemplate
-    int before(long a) {
-      return Ints.checkedCast(a);
+    int before(long l) {
+      return Ints.checkedCast(l);
     }
 
     @AfterTemplate
-    int after(long a) {
-      return Math.toIntExact(a);
+    int after(long l) {
+      return Math.toIntExact(l);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestInput.java
@@ -1,13 +1,28 @@
 package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Booleans;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Ints.class);
+    return ImmutableSet.of(
+        Booleans.class,
+        Bytes.class,
+        Chars.class,
+        Doubles.class,
+        Floats.class,
+        Ints.class,
+        Longs.class,
+        Shorts.class);
   }
 
   ImmutableSet<Boolean> testLessThan() {
@@ -56,5 +71,97 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
 
   int testLongToIntExact() {
     return Ints.checkedCast(Long.MAX_VALUE);
+  }
+
+  int testBooleanHashCode() {
+    return Booleans.hashCode(true);
+  }
+
+  int testByteHashCode() {
+    return Bytes.hashCode((byte) 1);
+  }
+
+  int testCharacterHashCode() {
+    return Chars.hashCode('a');
+  }
+
+  int testShortHashCode() {
+    return Shorts.hashCode((short) 1);
+  }
+
+  int testIntegerHashCode() {
+    return Ints.hashCode(1);
+  }
+
+  int testLongHashCode() {
+    return Longs.hashCode(1);
+  }
+
+  int testFloatHashCode() {
+    return Floats.hashCode(1);
+  }
+
+  int testDoubleHashCode() {
+    return Doubles.hashCode(1);
+  }
+
+  int testBooleanCompare() {
+    return Booleans.compare(false, true);
+  }
+
+  int testCharacterCompare() {
+    return Chars.compare('a', 'b');
+  }
+
+  int testShortCompare() {
+    return Shorts.compare((short) 1, (short) 2);
+  }
+
+  int testIntegerCompare() {
+    return Ints.compare(1, 2);
+  }
+
+  int testLongCompare() {
+    return Longs.compare(1, 2);
+  }
+
+  int testFloatCompare() {
+    return Floats.compare(1, 2);
+  }
+
+  int testDoubleCompare() {
+    return Doubles.compare(1, 2);
+  }
+
+  int testCharacterBytes() {
+    return Chars.BYTES;
+  }
+
+  int testShortBytes() {
+    return Shorts.BYTES;
+  }
+
+  int testIntegerBytes() {
+    return Ints.BYTES;
+  }
+
+  int testLongBytes() {
+    return Longs.BYTES;
+  }
+
+  int testFloatBytes() {
+    return Floats.BYTES;
+  }
+
+  int testDoubleBytes() {
+    return Doubles.BYTES;
+  }
+
+  boolean testFloatIsFinite() {
+    return Floats.isFinite(1);
+  }
+
+  boolean testDoubleIsFinite() {
+    return Doubles.isFinite(1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestOutput.java
@@ -1,13 +1,28 @@
 package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
+import com.google.common.primitives.Booleans;
+import com.google.common.primitives.Bytes;
+import com.google.common.primitives.Chars;
+import com.google.common.primitives.Doubles;
+import com.google.common.primitives.Floats;
 import com.google.common.primitives.Ints;
+import com.google.common.primitives.Longs;
+import com.google.common.primitives.Shorts;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Ints.class);
+    return ImmutableSet.of(
+        Booleans.class,
+        Bytes.class,
+        Chars.class,
+        Doubles.class,
+        Floats.class,
+        Ints.class,
+        Longs.class,
+        Shorts.class);
   }
 
   ImmutableSet<Boolean> testLessThan() {
@@ -56,5 +71,97 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
 
   int testLongToIntExact() {
     return Math.toIntExact(Long.MAX_VALUE);
+  }
+
+  int testBooleanHashCode() {
+    return Boolean.hashCode(true);
+  }
+
+  int testByteHashCode() {
+    return Byte.hashCode((byte) 1);
+  }
+
+  int testCharacterHashCode() {
+    return Character.hashCode('a');
+  }
+
+  int testShortHashCode() {
+    return Short.hashCode((short) 1);
+  }
+
+  int testIntegerHashCode() {
+    return Integer.hashCode(1);
+  }
+
+  int testLongHashCode() {
+    return Long.hashCode(1);
+  }
+
+  int testFloatHashCode() {
+    return Float.hashCode(1);
+  }
+
+  int testDoubleHashCode() {
+    return Double.hashCode(1);
+  }
+
+  int testBooleanCompare() {
+    return Boolean.compare(false, true);
+  }
+
+  int testCharacterCompare() {
+    return Character.compare('a', 'b');
+  }
+
+  int testShortCompare() {
+    return Short.compare((short) 1, (short) 2);
+  }
+
+  int testIntegerCompare() {
+    return Integer.compare(1, 2);
+  }
+
+  int testLongCompare() {
+    return Long.compare(1, 2);
+  }
+
+  int testFloatCompare() {
+    return Float.compare(1, 2);
+  }
+
+  int testDoubleCompare() {
+    return Double.compare(1, 2);
+  }
+
+  int testCharacterBytes() {
+    return Character.BYTES;
+  }
+
+  int testShortBytes() {
+    return Short.BYTES;
+  }
+
+  int testIntegerBytes() {
+    return Integer.BYTES;
+  }
+
+  int testLongBytes() {
+    return Long.BYTES;
+  }
+
+  int testFloatBytes() {
+    return Float.BYTES;
+  }
+
+  int testDoubleBytes() {
+    return Double.BYTES;
+  }
+
+  boolean testFloatIsFinite() {
+    return Float.isFinite(1);
+  }
+
+  boolean testDoubleIsFinite() {
+    return Double.isFinite(1);
   }
 }


### PR DESCRIPTION
Suggested commit message:
```
Extend `PrimitiveRules` Refaster rule collection (#608)

Assorted methods and constants exposed by Guava's
`com.google.common.primitives.*` types are now replaced with their JDK
equivalents.

While there, also update the parameter types of some existing `@AfterTemplate`
methods, resolving an inconsistency flagged by @knutwannheden.
```