### PR TITLE
Extend `AssertJThrowingCallableRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
@@ -319,6 +319,44 @@ final class AssertJThrowingCallableRules {
     }
   }
 
+  static final class AssertThatThrownByNullPointerExceptionHasMessageContaining {
+    @BeforeTemplate
+    @SuppressWarnings(
+        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatNullPointerException()
+          .isThrownBy(throwingCallable)
+          .withMessageContaining(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageContaining(message);
+    }
+  }
+
+  static final class AssertThatThrownByNullPointerExceptionHasMessageNotContaining {
+    @BeforeTemplate
+    @SuppressWarnings(
+        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatNullPointerException()
+          .isThrownBy(throwingCallable)
+          .withMessageNotContaining(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(NullPointerException.class)
+          .hasMessageNotContaining(message);
+    }
+  }
+
   static final class AssertThatThrownByIOException {
     @BeforeTemplate
     AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable) {
@@ -363,6 +401,54 @@ final class AssertJThrowingCallableRules {
       return assertThatThrownBy(throwingCallable)
           .isInstanceOf(IOException.class)
           .hasMessage(message, parameters);
+    }
+  }
+
+  static final class AssertThatThrownByIOExceptionHasMessageStartingWith {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatIOException().isThrownBy(throwingCallable).withMessageStartingWith(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(IOException.class)
+          .hasMessageStartingWith(message);
+    }
+  }
+
+  static final class AssertThatThrownByIOExceptionHasMessageContaining {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatIOException().isThrownBy(throwingCallable).withMessageContaining(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(IOException.class)
+          .hasMessageContaining(message);
+    }
+  }
+
+  static final class AssertThatThrownByIOExceptionHasMessageNotContaining {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatIOException().isThrownBy(throwingCallable).withMessageNotContaining(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(IOException.class)
+          .hasMessageNotContaining(message);
     }
   }
 
@@ -426,6 +512,78 @@ final class AssertJThrowingCallableRules {
       return assertThatThrownBy(throwingCallable)
           .isInstanceOf(exceptionType)
           .hasMessage(message, parameters);
+    }
+  }
+
+  static final class AssertThatThrownByHasMessageStartingWith {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownBy" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(
+        Class<? extends Throwable> exceptionType,
+        ThrowingCallable throwingCallable,
+        String message) {
+      return assertThatExceptionOfType(exceptionType)
+          .isThrownBy(throwingCallable)
+          .withMessageStartingWith(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(
+        Class<? extends Throwable> exceptionType,
+        ThrowingCallable throwingCallable,
+        String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(exceptionType)
+          .hasMessageStartingWith(message);
+    }
+  }
+
+  static final class AssertThatThrownByHasMessageContaining {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownBy" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(
+        Class<? extends Throwable> exceptionType,
+        ThrowingCallable throwingCallable,
+        String message) {
+      return assertThatExceptionOfType(exceptionType)
+          .isThrownBy(throwingCallable)
+          .withMessageContaining(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(
+        Class<? extends Throwable> exceptionType,
+        ThrowingCallable throwingCallable,
+        String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(exceptionType)
+          .hasMessageContaining(message);
+    }
+  }
+
+  static final class AssertThatThrownByHasMessageNotContaining {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownBy" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(
+        Class<? extends Throwable> exceptionType,
+        ThrowingCallable throwingCallable,
+        String message) {
+      return assertThatExceptionOfType(exceptionType)
+          .isThrownBy(throwingCallable)
+          .withMessageNotContaining(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(
+        Class<? extends Throwable> exceptionType,
+        ThrowingCallable throwingCallable,
+        String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(exceptionType)
+          .hasMessageNotContaining(message);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -91,6 +91,14 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatNullPointerException().isThrownBy(() -> {}).withMessageStartingWith("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageContaining() {
+    return assertThatNullPointerException().isThrownBy(() -> {}).withMessageContaining("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageNotContaining() {
+    return assertThatNullPointerException().isThrownBy(() -> {}).withMessageNotContaining("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIOException() {
     return assertThatIOException().isThrownBy(() -> {});
   }
@@ -101,6 +109,18 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
 
   AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageParameters() {
     return assertThatIOException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageStartingWith() {
+    return assertThatIOException().isThrownBy(() -> {}).withMessageStartingWith("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageContaining() {
+    return assertThatIOException().isThrownBy(() -> {}).withMessageContaining("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageNotContaining() {
+    return assertThatIOException().isThrownBy(() -> {}).withMessageNotContaining("foo");
   }
 
   AbstractObjectAssert<?, ?> testAssertThatThrownBy() {
@@ -117,6 +137,24 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
         .withMessage("foo %s", "bar");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageStartingWith() {
+    return assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> {})
+        .withMessageStartingWith("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageContaining() {
+    return assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> {})
+        .withMessageContaining("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageNotContaining() {
+    return assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> {})
+        .withMessageNotContaining("foo");
   }
 
   ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -112,6 +112,18 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
         .hasMessageStartingWith("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageContaining() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageContaining("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageNotContaining() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(NullPointerException.class)
+        .hasMessageNotContaining("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIOException() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class);
   }
@@ -122,6 +134,22 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
 
   AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageParameters() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class).hasMessage("foo %s", "bar");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageStartingWith() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IOException.class)
+        .hasMessageStartingWith("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageContaining() {
+    return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class).hasMessageContaining("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageNotContaining() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IOException.class)
+        .hasMessageNotContaining("foo");
   }
 
   AbstractObjectAssert<?, ?> testAssertThatThrownBy() {
@@ -138,6 +166,24 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("foo %s", "bar");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageStartingWith() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageStartingWith("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageContaining() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageNotContaining() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageNotContaining("foo");
   }
 
   ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>


### PR DESCRIPTION
While applying the Refaster rules internally I found another case that we are missing. This was intended as this list is not meant to be exhaustive. However, I feel it makes sense to be consistent and for that reason I added some of the missing cases for the `assertThatNullPointerException`, `assertThatIOException`, and `assertThatExceptionOfType`. 

Now we have a `StartsWith`, `MessageContaining`, and `MessageNotContaining` for the ones that already had `WithParams` :smile:.

Suggested commit message:
```
Extend `AssertJThrowingCallableRules` Refaster rule collection (#609)
```