### PR TITLE
Disallow static import of `com.google.errorprone.{VisitorState,util.ASTHelpers}` members

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -61,8 +61,8 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
       ImmutableSet.of(
           "com.google.common.base.Strings",
           "com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode",
-          "com.google.errorprone.util.ASTHelpers",
           "com.google.errorprone.VisitorState",
+          "com.google.errorprone.util.ASTHelpers",
           "java.time.Clock",
           "java.time.ZoneOffset");
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -61,6 +61,8 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
       ImmutableSet.of(
           "com.google.common.base.Strings",
           "com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode",
+          "com.google.errorprone.util.ASTHelpers",
+          "com.google.errorprone.VisitorState",
           "java.time.Clock",
           "java.time.ZoneOffset");
 


### PR DESCRIPTION
Saw this during a code review 😄.

Probably we can add more from Error Prone later. I checked some other classes from Error Prone but these are clear improvements that we also have been discussing before. Therefore, I decided to start with these two.