### PR TITLE
Extend `OptionalIdentity` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -388,6 +388,8 @@ final class OptionalRules {
     @BeforeTemplate
     Optional<T> before(Optional<T> optional, Comparator<? super T> comparator) {
       return Refaster.anyOf(
+          optional.or(() -> Optional.empty()),
+          optional.or(Optional::empty),
           optional.stream().findFirst(),
           optional.stream().findAny(),
           optional.stream().min(comparator),

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -388,8 +388,7 @@ final class OptionalRules {
     @BeforeTemplate
     Optional<T> before(Optional<T> optional, Comparator<? super T> comparator) {
       return Refaster.anyOf(
-          optional.or(() -> Optional.empty()),
-          optional.or(Optional::empty),
+          optional.or(Refaster.anyOf(() -> Optional.empty(), Optional::empty)),
           optional.stream().findFirst(),
           optional.stream().findAny(),
           optional.stream().min(comparator),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
@@ -122,8 +122,8 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("bar").or(Optional::empty),
         Optional.of("baz").stream().findFirst(),
         Optional.of("qux").stream().findAny(),
-        Optional.of("corge").stream().min(String::compareTo),
-        Optional.of("grault").stream().max(String::compareTo));
+        Optional.of("quux").stream().min(String::compareTo),
+        Optional.of("quuz").stream().max(String::compareTo));
   }
 
   ImmutableSet<Optional<String>> testOptionalFilter() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
@@ -118,10 +118,12 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Optional<String>> testOptionalIdentity() {
     return ImmutableSet.of(
-        Optional.of("foo").stream().findFirst(),
-        Optional.of("bar").stream().findAny(),
-        Optional.of("baz").stream().min(String::compareTo),
-        Optional.of("qux").stream().max(String::compareTo));
+        Optional.of("foo").or(() -> Optional.empty()),
+        Optional.of("bar").or(Optional::empty),
+        Optional.of("baz").stream().findFirst(),
+        Optional.of("qux").stream().findAny(),
+        Optional.of("corge").stream().min(String::compareTo),
+        Optional.of("grault").stream().max(String::compareTo));
   }
 
   ImmutableSet<Optional<String>> testOptionalFilter() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
@@ -115,7 +115,12 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Optional<String>> testOptionalIdentity() {
     return ImmutableSet.of(
-        Optional.of("foo"), Optional.of("bar"), Optional.of("baz"), Optional.of("qux"));
+        Optional.of("foo"),
+        Optional.of("bar"),
+        Optional.of("baz"),
+        Optional.of("qux"),
+        Optional.of("corge"),
+        Optional.of("grault"));
   }
 
   ImmutableSet<Optional<String>> testOptionalFilter() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
@@ -119,8 +119,8 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("bar"),
         Optional.of("baz"),
         Optional.of("qux"),
-        Optional.of("corge"),
-        Optional.of("grault"));
+        Optional.of("quux"),
+        Optional.of("quuz"));
   }
 
   ImmutableSet<Optional<String>> testOptionalFilter() {


### PR DESCRIPTION
As I spotted this no-op.

### Suggested commit message
```
Extend `OptionalIdentity` Refaster rule (#951)

By flagging expressions of the form `optional.or(() -> Optional.empty())` and 
`optional.or(Optional::empty)`.
```