### PR TITLE
Introduce `PatternRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -155,6 +155,7 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
   @VisibleForTesting
   static final ImmutableSetMultimap<String, String> STATIC_IMPORT_EXEMPTED_MEMBERS =
       ImmutableSetMultimap.<String, String>builder()
+          .put("com.google.common.base.Predicates", "contains")
           .put("com.mongodb.client.model.Filters", "empty")
           .putAll(
               "java.util.Collections",

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PatternRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PatternRules.java
@@ -1,0 +1,46 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static com.google.common.base.Predicates.containsPattern;
+
+import com.google.common.base.Predicates;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
+
+/** Refaster rules related to code dealing with regular expressions. */
+@OnlineDocumentation
+final class PatternRules {
+  private PatternRules() {}
+
+  /** Prefer {@link Pattern#asPredicate()} over non-JDK alternatives. */
+  // XXX: This rule could also replace `s -> pattern.matcher(s).find()`, though the lambda
+  // expression may match functional interfaces other than `Predicate`. If we do add such a rule, we
+  // should also add a rule that replaces `s -> pattern.matcher(s).matches()` with
+  // `pattern.asMatchPredicate()`.
+  static final class PatternAsPredicate {
+    @BeforeTemplate
+    Predicate<CharSequence> before(Pattern pattern) {
+      return Predicates.contains(pattern);
+    }
+
+    @AfterTemplate
+    Predicate<String> after(Pattern pattern) {
+      return pattern.asPredicate();
+    }
+  }
+
+  /** Prefer {@link Pattern#asPredicate()} over non-JDK alternatives. */
+  static final class PatternCompileAsPredicate {
+    @BeforeTemplate
+    Predicate<CharSequence> before(String pattern) {
+      return containsPattern(pattern);
+    }
+
+    @AfterTemplate
+    Predicate<String> after(String pattern) {
+      return Pattern.compile(pattern).asPredicate();
+    }
+  }
+}

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/AmbiguousJsonCreatorTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/AmbiguousJsonCreatorTest.java
@@ -1,7 +1,5 @@
 package tech.picnic.errorprone.bugpatterns;
 
-import static com.google.common.base.Predicates.containsPattern;
-
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
@@ -12,7 +10,7 @@ final class AmbiguousJsonCreatorTest {
   void identification() {
     CompilationTestHelper.newInstance(AmbiguousJsonCreator.class, getClass())
         .expectErrorMessage(
-            "X", containsPattern("`JsonCreator.Mode` should be set for single-argument creators"))
+            "X", m -> m.contains("`JsonCreator.Mode` should be set for single-argument creators"))
         .addSourceLines(
             "Container.java",
             "import com.fasterxml.jackson.annotation.JsonCreator;",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/FluxImplicitBlockTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/FluxImplicitBlockTest.java
@@ -1,14 +1,12 @@
 package tech.picnic.errorprone.bugpatterns;
 
-import static com.google.common.base.Predicates.and;
-import static com.google.common.base.Predicates.containsPattern;
-import static com.google.common.base.Predicates.not;
 import static com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers.SECOND;
 import static com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers.THIRD;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 import org.reactivestreams.Publisher;
 import reactor.core.CorePublisher;
@@ -20,10 +18,7 @@ final class FluxImplicitBlockTest {
     CompilationTestHelper.newInstance(FluxImplicitBlock.class, getClass())
         .expectErrorMessage(
             "X",
-            and(
-                containsPattern("SuppressWarnings"),
-                containsPattern("toImmutableList"),
-                containsPattern("toList")))
+            m -> Stream.of("SuppressWarnings", "toImmutableList", "toList").allMatch(m::contains))
         .addSourceLines(
             "A.java",
             "import com.google.common.collect.ImmutableList;",
@@ -63,7 +58,7 @@ final class FluxImplicitBlockTest {
   void identificationWithoutGuavaOnClasspath() {
     CompilationTestHelper.newInstance(FluxImplicitBlock.class, getClass())
         .withClasspath(CorePublisher.class, Flux.class, Publisher.class)
-        .expectErrorMessage("X", not(containsPattern("toImmutableList")))
+        .expectErrorMessage("X", m -> !m.contains("toImmutableList"))
         .addSourceLines(
             "A.java",
             "import reactor.core.publisher.Flux;",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StringJoinTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StringJoinTest.java
@@ -1,7 +1,5 @@
 package tech.picnic.errorprone.bugpatterns;
 
-import static com.google.common.base.Predicates.containsPattern;
-
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.CompilationTestHelper;
@@ -12,8 +10,8 @@ final class StringJoinTest {
   void identification() {
     CompilationTestHelper.newInstance(StringJoin.class, getClass())
         .expectErrorMessage(
-            "valueOf", containsPattern("Prefer `String#valueOf` over `String#format`"))
-        .expectErrorMessage("join", containsPattern("Prefer `String#join` over `String#format`"))
+            "valueOf", m -> m.contains("Prefer `String#valueOf` over `String#format`"))
+        .expectErrorMessage("join", m -> m.contains("Prefer `String#join` over `String#format`"))
         .addSourceLines(
             "A.java",
             "import java.util.Formattable;",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -61,6 +61,7 @@ final class RefasterRulesTest {
           MultimapRules.class,
           NullRules.class,
           OptionalRules.class,
+          PatternRules.class,
           PreconditionsRules.class,
           PrimitiveRules.class,
           ReactorRules.class,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PatternRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PatternRulesTestInput.java
@@ -1,0 +1,22 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class PatternRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<Object> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Predicates.class);
+  }
+
+  Predicate<?> testPatternAsPredicate() {
+    return Predicates.contains(Pattern.compile("foo"));
+  }
+
+  Predicate<?> testPatternCompileAsPredicate() {
+    return Predicates.containsPattern("foo");
+  }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PatternRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PatternRulesTestOutput.java
@@ -1,0 +1,22 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.common.base.Predicates;
+import com.google.common.collect.ImmutableSet;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class PatternRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<Object> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Predicates.class);
+  }
+
+  Predicate<?> testPatternAsPredicate() {
+    return Pattern.compile("foo").asPredicate();
+  }
+
+  Predicate<?> testPatternCompileAsPredicate() {
+    return Pattern.compile("foo").asPredicate();
+  }
+}


### PR DESCRIPTION
Suggested commit message:
```
Introduce `PatternRules` Refaster rule collection (#771)

While there, configure `StaticImport` to not require static importing of
`com.google.common.base.Predicates.contains`.

The new rules triggered cleanup of some `CompilationTestHelper` usages.

See google/guava#6483.
```