### PR TITLE
Fix the mutation test setup

### DIFF
--- a/documentation-support/pom.xml
+++ b/documentation-support/pom.xml
@@ -82,6 +82,13 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- XXX: Explicitly declared as a workaround for
+        https://github.com/pitest/pitest-junit5-plugin/issues/105. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>

--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -157,6 +157,13 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- XXX: Explicitly declared as a workaround for
+        https://github.com/pitest/pitest-junit5-plugin/issues/105. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>

--- a/refaster-runner/pom.xml
+++ b/refaster-runner/pom.xml
@@ -78,6 +78,13 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- XXX: Explicitly declared as a workaround for
+        https://github.com/pitest/pitest-junit5-plugin/issues/105. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>

--- a/refaster-support/pom.xml
+++ b/refaster-support/pom.xml
@@ -76,6 +76,13 @@
             <artifactId>junit-jupiter-api</artifactId>
             <scope>test</scope>
         </dependency>
+        <!-- XXX: Explicitly declared as a workaround for
+        https://github.com/pitest/pitest-junit5-plugin/issues/105. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>

--- a/refaster-test-support/pom.xml
+++ b/refaster-test-support/pom.xml
@@ -60,6 +60,13 @@
             <artifactId>jspecify</artifactId>
             <scope>provided</scope>
         </dependency>
+        <!-- XXX: Explicitly declared as a workaround for
+        https://github.com/pitest/pitest-junit5-plugin/issues/105. -->
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>


### PR DESCRIPTION
See https://github.com/PicnicSupermarket/error-prone-support/pull/972#issuecomment-1890770483 and pitest/pitest-junit5-plugin#105. This largely reverts #973.

I'll rebase #972 on top of this PR to prove that this fixes things, but one can also run `./run-mutation-tests.sh` locally to do the same.

Suggested commit message:
```
Fix the mutation test setup (#976)

This largely reverts commit dff67fecbceccde17c4839e37c73dc66a9c65c0f,
avoiding the issue described in pitest/pitest-junit5-plugin#105.
```