### PR TITLE
Optimized reductant boxing a value

### DIFF
--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
@@ -139,7 +139,7 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
 
   private static CharSequence toSimpleFlatName(ClassSymbol symbol) {
     Name flatName = symbol.flatName();
-    int lastDot = flatName.lastIndexOf((byte) '.');
+    int lastDot = flatName.lastIndexOf('.');
     return lastDot < 0 ? flatName : flatName.subSequence(lastDot + 1, flatName.length());
   }
 

--- a/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
+++ b/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java
@@ -140,7 +140,7 @@ final class RefasterRuleCompilerTaskListener implements TaskListener {
   private static CharSequence toSimpleFlatName(ClassSymbol symbol) {
     Name flatName = symbol.flatName();
     int lastDot = flatName.lastIndexOf('.');
-    return lastDot < 0 ? flatName : flatName.subSequence(lastDot + 1, flatName.length());
+    return lastDot < 0 ? flatName.toString() : flatName.toString().subString(lastDot + 1);
   }
 
   private static void outputCodeTransformer(CodeTransformer codeTransformer, FileObject target)


### PR DESCRIPTION
The lastIndexOf method in Java is typically used to find the last occurrence of a character or substring within a string. 

Issue here : 
https://github.com/PicnicSupermarket/error-prone-support/blob/b81ec973a1eaabfcd2cc75735fc809ea9dcf8ff0/refaster-compiler/src/main/java/tech/picnic/errorprone/refaster/plugin/RefasterRuleCompilerTaskListener.java#L142


Attempting to find the last occurrence of the byte value representing a dot. It may cause unexpected behaviour.