### PR TITLE
Have Renovate split minor and patch upgrades for Maven API

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -6,6 +6,7 @@
   "packageRules": [
     {
       "matchPackagePatterns": [
+        "Maven API",
         "^org\\.springframework:spring-framework-bom$",
         "^org\\.springframework\\.boot:spring-boot[a-z-]*$"
       ],

--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -6,7 +6,7 @@
   "packageRules": [
     {
       "matchPackagePatterns": [
-        "Maven API",
+        "^Maven API$",
         "^org\\.springframework:spring-framework-bom$",
         "^org\\.springframework\\.boot:spring-boot[a-z-]*$"
       ],


### PR DESCRIPTION
Based on @Stephan202's comment https://github.com/PicnicSupermarket/error-prone-support/pull/434#issuecomment-1596054545. 

Tested this locally with the exact same property: 
![image](https://github.com/PicnicSupermarket/error-prone-support/assets/16152615/c7ecf6dc-77ce-4987-85f9-c2991444de3f)

I'm not sure whether we should add entries for the "human readable name" variant of these packages or leave it as is. @Badbond 