### PR TITLE
Disallow static import of `BugCheckerRefasctoringTestHelper.TestMode#TEXT_MATCH`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -78,6 +78,7 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
   static final ImmutableSetMultimap<String, String> NON_STATIC_IMPORT_CANDIDATE_MEMBERS =
       ImmutableSetMultimap.<String, String>builder()
           .put("com.google.common.base.Predicates", "contains")
+          .put("com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode", "TEXT_MATCH")
           .putAll(
               "java.util.Collections",
               "addAll",

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -58,7 +58,11 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
    */
   @VisibleForTesting
   static final ImmutableSet<String> NON_STATIC_IMPORT_CANDIDATE_TYPES =
-      ImmutableSet.of("com.google.common.base.Strings", "java.time.Clock", "java.time.ZoneOffset");
+      ImmutableSet.of(
+          "com.google.common.base.Strings",
+          "com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode",
+          "java.time.Clock",
+          "java.time.ZoneOffset");
 
   /**
    * Type members that should never be statically imported.
@@ -78,7 +82,6 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
   static final ImmutableSetMultimap<String, String> NON_STATIC_IMPORT_CANDIDATE_MEMBERS =
       ImmutableSetMultimap.<String, String>builder()
           .put("com.google.common.base.Predicates", "contains")
-          .put("com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode", "TEXT_MATCH")
           .putAll(
               "java.util.Collections",
               "addAll",

--- a/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
+++ b/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
@@ -4,7 +4,6 @@ import static com.google.common.base.Preconditions.checkState;
 import static com.google.common.collect.ImmutableListMultimap.toImmutableListMultimap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static com.google.common.collect.ImmutableSortedSet.toImmutableSortedSet;
-import static com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH;
 import static com.google.errorprone.BugPattern.SeverityLevel.ERROR;
 import static java.util.Comparator.naturalOrder;
 import static tech.picnic.errorprone.refaster.runner.Refaster.INCLUDED_RULES_PATTERN_FLAG;
@@ -19,6 +18,7 @@ import com.google.common.collect.Iterables;
 import com.google.common.collect.Range;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
+import com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.SubContext;
@@ -126,7 +126,7 @@ public final class RefasterRuleCollection extends BugChecker implements Compilat
         .setArgs(ImmutableList.of("-XepOpt:" + RULE_COLLECTION_FLAG + '=' + className))
         .addInput(className + "TestInput.java")
         .addOutput(className + "TestOutput.java")
-        .doTest(TEXT_MATCH);
+        .doTest(TestMode.TEXT_MATCH);
   }
 
   @Override


### PR DESCRIPTION
I remembered we wanted to fix this one some time ago.

However, it does a non 100% optimal fix for this specific case as it rewrites it to:
```
BugCheckerRefactoringTestHelper.TestMode.TEXT_MATCH
```
Which can be easily fixed by removing the qualifier, but I'd say flagging this is an improvement for now.
Didn't add a test as we already extensively test the members in the `identification` test.

Suggested commit message:
```
Disallow static import of `BugCheckerRefasctoringTestHelper.TestMode#TEXT_MATCH` (#862)
``` 