### PR TITLE
Introduce `FluxEmpty` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -426,6 +426,25 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link Flux#empty()} over more contrived ways of creating an empty flux. */
+  static final class FluxEmpty<T> {
+    @BeforeTemplate
+    Flux<T> before() {
+      return Refaster.anyOf(
+          Flux.just(),
+          Flux.concat(),
+          Flux.concatDelayError(),
+          Flux.firstWithSignal(),
+          Flux.merge(),
+          Flux.mergeSequential());
+    }
+
+    @AfterTemplate
+    Flux<T> after() {
+      return Flux.empty();
+    }
+  }
+
   /** Don't unnecessarily transform a {@link Mono} to an equivalent instance. */
   static final class MonoIdentity<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -426,15 +426,15 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Flux#empty()} over more contrived ways of creating an empty flux. */
+  /** Prefer {@link Flux#empty()} over more contrived alternatives. */
   static final class FluxEmpty<T> {
     @BeforeTemplate
     Flux<T> before() {
       return Refaster.anyOf(
-          Flux.just(),
           Flux.concat(),
           Flux.concatDelayError(),
           Flux.firstWithSignal(),
+          Flux.just(),
           Flux.merge(),
           Flux.mergeSequential());
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -427,21 +427,70 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Flux#empty()} over more contrived alternatives. */
-  static final class FluxEmpty<T> {
+  // XXX: In combination with the `IsEmpty` matcher introduced by
+  // https://github.com/PicnicSupermarket/error-prone-support/pull/744, the non-varargs overloads of
+  // most methods referenced here can be rewritten as well. Additionally, some invocations of
+  // methods such as `Flux#fromIterable`, `Flux#fromArray` and `Flux#justOrEmpty` can also be
+  // rewritten.
+  static final class FluxEmpty<T, S extends Comparable<? super S>> {
     @BeforeTemplate
-    Flux<T> before() {
+    Flux<T> before(
+        int prefetch,
+        Function<? super Object[], ? extends T> combinator,
+        Comparator<? super T> comparator) {
       return Refaster.anyOf(
           Flux.concat(),
           Flux.concatDelayError(),
           Flux.firstWithSignal(),
           Flux.just(),
           Flux.merge(),
-          Flux.mergeSequential());
+          Flux.merge(prefetch),
+          Flux.mergeComparing(comparator),
+          Flux.mergeComparing(prefetch, comparator),
+          Flux.mergeComparingDelayError(prefetch, comparator),
+          Flux.mergeDelayError(prefetch),
+          Flux.mergePriority(comparator),
+          Flux.mergePriority(prefetch, comparator),
+          Flux.mergePriorityDelayError(prefetch, comparator),
+          Flux.mergeSequential(),
+          Flux.mergeSequential(prefetch),
+          Flux.mergeSequentialDelayError(prefetch),
+          Flux.zip(combinator),
+          Flux.zip(combinator, prefetch));
+    }
+
+    @BeforeTemplate
+    Flux<T> before(int prefetch, Function<Object[], T> combinator) {
+      return Refaster.anyOf(
+          Flux.combineLatest(combinator), Flux.combineLatest(combinator, prefetch));
+    }
+
+    @BeforeTemplate
+    Flux<S> before() {
+      return Refaster.anyOf(Flux.mergeComparing(), Flux.mergePriority());
+    }
+
+    @BeforeTemplate
+    Flux<Integer> before(int start) {
+      return Flux.range(start, 0);
     }
 
     @AfterTemplate
     Flux<T> after() {
       return Flux.empty();
+    }
+  }
+
+  /** Prefer {@link Flux#just(Object)} over more contrived alternatives. */
+  static final class FluxJust {
+    @BeforeTemplate
+    Flux<Integer> before(int start) {
+      return Flux.range(start, 1);
+    }
+
+    @AfterTemplate
+    Flux<Integer> after(int start) {
+      return Flux.just(start);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -148,14 +148,35 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("baz").switchIfEmpty(Flux.just("qux")));
   }
 
-  ImmutableSet<Flux<Void>> testFluxEmpty() {
+  ImmutableSet<Flux<?>> testFluxEmpty() {
     return ImmutableSet.of(
         Flux.concat(),
         Flux.concatDelayError(),
         Flux.firstWithSignal(),
         Flux.just(),
         Flux.merge(),
-        Flux.mergeSequential());
+        Flux.merge(1),
+        Flux.mergeComparing((a, b) -> 0),
+        Flux.mergeComparing(1, (a, b) -> 0),
+        Flux.mergeComparingDelayError(1, (a, b) -> 0),
+        Flux.mergeDelayError(1),
+        Flux.mergePriority((a, b) -> 0),
+        Flux.mergePriority(1, (a, b) -> 0),
+        Flux.mergePriorityDelayError(1, (a, b) -> 0),
+        Flux.mergeSequential(),
+        Flux.mergeSequential(1),
+        Flux.mergeSequentialDelayError(1),
+        Flux.zip(v -> v),
+        Flux.zip(v -> v, 1),
+        Flux.combineLatest(v -> v),
+        Flux.combineLatest(v -> v, 1),
+        Flux.mergeComparing(),
+        Flux.mergePriority(),
+        Flux.range(0, 0));
+  }
+
+  Flux<Integer> testFluxJust() {
+    return Flux.range(0, 1);
   }
 
   ImmutableSet<Mono<?>> testMonoIdentity() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -148,6 +148,16 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("baz").switchIfEmpty(Flux.just("qux")));
   }
 
+  ImmutableSet<Flux<Void>> testFluxEmpty() {
+    return ImmutableSet.of(
+        Flux.just(),
+        Flux.concat(),
+        Flux.concatDelayError(),
+        Flux.firstWithSignal(),
+        Flux.merge(),
+        Flux.mergeSequential());
+  }
+
   ImmutableSet<Mono<?>> testMonoIdentity() {
     return ImmutableSet.of(
         Mono.just(1).switchIfEmpty(Mono.empty()),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -150,10 +150,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Flux<Void>> testFluxEmpty() {
     return ImmutableSet.of(
-        Flux.just(),
         Flux.concat(),
         Flux.concatDelayError(),
         Flux.firstWithSignal(),
+        Flux.just(),
         Flux.merge(),
         Flux.mergeSequential());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -152,6 +152,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("foo").defaultIfEmpty("bar"), Flux.just("baz").defaultIfEmpty("qux"));
   }
 
+  ImmutableSet<Flux<Void>> testFluxEmpty() {
+    return ImmutableSet.of(
+        Flux.empty(), Flux.empty(), Flux.empty(), Flux.empty(), Flux.empty(), Flux.empty());
+  }
+
   ImmutableSet<Mono<?>> testMonoIdentity() {
     return ImmutableSet.of(
         Mono.just(1),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -152,9 +152,35 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just("foo").defaultIfEmpty("bar"), Flux.just("baz").defaultIfEmpty("qux"));
   }
 
-  ImmutableSet<Flux<Void>> testFluxEmpty() {
+  ImmutableSet<Flux<?>> testFluxEmpty() {
     return ImmutableSet.of(
-        Flux.empty(), Flux.empty(), Flux.empty(), Flux.empty(), Flux.empty(), Flux.empty());
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty(),
+        Flux.empty());
+  }
+
+  Flux<Integer> testFluxJust() {
+    return Flux.just(0);
   }
 
   ImmutableSet<Mono<?>> testMonoIdentity() {


### PR DESCRIPTION
This is mainly intended to prevent `Flux.just()`, preferring the more expressive `Flux.empty()`, but while there why not prevent the other `vararg` constructors from being used without arguments 🤷🏻‍♂️ 