### PR TITLE
Introduce `{Mono,Flux}OfType` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1053,6 +1053,40 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link Mono#ofType(Class)} over more contrived alternatives. */
+  static final class MonoOfType<T, S> {
+    @BeforeTemplate
+    Mono<S> before(Mono<T> mono) {
+      return mono.filter(
+              Refaster.anyOf(
+                  Refaster.<S>clazz()::isInstance,
+                  x -> Refaster.<S>clazz().isAssignableFrom(x.getClass())))
+          .cast(Refaster.<S>clazz());
+    }
+
+    @AfterTemplate
+    Mono<S> after(Mono<T> mono) {
+      return mono.ofType(Refaster.<S>clazz());
+    }
+  }
+
+  /** Prefer {@link Flux#ofType(Class)} over more contrived alternatives. */
+  static final class FluxOfType<T, S> {
+    @BeforeTemplate
+    Flux<S> before(Flux<T> flux) {
+      return flux.filter(
+              Refaster.anyOf(
+                  Refaster.<S>clazz()::isInstance,
+                  x -> Refaster.<S>clazz().isAssignableFrom(x.getClass())))
+          .cast(Refaster.<S>clazz());
+    }
+
+    @AfterTemplate
+    Flux<S> after(Flux<T> flux) {
+      return flux.ofType(Refaster.<S>clazz());
+    }
+  }
+
   /** Prefer {@link Mono#flatMap(Function)} over more contrived alternatives. */
   static final class MonoFlatMap<S, T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1056,34 +1056,26 @@ final class ReactorRules {
   /** Prefer {@link Mono#ofType(Class)} over more contrived alternatives. */
   static final class MonoOfType<T, S> {
     @BeforeTemplate
-    Mono<S> before(Mono<T> mono) {
-      return mono.filter(
-              Refaster.anyOf(
-                  Refaster.<S>clazz()::isInstance,
-                  x -> Refaster.<S>clazz().isAssignableFrom(x.getClass())))
-          .cast(Refaster.<S>clazz());
+    Mono<S> before(Mono<T> mono, Class<S> clazz) {
+      return mono.filter(clazz::isInstance).cast(clazz);
     }
 
     @AfterTemplate
-    Mono<S> after(Mono<T> mono) {
-      return mono.ofType(Refaster.<S>clazz());
+    Mono<S> after(Mono<T> mono, Class<S> clazz) {
+      return mono.ofType(clazz);
     }
   }
 
   /** Prefer {@link Flux#ofType(Class)} over more contrived alternatives. */
   static final class FluxOfType<T, S> {
     @BeforeTemplate
-    Flux<S> before(Flux<T> flux) {
-      return flux.filter(
-              Refaster.anyOf(
-                  Refaster.<S>clazz()::isInstance,
-                  x -> Refaster.<S>clazz().isAssignableFrom(x.getClass())))
-          .cast(Refaster.<S>clazz());
+    Flux<S> before(Flux<T> flux, Class<S> clazz) {
+      return flux.filter(clazz::isInstance).cast(clazz);
     }
 
     @AfterTemplate
-    Flux<S> after(Flux<T> flux) {
-      return flux.ofType(Refaster.<S>clazz());
+    Flux<S> after(Flux<T> flux, Class<S> clazz) {
+      return flux.ofType(clazz);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -364,16 +364,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
-  ImmutableSet<Mono<Number>> testMonoOfType() {
-    return ImmutableSet.of(
-        Mono.just(1).filter(Number.class::isInstance).cast(Number.class),
-        Mono.just(2).filter(n -> Number.class.isAssignableFrom(n.getClass())).cast(Number.class));
+  Mono<Number> testMonoOfType() {
+    return Mono.just(1).filter(Number.class::isInstance).cast(Number.class);
   }
 
-  ImmutableSet<Flux<Number>> testFluxOfType() {
-    return ImmutableSet.of(
-        Flux.just(1).filter(Number.class::isInstance).cast(Number.class),
-        Flux.just(2).filter(n -> Number.class.isAssignableFrom(n.getClass())).cast(Number.class));
+  Flux<Number> testFluxOfType() {
+    return Flux.just(1).filter(Number.class::isInstance).cast(Number.class);
   }
 
   Mono<String> testMonoFlatMap() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -364,6 +364,18 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).map(Number.class::cast);
   }
 
+  ImmutableSet<Mono<Number>> testMonoOfType() {
+    return ImmutableSet.of(
+        Mono.just(1).filter(Number.class::isInstance).cast(Number.class),
+        Mono.just(2).filter(n -> Number.class.isAssignableFrom(n.getClass())).cast(Number.class));
+  }
+
+  ImmutableSet<Flux<Number>> testFluxOfType() {
+    return ImmutableSet.of(
+        Flux.just(1).filter(Number.class::isInstance).cast(Number.class),
+        Flux.just(2).filter(n -> Number.class.isAssignableFrom(n.getClass())).cast(Number.class));
+  }
+
   Mono<String> testMonoFlatMap() {
     return Mono.just("foo").map(Mono::just).flatMap(identity());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -357,6 +357,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
+  ImmutableSet<Mono<Number>> testMonoOfType() {
+    return ImmutableSet.of(Mono.just(1).ofType(Number.class), Mono.just(2).ofType(Number.class));
+  }
+
+  ImmutableSet<Flux<Number>> testFluxOfType() {
+    return ImmutableSet.of(Flux.just(1).ofType(Number.class), Flux.just(2).ofType(Number.class));
+  }
+
   Mono<String> testMonoFlatMap() {
     return Mono.just("foo").flatMap(Mono::just);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -357,12 +357,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).cast(Number.class);
   }
 
-  ImmutableSet<Mono<Number>> testMonoOfType() {
-    return ImmutableSet.of(Mono.just(1).ofType(Number.class), Mono.just(2).ofType(Number.class));
+  Mono<Number> testMonoOfType() {
+    return Mono.just(1).ofType(Number.class);
   }
 
-  ImmutableSet<Flux<Number>> testFluxOfType() {
-    return ImmutableSet.of(Flux.just(1).ofType(Number.class), Flux.just(2).ofType(Number.class));
+  Flux<Number> testFluxOfType() {
+    return Flux.just(1).ofType(Number.class);
   }
 
   Mono<String> testMonoFlatMap() {


### PR DESCRIPTION
Since semantically this should be equivalent.

Suggested commit message:
```
Introduce `{Mono,Flux}OfType` Refaster rules (#810)
```
