### PR TITLE
Build and test against JDK 21 instead of JDK 20

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        jdk: [ 11.0.20, 17.0.8, 20.0.2 ]
+        jdk: [ 11.0.20, 17.0.8, 21.0.0 ]
         distribution: [ temurin ]
         experimental: [ false ]
         include:


### PR DESCRIPTION
Suggested commit message:
```
Build and test against JDK 21 instead of JDK 20 (#832)

See https://jdk.java.net/21/release-notes
```