### PR TITLE
Configure Renovate to pin GitHub Action digests

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -1,5 +1,8 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "helpers:pinGitHubActionDigests"
+  ],
   "packageRules": [
     {
       "matchPackagePatterns": [


### PR DESCRIPTION
Verified this against my local Renovate testing repository. Here are some examples:
```
-        uses: actions/checkout@v3.1.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.5.2
...
-        uses: actions/setup-java@v3.8.0
+        uses: actions/setup-java@5ffc13f4174014e2d4d4572b3d74c3fa61aeb2c2 # v3.11.0
```

So after we merge, we can retrigger Renovate and review the upgrade PRs.