### PR TITLE
Have `ErrorProneRuntimeClasspath` ignore non-public types

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/util/ThirdPartyLibrary.java
@@ -9,6 +9,7 @@ import com.sun.tools.javac.code.Source;
 import com.sun.tools.javac.code.Symbol.CompletionFailure;
 import com.sun.tools.javac.code.Symbol.ModuleSymbol;
 import com.sun.tools.javac.code.Symtab;
+import com.sun.tools.javac.code.Type;
 import com.sun.tools.javac.util.Name;
 
 /**
@@ -70,12 +71,12 @@ public enum ThirdPartyLibrary {
   /**
    * Tells whether the given fully qualified type is available on the current class path.
    *
-   * @param className The type of interest.
+   * @param typeName The type of interest.
    * @param state The context under consideration.
    * @return {@code true} iff it is okay to assume or create a dependency on this type.
    */
-  public static boolean canIntroduceUsage(String className, VisitorState state) {
-    return shouldIgnoreClasspath(state) || isKnownClass(className, state);
+  public static boolean canIntroduceUsage(String typeName, VisitorState state) {
+    return shouldIgnoreClasspath(state) || isKnownClass(typeName, state);
   }
 
   /**
@@ -84,11 +85,16 @@ public enum ThirdPartyLibrary {
    * <p>The {@link VisitorState}'s symbol table is consulted first. If the type has not yet been
    * loaded, then an attempt is made to do so.
    */
-  private static boolean isKnownClass(String className, VisitorState state) {
-    return state.getTypeFromString(className) != null || canLoadClass(className, state);
+  private static boolean isKnownClass(String typeName, VisitorState state) {
+    return isPublicClassInSymbolTable(typeName, state) || canLoadPublicClass(typeName, state);
   }
 
-  private static boolean canLoadClass(String className, VisitorState state) {
+  private static boolean isPublicClassInSymbolTable(String typeName, VisitorState state) {
+    Type type = state.getTypeFromString(typeName);
+    return type != null && type.tsym.isPublic();
+  }
+
+  private static boolean canLoadPublicClass(String typeName, VisitorState state) {
     ClassFinder classFinder = ClassFinder.instance(state.context);
     Symtab symtab = state.getSymtab();
     // XXX: Drop support for targeting Java 8 once the oldest supported JDK drops such support.
@@ -96,10 +102,9 @@ public enum ThirdPartyLibrary {
         Source.instance(state.context).compareTo(Source.JDK9) < 0
             ? symtab.noModule
             : symtab.unnamedModule;
-    Name binaryName = state.binaryNameFromClassname(className);
+    Name binaryName = state.binaryNameFromClassname(typeName);
     try {
-      classFinder.loadClass(module, binaryName);
-      return true;
+      return classFinder.loadClass(module, binaryName).isPublic();
     } catch (
         @SuppressWarnings("java:S1166" /* Not exceptional. */)
         CompletionFailure e) {

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ErrorProneRuntimeClasspathTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ErrorProneRuntimeClasspathTest.java
@@ -47,6 +47,7 @@ final class ErrorProneRuntimeClasspathTest {
             "    m(\"com.google.errorprone.NonExistent\");",
             "    m(\"com.google.common.NonExistent.toString\");",
             "    m(\"java.lang.NonExistent\");",
+            "    m(\"com.google.common.collect.ImmutableEnumSet\");",
             "    // BUG: Diagnostic matches: USE_CLASS_REFERENCE",
             "    m(\"com.google.errorprone.BugPattern\");",
             "    // BUG: Diagnostic matches: USE_CLASS_REFERENCE",


### PR DESCRIPTION
~:exclamation: This PR is on top of #976. :exclamation:~

Suggested commit message:
```
Have `ErrorProneRuntimeClasspath` ignore non-public types (#972)
```