### PR TITLE
Introduce `MonoSingle` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -418,10 +418,7 @@ final class ReactorRules {
     }
   }
 
-  /**
-   * Don't unnecessarily transform a {@link Mono} to a {@link Flux} before calling {@link
-   * Mono#single()}.
-   */
+  /** Don't unnecessarily transform a {@link Mono} to a {@link Flux} to expect exactly one item. */
   static final class MonoSingle<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -418,6 +418,22 @@ final class ReactorRules {
     }
   }
 
+  /**
+   * Don't unnecessarily transform a {@link Mono} to a {@link Flux} before calling {@link
+   * Mono#single()}.
+   */
+  static final class MonoSingle<T> {
+    @BeforeTemplate
+    Mono<T> before(Mono<T> mono) {
+      return mono.flux().single();
+    }
+
+    @AfterTemplate
+    Mono<T> after(Mono<T> mono) {
+      return mono.single();
+    }
+  }
+
   /** Don't unnecessarily pass an empty publisher to {@link Flux#switchIfEmpty(Publisher)}. */
   static final class FluxSwitchIfEmptyOfEmptyPublisher<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -145,6 +145,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.<ImmutableList<String>>empty().map(ImmutableList::copyOf));
   }
 
+  Mono<Integer> testMonoSingle() {
+    return Mono.just(1).flux().single();
+  }
+
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
     return ImmutableSet.of(
         Flux.just(1).switchIfEmpty(Mono.empty()), Flux.just(2).switchIfEmpty(Flux.empty()));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -150,6 +150,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.<ImmutableList<String>>empty());
   }
 
+  Mono<Integer> testMonoSingle() {
+    return Mono.just(1).single();
+  }
+
   ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
     return ImmutableSet.of(Flux.just(1), Flux.just(2));
   }


### PR DESCRIPTION
Identified as part of the ongoing internal migration to `WebClient`.