### PR TITLE
Upgrade JDKs used by GitHub Actions builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,7 +42,7 @@ Please replace this sentence with log output, if applicable.
 <!-- Please complete the following information: -->
 
 - Operating system (e.g. MacOS Monterey).
-- Java version (i.e. `java --version`, e.g. `17.0.7`).
+- Java version (i.e. `java --version`, e.g. `17.0.8`).
 - Error Prone version (e.g. `2.18.0`).
 - Error Prone Support version (e.g. `0.9.0`).
 

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,16 +10,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        jdk: [ 11.0.19, 17.0.7, 20.0.1 ]
+        jdk: [ 11.0.20, 17.0.8, 20.0.2 ]
         distribution: [ temurin ]
         experimental: [ false ]
         include:
           - os: macos-12
-            jdk: 17.0.7
+            jdk: 17.0.8
             distribution: temurin
             experimental: false
           - os: windows-2022
-            jdk: 17.0.7
+            jdk: 17.0.8
             distribution: temurin
             experimental: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
-          java-version: 17.0.7
+          java-version: 17.0.8
           distribution: temurin
           cache: maven
       - name: Initialize CodeQL

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
-          java-version: 17.0.7
+          java-version: 17.0.8
           distribution: temurin
           cache: maven
       - name: Run Pitest

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
-          java-version: 17.0.7
+          java-version: 17.0.8
           distribution: temurin
           cache: maven
       - name: Download Pitest analysis artifact

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Set up JDK
         uses: actions/setup-java@0ab4596768b603586c0de567f2430c30f5b0d2b0 # v3.13.0
         with:
-          java-version: 17.0.7
+          java-version: 17.0.8
           distribution: temurin
           cache: maven
       - name: Create missing `test` directory


### PR DESCRIPTION
Suggested commit message:
```
Upgrade JDKs used by GitHub Actions builds (#780)

Summary of changes:
- Use JDK 11.0.20 instead of 11.0.19.
- Use JDK 17.0.8 instead of 17.0.7.
- Use JDK 20.0.2 instead of 20.0.1.

See:
- https://www.oracle.com/java/technologies/javase/11-0-20-relnotes.html
- https://www.oracle.com/java/technologies/javase/17-0-8-relnotes.html
- https://www.oracle.com/java/technologies/javase/20-0-2-relnotes.html
```