### PR TITLE
Skip SonarCloud analysis of PRs from forked repositories

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -11,6 +11,9 @@ permissions:
   contents: read
 jobs:
   analyze:
+    # Analysis of code in forked repositories is skipped, as such workflow runs
+    # do not have access to the requisite secrets.
+    if: github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
     runs-on: ubuntu-22.04


### PR DESCRIPTION
This issue was observed in the context of #925. I added a commit there to validate that the new condition indeed skips the check. For _this_ PR the SonarCloud analysis _should_ run :eyes: :crossed_fingers:

Suggested commit message:
```
Skip SonarCloud analysis of PRs from forked repositories (#926)

Because such analysis will fail due to unavailability of the relevant
secrets. Working around this is nontrivial and a likely source of
security issues.
```