### PR TITLE
StreamsTakeWhileFilter & FluxTakeWhileFilter

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/DoubleStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/DoubleStreamRules.java
@@ -277,4 +277,16 @@ final class DoubleStreamRules {
       return stream.allMatch(e -> test(e));
     }
   }
+
+  static final class DoubleStreamTakeWhile {
+    @BeforeTemplate
+    DoubleStream before(DoubleStream stream, DoublePredicate predicate) {
+      return stream.takeWhile(predicate).filter(predicate);
+    }
+
+    @AfterTemplate
+    DoubleStream after(DoubleStream stream, DoublePredicate predicate) {
+      return stream.takeWhile(predicate);
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/IntStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/IntStreamRules.java
@@ -290,4 +290,16 @@ final class IntStreamRules {
       return stream.allMatch(e -> test(e));
     }
   }
+
+  static final class IntStreamTakeWhile {
+    @BeforeTemplate
+    IntStream before(IntStream stream, IntPredicate predicate) {
+      return stream.takeWhile(predicate).filter(predicate);
+    }
+
+    @AfterTemplate
+    IntStream after(IntStream stream, IntPredicate predicate) {
+      return stream.takeWhile(predicate);
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java
@@ -290,4 +290,16 @@ final class LongStreamRules {
       return stream.allMatch(e -> test(e));
     }
   }
+
+  static final class LongStreamTakeWhile {
+    @BeforeTemplate
+    LongStream before(LongStream stream, LongPredicate predicate) {
+      return stream.takeWhile(predicate).filter(predicate);
+    }
+
+    @AfterTemplate
+    LongStream after(LongStream stream, LongPredicate predicate) {
+      return stream.takeWhile(predicate);
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1194,10 +1194,10 @@ final class ReactorRules {
   }
 
   /**
-   * Do not unnecessarily {@link Flux#filter(Predicate)} using the same {@link Predicate} that is
-   * used to {@link Flux#takeWhile(Predicate)}.
+   * Do not unnecessarily {@link Flux#filter(Predicate) filter} the result of {@link
+   * Flux#takeWhile(Predicate)} using the same {@link Predicate}.
    */
-  static final class FluxTakeWhileFilter<T> {
+  static final class FluxTakeWhile<T> {
     @BeforeTemplate
     Flux<T> before(Flux<T> flux, Predicate<? super T> predicate) {
       return flux.takeWhile(predicate).filter(predicate);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1194,6 +1194,22 @@ final class ReactorRules {
   }
 
   /**
+   * Do not unnecessarily {@link Flux#filter(Predicate)} using the same {@link Predicate} that is
+   * used to {@link Flux#takeWhile(Predicate)}.
+   */
+  static final class FluxTakeWhileFilter<T> {
+    @BeforeTemplate
+    Flux<T> before(Flux<T> flux, Predicate<? super T> predicate) {
+      return flux.takeWhile(predicate).filter(predicate);
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flux<T> flux, Predicate<? super T> predicate) {
+      return flux.takeWhile(predicate);
+    }
+  }
+
+  /**
    * Prefer {@link Flux#collect(Collector)} with {@link ImmutableList#toImmutableList()} over
    * alternatives that do not explicitly return an immutable collection.
    */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -640,7 +640,7 @@ final class StreamRules {
     }
   }
 
-  static final class StreamsTakeWhileFilter<T> {
+  static final class StreamTakeWhile<T> {
     @BeforeTemplate
     Stream<T> before(Stream<T> stream, Predicate<? super T> predicate) {
       return stream.takeWhile(predicate).filter(predicate);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -639,4 +639,16 @@ final class StreamRules {
       return Streams.concat(Refaster.asVarargs(stream));
     }
   }
+
+  static final class StreamsTakeWhileFilter<T> {
+    @BeforeTemplate
+    Stream<T> before(Stream<T> stream, Predicate<? super T> predicate) {
+      return stream.takeWhile(predicate).filter(predicate);
+    }
+
+    @AfterTemplate
+    Stream<T> after(Stream<T> stream, Predicate<? super T> predicate) {
+      return stream.takeWhile(predicate);
+    }
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestInput.java
@@ -96,4 +96,8 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
   boolean testDoubleStreamAllMatch2() {
     return DoubleStream.of(1).noneMatch(n -> !(n > 1));
   }
+
+  DoubleStream testDoubleStreamTakeWhile() {
+    return DoubleStream.of(1, 2, 3).takeWhile(i -> i < 2).filter(i -> i < 2);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestOutput.java
@@ -95,4 +95,8 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
   boolean testDoubleStreamAllMatch2() {
     return DoubleStream.of(1).allMatch(n -> n > 1);
   }
+
+  DoubleStream testDoubleStreamTakeWhile() {
+    return DoubleStream.of(1, 2, 3).takeWhile(i -> i < 2);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestInput.java
@@ -100,4 +100,8 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
   boolean testIntStreamAllMatch2() {
     return IntStream.of(1).noneMatch(n -> !(n > 1));
   }
+
+  IntStream testIntStreamTakeWhile() {
+    return IntStream.of(1, 2, 3).takeWhile(i -> i < 2).filter(i -> i < 2);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestOutput.java
@@ -99,4 +99,8 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
   boolean testIntStreamAllMatch2() {
     return IntStream.of(1).allMatch(n -> n > 1);
   }
+
+  IntStream testIntStreamTakeWhile() {
+    return IntStream.of(1, 2, 3).takeWhile(i -> i < 2);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestInput.java
@@ -100,4 +100,8 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
   boolean testLongStreamAllMatch2() {
     return LongStream.of(1).noneMatch(n -> !(n > 1));
   }
+
+  LongStream testLongStreamTakeWhile() {
+    return LongStream.of(1, 2, 3).takeWhile(i -> i < 2).filter(i -> i < 2);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestOutput.java
@@ -99,4 +99,8 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
   boolean testLongStreamAllMatch2() {
     return LongStream.of(1).allMatch(n -> n > 1);
   }
+
+  LongStream testLongStreamTakeWhile() {
+    return LongStream.of(1, 2, 3).takeWhile(i -> i < 2);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -382,7 +382,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).sort(reverseOrder()).filter(i -> i % 2 == 0);
   }
 
-  Flux<Integer> testFluxTakeWhileFilter() {
+  Flux<Integer> testFluxTakeWhile() {
     return Flux.just(1, 2, 3).takeWhile(i -> i % 2 == 0).filter(i -> i % 2 == 0);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -382,6 +382,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).sort(reverseOrder()).filter(i -> i % 2 == 0);
   }
 
+  Flux<Integer> testFluxTakeWhileFilter() {
+    return Flux.just(1, 2, 3).takeWhile(i -> i % 2 == 0).filter(i -> i % 2 == 0);
+  }
+
   Mono<List<Integer>> testFluxCollectToImmutableList() {
     return Flux.just(1).collectList();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -375,7 +375,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).filter(i -> i % 2 == 0).sort(reverseOrder());
   }
 
-  Flux<Integer> testFluxTakeWhileFilter() {
+  Flux<Integer> testFluxTakeWhile() {
     return Flux.just(1, 2, 3).takeWhile(i -> i % 2 == 0);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -375,6 +375,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1, 4, 3, 2).filter(i -> i % 2 == 0).sort(reverseOrder());
   }
 
+  Flux<Integer> testFluxTakeWhileFilter() {
+    return Flux.just(1, 2, 3).takeWhile(i -> i % 2 == 0);
+  }
+
   Mono<List<Integer>> testFluxCollectToImmutableList() {
     return Flux.just(1).collect(toImmutableList());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -258,4 +258,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of(Stream.of(1), Stream.of(2)).flatMap(identity()),
         Stream.of(Stream.of(3), Stream.of(4)).flatMap(v -> v));
   }
+
+  Stream<Integer> testStreamsTakeWhileFilter() {
+    return Stream.of(1, 2, 3).takeWhile(i -> i < 2).filter(i -> i < 2);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -259,7 +259,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of(Stream.of(3), Stream.of(4)).flatMap(v -> v));
   }
 
-  Stream<Integer> testStreamsTakeWhileFilter() {
+  Stream<Integer> testStreamTakeWhile() {
     return Stream.of(1, 2, 3).takeWhile(i -> i < 2).filter(i -> i < 2);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -259,7 +259,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Streams.concat(Stream.of(1), Stream.of(2)), Streams.concat(Stream.of(3), Stream.of(4)));
   }
 
-  Stream<Integer> testStreamsTakeWhileFilter() {
+  Stream<Integer> testStreamTakeWhile() {
     return Stream.of(1, 2, 3).takeWhile(i -> i < 2);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -258,4 +258,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Streams.concat(Stream.of(1), Stream.of(2)), Streams.concat(Stream.of(3), Stream.of(4)));
   }
+
+  Stream<Integer> testStreamsTakeWhileFilter() {
+    return Stream.of(1, 2, 3).takeWhile(i -> i < 2);
+  }
 }


### PR DESCRIPTION
* Refaster redundant `.filter()` operator in a `Flux` or a `Stream` after using the same predicate in `takeWhile` operator; Since the `takeWhile` short-circuits the stream once predicate is false.

Suggested commit message:
```
Introduce `StreamsTakeWhileFilter` & `FluxTakeWhileFilter` refaster rules (#727)
```