### PR TITLE
Introduce `VerifyOnlyElementInFlux` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1332,20 +1332,13 @@ final class ReactorRules {
     }
   }
 
-  /** Avoid collecting when verifying only the given element is in the given {@link Flux}. */
+  /** Avoid value collection when verifying that a {@link Flux} emits exactly one value. */
   static final class FluxAsStepVerifierExpectNext<T> {
     @BeforeTemplate
     StepVerifier.Step<ImmutableList<T>> before(Flux<T> flux, T object) {
       return flux.collect(toImmutableList())
           .as(StepVerifier::create)
           .assertNext(list -> assertThat(list).containsExactly(object));
-    }
-
-    @BeforeTemplate
-    StepVerifier.Step<ImmutableSet<T>> before2(Flux<T> flux, T object) {
-      return flux.collect(toImmutableSet())
-          .as(StepVerifier::create)
-          .assertNext(set -> assertThat(set).containsExactly(object));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1434,4 +1434,20 @@ final class ReactorRules {
       return step.verifyTimeout(duration);
     }
   }
+
+  /** Avoid collecting when verifying only the given element is in the given {@link Flux}. */
+  static final class VerifyOnlyElementInFlux<T> {
+    @BeforeTemplate
+    Duration before(Flux<T> flux, T object) {
+      return flux.collect(toImmutableList())
+          .as(StepVerifier::create)
+          .assertNext(list -> assertThat(list).containsExactly(object))
+          .verifyComplete();
+    }
+
+    @AfterTemplate
+    Duration after(Flux<T> flux, T object) {
+      return flux.as(StepVerifier::create).expectNext(object).verifyComplete();
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1332,11 +1332,13 @@ final class ReactorRules {
     }
   }
 
-  /** Avoid value collection when verifying that a {@link Flux} emits exactly one value. */
-  static final class FluxAsStepVerifierExpectNext<T> {
+  /** Avoid list collection when verifying that a {@link Flux} emits exactly one value. */
+  // XXX: This rule assumes that the matched collector does not drop elements. Consider introducing
+  // a `@Matches(DoesNotDropElements.class)` or `@NotMatches(MayDropElements.class)` guard.
+  static final class FluxAsStepVerifierExpectNext<T, L extends List<T>> {
     @BeforeTemplate
-    StepVerifier.Step<ImmutableList<T>> before(Flux<T> flux, T object) {
-      return flux.collect(toImmutableList())
+    StepVerifier.Step<L> before(Flux<T> flux, Collector<? super T, ?, L> listCollector, T object) {
+      return flux.collect(listCollector)
           .as(StepVerifier::create)
           .assertNext(list -> assertThat(list).containsExactly(object));
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1332,6 +1332,28 @@ final class ReactorRules {
     }
   }
 
+  /** Avoid collecting when verifying only the given element is in the given {@link Flux}. */
+  static final class FluxAsStepVerifierExpectNext<T> {
+    @BeforeTemplate
+    StepVerifier.Step<ImmutableList<T>> before(Flux<T> flux, T object) {
+      return flux.collect(toImmutableList())
+          .as(StepVerifier::create)
+          .assertNext(list -> assertThat(list).containsExactly(object));
+    }
+
+    @BeforeTemplate
+    StepVerifier.Step<ImmutableSet<T>> before2(Flux<T> flux, T object) {
+      return flux.collect(toImmutableSet())
+          .as(StepVerifier::create)
+          .assertNext(set -> assertThat(set).containsExactly(object));
+    }
+
+    @AfterTemplate
+    StepVerifier.Step<T> after(Flux<T> flux, T object) {
+      return flux.as(StepVerifier::create).expectNext(object);
+    }
+  }
+
   /** Prefer {@link StepVerifier.LastStep#verifyComplete()} over more verbose alternatives. */
   static final class StepVerifierLastStepVerifyComplete {
     @BeforeTemplate
@@ -1432,22 +1454,6 @@ final class ReactorRules {
     @AfterTemplate
     Duration after(StepVerifier.LastStep step, Duration duration) {
       return step.verifyTimeout(duration);
-    }
-  }
-
-  /** Avoid collecting when verifying only the given element is in the given {@link Flux}. */
-  static final class VerifyOnlyElementInFlux<T> {
-    @BeforeTemplate
-    Duration before(Flux<T> flux, T object) {
-      return flux.collect(toImmutableList())
-          .as(StepVerifier::create)
-          .assertNext(list -> assertThat(list).containsExactly(object))
-          .verifyComplete();
-    }
-
-    @AfterTemplate
-    Duration after(Flux<T> flux, T object) {
-      return flux.as(StepVerifier::create).expectNext(object).verifyComplete();
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -1,7 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
-import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Function.identity;
@@ -423,18 +422,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNextMatches("qux"::equals));
   }
 
-  ImmutableSet<Duration> testFluxAsStepVerifierExpectNext() {
-    return ImmutableSet.of(
-        Flux.just(1)
-            .collect(toImmutableList())
-            .as(StepVerifier::create)
-            .assertNext(list -> assertThat(list).containsExactly(2))
-            .verifyComplete(),
-        Flux.just(3)
-            .collect(toImmutableSet())
-            .as(StepVerifier::create)
-            .assertNext(set -> assertThat(set).containsExactly(4))
-            .verifyComplete());
+  Duration testFluxAsStepVerifierExpectNext() {
+    return Flux.just(1)
+        .collect(toImmutableList())
+        .as(StepVerifier::create)
+        .assertNext(list -> assertThat(list).containsExactly(2))
+        .verifyComplete();
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Function.identity;
@@ -422,6 +423,20 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNextMatches("qux"::equals));
   }
 
+  ImmutableSet<Duration> testFluxAsStepVerifierExpectNext() {
+    return ImmutableSet.of(
+        Flux.just(1)
+            .collect(toImmutableList())
+            .as(StepVerifier::create)
+            .assertNext(list -> assertThat(list).containsExactly(2))
+            .verifyComplete(),
+        Flux.just(3)
+            .collect(toImmutableSet())
+            .as(StepVerifier::create)
+            .assertNext(set -> assertThat(set).containsExactly(4))
+            .verifyComplete());
+  }
+
   Duration testStepVerifierLastStepVerifyComplete() {
     return StepVerifier.create(Mono.empty()).expectComplete().verify();
   }
@@ -453,13 +468,5 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Duration testStepVerifierLastStepVerifyTimeout() {
     return StepVerifier.create(Mono.empty()).expectTimeout(Duration.ZERO).verify();
-  }
-
-  Duration testVerifyOnlyElementInFlux() {
-    return Flux.just(1)
-        .collect(toImmutableList())
-        .as(StepVerifier::create)
-        .assertNext(list -> assertThat(list).containsExactly(1))
-        .verifyComplete();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -454,4 +454,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   Duration testStepVerifierLastStepVerifyTimeout() {
     return StepVerifier.create(Mono.empty()).expectTimeout(Duration.ZERO).verify();
   }
+
+  Duration testVerifyOnlyElementInFlux() {
+    return Flux.just(1)
+        .collect(toImmutableList())
+        .as(StepVerifier::create)
+        .assertNext(list -> assertThat(list).containsExactly(1))
+        .verifyComplete();
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -422,16 +422,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNextMatches("qux"::equals));
   }
 
-  ImmutableSet<StepVerifier.Step<?>> testFluxAsStepVerifierExpectNext() {
-    return ImmutableSet.of(
-        Flux.just(1)
-            .collect(toImmutableList())
-            .as(StepVerifier::create)
-            .assertNext(list -> assertThat(list).containsExactly(2)),
-        Flux.just(3)
-            .collect(toCollection(ArrayList::new))
-            .as(StepVerifier::create)
-            .assertNext(list -> assertThat(list).containsExactly(4)));
+  StepVerifier.Step<?> testFluxAsStepVerifierExpectNext() {
+    return Flux.just(1)
+        .collect(toImmutableList())
+        .as(StepVerifier::create)
+        .assertNext(list -> assertThat(list).containsExactly(2));
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -422,12 +422,16 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNextMatches("qux"::equals));
   }
 
-  Duration testFluxAsStepVerifierExpectNext() {
-    return Flux.just(1)
-        .collect(toImmutableList())
-        .as(StepVerifier::create)
-        .assertNext(list -> assertThat(list).containsExactly(2))
-        .verifyComplete();
+  ImmutableSet<StepVerifier.Step<?>> testFluxAsStepVerifierExpectNext() {
+    return ImmutableSet.of(
+        Flux.just(1)
+            .collect(toImmutableList())
+            .as(StepVerifier::create)
+            .assertNext(list -> assertThat(list).containsExactly(2)),
+        Flux.just(3)
+            .collect(toCollection(ArrayList::new))
+            .as(StepVerifier::create)
+            .assertNext(list -> assertThat(list).containsExactly(4)));
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -413,6 +413,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNext("qux"));
   }
 
+  ImmutableSet<Duration> testFluxAsStepVerifierExpectNext() {
+    return ImmutableSet.of(
+        Flux.just(1).as(StepVerifier::create).expectNext(2).verifyComplete(),
+        Flux.just(3).as(StepVerifier::create).expectNext(4).verifyComplete());
+  }
+
   Duration testStepVerifierLastStepVerifyComplete() {
     return StepVerifier.create(Mono.empty()).verifyComplete();
   }
@@ -442,9 +448,5 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Duration testStepVerifierLastStepVerifyTimeout() {
     return StepVerifier.create(Mono.empty()).verifyTimeout(Duration.ZERO);
-  }
-
-  Duration testVerifyOnlyElementInFlux() {
-    return Flux.just(1).as(StepVerifier::create).expectNext(1).verifyComplete();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -413,8 +413,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNext("qux"));
   }
 
-  Duration testFluxAsStepVerifierExpectNext() {
-    return Flux.just(1).as(StepVerifier::create).expectNext(2).verifyComplete();
+  ImmutableSet<StepVerifier.Step<?>> testFluxAsStepVerifierExpectNext() {
+    return ImmutableSet.of(
+        Flux.just(1).as(StepVerifier::create).expectNext(2),
+        Flux.just(3).as(StepVerifier::create).expectNext(4));
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -413,10 +413,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNext("qux"));
   }
 
-  ImmutableSet<StepVerifier.Step<?>> testFluxAsStepVerifierExpectNext() {
-    return ImmutableSet.of(
-        Flux.just(1).as(StepVerifier::create).expectNext(2),
-        Flux.just(3).as(StepVerifier::create).expectNext(4));
+  StepVerifier.Step<?> testFluxAsStepVerifierExpectNext() {
+    return Flux.just(1).as(StepVerifier::create).expectNext(2);
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -413,10 +413,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.just("baz")).expectNext("qux"));
   }
 
-  ImmutableSet<Duration> testFluxAsStepVerifierExpectNext() {
-    return ImmutableSet.of(
-        Flux.just(1).as(StepVerifier::create).expectNext(2).verifyComplete(),
-        Flux.just(3).as(StepVerifier::create).expectNext(4).verifyComplete());
+  Duration testFluxAsStepVerifierExpectNext() {
+    return Flux.just(1).as(StepVerifier::create).expectNext(2).verifyComplete();
   }
 
   Duration testStepVerifierLastStepVerifyComplete() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -443,4 +443,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   Duration testStepVerifierLastStepVerifyTimeout() {
     return StepVerifier.create(Mono.empty()).verifyTimeout(Duration.ZERO);
   }
+
+  Duration testVerifyOnlyElementInFlux() {
+    return Flux.just(1).as(StepVerifier::create).expectNext(1).verifyComplete();
+  }
 }


### PR DESCRIPTION
When verifying a `Flux` only has one element, avoid collecting to list.

Notes:

1. The `@BeforeTemplate` is quite big, can it be a problem? I don't know if/how it can be reduced in size;
2. I am pretty sure the name of the rule is not the best, please suggest one that follows existing standards if you have better ideas;
3. It could be extended to `toImmutableSet` as well (see comment)
4. I used `flux.collect(toImmutableList())` instead of `flux.collectList()` because of the rule `FluxCollectToImmutableList`; 
5. How does it work if there is a match for this rule, but with `flux.collectList()`? Will error-prone perform "two passes" and first move `flux.collectList()` to `flux.collect(toImmutableList())` and then apply my rule?