### PR TITLE
Drop workaround for resolved Refaster bug

### DIFF
--- a/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
+++ b/refaster-runner/src/main/java/tech/picnic/errorprone/refaster/runner/Refaster.java
@@ -88,16 +88,8 @@ public final class Refaster extends BugChecker implements CompilationUnitTreeMat
   public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
     /* First, collect all matches. */
     List<Description> matches = new ArrayList<>();
-    try {
-      codeTransformer.apply(state.getPath(), new SubContext(state.context), matches::add);
-    } catch (LinkageError e) {
-      // XXX: This `try/catch` block handles the issue described and resolved in
-      // https://github.com/google/error-prone/pull/2456. Drop this block once that change is
-      // released.
-      // XXX: Find a way to identify that we're running Picnic's Error Prone fork and disable this
-      // fallback if so, as it might hide other bugs.
-      return Description.NO_MATCH;
-    }
+    codeTransformer.apply(state.getPath(), new SubContext(state.context), matches::add);
+
     /* Then apply them. */
     applyMatches(matches, ((JCCompilationUnit) tree).endPositions, state);
 


### PR DESCRIPTION
Suggested commit message:
```
Drop workaround for resolved Refaster bug (#974)

Issue google/error-prone#2456 was fixed in Error Prone 2.22.0.
```