### PR TITLE
Build with Maven 3.9.6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -30,16 +30,12 @@ jobs:
       # on Maven Central, and once against the Picnic Error Prone fork,
       # additionally enabling all checks defined in this project and any Error
       # Prone checks available only from other artifact repositories.
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: false
-      - name: Set up JDK
-        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # v1.11.0
         with:
           java-version: ${{ matrix.jdk }}
-          distribution: ${{ matrix.distribution }}
-          cache: maven
+          java-distribution: ${{ matrix.distribution }}
+          maven-version: 3.9.6
       - name: Display build environment details
         run: mvn --version
       - name: Build project against vanilla Error Prone, compile Javadoc

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,16 +21,12 @@ jobs:
       security-events: write
     runs-on: ubuntu-22.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: false
-      - name: Set up JDK
-        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # v1.11.0
         with:
           java-version: 17.0.8
-          distribution: temurin
-          cache: maven
+          java-distribution: temurin
+          maven-version: 3.9.6
       - name: Initialize CodeQL
         uses: github/codeql-action/init@012739e5082ff0c22ca6d6ab32e07c36df03c4a4 # v3.22.12
         with:

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -11,17 +11,13 @@ jobs:
   analyze-pr:
     runs-on: ubuntu-22.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # v1.11.0
         with:
-          fetch-depth: 2
-          persist-credentials: false
-      - name: Set up JDK
-        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
-        with:
+          checkout-fetch-depth: 2
           java-version: 17.0.8
-          distribution: temurin
-          cache: maven
+          java-distribution: temurin
+          maven-version: 3.9.6
       - name: Run Pitest
         # By running with features `+GIT(from[HEAD~1]), +gitci`, Pitest only
         # analyzes lines changed in the associated pull request, as GitHub

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -19,16 +19,12 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
-        with:
-          persist-credentials: false
-      - name: Set up JDK
-        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # v1.11.0
         with:
           java-version: 17.0.8
-          distribution: temurin
-          cache: maven
+          java-distribution: temurin
+          maven-version: 3.9.6
       - name: Download Pitest analysis artifact
         uses: dawidd6/action-download-artifact@e7466d1a7587ed14867642c2ca74b5bcc1e19a2d # v3.0.0
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -18,17 +18,13 @@ jobs:
       github.event.issue.pull_request && contains(github.event.comment.body, '/integration-test')
     runs-on: ubuntu-22.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # v1.11.0
         with:
-          persist-credentials: false
-          ref: refs/pull/${{ github.event.issue.number }}/head
-      - name: Set up JDK
-        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
-        with:
+          checkout-ref: "refs/pull/${{ github.event.issue.number }}/head"
           java-version: 17.0.8
-          distribution: temurin
-          cache: maven
+          java-distribution: temurin
+          maven-version: 3.9.6
       - name: Install project to local Maven repository
         run: mvn -T1C install -DskipTests -Dverification.skip
       - name: Run integration test

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,17 +18,13 @@ jobs:
       contents: read
     runs-on: ubuntu-22.04
     steps:
-      - name: Check out code
-        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@fa2c7e4517ed008b1f73e7e0195a9eecf5582cd4 # v1.11.0
         with:
-          fetch-depth: 0
-          persist-credentials: false
-      - name: Set up JDK
-        uses: actions/setup-java@387ac29b308b003ca37ba93a6cab5eb57c8f5f93 # v4.0.0
-        with:
+          checkout-fetch-depth: 0
           java-version: 17.0.8
-          distribution: temurin
-          cache: maven
+          java-distribution: temurin
+          maven-version: 3.9.6
       - name: Create missing `test` directory
         # XXX: Drop this step in favour of actually having a test.
         run: mkdir refaster-compiler/src/test


### PR DESCRIPTION
This should unblock PRs #434 and #491.

Suggested commit message:
```
Build with Maven 3.9.6 (#964)

Using the `setup-maven-action` GitHub action we can both simplify the
build configuration and configure the version of Maven to use.

See https://github.com/s4u/setup-maven-action
```