### PR TITLE
`DirectReturn` bugpattern clash with lombok's @Data

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -182,6 +182,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.projectlombok</groupId>
+            <artifactId>lombok</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>org.reactivestreams</groupId>
             <artifactId>reactive-streams</artifactId>
             <scope>provided</scope>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/DirectReturn.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/DirectReturn.java
@@ -12,7 +12,7 @@ import static com.google.errorprone.matchers.Matchers.returnStatement;
 import static com.google.errorprone.matchers.Matchers.staticMethod;
 import static com.google.errorprone.matchers.Matchers.toType;
 import static tech.picnic.errorprone.bugpatterns.util.Documentation.BUG_PATTERNS_BASE_URL;
-import static tech.picnic.errorprone.bugpatterns.util.MoreMatchers.isClassAnnotatedWithLombokData;
+import static tech.picnic.errorprone.bugpatterns.util.MoreMatchers.HAS_LOMBOK_DATA;
 
 import com.google.auto.service.AutoService;
 import com.google.common.collect.Streams;
@@ -62,8 +62,6 @@ public final class DirectReturn extends BugChecker implements BlockTreeMatcher {
       allOf(
           not(toType(MethodInvocationTree.class, argument(0, isSameType(Class.class.getName())))),
           staticMethod().onClass("org.mockito.Mockito").namedAnyOf("mock", "spy"));
-  private static final Matcher<ClassTree> IS_CLASS_ANNOTATED_WITH_LOMBOK_DATA =
-      isClassAnnotatedWithLombokData();
 
   /** Instantiates a new {@link DirectReturn} instance. */
   public DirectReturn() {}
@@ -72,8 +70,7 @@ public final class DirectReturn extends BugChecker implements BlockTreeMatcher {
   public Description matchBlock(BlockTree tree, VisitorState state) {
     List<? extends StatementTree> statements = tree.getStatements();
     ClassTree enclosingNode = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
-    if (statements.size() < 2
-        || IS_CLASS_ANNOTATED_WITH_LOMBOK_DATA.matches(enclosingNode, state)) {
+    if (statements.size() < 2 || HAS_LOMBOK_DATA.matches(enclosingNode, state)) {
       return Description.NO_MATCH;
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/DirectReturn.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/DirectReturn.java
@@ -69,8 +69,8 @@ public final class DirectReturn extends BugChecker implements BlockTreeMatcher {
   @Override
   public Description matchBlock(BlockTree tree, VisitorState state) {
     List<? extends StatementTree> statements = tree.getStatements();
-    ClassTree enclosingNode = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
-    if (statements.size() < 2 || HAS_LOMBOK_DATA.matches(enclosingNode, state)) {
+    ClassTree enclosingClass = ASTHelpers.findEnclosingNode(state.getPath(), ClassTree.class);
+    if (statements.size() < 2 || HAS_LOMBOK_DATA.matches(enclosingClass, state)) {
       return Description.NO_MATCH;
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchers.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchers.java
@@ -9,6 +9,7 @@ import com.google.errorprone.suppliers.Supplier;
 import com.sun.source.tree.AnnotationTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Type;
+import com.sun.source.tree.ClassTree;
 
 /**
  * A collection of general-purpose {@link Matcher}s.
@@ -16,6 +17,9 @@ import com.sun.tools.javac.code.Type;
  * <p>These methods are additions to the ones found in {@link Matchers}.
  */
 public final class MoreMatchers {
+  /** Matches classes annotated with Lombok's `@Data` annotation. */
+  public static final Matcher<ClassTree> HAS_LOMBOK_DATA = Matchers.hasAnnotation("lombok.Data");
+
   private MoreMatchers() {}
 
   /**

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchers.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchers.java
@@ -7,9 +7,9 @@ import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.suppliers.Supplier;
 import com.sun.source.tree.AnnotationTree;
+import com.sun.source.tree.ClassTree;
 import com.sun.source.tree.Tree;
 import com.sun.tools.javac.code.Type;
-import com.sun.source.tree.ClassTree;
 
 /**
  * A collection of general-purpose {@link Matcher}s.

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
@@ -225,14 +225,16 @@ final class DirectReturnTest {
   }
 
   @Test
-  void excludeClassesAnnotatedWithLombokData() {
+  void ignoreClassesAnnotatedWithLombokData() {
     BugCheckerRefactoringTestHelper.newInstance(DirectReturn.class, getClass())
+        .addInputLines("Data.java", "package lombok;", "public @interface Data {}")
+        .expectUnchanged()
         .addInputLines(
             "A.java",
             "import lombok.Data;",
             "",
             "@Data",
-            "public class A {",
+            "class A {",
             "  private String field;",
             "}")
         .addOutputLines(
@@ -240,7 +242,7 @@ final class DirectReturnTest {
             "import lombok.Data;",
             "",
             "@Data",
-            "public class A {",
+            "class A {",
             "  private String field;",
             "}")
         .doTest(TestMode.TEXT_MATCH);

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
@@ -226,10 +226,8 @@ final class DirectReturnTest {
 
   @Test
   void ignoreClassesAnnotatedWithLombokData() {
-    BugCheckerRefactoringTestHelper.newInstance(DirectReturn.class, getClass())
-        .addInputLines("Data.java", "package lombok;", "", "public @interface Data {}")
-        .expectUnchanged()
-        .addInputLines(
+    CompilationTestHelper.newInstance(DirectReturn.class, getClass())
+        .addSourceLines(
             "A.java",
             "import lombok.Data;",
             "",
@@ -237,14 +235,7 @@ final class DirectReturnTest {
             "class A {",
             "  private String field;",
             "}")
-        .addOutputLines(
-            "A.java",
-            "import lombok.Data;",
-            "",
-            "@Data",
-            "class A {",
-            "  private String field;",
-            "}")
-        .doTest(TestMode.TEXT_MATCH);
+        .expectNoDiagnostics()
+        .doTest();
   }
 }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
@@ -223,4 +223,26 @@ final class DirectReturnTest {
             "}")
         .doTest(TestMode.TEXT_MATCH);
   }
+
+  @Test
+  void excludeClassesAnnotatedWithLombokData() {
+    BugCheckerRefactoringTestHelper.newInstance(DirectReturn.class, getClass())
+        .addInputLines(
+            "A.java",
+            "import lombok.Data;",
+            "",
+            "@Data",
+            "public class A {",
+            "  private String field;",
+            "}")
+        .addOutputLines(
+            "A.java",
+            "import lombok.Data;",
+            "",
+            "@Data",
+            "public class A {",
+            "  private String field;",
+            "}")
+        .doTest(TestMode.TEXT_MATCH);
+  }
 }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
@@ -227,7 +227,7 @@ final class DirectReturnTest {
   @Test
   void ignoreClassesAnnotatedWithLombokData() {
     BugCheckerRefactoringTestHelper.newInstance(DirectReturn.class, getClass())
-        .addInputLines("Data.java", "package lombok;", "public @interface Data {}")
+        .addInputLines("Data.java", "package lombok;", "", "public @interface Data {}")
         .expectUnchanged()
         .addInputLines(
             "A.java",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
@@ -235,7 +235,6 @@ final class DirectReturnTest {
             "class A {",
             "  private String field;",
             "}")
-        .expectNoDiagnostics()
         .doTest();
   }
 }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/DirectReturnTest.java
@@ -227,6 +227,7 @@ final class DirectReturnTest {
   @Test
   void ignoreClassesAnnotatedWithLombokData() {
     CompilationTestHelper.newInstance(DirectReturn.class, getClass())
+        .setArgs("-processor", "lombok.launch.AnnotationProcessorHider$AnnotationProcessor")
         .addSourceLines(
             "A.java",
             "import lombok.Data;",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchersTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchersTest.java
@@ -26,7 +26,6 @@ final class MoreMatchersTest {
   @Test
   void hasLombokDataAnnotation() {
     CompilationTestHelper.newInstance(HasLombokDataTestChecker.class, getClass())
-        .addSourceLines("Data.java", "package lombok;", "", "public @interface Data {}")
         .addSourceLines(
             "A.java",
             "import lombok.Data;",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchersTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/util/MoreMatchersTest.java
@@ -110,7 +110,7 @@ final class MoreMatchersTest {
 @Test
   void hasLombokDataAnnotation() {
     CompilationTestHelper.newInstance(LombokDataAnnotationMatcher.class, getClass())
-        .addSourceLines("Data.java", "package lombok;", "public @interface Data {}")
+        .addSourceLines("Data.java", "package lombok;", "", "public @interface Data {}")
         .addSourceLines(
             "A.java",
             "import lombok.Data;",
@@ -120,13 +120,13 @@ final class MoreMatchersTest {
             "public class A {",
             "  private String field;",
             "",
-            "  static class B { }",
+            "  static class B {}",
             "",
             "  @Data",
             "  // BUG: Diagnostic contains:",
-            "  static class C { }",
+            "  static class C {}",
             "}")
-        .addSourceLines("D.java", "import lombok.Data;", "", "public class D { }")
+        .addSourceLines("D.java", "public class D {}")
         .doTest();
   }
 
@@ -159,7 +159,7 @@ final class MoreMatchersTest {
 }
 }
 
-  /** A {@link BugChecker} that delegates to {@link MoreMatchers#HAS_LOMBOK_DATA} . */
+  /** A {@link BugChecker} that delegates to {@link MoreMatchers#HAS_LOMBOK_DATA}. */
   @BugPattern(summary = "Interacts with `MoreMatchers` for testing purposes", severity = ERROR)
   public static final class LombokDataAnnotationMatcher extends BugChecker
       implements ClassTreeMatcher {

--- a/pom.xml
+++ b/pom.xml
@@ -457,6 +457,11 @@
                 </exclusions>
             </dependency>
             <dependency>
+                <groupId>org.projectlombok</groupId>
+                <artifactId>lombok</artifactId>
+                <version>1.18.28</version>
+            </dependency>
+            <dependency>
                 <groupId>org.slf4j</groupId>
                 <artifactId>slf4j-api</artifactId>
                 <version>2.0.7</version>


### PR DESCRIPTION
Suggested commit message:
```
Have `DirectReturn` ignore classes annotated with Lombok's `@Data` (#728)

While there, introduce the `MoreMatchers#HAS_LOMBOK_DATA` matcher.
```

**TL;DR `DirectReturn` bug pattern (If not all bug patterns that use replacements) detects bugs for generated resources, but replaces the suggested fixes in the original source code.**

Notes 📝 
This is the generated class from the project associated with this ticket. (#716 )
```
public class AnyClass {
    private String anything;

    @java.lang.SuppressWarnings(value = "all")
    public AnyClass() {
        super();
    }

    @java.lang.SuppressWarnings(value = "all")
    public String getAnything() {
        return this.anything;
    }

    @java.lang.SuppressWarnings(value = "all")
    public void setAnything(final String anything) {
        this.anything = anything;
    }

    @java.lang.Override
    @java.lang.SuppressWarnings(value = "all")
    public boolean equals(final java.lang.Object o) {
        if (o == this) return true;
        if (!(o instanceof AnyClass)) return false;
        final AnyClass other = (AnyClass)o;
        if (!other.canEqual((java.lang.Object)this)) return false;
        final java.lang.Object this$anything = this.getAnything();
        final java.lang.Object other$anything = other.getAnything();
        if (this$anything == null ? other$anything != null : !this$anything.equals(other$anything)) return false;
        return true;
    }

    @java.lang.SuppressWarnings(value = "all")
    protected boolean canEqual(final java.lang.Object other) {
        return other instanceof AnyClass;
    }

    @java.lang.Override
    @java.lang.SuppressWarnings(value = "all")
    public int hashCode() {
        final int PRIME = 59;
        int result = 1;
        final java.lang.Object $anything = this.getAnything();
        result = result * PRIME + ($anything == null ? 43 : $anything.hashCode());
        return result;
    }

    @java.lang.Override
    @java.lang.SuppressWarnings(value = "all")
    public java.lang.String toString() {
        return "AnyClass(anything=" + this.getAnything() + ")";
    }
}
```

The issue seems to be when `DirectReturn` tries to optimize line 
```
        result = result * PRIME + ($anything == null ? 43 : $anything.hashCode());
```
in the `hashCode` method.

Due to the (helper?) methods used inside `DirectReturn` error prone parses and tries to replace the "source code" (The original annotated class) and not the generated resource.


**Fix:**

1. Ignore files that are using `@Data` annotation. (See [this](https://github.com/PicnicSupermarket/error-prone-support/pull/728#pullrequestreview-1544783907))
~~2. Force `DirectReturn` to replace the generated sources instead of source code, but:
  a. Should Error prone change generated files or files of other libraries ?
  b. I dont know how to do that (Any references would be helpful 😄 )~~