### PR TITLE
Introduce assorted `BigDecimal#signum` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -68,8 +68,8 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
-  static final class BigDecimalCompareToZero {
+  /** Prefer using {@link BigDecimal#signum()} over more contrived alternatives. */
+  static final class BigDecimalSignumIsZero {
     @BeforeTemplate
     boolean before(BigDecimal value) {
       return Refaster.anyOf(
@@ -83,30 +83,38 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer using {@link BigDecimal#signum()} over more contrived alternatives. */
-  static final class BigDecimalCompareToZeroPositive {
+  /**
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
+   * alternatives.
+   */
+  static final class BigDecimalSignumIsPositive {
     @BeforeTemplate
     boolean before(BigDecimal value) {
       return Refaster.anyOf(
           value.compareTo(BigDecimal.ZERO) > 0,
           BigDecimal.ZERO.compareTo(value) < 0,
-          value.signum() > 0,
-          value.signum() >= 1,
-          value.signum() != -1);
+          value.signum() == 1,
+          value.signum() >= 1);
     }
 
     @AfterTemplate
     boolean after(BigDecimal value) {
-      return value.signum() == 1;
+      return value.signum() > 0;
     }
   }
 
-  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
-  static final class BigDecimalCompareToZeroPositiveInclusive {
+  /**
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
+   * alternatives.
+   */
+  static final class BigDecimalSignumIsNonnegative {
     @BeforeTemplate
     boolean before(BigDecimal value) {
       return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) >= 0, BigDecimal.ZERO.compareTo(value) <= 0);
+          value.compareTo(BigDecimal.ZERO) >= 0,
+          BigDecimal.ZERO.compareTo(value) <= 0,
+          value.signum() != -1,
+          value.signum() > -1);
     }
 
     @AfterTemplate
@@ -115,44 +123,43 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
-  static final class BigDecimalCompareToZeroNegative {
+  /**
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
+   * alternatives.
+   */
+  static final class BigDecimalSignumIsNegative {
     @BeforeTemplate
     boolean before(BigDecimal value) {
       return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) < 0, BigDecimal.ZERO.compareTo(value) > 0);
+          value.compareTo(BigDecimal.ZERO) < 0,
+          BigDecimal.ZERO.compareTo(value) > 0,
+          value.signum() == -1,
+          value.signum() <= -1);
     }
 
     @AfterTemplate
     boolean after(BigDecimal value) {
-      return value.signum() == -1;
+      return value.signum() < 0;
     }
   }
 
-  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
-  static final class BigDecimalCompareToZeroNegativeInclusive {
+  /**
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
+   * alternatives.
+   */
+  static final class BigDecimalSignumIsNonpositive {
     @BeforeTemplate
     boolean before(BigDecimal value) {
       return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) <= 0, BigDecimal.ZERO.compareTo(value) >= 0);
+          value.compareTo(BigDecimal.ZERO) <= 0,
+          BigDecimal.ZERO.compareTo(value) >= 0,
+          value.signum() != 1,
+          value.signum() < 1);
     }
 
     @AfterTemplate
     boolean after(BigDecimal value) {
       return value.signum() <= 0;
-    }
-  }
-
-  /** {@link BigDecimal#signum()} does not produce values lower than {@code -1}. */
-  static final class BigDecimalNegativeSignum {
-    @BeforeTemplate
-    boolean before(BigDecimal value) {
-      return Refaster.anyOf(value.signum() < 0, value.signum() <= -1, value.signum() != 1);
-    }
-
-    @AfterTemplate
-    boolean after(BigDecimal value) {
-      return value.signum() == -1;
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -84,7 +84,7 @@ final class BigDecimalRules {
   }
 
   /**
-   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
+   * Prefer a {@link BigDecimal#signum()} comparison to 1 over more contrived or less clear
    * alternatives.
    */
   static final class BigDecimalSignumIsPositive {
@@ -93,19 +93,19 @@ final class BigDecimalRules {
       return Refaster.anyOf(
           value.compareTo(BigDecimal.ZERO) > 0,
           BigDecimal.ZERO.compareTo(value) < 0,
-          value.signum() == 1,
+          value.signum() > 0,
           value.signum() >= 1);
     }
 
     @AfterTemplate
     @AlsoNegation
     boolean after(BigDecimal value) {
-      return value.signum() > 0;
+      return value.signum() == 1;
     }
   }
 
   /**
-   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
+   * Prefer a {@link BigDecimal#signum()} comparison to -1 over more contrived or less clear
    * alternatives.
    */
   static final class BigDecimalSignumIsNegative {
@@ -114,14 +114,14 @@ final class BigDecimalRules {
       return Refaster.anyOf(
           value.compareTo(BigDecimal.ZERO) < 0,
           BigDecimal.ZERO.compareTo(value) > 0,
-          value.signum() == -1,
+          value.signum() < 0,
           value.signum() <= -1);
     }
 
     @AfterTemplate
     @AlsoNegation
     boolean after(BigDecimal value) {
-      return value.signum() < 0;
+      return value.signum() == -1;
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -98,28 +98,9 @@ final class BigDecimalRules {
     }
 
     @AfterTemplate
+    @AlsoNegation
     boolean after(BigDecimal value) {
       return value.signum() > 0;
-    }
-  }
-
-  /**
-   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
-   * alternatives.
-   */
-  static final class BigDecimalSignumIsNonnegative {
-    @BeforeTemplate
-    boolean before(BigDecimal value) {
-      return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) >= 0,
-          BigDecimal.ZERO.compareTo(value) <= 0,
-          value.signum() != -1,
-          value.signum() > -1);
-    }
-
-    @AfterTemplate
-    boolean after(BigDecimal value) {
-      return value.signum() >= 0;
     }
   }
 
@@ -138,28 +119,9 @@ final class BigDecimalRules {
     }
 
     @AfterTemplate
+    @AlsoNegation
     boolean after(BigDecimal value) {
       return value.signum() < 0;
-    }
-  }
-
-  /**
-   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less clear
-   * alternatives.
-   */
-  static final class BigDecimalSignumIsNonpositive {
-    @BeforeTemplate
-    boolean before(BigDecimal value) {
-      return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) <= 0,
-          BigDecimal.ZERO.compareTo(value) >= 0,
-          value.signum() != 1,
-          value.signum() < 1);
-    }
-
-    @AfterTemplate
-    boolean after(BigDecimal value) {
-      return value.signum() <= 0;
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -66,4 +66,114 @@ final class BigDecimalRules {
       return BigDecimal.valueOf(value);
     }
   }
+
+  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
+  static final class BigDecimalCompareToZero {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(
+          value.compareTo(BigDecimal.ZERO) == 0, BigDecimal.ZERO.compareTo(value) == 0);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() == 0;
+    }
+  }
+
+  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
+  static final class BigDecimalCompareToNonZero {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(
+          value.compareTo(BigDecimal.ZERO) != 0, BigDecimal.ZERO.compareTo(value) != 0);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() != 0;
+    }
+  }
+
+  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
+  static final class BigDecimalCompareToZeroPositive {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(
+          value.compareTo(BigDecimal.ZERO) > 0, BigDecimal.ZERO.compareTo(value) < 0);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() == 1;
+    }
+  }
+
+  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
+  static final class BigDecimalCompareToZeroPositiveInclusive {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(
+          value.compareTo(BigDecimal.ZERO) >= 0, BigDecimal.ZERO.compareTo(value) <= 0);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() >= 0;
+    }
+  }
+
+  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
+  static final class BigDecimalCompareToZeroNegative {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(
+          value.compareTo(BigDecimal.ZERO) < 0, BigDecimal.ZERO.compareTo(value) > 0);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() == -1;
+    }
+  }
+
+  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
+  static final class BigDecimalCompareToZeroNegativeInclusive {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(
+          value.compareTo(BigDecimal.ZERO) <= 0, BigDecimal.ZERO.compareTo(value) >= 0);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() <= 0;
+    }
+  }
+
+  /** {@link BigDecimal#signum()} does not produce values higher than {@code 1}. */
+  static final class BigDecimalPositiveSignum {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(value.signum() > 0, value.signum() >= 1, value.signum() != -1);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() == 1;
+    }
+  }
+
+  /** {@link BigDecimal#signum()} does not produce values lower than {@code -1}. */
+  static final class BigDecimalNegativeSignum {
+    @BeforeTemplate
+    boolean before(BigDecimal value) {
+      return Refaster.anyOf(value.signum() < 0, value.signum() <= -1, value.signum() != 1);
+    }
+
+    @AfterTemplate
+    boolean after(BigDecimal value) {
+      return value.signum() == -1;
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -2,6 +2,7 @@ package tech.picnic.errorprone.refasterrules;
 
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import java.math.BigDecimal;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -76,31 +77,22 @@ final class BigDecimalRules {
     }
 
     @AfterTemplate
+    @AlsoNegation
     boolean after(BigDecimal value) {
       return value.signum() == 0;
     }
   }
 
-  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
-  static final class BigDecimalCompareToNonZero {
-    @BeforeTemplate
-    boolean before(BigDecimal value) {
-      return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) != 0, BigDecimal.ZERO.compareTo(value) != 0);
-    }
-
-    @AfterTemplate
-    boolean after(BigDecimal value) {
-      return value.signum() != 0;
-    }
-  }
-
-  /** Prefer using {@link BigDecimal#signum()} over comparing to {@link BigDecimal#ZERO}. */
+  /** Prefer using {@link BigDecimal#signum()} over more contrived alternatives. */
   static final class BigDecimalCompareToZeroPositive {
     @BeforeTemplate
     boolean before(BigDecimal value) {
       return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) > 0, BigDecimal.ZERO.compareTo(value) < 0);
+          value.compareTo(BigDecimal.ZERO) > 0,
+          BigDecimal.ZERO.compareTo(value) < 0,
+          value.signum() > 0,
+          value.signum() >= 1,
+          value.signum() != -1);
     }
 
     @AfterTemplate
@@ -148,19 +140,6 @@ final class BigDecimalRules {
     @AfterTemplate
     boolean after(BigDecimal value) {
       return value.signum() <= 0;
-    }
-  }
-
-  /** {@link BigDecimal#signum()} does not produce values higher than {@code 1}. */
-  static final class BigDecimalPositiveSignum {
-    @BeforeTemplate
-    boolean before(BigDecimal value) {
-      return Refaster.anyOf(value.signum() > 0, value.signum() >= 1, value.signum() != -1);
-    }
-
-    @AfterTemplate
-    boolean after(BigDecimal value) {
-      return value.signum() == 1;
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -21,7 +21,7 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(new BigDecimal(2), new BigDecimal(2L), new BigDecimal(2.0));
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZero() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsZero() {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) == 0,
         BigDecimal.ZERO.compareTo(BigDecimal.ONE) == 0,
@@ -29,37 +29,35 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
         BigDecimal.ZERO.compareTo(BigDecimal.ONE) != 0);
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositive() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsPositive() {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) > 0,
         BigDecimal.ZERO.compareTo(BigDecimal.ONE) < 0,
-        BigDecimal.ZERO.signum() > 0,
-        BigDecimal.ZERO.signum() >= 1,
-        BigDecimal.ZERO.signum() != -1);
+        BigDecimal.ZERO.signum() == 1,
+        BigDecimal.ZERO.signum() >= 1);
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositiveInclusive() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsNonnegative() {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) >= 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) <= 0);
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) <= 0,
+        BigDecimal.ZERO.signum() != -1,
+        BigDecimal.ZERO.signum() > -1);
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegative() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsNegative() {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) < 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) > 0);
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) > 0,
+        BigDecimal.ZERO.signum() == -1,
+        BigDecimal.ZERO.signum() <= -1);
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegativeInclusive() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsNonpositive() {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) <= 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) >= 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalNegativeSignum() {
-    return ImmutableSet.of(
-        BigDecimal.ZERO.signum() < 0,
-        BigDecimal.ZERO.signum() <= -1,
-        BigDecimal.ZERO.signum() != 1);
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) >= 0,
+        BigDecimal.ZERO.signum() != 1,
+        BigDecimal.ZERO.signum() < 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -34,15 +34,11 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) > 0,
         BigDecimal.ZERO.compareTo(BigDecimal.ONE) < 0,
         BigDecimal.ZERO.signum() == 1,
-        BigDecimal.ZERO.signum() >= 1);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalSignumIsNonnegative() {
-    return ImmutableSet.of(
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) >= 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) <= 0,
-        BigDecimal.ZERO.signum() != -1,
-        BigDecimal.ZERO.signum() > -1);
+        BigDecimal.ZERO.signum() >= 1,
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) <= 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) >= 0,
+        BigDecimal.ZERO.signum() != 1,
+        BigDecimal.ZERO.signum() < 1);
   }
 
   ImmutableSet<Boolean> testBigDecimalSignumIsNegative() {
@@ -50,14 +46,10 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) < 0,
         BigDecimal.ZERO.compareTo(BigDecimal.ONE) > 0,
         BigDecimal.ZERO.signum() == -1,
-        BigDecimal.ZERO.signum() <= -1);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalSignumIsNonpositive() {
-    return ImmutableSet.of(
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) <= 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) >= 0,
-        BigDecimal.ZERO.signum() != 1,
-        BigDecimal.ZERO.signum() < 1);
+        BigDecimal.ZERO.signum() <= -1,
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) >= 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) <= 0,
+        BigDecimal.ZERO.signum() != -1,
+        BigDecimal.ZERO.signum() > -1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -33,11 +33,11 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         BigDecimal.valueOf(1).compareTo(BigDecimal.ZERO) > 0,
         BigDecimal.ZERO.compareTo(BigDecimal.valueOf(2)) < 0,
-        BigDecimal.valueOf(3).signum() == 1,
+        BigDecimal.valueOf(3).signum() > 0,
         BigDecimal.valueOf(4).signum() >= 1,
         BigDecimal.valueOf(5).compareTo(BigDecimal.ZERO) <= 0,
         BigDecimal.ZERO.compareTo(BigDecimal.valueOf(6)) >= 0,
-        BigDecimal.valueOf(7).signum() != 1,
+        BigDecimal.valueOf(7).signum() <= 0,
         BigDecimal.valueOf(8).signum() < 1);
   }
 
@@ -45,11 +45,11 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         BigDecimal.valueOf(1).compareTo(BigDecimal.ZERO) < 0,
         BigDecimal.ZERO.compareTo(BigDecimal.valueOf(2)) > 0,
-        BigDecimal.valueOf(3).signum() == -1,
+        BigDecimal.valueOf(3).signum() < 0,
         BigDecimal.valueOf(4).signum() <= -1,
         BigDecimal.valueOf(5).compareTo(BigDecimal.ZERO) >= 0,
         BigDecimal.ZERO.compareTo(BigDecimal.valueOf(6)) <= 0,
-        BigDecimal.valueOf(7).signum() != -1,
+        BigDecimal.valueOf(7).signum() >= 0,
         BigDecimal.valueOf(8).signum() > -1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -20,4 +20,54 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<BigDecimal> testBigDecimalValueOf() {
     return ImmutableSet.of(new BigDecimal(2), new BigDecimal(2L), new BigDecimal(2.0));
   }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZero() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) == 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) == 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToNonZero() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) != 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) != 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositive() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) > 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) < 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositiveInclusive() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) >= 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) <= 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegative() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) < 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) > 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegativeInclusive() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.compareTo(BigDecimal.ZERO) <= 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) >= 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalPositiveSignum() {
+    return ImmutableSet.of(
+        BigDecimal.ZERO.signum() > 0,
+        BigDecimal.ZERO.signum() >= 1,
+        BigDecimal.ZERO.signum() != -1);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalNegativeSignum() {
+    return ImmutableSet.of(
+        BigDecimal.ZERO.signum() < 0,
+        BigDecimal.ZERO.signum() <= -1,
+        BigDecimal.ZERO.signum() != 1);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -23,33 +23,33 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Boolean> testBigDecimalSignumIsZero() {
     return ImmutableSet.of(
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) == 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) == 0,
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) != 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) != 0);
+        BigDecimal.valueOf(1).compareTo(BigDecimal.ZERO) == 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.valueOf(2)) == 0,
+        BigDecimal.valueOf(3).compareTo(BigDecimal.ZERO) != 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.valueOf(4)) != 0);
   }
 
   ImmutableSet<Boolean> testBigDecimalSignumIsPositive() {
     return ImmutableSet.of(
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) > 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) < 0,
-        BigDecimal.ZERO.signum() == 1,
-        BigDecimal.ZERO.signum() >= 1,
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) <= 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) >= 0,
-        BigDecimal.ZERO.signum() != 1,
-        BigDecimal.ZERO.signum() < 1);
+        BigDecimal.valueOf(1).compareTo(BigDecimal.ZERO) > 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.valueOf(2)) < 0,
+        BigDecimal.valueOf(3).signum() == 1,
+        BigDecimal.valueOf(4).signum() >= 1,
+        BigDecimal.valueOf(5).compareTo(BigDecimal.ZERO) <= 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.valueOf(6)) >= 0,
+        BigDecimal.valueOf(7).signum() != 1,
+        BigDecimal.valueOf(8).signum() < 1);
   }
 
   ImmutableSet<Boolean> testBigDecimalSignumIsNegative() {
     return ImmutableSet.of(
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) < 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) > 0,
-        BigDecimal.ZERO.signum() == -1,
-        BigDecimal.ZERO.signum() <= -1,
-        BigDecimal.ONE.compareTo(BigDecimal.ZERO) >= 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) <= 0,
-        BigDecimal.ZERO.signum() != -1,
-        BigDecimal.ZERO.signum() > -1);
+        BigDecimal.valueOf(1).compareTo(BigDecimal.ZERO) < 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.valueOf(2)) > 0,
+        BigDecimal.valueOf(3).signum() == -1,
+        BigDecimal.valueOf(4).signum() <= -1,
+        BigDecimal.valueOf(5).compareTo(BigDecimal.ZERO) >= 0,
+        BigDecimal.ZERO.compareTo(BigDecimal.valueOf(6)) <= 0,
+        BigDecimal.valueOf(7).signum() != -1,
+        BigDecimal.valueOf(8).signum() > -1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -24,11 +24,7 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Boolean> testBigDecimalCompareToZero() {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) == 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) == 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalCompareToNonZero() {
-    return ImmutableSet.of(
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) == 0,
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) != 0,
         BigDecimal.ZERO.compareTo(BigDecimal.ONE) != 0);
   }
@@ -36,7 +32,10 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Boolean> testBigDecimalCompareToZeroPositive() {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) > 0,
-        BigDecimal.ZERO.compareTo(BigDecimal.ONE) < 0);
+        BigDecimal.ZERO.compareTo(BigDecimal.ONE) < 0,
+        BigDecimal.ZERO.signum() > 0,
+        BigDecimal.ZERO.signum() >= 1,
+        BigDecimal.ZERO.signum() != -1);
   }
 
   ImmutableSet<Boolean> testBigDecimalCompareToZeroPositiveInclusive() {
@@ -55,13 +54,6 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         BigDecimal.ONE.compareTo(BigDecimal.ZERO) <= 0,
         BigDecimal.ZERO.compareTo(BigDecimal.ONE) >= 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalPositiveSignum() {
-    return ImmutableSet.of(
-        BigDecimal.ZERO.signum() > 0,
-        BigDecimal.ZERO.signum() >= 1,
-        BigDecimal.ZERO.signum() != -1);
   }
 
   ImmutableSet<Boolean> testBigDecimalNegativeSignum() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -23,33 +23,33 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Boolean> testBigDecimalSignumIsZero() {
     return ImmutableSet.of(
-        BigDecimal.ONE.signum() == 0,
-        BigDecimal.ONE.signum() == 0,
-        BigDecimal.ONE.signum() != 0,
-        BigDecimal.ONE.signum() != 0);
+        BigDecimal.valueOf(1).signum() == 0,
+        BigDecimal.valueOf(2).signum() == 0,
+        BigDecimal.valueOf(3).signum() != 0,
+        BigDecimal.valueOf(4).signum() != 0);
   }
 
   ImmutableSet<Boolean> testBigDecimalSignumIsPositive() {
     return ImmutableSet.of(
-        BigDecimal.ONE.signum() > 0,
-        BigDecimal.ONE.signum() > 0,
-        BigDecimal.ZERO.signum() > 0,
-        BigDecimal.ZERO.signum() > 0,
-        BigDecimal.ONE.signum() <= 0,
-        BigDecimal.ONE.signum() <= 0,
-        BigDecimal.ZERO.signum() <= 0,
-        BigDecimal.ZERO.signum() <= 0);
+        BigDecimal.valueOf(1).signum() > 0,
+        BigDecimal.valueOf(2).signum() > 0,
+        BigDecimal.valueOf(3).signum() > 0,
+        BigDecimal.valueOf(4).signum() > 0,
+        BigDecimal.valueOf(5).signum() <= 0,
+        BigDecimal.valueOf(6).signum() <= 0,
+        BigDecimal.valueOf(7).signum() <= 0,
+        BigDecimal.valueOf(8).signum() <= 0);
   }
 
   ImmutableSet<Boolean> testBigDecimalSignumIsNegative() {
     return ImmutableSet.of(
-        BigDecimal.ONE.signum() < 0,
-        BigDecimal.ONE.signum() < 0,
-        BigDecimal.ZERO.signum() < 0,
-        BigDecimal.ZERO.signum() < 0,
-        BigDecimal.ONE.signum() >= 0,
-        BigDecimal.ONE.signum() >= 0,
-        BigDecimal.ZERO.signum() >= 0,
-        BigDecimal.ZERO.signum() >= 0);
+        BigDecimal.valueOf(1).signum() < 0,
+        BigDecimal.valueOf(2).signum() < 0,
+        BigDecimal.valueOf(3).signum() < 0,
+        BigDecimal.valueOf(4).signum() < 0,
+        BigDecimal.valueOf(5).signum() >= 0,
+        BigDecimal.valueOf(6).signum() >= 0,
+        BigDecimal.valueOf(7).signum() >= 0,
+        BigDecimal.valueOf(8).signum() >= 0);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -34,15 +34,11 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
         BigDecimal.ONE.signum() > 0,
         BigDecimal.ONE.signum() > 0,
         BigDecimal.ZERO.signum() > 0,
-        BigDecimal.ZERO.signum() > 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalSignumIsNonnegative() {
-    return ImmutableSet.of(
-        BigDecimal.ONE.signum() >= 0,
-        BigDecimal.ONE.signum() >= 0,
-        BigDecimal.ZERO.signum() >= 0,
-        BigDecimal.ZERO.signum() >= 0);
+        BigDecimal.ZERO.signum() > 0,
+        BigDecimal.ONE.signum() <= 0,
+        BigDecimal.ONE.signum() <= 0,
+        BigDecimal.ZERO.signum() <= 0,
+        BigDecimal.ZERO.signum() <= 0);
   }
 
   ImmutableSet<Boolean> testBigDecimalSignumIsNegative() {
@@ -50,14 +46,10 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
         BigDecimal.ONE.signum() < 0,
         BigDecimal.ONE.signum() < 0,
         BigDecimal.ZERO.signum() < 0,
-        BigDecimal.ZERO.signum() < 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalSignumIsNonpositive() {
-    return ImmutableSet.of(
-        BigDecimal.ONE.signum() <= 0,
-        BigDecimal.ONE.signum() <= 0,
-        BigDecimal.ZERO.signum() <= 0,
-        BigDecimal.ZERO.signum() <= 0);
+        BigDecimal.ZERO.signum() < 0,
+        BigDecimal.ONE.signum() >= 0,
+        BigDecimal.ONE.signum() >= 0,
+        BigDecimal.ZERO.signum() >= 0,
+        BigDecimal.ZERO.signum() >= 0);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -20,4 +20,42 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<BigDecimal> testBigDecimalValueOf() {
     return ImmutableSet.of(BigDecimal.valueOf(2), BigDecimal.valueOf(2L), BigDecimal.valueOf(2.0));
   }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZero() {
+    return ImmutableSet.of(BigDecimal.ONE.signum() == 0, BigDecimal.ONE.signum() == 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToNonZero() {
+    return ImmutableSet.of(BigDecimal.ONE.signum() != 0, BigDecimal.ONE.signum() != 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositive() {
+    return ImmutableSet.of(BigDecimal.ONE.signum() == 1, BigDecimal.ONE.signum() == 1);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositiveInclusive() {
+    return ImmutableSet.of(BigDecimal.ONE.signum() >= 0, BigDecimal.ONE.signum() >= 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegative() {
+    return ImmutableSet.of(BigDecimal.ONE.signum() == -1, BigDecimal.ONE.signum() == -1);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegativeInclusive() {
+    return ImmutableSet.of(BigDecimal.ONE.signum() <= 0, BigDecimal.ONE.signum() <= 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalPositiveSignum() {
+    return ImmutableSet.of(
+        BigDecimal.ZERO.signum() == 1,
+        BigDecimal.ZERO.signum() == 1,
+        BigDecimal.ZERO.signum() == 1);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalNegativeSignum() {
+    return ImmutableSet.of(
+        BigDecimal.ZERO.signum() == -1,
+        BigDecimal.ZERO.signum() == -1,
+        BigDecimal.ZERO.signum() == -1);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -22,15 +22,20 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Boolean> testBigDecimalCompareToZero() {
-    return ImmutableSet.of(BigDecimal.ONE.signum() == 0, BigDecimal.ONE.signum() == 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalCompareToNonZero() {
-    return ImmutableSet.of(BigDecimal.ONE.signum() != 0, BigDecimal.ONE.signum() != 0);
+    return ImmutableSet.of(
+        BigDecimal.ONE.signum() == 0,
+        BigDecimal.ONE.signum() == 0,
+        BigDecimal.ONE.signum() != 0,
+        BigDecimal.ONE.signum() != 0);
   }
 
   ImmutableSet<Boolean> testBigDecimalCompareToZeroPositive() {
-    return ImmutableSet.of(BigDecimal.ONE.signum() == 1, BigDecimal.ONE.signum() == 1);
+    return ImmutableSet.of(
+        BigDecimal.ONE.signum() == 1,
+        BigDecimal.ONE.signum() == 1,
+        BigDecimal.ZERO.signum() == 1,
+        BigDecimal.ZERO.signum() == 1,
+        BigDecimal.ZERO.signum() == 1);
   }
 
   ImmutableSet<Boolean> testBigDecimalCompareToZeroPositiveInclusive() {
@@ -43,13 +48,6 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Boolean> testBigDecimalCompareToZeroNegativeInclusive() {
     return ImmutableSet.of(BigDecimal.ONE.signum() <= 0, BigDecimal.ONE.signum() <= 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalPositiveSignum() {
-    return ImmutableSet.of(
-        BigDecimal.ZERO.signum() == 1,
-        BigDecimal.ZERO.signum() == 1,
-        BigDecimal.ZERO.signum() == 1);
   }
 
   ImmutableSet<Boolean> testBigDecimalNegativeSignum() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -21,7 +21,7 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(BigDecimal.valueOf(2), BigDecimal.valueOf(2L), BigDecimal.valueOf(2.0));
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZero() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsZero() {
     return ImmutableSet.of(
         BigDecimal.ONE.signum() == 0,
         BigDecimal.ONE.signum() == 0,
@@ -29,31 +29,35 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
         BigDecimal.ONE.signum() != 0);
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositive() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsPositive() {
     return ImmutableSet.of(
-        BigDecimal.ONE.signum() == 1,
-        BigDecimal.ONE.signum() == 1,
-        BigDecimal.ZERO.signum() == 1,
-        BigDecimal.ZERO.signum() == 1,
-        BigDecimal.ZERO.signum() == 1);
+        BigDecimal.ONE.signum() > 0,
+        BigDecimal.ONE.signum() > 0,
+        BigDecimal.ZERO.signum() > 0,
+        BigDecimal.ZERO.signum() > 0);
   }
 
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroPositiveInclusive() {
-    return ImmutableSet.of(BigDecimal.ONE.signum() >= 0, BigDecimal.ONE.signum() >= 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegative() {
-    return ImmutableSet.of(BigDecimal.ONE.signum() == -1, BigDecimal.ONE.signum() == -1);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalCompareToZeroNegativeInclusive() {
-    return ImmutableSet.of(BigDecimal.ONE.signum() <= 0, BigDecimal.ONE.signum() <= 0);
-  }
-
-  ImmutableSet<Boolean> testBigDecimalNegativeSignum() {
+  ImmutableSet<Boolean> testBigDecimalSignumIsNonnegative() {
     return ImmutableSet.of(
-        BigDecimal.ZERO.signum() == -1,
-        BigDecimal.ZERO.signum() == -1,
-        BigDecimal.ZERO.signum() == -1);
+        BigDecimal.ONE.signum() >= 0,
+        BigDecimal.ONE.signum() >= 0,
+        BigDecimal.ZERO.signum() >= 0,
+        BigDecimal.ZERO.signum() >= 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalSignumIsNegative() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.signum() < 0,
+        BigDecimal.ONE.signum() < 0,
+        BigDecimal.ZERO.signum() < 0,
+        BigDecimal.ZERO.signum() < 0);
+  }
+
+  ImmutableSet<Boolean> testBigDecimalSignumIsNonpositive() {
+    return ImmutableSet.of(
+        BigDecimal.ONE.signum() <= 0,
+        BigDecimal.ONE.signum() <= 0,
+        BigDecimal.ZERO.signum() <= 0,
+        BigDecimal.ZERO.signum() <= 0);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -31,25 +31,25 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Boolean> testBigDecimalSignumIsPositive() {
     return ImmutableSet.of(
-        BigDecimal.valueOf(1).signum() > 0,
-        BigDecimal.valueOf(2).signum() > 0,
-        BigDecimal.valueOf(3).signum() > 0,
-        BigDecimal.valueOf(4).signum() > 0,
-        BigDecimal.valueOf(5).signum() <= 0,
-        BigDecimal.valueOf(6).signum() <= 0,
-        BigDecimal.valueOf(7).signum() <= 0,
-        BigDecimal.valueOf(8).signum() <= 0);
+        BigDecimal.valueOf(1).signum() == 1,
+        BigDecimal.valueOf(2).signum() == 1,
+        BigDecimal.valueOf(3).signum() == 1,
+        BigDecimal.valueOf(4).signum() == 1,
+        BigDecimal.valueOf(5).signum() != 1,
+        BigDecimal.valueOf(6).signum() != 1,
+        BigDecimal.valueOf(7).signum() != 1,
+        BigDecimal.valueOf(8).signum() != 1);
   }
 
   ImmutableSet<Boolean> testBigDecimalSignumIsNegative() {
     return ImmutableSet.of(
-        BigDecimal.valueOf(1).signum() < 0,
-        BigDecimal.valueOf(2).signum() < 0,
-        BigDecimal.valueOf(3).signum() < 0,
-        BigDecimal.valueOf(4).signum() < 0,
-        BigDecimal.valueOf(5).signum() >= 0,
-        BigDecimal.valueOf(6).signum() >= 0,
-        BigDecimal.valueOf(7).signum() >= 0,
-        BigDecimal.valueOf(8).signum() >= 0);
+        BigDecimal.valueOf(1).signum() == -1,
+        BigDecimal.valueOf(2).signum() == -1,
+        BigDecimal.valueOf(3).signum() == -1,
+        BigDecimal.valueOf(4).signum() == -1,
+        BigDecimal.valueOf(5).signum() != -1,
+        BigDecimal.valueOf(6).signum() != -1,
+        BigDecimal.valueOf(7).signum() != -1,
+        BigDecimal.valueOf(8).signum() != -1);
   }
 }


### PR DESCRIPTION
Expands the `BigDecimalRules`, mainly preventing contrived uses of `compareTo(BigDecimal.ZERO)` by using `signum()` instead. 
Also adds some rules surrounding the use of `signum()`. 