### PR TITLE
Add another variant to the `StepVerifierLastStepVerifyErrorClass`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1594,6 +1594,7 @@ final class ReactorRules {
     Duration before(StepVerifier.LastStep step, Class<T> clazz) {
       return Refaster.anyOf(
           step.expectError(clazz).verify(),
+          step.verifyErrorMatches(clazz::isInstance),
           step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz)));
     }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -520,7 +520,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         StepVerifier.create(Mono.empty())
             .verifyErrorMatches(IllegalStateException.class::isInstance),
         StepVerifier.create(Mono.empty())
-            .verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(IllegalStateException.class)));
+            .verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(AssertionError.class)));
   }
 
   Duration testStepVerifierLastStepVerifyErrorMatches() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -518,6 +518,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         StepVerifier.create(Mono.empty()).expectError(IllegalArgumentException.class).verify(),
         StepVerifier.create(Mono.empty())
+            .verifyErrorMatches(IllegalStateException.class::isInstance),
+        StepVerifier.create(Mono.empty())
             .verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(IllegalStateException.class)));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -502,7 +502,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         StepVerifier.create(Mono.empty()).verifyError(IllegalArgumentException.class),
         StepVerifier.create(Mono.empty()).verifyError(IllegalStateException.class),
-        StepVerifier.create(Mono.empty()).verifyError(IllegalStateException.class));
+        StepVerifier.create(Mono.empty()).verifyError(AssertionError.class));
   }
 
   Duration testStepVerifierLastStepVerifyErrorMatches() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -501,6 +501,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Duration> testStepVerifierLastStepVerifyErrorClass() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.empty()).verifyError(IllegalArgumentException.class),
+        StepVerifier.create(Mono.empty()).verifyError(IllegalStateException.class),
         StepVerifier.create(Mono.empty()).verifyError(IllegalStateException.class));
   }
 


### PR DESCRIPTION
Added `verifyErrorMatches(clazz::isInstance)` as a variant of `verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz))` that we already rewrite.