### PR TITLE
Update Error Prone `-XepExcludedPaths` flag to be Windows-compatible

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1741,7 +1741,13 @@
                                     avoid that, so we simply tell Error Prone
                                     not to warn about generated code. -->
                                     -XepDisableWarningsInGeneratedCode
-                                    -XepExcludedPaths:\Q${project.build.directory}${file.separator}\E.*
+                                    <!-- XXX: Ideally we'd match against
+                                    `\Q${project.build.directory}${file.separator}\E.*`,
+                                    but that approach doesn't work on Windows,
+                                    as Error Prone matches against a path that
+                                    always contains forward-slash path
+                                    separators. -->
+                                    -XepExcludedPaths:(?!.*/src/[^/]+/java/.*).*
                                     <!-- We don't target Android. -->
                                     -Xep:AndroidJdkLibsChecker:OFF
                                     <!-- XXX: Enable this once we open-source


### PR DESCRIPTION
See https://github.com/PicnicSupermarket/error-prone-support/pull/925#issuecomment-1861178378: `-XepExcludedPaths:\Q${project.build.directory}${file.separator}\E.*` doesn't work because Error Prone [matches](https://github.com/google/error-prone/blob/21c190a6fc76f3ad3c895639dc66b7a3f570c55d/check_api/src/main/java/com/google/errorprone/ErrorProneAnalyzer.java#L192-L197) against a path that's [derived](https://github.com/google/error-prone/blob/21c190a6fc76f3ad3c895639dc66b7a3f570c55d/check_api/src/main/java/com/google/errorprone/util/ASTHelpers.java#L1552-L1586) from a file's URI, which in practice will always contain forward slashes.

Suggested commit message:
```
Update Error Prone `-XepExcludedPaths` flag to be Windows-compatible (#927)

Prior to these changes the provided pattern would never match on
Windows, as Error Prone matches against file URIs, which in practice
will always contain forward slashes, even on Windows.
```

Testing:
1. In #925 I validated that these changes prevent Error Prone from flagging violations against OpenRewrite-generated recipes when running on Windows.
2. (Tested locally on Linux:) Violations in non-generated source code are still reported, as validated by running the build after executing `git show a0b1f7091ee4f902f4abdcc9649fe0e902669948 -- error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java | git apply -R`.