### PR TITLE
Work around IntelliJ IDEA bug IDEA-342187

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -256,6 +256,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <annotationProcessorPaths combine.children="append">
+                            <!-- XXX: Drop the version declarations once
+                            properly supported. See
+                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>documentation-support</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -206,9 +206,16 @@
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
         <version.error-prone-fork>v${version.error-prone-orig}-picnic-1</version.error-prone-fork>
         <version.error-prone-orig>2.24.1</version.error-prone-orig>
+        <version.error-prone-slf4j>0.1.22</version.error-prone-slf4j>
+        <version.guava-beta-checker>1.0</version.guava-beta-checker>
         <version.jdk>11</version.jdk>
         <version.maven>3.8.7</version.maven>
+        <version.mockito>5.8.0</version.mockito>
+        <version.nopen-checker>1.0.1</version.nopen-checker>
+        <version.nullaway>0.10.19</version.nullaway>
         <version.pitest-git>1.1.4</version.pitest-git>
+        <version.rewrite-templating>1.3.14</version.rewrite-templating>
+        <version.surefire>3.2.3</version.surefire>
     </properties>
 
     <dependencyManagement>
@@ -308,7 +315,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava-beta-checker</artifactId>
-                <version>1.0</version>
+                <version>${version.guava-beta-checker}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -325,12 +332,12 @@
             <dependency>
                 <groupId>com.jakewharton.nopen</groupId>
                 <artifactId>nopen-checker</artifactId>
-                <version>1.0.1</version>
+                <version>${version.nopen-checker}</version>
             </dependency>
             <dependency>
                 <groupId>com.uber.nullaway</groupId>
                 <artifactId>nullaway</artifactId>
-                <version>0.10.19</version>
+                <version>${version.nullaway}</version>
             </dependency>
             <dependency>
                 <groupId>io.projectreactor</groupId>
@@ -372,7 +379,7 @@
             <dependency>
                 <groupId>jp.skypencil.errorprone.slf4j</groupId>
                 <artifactId>errorprone-slf4j</artifactId>
-                <version>0.1.22</version>
+                <version>${version.error-prone-slf4j}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -434,7 +441,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
-                <version>5.8.0</version>
+                <version>${version.mockito}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -454,7 +461,7 @@
             <dependency>
                 <groupId>org.openrewrite</groupId>
                 <artifactId>rewrite-templating</artifactId>
-                <version>1.3.14</version>
+                <version>${version.rewrite-templating}</version>
             </dependency>
             <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
@@ -895,17 +902,23 @@
                     <version>3.12.1</version>
                     <configuration>
                         <annotationProcessorPaths>
+                            <!-- XXX: Inline and drop the version
+                            declarations once properly supported. See
+                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>com.google.auto.value</groupId>
                                 <artifactId>auto-value</artifactId>
+                                <version>${version.auto-value}</version>
                             </path>
                             <path>
                                 <groupId>com.google.auto.service</groupId>
                                 <artifactId>auto-service</artifactId>
+                                <version>${version.auto-service}</version>
                             </path>
                             <path>
                                 <groupId>org.openrewrite</groupId>
                                 <artifactId>rewrite-templating</artifactId>
+                                <version>${version.rewrite-templating}</version>
                             </path>
                         </annotationProcessorPaths>
                         <compilerArgs>
@@ -1500,12 +1513,15 @@
             <!-- Error Prone checks that are not available from Maven Central;
             these are therefore not enabled by default. -->
             <id>non-maven-central</id>
+            <properties>
+                <version.reactor-error-prone>0.1.4</version.reactor-error-prone>
+            </properties>
             <dependencyManagement>
                 <dependencies>
                     <dependency>
                         <groupId>com.github.lhotari</groupId>
                         <artifactId>reactor-error-prone</artifactId>
-                        <version>0.1.4</version>
+                        <version>${version.reactor-error-prone}</version>
                     </dependency>
                 </dependencies>
             </dependencyManagement>
@@ -1516,9 +1532,13 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <annotationProcessorPaths combine.children="append">
+                                <!-- XXX: Inline and drop the version
+                                declaration once properly supported. See
+                                https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                                 <path>
                                     <groupId>com.github.lhotari</groupId>
                                     <artifactId>reactor-error-prone</artifactId>
+                                    <version>${version.reactor-error-prone}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>
@@ -1548,13 +1568,18 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <annotationProcessorPaths combine.children="append">
+                                <!-- XXX: Drop the version declarations once
+                                properly supported. See
+                                https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                                 <path>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>error-prone-contrib</artifactId>
+                                    <version>${project.version}</version>
                                 </path>
                                 <path>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>refaster-runner</artifactId>
+                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>
@@ -1714,29 +1739,38 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <annotationProcessorPaths combine.children="append">
+                                <!-- XXX: Inline and drop the version
+                                declarations once properly supported. See
+                                https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                                 <path>
                                     <groupId>${groupId.error-prone}</groupId>
                                     <artifactId>error_prone_core</artifactId>
+                                    <version>${version.error-prone}</version>
                                 </path>
                                 <path>
                                     <groupId>com.google.guava</groupId>
                                     <artifactId>guava-beta-checker</artifactId>
+                                    <version>${version.guava-beta-checker}</version>
                                 </path>
                                 <path>
                                     <groupId>com.jakewharton.nopen</groupId>
                                     <artifactId>nopen-checker</artifactId>
+                                    <version>${version.nopen-checker}</version>
                                 </path>
                                 <path>
                                     <groupId>com.uber.nullaway</groupId>
                                     <artifactId>nullaway</artifactId>
+                                    <version>${version.nullaway}</version>
                                 </path>
                                 <path>
                                     <groupId>jp.skypencil.errorprone.slf4j</groupId>
                                     <artifactId>errorprone-slf4j</artifactId>
+                                    <version>${version.error-prone-slf4j}</version>
                                 </path>
                                 <path>
                                     <groupId>org.mockito</groupId>
                                     <artifactId>mockito-errorprone</artifactId>
+                                    <version>${version.mockito}</version>
                                 </path>
                             </annotationProcessorPaths>
                             <compilerArgs combine.children="append">

--- a/refaster-runner/pom.xml
+++ b/refaster-runner/pom.xml
@@ -112,6 +112,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <annotationProcessorPaths combine.children="append">
+                            <!-- XXX: Drop the version declaration once
+                            properly supported. See
+                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>refaster-compiler</artifactId>

--- a/refaster-test-support/pom.xml
+++ b/refaster-test-support/pom.xml
@@ -94,6 +94,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <annotationProcessorPaths combine.children="append">
+                            <!-- XXX: Drop the version declaration once
+                            properly supported. See
+                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>refaster-compiler</artifactId>


### PR DESCRIPTION
See https://github.com/PicnicSupermarket/error-prone-support/pull/925#issuecomment-1873305005 and https://github.com/PicnicSupermarket/error-prone-support/pull/775#issuecomment-1884329098 for context. It turns out that since #515 our IDEA setup is broken due to [IDEA-342187](https://youtrack.jetbrains.com/issue/IDEA-342187). With these changes we can once again run all tests in IDEA. 

Suggested commit message:
```
Work around IntelliJ IDEA bug IDEA-342187 (#958)

This reverts some of the changes in
3578a8cbec7c2d85f20ca8093e257440790d0953.

See https://youtrack.jetbrains.com/issue/IDEA-342187
```