### PR TITLE
Fix typos in `CanonicalSyntaxAnnotation.java`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
@@ -91,8 +91,8 @@ public final class CanonicalAnnotationSyntax extends BugChecker implements Annot
     ExpressionTree arg = args.get(0);
     if (state.getSourceForNode(arg) == null) {
       /*
-       * The annotation argument doesn't have a source representation, e.g. because `value`
-       * isn't assigned explicitly.
+       * The annotation argument doesn't have a source representation, e.g. because `value` isn't
+       * assigned explicitly.
        */
       return Optional.empty();
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CanonicalAnnotationSyntax.java
@@ -91,8 +91,8 @@ public final class CanonicalAnnotationSyntax extends BugChecker implements Annot
     ExpressionTree arg = args.get(0);
     if (state.getSourceForNode(arg) == null) {
       /*
-       * The annotation argument isn't doesn't have a source representation, e.g. because `value`
-       * isn't assigned to explicitly.
+       * The annotation argument doesn't have a source representation, e.g. because `value`
+       * isn't assigned explicitly.
        */
       return Optional.empty();
     }


### PR DESCRIPTION
Had these on my list and wanted to fix it.