### PR TITLE
Introduce `FluxCollect` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1180,6 +1180,19 @@ final class ReactorRules {
     }
   }
 
+  /* Don't unnecessarily invoke {@link Mono#single()} as {@link Flux#collect(Collector)} always yields one item. */
+  static final class FluxCollect<T, R> {
+    @BeforeTemplate
+    Mono<R> before(Flux<T> flux, Collector<T, ?, R> collector) {
+      return flux.collect(collector).single();
+    }
+
+    @AfterTemplate
+    Mono<R> after(Flux<T> flux, Collector<? super T, ?, R> collector) {
+      return flux.collect(collector);
+    }
+  }
+
   /**
    * Prefer {@link Flux#collect(Collector)} with {@link ImmutableList#toImmutableList()} over
    * alternatives that do not explicitly return an immutable collection.

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.MoreCollectors.toOptional;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Function.identity;
@@ -376,6 +377,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Flux<Integer> testFluxFilterSortWithComparator() {
     return Flux.just(1, 4, 3, 2).sort(reverseOrder()).filter(i -> i % 2 == 0);
+  }
+
+  Mono<ImmutableSet<Integer>> testFluxCollect() {
+    return Flux.just(1).collect(toImmutableSet()).single();
   }
 
   Mono<List<Integer>> testFluxCollectToImmutableList() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -371,6 +371,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).filter(i -> i % 2 == 0).sort(reverseOrder());
   }
 
+  Mono<ImmutableSet<Integer>> testFluxCollect() {
+    return Flux.just(1).collect(toImmutableSet());
+  }
+
   Mono<List<Integer>> testFluxCollectToImmutableList() {
     return Flux.just(1).collect(toImmutableList());
   }


### PR DESCRIPTION
As suggested by @Stephan202 in [this PR](https://github.com/PicnicSupermarket/error-prone-support/pull/703#issuecomment-1613280549).