### PR TITLE
Use `plus###` and `minus###` shorthands when possible for dates/times

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
@@ -582,4 +582,898 @@ final class TimeRules {
       return Period.ZERO;
     }
   }
+
+  /** Prefer {@link LocalDate#plusDays} (and variants) over more contrived alternatives. */
+  static final class LocalDatePlusDays {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int days) {
+      return Refaster.anyOf(
+          localDate.plus(days, ChronoUnit.DAYS), localDate.plus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int days) {
+      return localDate.plusDays(days);
+    }
+  }
+
+  static final class LocalDatePlusWeeks {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int weeks) {
+      return Refaster.anyOf(
+          localDate.plus(weeks, ChronoUnit.WEEKS), localDate.plus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int weeks) {
+      return localDate.plusWeeks(weeks);
+    }
+  }
+
+  static final class LocalDatePlusMonths {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int months) {
+      return Refaster.anyOf(
+          localDate.plus(months, ChronoUnit.MONTHS), localDate.plus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int months) {
+      return localDate.plusMonths(months);
+    }
+  }
+
+  static final class LocalDatePlusYears {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int years) {
+      return Refaster.anyOf(
+          localDate.plus(years, ChronoUnit.YEARS), localDate.plus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int years) {
+      return localDate.plusYears(years);
+    }
+  }
+
+  static final class LocalDateMinusDays {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int days) {
+      return Refaster.anyOf(
+          localDate.minus(days, ChronoUnit.DAYS), localDate.minus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int days) {
+      return localDate.minusDays(days);
+    }
+  }
+
+  static final class LocalDateMinusWeeks {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int weeks) {
+      return Refaster.anyOf(
+          localDate.minus(weeks, ChronoUnit.WEEKS), localDate.minus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int weeks) {
+      return localDate.minusWeeks(weeks);
+    }
+  }
+
+  static final class LocalDateMinusMonths {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int months) {
+      return Refaster.anyOf(
+          localDate.minus(months, ChronoUnit.MONTHS), localDate.minus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int months) {
+      return localDate.minusMonths(months);
+    }
+  }
+
+  static final class LocalDateMinusYears {
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, int years) {
+      return Refaster.anyOf(
+          localDate.minus(years, ChronoUnit.YEARS), localDate.minus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    LocalDate after(LocalDate localDate, int years) {
+      return localDate.minusYears(years);
+    }
+  }
+
+  /** Prefer {@link LocalTime#plusNanos} (and variants) over more contrived alternatives. */
+  static final class LocalTimePlusNanos {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int nanos) {
+      return Refaster.anyOf(
+          localTime.plus(nanos, ChronoUnit.NANOS), localTime.plus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int nanos) {
+      return localTime.plusNanos(nanos);
+    }
+  }
+
+  static final class LocalTimePlusSeconds {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int seconds) {
+      return Refaster.anyOf(
+          localTime.plus(seconds, ChronoUnit.SECONDS), localTime.plus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int seconds) {
+      return localTime.plusSeconds(seconds);
+    }
+  }
+
+  static final class LocalTimePlusMinutes {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int minutes) {
+      return Refaster.anyOf(
+          localTime.plus(minutes, ChronoUnit.MINUTES), localTime.plus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int minutes) {
+      return localTime.plusMinutes(minutes);
+    }
+  }
+
+  static final class LocalTimePlusHours {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int hours) {
+      return Refaster.anyOf(
+          localTime.plus(hours, ChronoUnit.HOURS), localTime.plus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int hours) {
+      return localTime.plusHours(hours);
+    }
+  }
+
+  static final class LocalTimeMinusNanos {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int nanos) {
+      return Refaster.anyOf(
+          localTime.minus(nanos, ChronoUnit.NANOS), localTime.minus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int nanos) {
+      return localTime.minusNanos(nanos);
+    }
+  }
+
+  static final class LocalTimeMinusSeconds {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int seconds) {
+      return Refaster.anyOf(
+          localTime.minus(seconds, ChronoUnit.SECONDS),
+          localTime.minus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int seconds) {
+      return localTime.minusSeconds(seconds);
+    }
+  }
+
+  static final class LocalTimeMinusMinutes {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int minutes) {
+      return Refaster.anyOf(
+          localTime.minus(minutes, ChronoUnit.MINUTES),
+          localTime.minus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int minutes) {
+      return localTime.minusMinutes(minutes);
+    }
+  }
+
+  static final class LocalTimeMinusHours {
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, int hours) {
+      return Refaster.anyOf(
+          localTime.minus(hours, ChronoUnit.HOURS), localTime.minus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    LocalTime after(LocalTime localTime, int hours) {
+      return localTime.minusHours(hours);
+    }
+  }
+
+  /** Prefer {@link OffsetTime#plusNanos} (and variants) over more contrived alternatives. */
+  static final class OffsetTimePlusNanos {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int nanos) {
+      return Refaster.anyOf(
+          offsetTime.plus(nanos, ChronoUnit.NANOS), offsetTime.plus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int nanos) {
+      return offsetTime.plusNanos(nanos);
+    }
+  }
+
+  static final class OffsetTimePlusSeconds {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int seconds) {
+      return Refaster.anyOf(
+          offsetTime.plus(seconds, ChronoUnit.SECONDS),
+          offsetTime.plus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int seconds) {
+      return offsetTime.plusSeconds(seconds);
+    }
+  }
+
+  static final class OffsetTimePlusMinutes {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int minutes) {
+      return Refaster.anyOf(
+          offsetTime.plus(minutes, ChronoUnit.MINUTES),
+          offsetTime.plus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int minutes) {
+      return offsetTime.plusMinutes(minutes);
+    }
+  }
+
+  static final class OffsetTimePlusHours {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int hours) {
+      return Refaster.anyOf(
+          offsetTime.plus(hours, ChronoUnit.HOURS), offsetTime.plus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int hours) {
+      return offsetTime.plusHours(hours);
+    }
+  }
+
+  static final class OffsetTimeMinusNanos {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int nanos) {
+      return Refaster.anyOf(
+          offsetTime.minus(nanos, ChronoUnit.NANOS), offsetTime.minus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int nanos) {
+      return offsetTime.minusNanos(nanos);
+    }
+  }
+
+  static final class OffsetTimeMinusSeconds {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int seconds) {
+      return Refaster.anyOf(
+          offsetTime.minus(seconds, ChronoUnit.SECONDS),
+          offsetTime.minus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int seconds) {
+      return offsetTime.minusSeconds(seconds);
+    }
+  }
+
+  static final class OffsetTimeMinusMinutes {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int minutes) {
+      return Refaster.anyOf(
+          offsetTime.minus(minutes, ChronoUnit.MINUTES),
+          offsetTime.minus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int minutes) {
+      return offsetTime.minusMinutes(minutes);
+    }
+  }
+
+  static final class OffsetTimeMinusHours {
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, int hours) {
+      return Refaster.anyOf(
+          offsetTime.minus(hours, ChronoUnit.HOURS), offsetTime.minus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    OffsetTime after(OffsetTime offsetTime, int hours) {
+      return offsetTime.minusHours(hours);
+    }
+  }
+
+  /** Prefer {@link LocalDateTime#plusNanos} (and variants) over more contrived alternatives. */
+  static final class LocalDateTimePlusNanos {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int nanos) {
+      return Refaster.anyOf(
+          localDateTime.plus(nanos, ChronoUnit.NANOS), localDateTime.plus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int nanos) {
+      return localDateTime.plusNanos(nanos);
+    }
+  }
+
+  static final class LocalDateTimePlusSeconds {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int seconds) {
+      return Refaster.anyOf(
+          localDateTime.plus(seconds, ChronoUnit.SECONDS),
+          localDateTime.plus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int seconds) {
+      return localDateTime.plusSeconds(seconds);
+    }
+  }
+
+  static final class LocalDateTimePlusMinutes {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int minutes) {
+      return Refaster.anyOf(
+          localDateTime.plus(minutes, ChronoUnit.MINUTES),
+          localDateTime.plus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int minutes) {
+      return localDateTime.plusMinutes(minutes);
+    }
+  }
+
+  static final class LocalDateTimePlusHours {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int hours) {
+      return Refaster.anyOf(
+          localDateTime.plus(hours, ChronoUnit.HOURS), localDateTime.plus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int hours) {
+      return localDateTime.plusHours(hours);
+    }
+  }
+
+  static final class LocalDateTimePlusWeeks {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int weeks) {
+      return Refaster.anyOf(
+          localDateTime.plus(weeks, ChronoUnit.WEEKS), localDateTime.plus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int weeks) {
+      return localDateTime.plusWeeks(weeks);
+    }
+  }
+
+  static final class LocalDateTimePlusMonths {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int months) {
+      return Refaster.anyOf(
+          localDateTime.plus(months, ChronoUnit.MONTHS),
+          localDateTime.plus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int months) {
+      return localDateTime.plusMonths(months);
+    }
+  }
+
+  static final class LocalDateTimePlusYears {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int years) {
+      return Refaster.anyOf(
+          localDateTime.plus(years, ChronoUnit.YEARS), localDateTime.plus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int years) {
+      return localDateTime.plusYears(years);
+    }
+  }
+
+  static final class LocalDateTimeMinusNanos {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int nanos) {
+      return Refaster.anyOf(
+          localDateTime.minus(nanos, ChronoUnit.NANOS),
+          localDateTime.minus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int nanos) {
+      return localDateTime.minusNanos(nanos);
+    }
+  }
+
+  static final class LocalDateTimeMinusSeconds {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int seconds) {
+      return Refaster.anyOf(
+          localDateTime.minus(seconds, ChronoUnit.SECONDS),
+          localDateTime.minus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int seconds) {
+      return localDateTime.minusSeconds(seconds);
+    }
+  }
+
+  static final class LocalDateTimeMinusMinutes {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int minutes) {
+      return Refaster.anyOf(
+          localDateTime.minus(minutes, ChronoUnit.MINUTES),
+          localDateTime.minus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int minutes) {
+      return localDateTime.minusMinutes(minutes);
+    }
+  }
+
+  static final class LocalDateTimeMinusHours {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int hours) {
+      return Refaster.anyOf(
+          localDateTime.minus(hours, ChronoUnit.HOURS),
+          localDateTime.minus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int hours) {
+      return localDateTime.minusHours(hours);
+    }
+  }
+
+  static final class LocalDateTimeMinusWeeks {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int weeks) {
+      return Refaster.anyOf(
+          localDateTime.minus(weeks, ChronoUnit.WEEKS), localDateTime.minus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int weeks) {
+      return localDateTime.minusWeeks(weeks);
+    }
+  }
+
+  static final class LocalDateTimeMinusMonths {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int months) {
+      return Refaster.anyOf(
+          localDateTime.minus(months, ChronoUnit.MONTHS),
+          localDateTime.minus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int months) {
+      return localDateTime.minusMonths(months);
+    }
+  }
+
+  static final class LocalDateTimeMinusYears {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int years) {
+      return Refaster.anyOf(
+          localDateTime.minus(years, ChronoUnit.YEARS), localDateTime.minus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int years) {
+      return localDateTime.minusYears(years);
+    }
+  }
+
+  /** Prefer {@link OffsetDateTime#plusNanos} (and variants) over more contrived alternatives. */
+  static final class OffsetDateTimePlusNanos {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int nanos) {
+      return Refaster.anyOf(
+          localDateTime.plus(nanos, ChronoUnit.NANOS), localDateTime.plus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int nanos) {
+      return localDateTime.plusNanos(nanos);
+    }
+  }
+
+  static final class OffsetDateTimePlusSeconds {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int seconds) {
+      return Refaster.anyOf(
+          localDateTime.plus(seconds, ChronoUnit.SECONDS),
+          localDateTime.plus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int seconds) {
+      return localDateTime.plusSeconds(seconds);
+    }
+  }
+
+  static final class OffsetDateTimePlusMinutes {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int minutes) {
+      return Refaster.anyOf(
+          localDateTime.plus(minutes, ChronoUnit.MINUTES),
+          localDateTime.plus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int minutes) {
+      return localDateTime.plusMinutes(minutes);
+    }
+  }
+
+  static final class OffsetDateTimePlusHours {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int hours) {
+      return Refaster.anyOf(
+          localDateTime.plus(hours, ChronoUnit.HOURS), localDateTime.plus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int hours) {
+      return localDateTime.plusHours(hours);
+    }
+  }
+
+  static final class OffsetDateTimePlusWeeks {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int weeks) {
+      return Refaster.anyOf(
+          localDateTime.plus(weeks, ChronoUnit.WEEKS), localDateTime.plus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int weeks) {
+      return localDateTime.plusWeeks(weeks);
+    }
+  }
+
+  static final class OffsetDateTimePlusMonths {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int months) {
+      return Refaster.anyOf(
+          localDateTime.plus(months, ChronoUnit.MONTHS),
+          localDateTime.plus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int months) {
+      return localDateTime.plusMonths(months);
+    }
+  }
+
+  static final class OffsetDateTimePlusYears {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int years) {
+      return Refaster.anyOf(
+          localDateTime.plus(years, ChronoUnit.YEARS), localDateTime.plus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int years) {
+      return localDateTime.plusYears(years);
+    }
+  }
+
+  static final class OffsetDateTimeMinusNanos {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int nanos) {
+      return Refaster.anyOf(
+          localDateTime.minus(nanos, ChronoUnit.NANOS),
+          localDateTime.minus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int nanos) {
+      return localDateTime.minusNanos(nanos);
+    }
+  }
+
+  static final class OffsetDateTimeMinusSeconds {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int seconds) {
+      return Refaster.anyOf(
+          localDateTime.minus(seconds, ChronoUnit.SECONDS),
+          localDateTime.minus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int seconds) {
+      return localDateTime.minusSeconds(seconds);
+    }
+  }
+
+  static final class OffsetDateTimeMinusMinutes {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int minutes) {
+      return Refaster.anyOf(
+          localDateTime.minus(minutes, ChronoUnit.MINUTES),
+          localDateTime.minus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int minutes) {
+      return localDateTime.minusMinutes(minutes);
+    }
+  }
+
+  static final class OffsetDateTimeMinusHours {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int hours) {
+      return Refaster.anyOf(
+          localDateTime.minus(hours, ChronoUnit.HOURS),
+          localDateTime.minus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int hours) {
+      return localDateTime.minusHours(hours);
+    }
+  }
+
+  static final class OffsetDateTimeMinusWeeks {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int weeks) {
+      return Refaster.anyOf(
+          localDateTime.minus(weeks, ChronoUnit.WEEKS), localDateTime.minus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int weeks) {
+      return localDateTime.minusWeeks(weeks);
+    }
+  }
+
+  static final class OffsetDateTimeMinusMonths {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int months) {
+      return Refaster.anyOf(
+          localDateTime.minus(months, ChronoUnit.MONTHS),
+          localDateTime.minus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int months) {
+      return localDateTime.minusMonths(months);
+    }
+  }
+
+  static final class OffsetDateTimeMinusYears {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime localDateTime, int years) {
+      return Refaster.anyOf(
+          localDateTime.minus(years, ChronoUnit.YEARS), localDateTime.minus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime localDateTime, int years) {
+      return localDateTime.minusYears(years);
+    }
+  }
+
+  /** Prefer {@link ZonedDateTime#plusNanos} (and variants) over more contrived alternatives. */
+  static final class ZonedDateTimePlusNanos {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int nanos) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(nanos, ChronoUnit.NANOS), zonedDateTime.plus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int nanos) {
+      return zonedDateTime.plusNanos(nanos);
+    }
+  }
+
+  static final class ZonedDateTimePlusSeconds {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int seconds) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(seconds, ChronoUnit.SECONDS),
+          zonedDateTime.plus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int seconds) {
+      return zonedDateTime.plusSeconds(seconds);
+    }
+  }
+
+  static final class ZonedDateTimePlusMinutes {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int minutes) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(minutes, ChronoUnit.MINUTES),
+          zonedDateTime.plus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int minutes) {
+      return zonedDateTime.plusMinutes(minutes);
+    }
+  }
+
+  static final class ZonedDateTimePlusHours {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int hours) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(hours, ChronoUnit.HOURS), zonedDateTime.plus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int hours) {
+      return zonedDateTime.plusHours(hours);
+    }
+  }
+
+  static final class ZonedDateTimePlusWeeks {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int weeks) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(weeks, ChronoUnit.WEEKS), zonedDateTime.plus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int weeks) {
+      return zonedDateTime.plusWeeks(weeks);
+    }
+  }
+
+  static final class ZonedDateTimePlusMonths {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int months) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(months, ChronoUnit.MONTHS),
+          zonedDateTime.plus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int months) {
+      return zonedDateTime.plusMonths(months);
+    }
+  }
+
+  static final class ZonedDateTimePlusYears {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int years) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(years, ChronoUnit.YEARS), zonedDateTime.plus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int years) {
+      return zonedDateTime.plusYears(years);
+    }
+  }
+
+  static final class ZonedDateTimeMinusNanos {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int nanos) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(nanos, ChronoUnit.NANOS),
+          zonedDateTime.minus(Duration.ofNanos(nanos)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int nanos) {
+      return zonedDateTime.minusNanos(nanos);
+    }
+  }
+
+  static final class ZonedDateTimeMinusSeconds {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int seconds) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(seconds, ChronoUnit.SECONDS),
+          zonedDateTime.minus(Duration.ofSeconds(seconds)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int seconds) {
+      return zonedDateTime.minusSeconds(seconds);
+    }
+  }
+
+  static final class ZonedDateTimeMinusMinutes {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int minutes) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(minutes, ChronoUnit.MINUTES),
+          zonedDateTime.minus(Duration.ofMinutes(minutes)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int minutes) {
+      return zonedDateTime.minusMinutes(minutes);
+    }
+  }
+
+  static final class ZonedDateTimeMinusHours {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int hours) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(hours, ChronoUnit.HOURS),
+          zonedDateTime.minus(Duration.ofHours(hours)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int hours) {
+      return zonedDateTime.minusHours(hours);
+    }
+  }
+
+  static final class ZonedDateTimeMinusWeeks {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int weeks) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(weeks, ChronoUnit.WEEKS), zonedDateTime.minus(Period.ofWeeks(weeks)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int weeks) {
+      return zonedDateTime.minusWeeks(weeks);
+    }
+  }
+
+  static final class ZonedDateTimeMinusMonths {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int months) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(months, ChronoUnit.MONTHS),
+          zonedDateTime.minus(Period.ofMonths(months)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int months) {
+      return zonedDateTime.minusMonths(months);
+    }
+  }
+
+  static final class ZonedDateTimeMinusYears {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int years) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(years, ChronoUnit.YEARS), zonedDateTime.minus(Period.ofYears(years)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int years) {
+      return zonedDateTime.minusYears(years);
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
@@ -587,8 +587,12 @@ final class TimeRules {
   static final class LocalDatePlusDays {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int days) {
-      return Refaster.anyOf(
-          localDate.plus(days, ChronoUnit.DAYS), localDate.plus(Period.ofDays(days)));
+      return localDate.plus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long days) {
+      return localDate.plus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -601,8 +605,12 @@ final class TimeRules {
   static final class LocalDatePlusWeeks {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int weeks) {
-      return Refaster.anyOf(
-          localDate.plus(weeks, ChronoUnit.WEEKS), localDate.plus(Period.ofWeeks(weeks)));
+      return localDate.plus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long weeks) {
+      return localDate.plus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -615,8 +623,12 @@ final class TimeRules {
   static final class LocalDatePlusMonths {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int months) {
-      return Refaster.anyOf(
-          localDate.plus(months, ChronoUnit.MONTHS), localDate.plus(Period.ofMonths(months)));
+      return localDate.plus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long months) {
+      return localDate.plus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -629,8 +641,12 @@ final class TimeRules {
   static final class LocalDatePlusYears {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int years) {
-      return Refaster.anyOf(
-          localDate.plus(years, ChronoUnit.YEARS), localDate.plus(Period.ofYears(years)));
+      return localDate.plus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long years) {
+      return localDate.plus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
@@ -643,8 +659,12 @@ final class TimeRules {
   static final class LocalDateMinusDays {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int days) {
-      return Refaster.anyOf(
-          localDate.minus(days, ChronoUnit.DAYS), localDate.minus(Period.ofDays(days)));
+      return localDate.minus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long days) {
+      return localDate.minus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -657,8 +677,12 @@ final class TimeRules {
   static final class LocalDateMinusWeeks {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int weeks) {
-      return Refaster.anyOf(
-          localDate.minus(weeks, ChronoUnit.WEEKS), localDate.minus(Period.ofWeeks(weeks)));
+      return localDate.minus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long weeks) {
+      return localDate.minus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -671,8 +695,12 @@ final class TimeRules {
   static final class LocalDateMinusMonths {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int months) {
-      return Refaster.anyOf(
-          localDate.minus(months, ChronoUnit.MONTHS), localDate.minus(Period.ofMonths(months)));
+      return localDate.minus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long months) {
+      return localDate.minus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -685,8 +713,12 @@ final class TimeRules {
   static final class LocalDateMinusYears {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int years) {
-      return Refaster.anyOf(
-          localDate.minus(years, ChronoUnit.YEARS), localDate.minus(Period.ofYears(years)));
+      return localDate.minus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    LocalDate before(LocalDate localDate, long years) {
+      return localDate.minus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
@@ -699,8 +731,12 @@ final class TimeRules {
   static final class LocalTimePlusNanos {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int nanos) {
-      return Refaster.anyOf(
-          localTime.plus(nanos, ChronoUnit.NANOS), localTime.plus(Duration.ofNanos(nanos)));
+      return localTime.plus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long nanos) {
+      return localTime.plus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -713,8 +749,12 @@ final class TimeRules {
   static final class LocalTimePlusSeconds {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int seconds) {
-      return Refaster.anyOf(
-          localTime.plus(seconds, ChronoUnit.SECONDS), localTime.plus(Duration.ofSeconds(seconds)));
+      return localTime.plus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long seconds) {
+      return localTime.plus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -727,8 +767,12 @@ final class TimeRules {
   static final class LocalTimePlusMinutes {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int minutes) {
-      return Refaster.anyOf(
-          localTime.plus(minutes, ChronoUnit.MINUTES), localTime.plus(Duration.ofMinutes(minutes)));
+      return localTime.plus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long minutes) {
+      return localTime.plus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -741,8 +785,12 @@ final class TimeRules {
   static final class LocalTimePlusHours {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int hours) {
-      return Refaster.anyOf(
-          localTime.plus(hours, ChronoUnit.HOURS), localTime.plus(Duration.ofHours(hours)));
+      return localTime.plus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long hours) {
+      return localTime.plus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -755,8 +803,12 @@ final class TimeRules {
   static final class LocalTimeMinusNanos {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int nanos) {
-      return Refaster.anyOf(
-          localTime.minus(nanos, ChronoUnit.NANOS), localTime.minus(Duration.ofNanos(nanos)));
+      return localTime.minus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long nanos) {
+      return localTime.minus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -769,9 +821,12 @@ final class TimeRules {
   static final class LocalTimeMinusSeconds {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int seconds) {
-      return Refaster.anyOf(
-          localTime.minus(seconds, ChronoUnit.SECONDS),
-          localTime.minus(Duration.ofSeconds(seconds)));
+      return localTime.minus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long seconds) {
+      return localTime.minus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -784,9 +839,12 @@ final class TimeRules {
   static final class LocalTimeMinusMinutes {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int minutes) {
-      return Refaster.anyOf(
-          localTime.minus(minutes, ChronoUnit.MINUTES),
-          localTime.minus(Duration.ofMinutes(minutes)));
+      return localTime.minus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long minutes) {
+      return localTime.minus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -799,8 +857,12 @@ final class TimeRules {
   static final class LocalTimeMinusHours {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int hours) {
-      return Refaster.anyOf(
-          localTime.minus(hours, ChronoUnit.HOURS), localTime.minus(Duration.ofHours(hours)));
+      return localTime.minus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    LocalTime before(LocalTime localTime, long hours) {
+      return localTime.minus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -813,8 +875,12 @@ final class TimeRules {
   static final class OffsetTimePlusNanos {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int nanos) {
-      return Refaster.anyOf(
-          offsetTime.plus(nanos, ChronoUnit.NANOS), offsetTime.plus(Duration.ofNanos(nanos)));
+      return offsetTime.plus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long nanos) {
+      return offsetTime.plus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -827,9 +893,12 @@ final class TimeRules {
   static final class OffsetTimePlusSeconds {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int seconds) {
-      return Refaster.anyOf(
-          offsetTime.plus(seconds, ChronoUnit.SECONDS),
-          offsetTime.plus(Duration.ofSeconds(seconds)));
+      return offsetTime.plus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long seconds) {
+      return offsetTime.plus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -842,9 +911,12 @@ final class TimeRules {
   static final class OffsetTimePlusMinutes {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int minutes) {
-      return Refaster.anyOf(
-          offsetTime.plus(minutes, ChronoUnit.MINUTES),
-          offsetTime.plus(Duration.ofMinutes(minutes)));
+      return offsetTime.plus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long minutes) {
+      return offsetTime.plus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -857,8 +929,12 @@ final class TimeRules {
   static final class OffsetTimePlusHours {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int hours) {
-      return Refaster.anyOf(
-          offsetTime.plus(hours, ChronoUnit.HOURS), offsetTime.plus(Duration.ofHours(hours)));
+      return offsetTime.plus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long hours) {
+      return offsetTime.plus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -871,8 +947,12 @@ final class TimeRules {
   static final class OffsetTimeMinusNanos {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int nanos) {
-      return Refaster.anyOf(
-          offsetTime.minus(nanos, ChronoUnit.NANOS), offsetTime.minus(Duration.ofNanos(nanos)));
+      return offsetTime.minus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long nanos) {
+      return offsetTime.minus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -885,9 +965,12 @@ final class TimeRules {
   static final class OffsetTimeMinusSeconds {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int seconds) {
-      return Refaster.anyOf(
-          offsetTime.minus(seconds, ChronoUnit.SECONDS),
-          offsetTime.minus(Duration.ofSeconds(seconds)));
+      return offsetTime.minus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long seconds) {
+      return offsetTime.minus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -900,9 +983,12 @@ final class TimeRules {
   static final class OffsetTimeMinusMinutes {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int minutes) {
-      return Refaster.anyOf(
-          offsetTime.minus(minutes, ChronoUnit.MINUTES),
-          offsetTime.minus(Duration.ofMinutes(minutes)));
+      return offsetTime.minus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long minutes) {
+      return offsetTime.minus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -915,8 +1001,12 @@ final class TimeRules {
   static final class OffsetTimeMinusHours {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int hours) {
-      return Refaster.anyOf(
-          offsetTime.minus(hours, ChronoUnit.HOURS), offsetTime.minus(Duration.ofHours(hours)));
+      return offsetTime.minus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    OffsetTime before(OffsetTime offsetTime, long hours) {
+      return offsetTime.minus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -929,8 +1019,12 @@ final class TimeRules {
   static final class LocalDateTimePlusNanos {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int nanos) {
-      return Refaster.anyOf(
-          localDateTime.plus(nanos, ChronoUnit.NANOS), localDateTime.plus(Duration.ofNanos(nanos)));
+      return localDateTime.plus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long nanos) {
+      return localDateTime.plus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -943,9 +1037,12 @@ final class TimeRules {
   static final class LocalDateTimePlusSeconds {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int seconds) {
-      return Refaster.anyOf(
-          localDateTime.plus(seconds, ChronoUnit.SECONDS),
-          localDateTime.plus(Duration.ofSeconds(seconds)));
+      return localDateTime.plus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long seconds) {
+      return localDateTime.plus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -958,9 +1055,12 @@ final class TimeRules {
   static final class LocalDateTimePlusMinutes {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int minutes) {
-      return Refaster.anyOf(
-          localDateTime.plus(minutes, ChronoUnit.MINUTES),
-          localDateTime.plus(Duration.ofMinutes(minutes)));
+      return localDateTime.plus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long minutes) {
+      return localDateTime.plus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -973,8 +1073,12 @@ final class TimeRules {
   static final class LocalDateTimePlusHours {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int hours) {
-      return Refaster.anyOf(
-          localDateTime.plus(hours, ChronoUnit.HOURS), localDateTime.plus(Duration.ofHours(hours)));
+      return localDateTime.plus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long hours) {
+      return localDateTime.plus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -987,8 +1091,12 @@ final class TimeRules {
   static final class LocalDateTimePlusDays {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int days) {
-      return Refaster.anyOf(
-          localDateTime.plus(days, ChronoUnit.DAYS), localDateTime.plus(Period.ofDays(days)));
+      return localDateTime.plus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long days) {
+      return localDateTime.plus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -1001,8 +1109,12 @@ final class TimeRules {
   static final class LocalDateTimePlusWeeks {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int weeks) {
-      return Refaster.anyOf(
-          localDateTime.plus(weeks, ChronoUnit.WEEKS), localDateTime.plus(Period.ofWeeks(weeks)));
+      return localDateTime.plus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long weeks) {
+      return localDateTime.plus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -1015,9 +1127,12 @@ final class TimeRules {
   static final class LocalDateTimePlusMonths {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int months) {
-      return Refaster.anyOf(
-          localDateTime.plus(months, ChronoUnit.MONTHS),
-          localDateTime.plus(Period.ofMonths(months)));
+      return localDateTime.plus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long months) {
+      return localDateTime.plus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -1030,8 +1145,12 @@ final class TimeRules {
   static final class LocalDateTimePlusYears {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int years) {
-      return Refaster.anyOf(
-          localDateTime.plus(years, ChronoUnit.YEARS), localDateTime.plus(Period.ofYears(years)));
+      return localDateTime.plus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long years) {
+      return localDateTime.plus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
@@ -1044,9 +1163,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusNanos {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int nanos) {
-      return Refaster.anyOf(
-          localDateTime.minus(nanos, ChronoUnit.NANOS),
-          localDateTime.minus(Duration.ofNanos(nanos)));
+      return localDateTime.minus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long nanos) {
+      return localDateTime.minus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -1059,9 +1181,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusSeconds {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int seconds) {
-      return Refaster.anyOf(
-          localDateTime.minus(seconds, ChronoUnit.SECONDS),
-          localDateTime.minus(Duration.ofSeconds(seconds)));
+      return localDateTime.minus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long seconds) {
+      return localDateTime.minus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -1074,9 +1199,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusMinutes {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int minutes) {
-      return Refaster.anyOf(
-          localDateTime.minus(minutes, ChronoUnit.MINUTES),
-          localDateTime.minus(Duration.ofMinutes(minutes)));
+      return localDateTime.minus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long minutes) {
+      return localDateTime.minus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -1089,9 +1217,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusHours {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int hours) {
-      return Refaster.anyOf(
-          localDateTime.minus(hours, ChronoUnit.HOURS),
-          localDateTime.minus(Duration.ofHours(hours)));
+      return localDateTime.minus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long hours) {
+      return localDateTime.minus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -1104,8 +1235,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusDays {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int days) {
-      return Refaster.anyOf(
-          localDateTime.minus(days, ChronoUnit.DAYS), localDateTime.minus(Period.ofDays(days)));
+      return localDateTime.minus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long days) {
+      return localDateTime.minus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -1118,8 +1253,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusWeeks {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int weeks) {
-      return Refaster.anyOf(
-          localDateTime.minus(weeks, ChronoUnit.WEEKS), localDateTime.minus(Period.ofWeeks(weeks)));
+      return localDateTime.minus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long weeks) {
+      return localDateTime.minus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -1132,9 +1271,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusMonths {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int months) {
-      return Refaster.anyOf(
-          localDateTime.minus(months, ChronoUnit.MONTHS),
-          localDateTime.minus(Period.ofMonths(months)));
+      return localDateTime.minus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long months) {
+      return localDateTime.minus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -1147,8 +1289,12 @@ final class TimeRules {
   static final class LocalDateTimeMinusYears {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int years) {
-      return Refaster.anyOf(
-          localDateTime.minus(years, ChronoUnit.YEARS), localDateTime.minus(Period.ofYears(years)));
+      return localDateTime.minus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, long years) {
+      return localDateTime.minus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
@@ -1161,9 +1307,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusNanos {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int nanos) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(nanos, ChronoUnit.NANOS),
-          offsetDateTime.plus(Duration.ofNanos(nanos)));
+      return offsetDateTime.plus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long nanos) {
+      return offsetDateTime.plus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -1176,9 +1325,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusSeconds {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int seconds) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(seconds, ChronoUnit.SECONDS),
-          offsetDateTime.plus(Duration.ofSeconds(seconds)));
+      return offsetDateTime.plus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long seconds) {
+      return offsetDateTime.plus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -1191,9 +1343,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusMinutes {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int minutes) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(minutes, ChronoUnit.MINUTES),
-          offsetDateTime.plus(Duration.ofMinutes(minutes)));
+      return offsetDateTime.plus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long minutes) {
+      return offsetDateTime.plus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -1206,9 +1361,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusHours {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int hours) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(hours, ChronoUnit.HOURS),
-          offsetDateTime.plus(Duration.ofHours(hours)));
+      return offsetDateTime.plus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long hours) {
+      return offsetDateTime.plus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -1221,8 +1379,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusDays {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int days) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(days, ChronoUnit.DAYS), offsetDateTime.plus(Period.ofDays(days)));
+      return offsetDateTime.plus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long days) {
+      return offsetDateTime.plus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -1235,8 +1397,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusWeeks {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int weeks) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(weeks, ChronoUnit.WEEKS), offsetDateTime.plus(Period.ofWeeks(weeks)));
+      return offsetDateTime.plus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long weeks) {
+      return offsetDateTime.plus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -1249,9 +1415,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusMonths {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int months) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(months, ChronoUnit.MONTHS),
-          offsetDateTime.plus(Period.ofMonths(months)));
+      return offsetDateTime.plus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long months) {
+      return offsetDateTime.plus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -1264,8 +1433,12 @@ final class TimeRules {
   static final class OffsetDateTimePlusYears {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int years) {
-      return Refaster.anyOf(
-          offsetDateTime.plus(years, ChronoUnit.YEARS), offsetDateTime.plus(Period.ofYears(years)));
+      return offsetDateTime.plus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long years) {
+      return offsetDateTime.plus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
@@ -1278,9 +1451,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusNanos {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int nanos) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(nanos, ChronoUnit.NANOS),
-          offsetDateTime.minus(Duration.ofNanos(nanos)));
+      return offsetDateTime.minus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long nanos) {
+      return offsetDateTime.minus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -1293,9 +1469,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusSeconds {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int seconds) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(seconds, ChronoUnit.SECONDS),
-          offsetDateTime.minus(Duration.ofSeconds(seconds)));
+      return offsetDateTime.minus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long seconds) {
+      return offsetDateTime.minus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -1308,9 +1487,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusMinutes {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int minutes) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(minutes, ChronoUnit.MINUTES),
-          offsetDateTime.minus(Duration.ofMinutes(minutes)));
+      return offsetDateTime.minus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long minutes) {
+      return offsetDateTime.minus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -1323,9 +1505,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusHours {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int hours) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(hours, ChronoUnit.HOURS),
-          offsetDateTime.minus(Duration.ofHours(hours)));
+      return offsetDateTime.minus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long hours) {
+      return offsetDateTime.minus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -1338,8 +1523,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusDays {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int days) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(days, ChronoUnit.DAYS), offsetDateTime.minus(Period.ofDays(days)));
+      return offsetDateTime.minus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long days) {
+      return offsetDateTime.minus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -1352,9 +1541,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusWeeks {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int weeks) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(weeks, ChronoUnit.WEEKS),
-          offsetDateTime.minus(Period.ofWeeks(weeks)));
+      return offsetDateTime.minus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long weeks) {
+      return offsetDateTime.minus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -1367,9 +1559,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusMonths {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int months) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(months, ChronoUnit.MONTHS),
-          offsetDateTime.minus(Period.ofMonths(months)));
+      return offsetDateTime.minus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long months) {
+      return offsetDateTime.minus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -1382,9 +1577,12 @@ final class TimeRules {
   static final class OffsetDateTimeMinusYears {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int years) {
-      return Refaster.anyOf(
-          offsetDateTime.minus(years, ChronoUnit.YEARS),
-          offsetDateTime.minus(Period.ofYears(years)));
+      return offsetDateTime.minus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, long years) {
+      return offsetDateTime.minus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
@@ -1397,8 +1595,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusNanos {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int nanos) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(nanos, ChronoUnit.NANOS), zonedDateTime.plus(Duration.ofNanos(nanos)));
+      return zonedDateTime.plus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long nanos) {
+      return zonedDateTime.plus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -1411,9 +1613,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusSeconds {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int seconds) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(seconds, ChronoUnit.SECONDS),
-          zonedDateTime.plus(Duration.ofSeconds(seconds)));
+      return zonedDateTime.plus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long seconds) {
+      return zonedDateTime.plus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -1426,9 +1631,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusMinutes {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int minutes) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(minutes, ChronoUnit.MINUTES),
-          zonedDateTime.plus(Duration.ofMinutes(minutes)));
+      return zonedDateTime.plus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long minutes) {
+      return zonedDateTime.plus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -1441,8 +1649,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusHours {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int hours) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(hours, ChronoUnit.HOURS), zonedDateTime.plus(Duration.ofHours(hours)));
+      return zonedDateTime.plus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long hours) {
+      return zonedDateTime.plus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -1455,8 +1667,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusDays {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int days) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(days, ChronoUnit.DAYS), zonedDateTime.plus(Period.ofDays(days)));
+      return zonedDateTime.plus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long days) {
+      return zonedDateTime.plus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -1469,8 +1685,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusWeeks {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int weeks) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(weeks, ChronoUnit.WEEKS), zonedDateTime.plus(Period.ofWeeks(weeks)));
+      return zonedDateTime.plus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long weeks) {
+      return zonedDateTime.plus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -1483,9 +1703,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusMonths {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int months) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(months, ChronoUnit.MONTHS),
-          zonedDateTime.plus(Period.ofMonths(months)));
+      return zonedDateTime.plus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long months) {
+      return zonedDateTime.plus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -1498,8 +1721,12 @@ final class TimeRules {
   static final class ZonedDateTimePlusYears {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int years) {
-      return Refaster.anyOf(
-          zonedDateTime.plus(years, ChronoUnit.YEARS), zonedDateTime.plus(Period.ofYears(years)));
+      return zonedDateTime.plus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long years) {
+      return zonedDateTime.plus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
@@ -1512,9 +1739,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusNanos {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int nanos) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(nanos, ChronoUnit.NANOS),
-          zonedDateTime.minus(Duration.ofNanos(nanos)));
+      return zonedDateTime.minus(Duration.ofNanos(nanos));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long nanos) {
+      return zonedDateTime.minus(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
@@ -1527,9 +1757,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusSeconds {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int seconds) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(seconds, ChronoUnit.SECONDS),
-          zonedDateTime.minus(Duration.ofSeconds(seconds)));
+      return zonedDateTime.minus(Duration.ofSeconds(seconds));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long seconds) {
+      return zonedDateTime.minus(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
@@ -1542,9 +1775,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusMinutes {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int minutes) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(minutes, ChronoUnit.MINUTES),
-          zonedDateTime.minus(Duration.ofMinutes(minutes)));
+      return zonedDateTime.minus(Duration.ofMinutes(minutes));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long minutes) {
+      return zonedDateTime.minus(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
@@ -1557,9 +1793,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusHours {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int hours) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(hours, ChronoUnit.HOURS),
-          zonedDateTime.minus(Duration.ofHours(hours)));
+      return zonedDateTime.minus(Duration.ofHours(hours));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long hours) {
+      return zonedDateTime.minus(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
@@ -1572,8 +1811,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusDays {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int days) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(days, ChronoUnit.DAYS), zonedDateTime.minus(Period.ofDays(days)));
+      return zonedDateTime.minus(Period.ofDays(days));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long days) {
+      return zonedDateTime.minus(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
@@ -1586,8 +1829,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusWeeks {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int weeks) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(weeks, ChronoUnit.WEEKS), zonedDateTime.minus(Period.ofWeeks(weeks)));
+      return zonedDateTime.minus(Period.ofWeeks(weeks));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long weeks) {
+      return zonedDateTime.minus(weeks, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
@@ -1600,9 +1847,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusMonths {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int months) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(months, ChronoUnit.MONTHS),
-          zonedDateTime.minus(Period.ofMonths(months)));
+      return zonedDateTime.minus(Period.ofMonths(months));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long months) {
+      return zonedDateTime.minus(months, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
@@ -1615,8 +1865,12 @@ final class TimeRules {
   static final class ZonedDateTimeMinusYears {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int years) {
-      return Refaster.anyOf(
-          zonedDateTime.minus(years, ChronoUnit.YEARS), zonedDateTime.minus(Period.ofYears(years)));
+      return zonedDateTime.minus(Period.ofYears(years));
+    }
+
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, long years) {
+      return zonedDateTime.minus(years, ChronoUnit.YEARS);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
@@ -583,7 +583,7 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link LocalDate#plusDays} (and variants) over more contrived alternatives. */
+  /** Prefer {@link LocalDate#plusDays(long)} over more contrived alternatives. */
   static final class LocalDatePlusDays {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int days) {
@@ -597,6 +597,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDate#plusWeeks(long)} over more contrived alternatives. */
   static final class LocalDatePlusWeeks {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int weeks) {
@@ -610,6 +611,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDate#plusMonths(long)} over more contrived alternatives. */
   static final class LocalDatePlusMonths {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int months) {
@@ -623,6 +625,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDate#plusYears(long)} over more contrived alternatives. */
   static final class LocalDatePlusYears {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int years) {
@@ -636,6 +639,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDate#minusDays(long)} over more contrived alternatives. */
   static final class LocalDateMinusDays {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int days) {
@@ -649,6 +653,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDate#minusWeeks(long)} over more contrived alternatives. */
   static final class LocalDateMinusWeeks {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int weeks) {
@@ -662,6 +667,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDate#minusMonths(long)} over more contrived alternatives. */
   static final class LocalDateMinusMonths {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int months) {
@@ -675,6 +681,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDate#minusYears(long)} over more contrived alternatives. */
   static final class LocalDateMinusYears {
     @BeforeTemplate
     LocalDate before(LocalDate localDate, int years) {
@@ -688,7 +695,7 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link LocalTime#plusNanos} (and variants) over more contrived alternatives. */
+  /** Prefer {@link LocalTime#plusNanos(long)} over more contrived alternatives. */
   static final class LocalTimePlusNanos {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int nanos) {
@@ -702,6 +709,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalTime#plusSeconds(long)} over more contrived alternatives. */
   static final class LocalTimePlusSeconds {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int seconds) {
@@ -715,6 +723,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalTime#plusMinutes(long)} over more contrived alternatives. */
   static final class LocalTimePlusMinutes {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int minutes) {
@@ -728,6 +737,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalTime#plusHours(long)} over more contrived alternatives. */
   static final class LocalTimePlusHours {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int hours) {
@@ -741,6 +751,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalTime#minusNanos(long)} over more contrived alternatives. */
   static final class LocalTimeMinusNanos {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int nanos) {
@@ -754,6 +765,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalTime#minusSeconds(long)} over more contrived alternatives. */
   static final class LocalTimeMinusSeconds {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int seconds) {
@@ -768,6 +780,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalTime#minusMinutes(long)} over more contrived alternatives. */
   static final class LocalTimeMinusMinutes {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int minutes) {
@@ -782,6 +795,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalTime#minusHours(long)} over more contrived alternatives. */
   static final class LocalTimeMinusHours {
     @BeforeTemplate
     LocalTime before(LocalTime localTime, int hours) {
@@ -795,7 +809,7 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link OffsetTime#plusNanos} (and variants) over more contrived alternatives. */
+  /** Prefer {@link OffsetTime#plusNanos(long)} over more contrived alternatives. */
   static final class OffsetTimePlusNanos {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int nanos) {
@@ -809,6 +823,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetTime#plusSeconds(long)} over more contrived alternatives. */
   static final class OffsetTimePlusSeconds {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int seconds) {
@@ -823,6 +838,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetTime#plusMinutes(long)} over more contrived alternatives. */
   static final class OffsetTimePlusMinutes {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int minutes) {
@@ -837,6 +853,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetTime#plusHours(long)} over more contrived alternatives. */
   static final class OffsetTimePlusHours {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int hours) {
@@ -850,6 +867,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetTime#minusNanos(long)} over more contrived alternatives. */
   static final class OffsetTimeMinusNanos {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int nanos) {
@@ -863,6 +881,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetTime#minusSeconds(long)} over more contrived alternatives. */
   static final class OffsetTimeMinusSeconds {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int seconds) {
@@ -877,6 +896,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetTime#minusMinutes(long)} over more contrived alternatives. */
   static final class OffsetTimeMinusMinutes {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int minutes) {
@@ -891,6 +911,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetTime#minusHours(long)} over more contrived alternatives. */
   static final class OffsetTimeMinusHours {
     @BeforeTemplate
     OffsetTime before(OffsetTime offsetTime, int hours) {
@@ -904,7 +925,7 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link LocalDateTime#plusNanos} (and variants) over more contrived alternatives. */
+  /** Prefer {@link LocalDateTime#plusNanos(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusNanos {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int nanos) {
@@ -918,6 +939,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#plusSeconds(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusSeconds {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int seconds) {
@@ -932,6 +954,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#plusMinutes(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusMinutes {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int minutes) {
@@ -946,6 +969,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#plusHours(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusHours {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int hours) {
@@ -959,6 +983,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#plusDays(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusDays {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int days) {
@@ -972,6 +997,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#plusWeeks(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusWeeks {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int weeks) {
@@ -985,6 +1011,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#plusMonths(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusMonths {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int months) {
@@ -999,6 +1026,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#plusYears(long)} over more contrived alternatives. */
   static final class LocalDateTimePlusYears {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int years) {
@@ -1012,6 +1040,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusNanos(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusNanos {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int nanos) {
@@ -1026,6 +1055,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusSeconds(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusSeconds {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int seconds) {
@@ -1040,6 +1070,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusMinutes(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusMinutes {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int minutes) {
@@ -1054,6 +1085,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusHours(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusHours {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int hours) {
@@ -1068,6 +1100,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusDays(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusDays {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int days) {
@@ -1081,6 +1114,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusWeeks(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusWeeks {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int weeks) {
@@ -1094,6 +1128,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusMonths(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusMonths {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int months) {
@@ -1108,6 +1143,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link LocalDateTime#minusYears(long)} over more contrived alternatives. */
   static final class LocalDateTimeMinusYears {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int years) {
@@ -1121,7 +1157,7 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link OffsetDateTime#plusNanos} (and variants) over more contrived alternatives. */
+  /** Prefer {@link OffsetDateTime#plusNanos(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusNanos {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int nanos) {
@@ -1136,6 +1172,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#plusSeconds(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusSeconds {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int seconds) {
@@ -1150,6 +1187,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#plusMinutes(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusMinutes {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int minutes) {
@@ -1164,6 +1202,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#plusHours(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusHours {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int hours) {
@@ -1178,6 +1217,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#plusDays(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusDays {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int days) {
@@ -1191,6 +1231,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#plusWeeks(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusWeeks {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int weeks) {
@@ -1204,6 +1245,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#plusMonths(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusMonths {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int months) {
@@ -1218,6 +1260,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#plusYears(long)} over more contrived alternatives. */
   static final class OffsetDateTimePlusYears {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int years) {
@@ -1231,6 +1274,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusNanos(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusNanos {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int nanos) {
@@ -1245,6 +1289,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusSeconds(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusSeconds {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int seconds) {
@@ -1259,6 +1304,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusMinutes(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusMinutes {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int minutes) {
@@ -1273,6 +1319,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusHours(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusHours {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int hours) {
@@ -1287,6 +1334,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusDays(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusDays {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int days) {
@@ -1300,6 +1348,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusWeeks(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusWeeks {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int weeks) {
@@ -1314,6 +1363,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusMonths(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusMonths {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int months) {
@@ -1328,6 +1378,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link OffsetDateTime#minusYears(long)} over more contrived alternatives. */
   static final class OffsetDateTimeMinusYears {
     @BeforeTemplate
     OffsetDateTime before(OffsetDateTime offsetDateTime, int years) {
@@ -1342,7 +1393,7 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link ZonedDateTime#plusNanos} (and variants) over more contrived alternatives. */
+  /** Prefer {@link ZonedDateTime#plusNanos(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusNanos {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int nanos) {
@@ -1356,6 +1407,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#plusSeconds(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusSeconds {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int seconds) {
@@ -1370,6 +1422,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#plusMinutes(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusMinutes {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int minutes) {
@@ -1384,6 +1437,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#plusHours(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusHours {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int hours) {
@@ -1397,6 +1451,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#plusDays(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusDays {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int days) {
@@ -1410,6 +1465,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#plusWeeks(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusWeeks {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int weeks) {
@@ -1423,6 +1479,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#plusMonths(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusMonths {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int months) {
@@ -1437,6 +1494,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#plusYears(long)} over more contrived alternatives. */
   static final class ZonedDateTimePlusYears {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int years) {
@@ -1450,6 +1508,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusNanos(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusNanos {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int nanos) {
@@ -1464,6 +1523,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusSeconds(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusSeconds {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int seconds) {
@@ -1478,6 +1538,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusMinutes(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusMinutes {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int minutes) {
@@ -1492,6 +1553,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusHours(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusHours {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int hours) {
@@ -1506,6 +1568,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusDays(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusDays {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int days) {
@@ -1519,6 +1582,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusWeeks(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusWeeks {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int weeks) {
@@ -1532,6 +1596,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusMonths(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusMonths {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int months) {
@@ -1546,6 +1611,7 @@ final class TimeRules {
     }
   }
 
+  /** Prefer {@link ZonedDateTime#minusYears(long)} over more contrived alternatives. */
   static final class ZonedDateTimeMinusYears {
     @BeforeTemplate
     ZonedDateTime before(ZonedDateTime zonedDateTime, int years) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
@@ -959,6 +959,19 @@ final class TimeRules {
     }
   }
 
+  static final class LocalDateTimePlusDays {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int days) {
+      return Refaster.anyOf(
+          localDateTime.plus(days, ChronoUnit.DAYS), localDateTime.plus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int days) {
+      return localDateTime.plusDays(days);
+    }
+  }
+
   static final class LocalDateTimePlusWeeks {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int weeks) {
@@ -1055,6 +1068,19 @@ final class TimeRules {
     }
   }
 
+  static final class LocalDateTimeMinusDays {
+    @BeforeTemplate
+    LocalDateTime before(LocalDateTime localDateTime, int days) {
+      return Refaster.anyOf(
+          localDateTime.minus(days, ChronoUnit.DAYS), localDateTime.minus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    LocalDateTime after(LocalDateTime localDateTime, int days) {
+      return localDateTime.minusDays(days);
+    }
+  }
+
   static final class LocalDateTimeMinusWeeks {
     @BeforeTemplate
     LocalDateTime before(LocalDateTime localDateTime, int weeks) {
@@ -1098,191 +1124,221 @@ final class TimeRules {
   /** Prefer {@link OffsetDateTime#plusNanos} (and variants) over more contrived alternatives. */
   static final class OffsetDateTimePlusNanos {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int nanos) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int nanos) {
       return Refaster.anyOf(
-          localDateTime.plus(nanos, ChronoUnit.NANOS), localDateTime.plus(Duration.ofNanos(nanos)));
+          offsetDateTime.plus(nanos, ChronoUnit.NANOS),
+          offsetDateTime.plus(Duration.ofNanos(nanos)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int nanos) {
-      return localDateTime.plusNanos(nanos);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int nanos) {
+      return offsetDateTime.plusNanos(nanos);
     }
   }
 
   static final class OffsetDateTimePlusSeconds {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int seconds) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int seconds) {
       return Refaster.anyOf(
-          localDateTime.plus(seconds, ChronoUnit.SECONDS),
-          localDateTime.plus(Duration.ofSeconds(seconds)));
+          offsetDateTime.plus(seconds, ChronoUnit.SECONDS),
+          offsetDateTime.plus(Duration.ofSeconds(seconds)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int seconds) {
-      return localDateTime.plusSeconds(seconds);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int seconds) {
+      return offsetDateTime.plusSeconds(seconds);
     }
   }
 
   static final class OffsetDateTimePlusMinutes {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int minutes) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int minutes) {
       return Refaster.anyOf(
-          localDateTime.plus(minutes, ChronoUnit.MINUTES),
-          localDateTime.plus(Duration.ofMinutes(minutes)));
+          offsetDateTime.plus(minutes, ChronoUnit.MINUTES),
+          offsetDateTime.plus(Duration.ofMinutes(minutes)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int minutes) {
-      return localDateTime.plusMinutes(minutes);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int minutes) {
+      return offsetDateTime.plusMinutes(minutes);
     }
   }
 
   static final class OffsetDateTimePlusHours {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int hours) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int hours) {
       return Refaster.anyOf(
-          localDateTime.plus(hours, ChronoUnit.HOURS), localDateTime.plus(Duration.ofHours(hours)));
+          offsetDateTime.plus(hours, ChronoUnit.HOURS),
+          offsetDateTime.plus(Duration.ofHours(hours)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int hours) {
-      return localDateTime.plusHours(hours);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int hours) {
+      return offsetDateTime.plusHours(hours);
+    }
+  }
+
+  static final class OffsetDateTimePlusDays {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int days) {
+      return Refaster.anyOf(
+          offsetDateTime.plus(days, ChronoUnit.DAYS), offsetDateTime.plus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int days) {
+      return offsetDateTime.plusDays(days);
     }
   }
 
   static final class OffsetDateTimePlusWeeks {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int weeks) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int weeks) {
       return Refaster.anyOf(
-          localDateTime.plus(weeks, ChronoUnit.WEEKS), localDateTime.plus(Period.ofWeeks(weeks)));
+          offsetDateTime.plus(weeks, ChronoUnit.WEEKS), offsetDateTime.plus(Period.ofWeeks(weeks)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int weeks) {
-      return localDateTime.plusWeeks(weeks);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int weeks) {
+      return offsetDateTime.plusWeeks(weeks);
     }
   }
 
   static final class OffsetDateTimePlusMonths {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int months) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int months) {
       return Refaster.anyOf(
-          localDateTime.plus(months, ChronoUnit.MONTHS),
-          localDateTime.plus(Period.ofMonths(months)));
+          offsetDateTime.plus(months, ChronoUnit.MONTHS),
+          offsetDateTime.plus(Period.ofMonths(months)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int months) {
-      return localDateTime.plusMonths(months);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int months) {
+      return offsetDateTime.plusMonths(months);
     }
   }
 
   static final class OffsetDateTimePlusYears {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int years) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int years) {
       return Refaster.anyOf(
-          localDateTime.plus(years, ChronoUnit.YEARS), localDateTime.plus(Period.ofYears(years)));
+          offsetDateTime.plus(years, ChronoUnit.YEARS), offsetDateTime.plus(Period.ofYears(years)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int years) {
-      return localDateTime.plusYears(years);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int years) {
+      return offsetDateTime.plusYears(years);
     }
   }
 
   static final class OffsetDateTimeMinusNanos {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int nanos) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int nanos) {
       return Refaster.anyOf(
-          localDateTime.minus(nanos, ChronoUnit.NANOS),
-          localDateTime.minus(Duration.ofNanos(nanos)));
+          offsetDateTime.minus(nanos, ChronoUnit.NANOS),
+          offsetDateTime.minus(Duration.ofNanos(nanos)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int nanos) {
-      return localDateTime.minusNanos(nanos);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int nanos) {
+      return offsetDateTime.minusNanos(nanos);
     }
   }
 
   static final class OffsetDateTimeMinusSeconds {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int seconds) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int seconds) {
       return Refaster.anyOf(
-          localDateTime.minus(seconds, ChronoUnit.SECONDS),
-          localDateTime.minus(Duration.ofSeconds(seconds)));
+          offsetDateTime.minus(seconds, ChronoUnit.SECONDS),
+          offsetDateTime.minus(Duration.ofSeconds(seconds)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int seconds) {
-      return localDateTime.minusSeconds(seconds);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int seconds) {
+      return offsetDateTime.minusSeconds(seconds);
     }
   }
 
   static final class OffsetDateTimeMinusMinutes {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int minutes) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int minutes) {
       return Refaster.anyOf(
-          localDateTime.minus(minutes, ChronoUnit.MINUTES),
-          localDateTime.minus(Duration.ofMinutes(minutes)));
+          offsetDateTime.minus(minutes, ChronoUnit.MINUTES),
+          offsetDateTime.minus(Duration.ofMinutes(minutes)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int minutes) {
-      return localDateTime.minusMinutes(minutes);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int minutes) {
+      return offsetDateTime.minusMinutes(minutes);
     }
   }
 
   static final class OffsetDateTimeMinusHours {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int hours) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int hours) {
       return Refaster.anyOf(
-          localDateTime.minus(hours, ChronoUnit.HOURS),
-          localDateTime.minus(Duration.ofHours(hours)));
+          offsetDateTime.minus(hours, ChronoUnit.HOURS),
+          offsetDateTime.minus(Duration.ofHours(hours)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int hours) {
-      return localDateTime.minusHours(hours);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int hours) {
+      return offsetDateTime.minusHours(hours);
+    }
+  }
+
+  static final class OffsetDateTimeMinusDays {
+    @BeforeTemplate
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int days) {
+      return Refaster.anyOf(
+          offsetDateTime.minus(days, ChronoUnit.DAYS), offsetDateTime.minus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int days) {
+      return offsetDateTime.minusDays(days);
     }
   }
 
   static final class OffsetDateTimeMinusWeeks {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int weeks) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int weeks) {
       return Refaster.anyOf(
-          localDateTime.minus(weeks, ChronoUnit.WEEKS), localDateTime.minus(Period.ofWeeks(weeks)));
+          offsetDateTime.minus(weeks, ChronoUnit.WEEKS),
+          offsetDateTime.minus(Period.ofWeeks(weeks)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int weeks) {
-      return localDateTime.minusWeeks(weeks);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int weeks) {
+      return offsetDateTime.minusWeeks(weeks);
     }
   }
 
   static final class OffsetDateTimeMinusMonths {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int months) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int months) {
       return Refaster.anyOf(
-          localDateTime.minus(months, ChronoUnit.MONTHS),
-          localDateTime.minus(Period.ofMonths(months)));
+          offsetDateTime.minus(months, ChronoUnit.MONTHS),
+          offsetDateTime.minus(Period.ofMonths(months)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int months) {
-      return localDateTime.minusMonths(months);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int months) {
+      return offsetDateTime.minusMonths(months);
     }
   }
 
   static final class OffsetDateTimeMinusYears {
     @BeforeTemplate
-    OffsetDateTime before(OffsetDateTime localDateTime, int years) {
+    OffsetDateTime before(OffsetDateTime offsetDateTime, int years) {
       return Refaster.anyOf(
-          localDateTime.minus(years, ChronoUnit.YEARS), localDateTime.minus(Period.ofYears(years)));
+          offsetDateTime.minus(years, ChronoUnit.YEARS),
+          offsetDateTime.minus(Period.ofYears(years)));
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime localDateTime, int years) {
-      return localDateTime.minusYears(years);
+    OffsetDateTime after(OffsetDateTime offsetDateTime, int years) {
+      return offsetDateTime.minusYears(years);
     }
   }
 
@@ -1338,6 +1394,19 @@ final class TimeRules {
     @AfterTemplate
     ZonedDateTime after(ZonedDateTime zonedDateTime, int hours) {
       return zonedDateTime.plusHours(hours);
+    }
+  }
+
+  static final class ZonedDateTimePlusDays {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int days) {
+      return Refaster.anyOf(
+          zonedDateTime.plus(days, ChronoUnit.DAYS), zonedDateTime.plus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int days) {
+      return zonedDateTime.plusDays(days);
     }
   }
 
@@ -1434,6 +1503,19 @@ final class TimeRules {
     @AfterTemplate
     ZonedDateTime after(ZonedDateTime zonedDateTime, int hours) {
       return zonedDateTime.minusHours(hours);
+    }
+  }
+
+  static final class ZonedDateTimeMinusDays {
+    @BeforeTemplate
+    ZonedDateTime before(ZonedDateTime zonedDateTime, int days) {
+      return Refaster.anyOf(
+          zonedDateTime.minus(days, ChronoUnit.DAYS), zonedDateTime.minus(Period.ofDays(days)));
+    }
+
+    @AfterTemplate
+    ZonedDateTime after(ZonedDateTime zonedDateTime, int days) {
+      return zonedDateTime.minusDays(days);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
@@ -583,6 +583,9 @@ final class TimeRules {
     }
   }
 
+  // XXX: The `DateType{Plus,Minus}Unit` rules below contain a lot of boilerplate. Consider
+  // introducing an Error Prone check instead.
+
   /** Prefer {@link LocalDate#plusDays(long)} over more contrived alternatives. */
   static final class LocalDatePlusDays {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
@@ -225,372 +225,382 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<LocalDate> testLocalDatePlusDays() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.plus(1, ChronoUnit.DAYS), LocalDate.EPOCH.plus(Period.ofDays(1)));
+        LocalDate.EPOCH.plus(1L, ChronoUnit.DAYS), LocalDate.EPOCH.plus(Period.ofDays(1)));
   }
 
   ImmutableSet<LocalDate> testLocalDatePlusWeeks() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.plus(1, ChronoUnit.WEEKS), LocalDate.EPOCH.plus(Period.ofWeeks(1)));
+        LocalDate.EPOCH.plus(1L, ChronoUnit.WEEKS), LocalDate.EPOCH.plus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<LocalDate> testLocalDatePlusMonths() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.plus(1, ChronoUnit.MONTHS), LocalDate.EPOCH.plus(Period.ofMonths(1)));
+        LocalDate.EPOCH.plus(1L, ChronoUnit.MONTHS), LocalDate.EPOCH.plus(Period.ofMonths(1)));
   }
 
   ImmutableSet<LocalDate> testLocalDatePlusYears() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.plus(1, ChronoUnit.YEARS), LocalDate.EPOCH.plus(Period.ofYears(1)));
+        LocalDate.EPOCH.plus(1L, ChronoUnit.YEARS), LocalDate.EPOCH.plus(Period.ofYears(1)));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusDays() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.minus(1, ChronoUnit.DAYS), LocalDate.EPOCH.minus(Period.ofDays(1)));
+        LocalDate.EPOCH.minus(1L, ChronoUnit.DAYS), LocalDate.EPOCH.minus(Period.ofDays(1)));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusWeeks() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.minus(1, ChronoUnit.WEEKS), LocalDate.EPOCH.minus(Period.ofWeeks(1)));
+        LocalDate.EPOCH.minus(1L, ChronoUnit.WEEKS), LocalDate.EPOCH.minus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusMonths() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.minus(1, ChronoUnit.MONTHS), LocalDate.EPOCH.minus(Period.ofMonths(1)));
+        LocalDate.EPOCH.minus(1L, ChronoUnit.MONTHS), LocalDate.EPOCH.minus(Period.ofMonths(1)));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusYears() {
     return ImmutableSet.of(
-        LocalDate.EPOCH.minus(1, ChronoUnit.YEARS), LocalDate.EPOCH.minus(Period.ofYears(1)));
+        LocalDate.EPOCH.minus(1L, ChronoUnit.YEARS), LocalDate.EPOCH.minus(Period.ofYears(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusNanos() {
     return ImmutableSet.of(
-        LocalTime.NOON.plus(1, ChronoUnit.NANOS), LocalTime.NOON.plus(Duration.ofNanos(1)));
+        LocalTime.NOON.plus(1L, ChronoUnit.NANOS), LocalTime.NOON.plus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusSeconds() {
     return ImmutableSet.of(
-        LocalTime.NOON.plus(1, ChronoUnit.SECONDS), LocalTime.NOON.plus(Duration.ofSeconds(1)));
+        LocalTime.NOON.plus(1L, ChronoUnit.SECONDS), LocalTime.NOON.plus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusMinutes() {
     return ImmutableSet.of(
-        LocalTime.NOON.plus(1, ChronoUnit.MINUTES), LocalTime.NOON.plus(Duration.ofMinutes(1)));
+        LocalTime.NOON.plus(1L, ChronoUnit.MINUTES), LocalTime.NOON.plus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusHours() {
     return ImmutableSet.of(
-        LocalTime.NOON.plus(1, ChronoUnit.HOURS), LocalTime.NOON.plus(Duration.ofHours(1)));
+        LocalTime.NOON.plus(1L, ChronoUnit.HOURS), LocalTime.NOON.plus(Duration.ofHours(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusNanos() {
     return ImmutableSet.of(
-        LocalTime.NOON.minus(1, ChronoUnit.NANOS), LocalTime.NOON.minus(Duration.ofNanos(1)));
+        LocalTime.NOON.minus(1L, ChronoUnit.NANOS), LocalTime.NOON.minus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusSeconds() {
     return ImmutableSet.of(
-        LocalTime.NOON.minus(1, ChronoUnit.SECONDS), LocalTime.NOON.minus(Duration.ofSeconds(1)));
+        LocalTime.NOON.minus(1L, ChronoUnit.SECONDS), LocalTime.NOON.minus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusMinutes() {
     return ImmutableSet.of(
-        LocalTime.NOON.minus(1, ChronoUnit.MINUTES), LocalTime.NOON.minus(Duration.ofMinutes(1)));
+        LocalTime.NOON.minus(1L, ChronoUnit.MINUTES), LocalTime.NOON.minus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusHours() {
     return ImmutableSet.of(
-        LocalTime.NOON.minus(1, ChronoUnit.HOURS), LocalTime.NOON.minus(Duration.ofHours(1)));
+        LocalTime.NOON.minus(1L, ChronoUnit.HOURS), LocalTime.NOON.minus(Duration.ofHours(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusNanos() {
     return ImmutableSet.of(
-        OffsetTime.MIN.plus(1, ChronoUnit.NANOS), OffsetTime.MIN.plus(Duration.ofNanos(1)));
+        OffsetTime.MIN.plus(1L, ChronoUnit.NANOS), OffsetTime.MIN.plus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusSeconds() {
     return ImmutableSet.of(
-        OffsetTime.MIN.plus(1, ChronoUnit.SECONDS), OffsetTime.MIN.plus(Duration.ofSeconds(1)));
+        OffsetTime.MIN.plus(1L, ChronoUnit.SECONDS), OffsetTime.MIN.plus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusMinutes() {
     return ImmutableSet.of(
-        OffsetTime.MIN.plus(1, ChronoUnit.MINUTES), OffsetTime.MIN.plus(Duration.ofMinutes(1)));
+        OffsetTime.MIN.plus(1L, ChronoUnit.MINUTES), OffsetTime.MIN.plus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusHours() {
     return ImmutableSet.of(
-        OffsetTime.MIN.plus(1, ChronoUnit.HOURS), OffsetTime.MIN.plus(Duration.ofHours(1)));
+        OffsetTime.MIN.plus(1L, ChronoUnit.HOURS), OffsetTime.MIN.plus(Duration.ofHours(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusNanos() {
     return ImmutableSet.of(
-        OffsetTime.MAX.minus(1, ChronoUnit.NANOS), OffsetTime.MAX.minus(Duration.ofNanos(1)));
+        OffsetTime.MAX.minus(1L, ChronoUnit.NANOS), OffsetTime.MAX.minus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusSeconds() {
     return ImmutableSet.of(
-        OffsetTime.MAX.minus(1, ChronoUnit.SECONDS), OffsetTime.MAX.minus(Duration.ofSeconds(1)));
+        OffsetTime.MAX.minus(1L, ChronoUnit.SECONDS), OffsetTime.MAX.minus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusMinutes() {
     return ImmutableSet.of(
-        OffsetTime.MAX.minus(1, ChronoUnit.MINUTES), OffsetTime.MAX.minus(Duration.ofMinutes(1)));
+        OffsetTime.MAX.minus(1L, ChronoUnit.MINUTES), OffsetTime.MAX.minus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusHours() {
     return ImmutableSet.of(
-        OffsetTime.MAX.minus(1, ChronoUnit.HOURS), OffsetTime.MAX.minus(Duration.ofHours(1)));
+        OffsetTime.MAX.minus(1L, ChronoUnit.HOURS), OffsetTime.MAX.minus(Duration.ofHours(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusNanos() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.NANOS), LocalDateTime.MIN.plus(Duration.ofNanos(1)));
+        LocalDateTime.MIN.plus(1L, ChronoUnit.NANOS), LocalDateTime.MIN.plus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusSeconds() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.SECONDS),
+        LocalDateTime.MIN.plus(1L, ChronoUnit.SECONDS),
         LocalDateTime.MIN.plus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusMinutes() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.MINUTES),
+        LocalDateTime.MIN.plus(1L, ChronoUnit.MINUTES),
         LocalDateTime.MIN.plus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusHours() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.HOURS), LocalDateTime.MIN.plus(Duration.ofHours(1)));
+        LocalDateTime.MIN.plus(1L, ChronoUnit.HOURS), LocalDateTime.MIN.plus(Duration.ofHours(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusDays() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.DAYS), LocalDateTime.MIN.plus(Period.ofDays(1)));
+        LocalDateTime.MIN.plus(1L, ChronoUnit.DAYS), LocalDateTime.MIN.plus(Period.ofDays(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusWeeks() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.WEEKS), LocalDateTime.MIN.plus(Period.ofWeeks(1)));
+        LocalDateTime.MIN.plus(1L, ChronoUnit.WEEKS), LocalDateTime.MIN.plus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusMonths() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.MONTHS), LocalDateTime.MIN.plus(Period.ofMonths(1)));
+        LocalDateTime.MIN.plus(1L, ChronoUnit.MONTHS), LocalDateTime.MIN.plus(Period.ofMonths(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusYears() {
     return ImmutableSet.of(
-        LocalDateTime.MIN.plus(1, ChronoUnit.YEARS), LocalDateTime.MIN.plus(Period.ofYears(1)));
+        LocalDateTime.MIN.plus(1L, ChronoUnit.YEARS), LocalDateTime.MIN.plus(Period.ofYears(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusNanos() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.NANOS), LocalDateTime.MAX.minus(Duration.ofNanos(1)));
+        LocalDateTime.MAX.minus(1L, ChronoUnit.NANOS),
+        LocalDateTime.MAX.minus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusSeconds() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.SECONDS),
+        LocalDateTime.MAX.minus(1L, ChronoUnit.SECONDS),
         LocalDateTime.MAX.minus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusMinutes() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.MINUTES),
+        LocalDateTime.MAX.minus(1L, ChronoUnit.MINUTES),
         LocalDateTime.MAX.minus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusHours() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.HOURS), LocalDateTime.MAX.minus(Duration.ofHours(1)));
+        LocalDateTime.MAX.minus(1L, ChronoUnit.HOURS),
+        LocalDateTime.MAX.minus(Duration.ofHours(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusDays() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.DAYS), LocalDateTime.MAX.minus(Period.ofDays(1)));
+        LocalDateTime.MAX.minus(1L, ChronoUnit.DAYS), LocalDateTime.MAX.minus(Period.ofDays(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusWeeks() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.WEEKS), LocalDateTime.MAX.minus(Period.ofWeeks(1)));
+        LocalDateTime.MAX.minus(1L, ChronoUnit.WEEKS), LocalDateTime.MAX.minus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusMonths() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.MONTHS), LocalDateTime.MAX.minus(Period.ofMonths(1)));
+        LocalDateTime.MAX.minus(1L, ChronoUnit.MONTHS),
+        LocalDateTime.MAX.minus(Period.ofMonths(1)));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusYears() {
     return ImmutableSet.of(
-        LocalDateTime.MAX.minus(1, ChronoUnit.YEARS), LocalDateTime.MAX.minus(Period.ofYears(1)));
+        LocalDateTime.MAX.minus(1L, ChronoUnit.YEARS), LocalDateTime.MAX.minus(Period.ofYears(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusNanos() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.NANOS), OffsetDateTime.MIN.plus(Duration.ofNanos(1)));
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.NANOS),
+        OffsetDateTime.MIN.plus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusSeconds() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.SECONDS),
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.SECONDS),
         OffsetDateTime.MIN.plus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMinutes() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.MINUTES),
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.MINUTES),
         OffsetDateTime.MIN.plus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusHours() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.HOURS), OffsetDateTime.MIN.plus(Duration.ofHours(1)));
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.HOURS),
+        OffsetDateTime.MIN.plus(Duration.ofHours(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusDays() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.DAYS), OffsetDateTime.MIN.plus(Period.ofDays(1)));
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.DAYS), OffsetDateTime.MIN.plus(Period.ofDays(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusWeeks() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.WEEKS), OffsetDateTime.MIN.plus(Period.ofWeeks(1)));
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.WEEKS), OffsetDateTime.MIN.plus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMonths() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.MONTHS), OffsetDateTime.MIN.plus(Period.ofMonths(1)));
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.MONTHS),
+        OffsetDateTime.MIN.plus(Period.ofMonths(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusYears() {
     return ImmutableSet.of(
-        OffsetDateTime.MIN.plus(1, ChronoUnit.YEARS), OffsetDateTime.MIN.plus(Period.ofYears(1)));
+        OffsetDateTime.MIN.plus(1L, ChronoUnit.YEARS), OffsetDateTime.MIN.plus(Period.ofYears(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusNanos() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.NANOS),
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.NANOS),
         OffsetDateTime.MAX.minus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusSeconds() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.SECONDS),
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.SECONDS),
         OffsetDateTime.MAX.minus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMinutes() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.MINUTES),
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.MINUTES),
         OffsetDateTime.MAX.minus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusHours() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.HOURS),
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.HOURS),
         OffsetDateTime.MAX.minus(Duration.ofHours(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusDays() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.DAYS), OffsetDateTime.MAX.minus(Period.ofDays(1)));
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.DAYS), OffsetDateTime.MAX.minus(Period.ofDays(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusWeeks() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.WEEKS), OffsetDateTime.MAX.minus(Period.ofWeeks(1)));
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.WEEKS),
+        OffsetDateTime.MAX.minus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMonths() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.MONTHS),
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.MONTHS),
         OffsetDateTime.MAX.minus(Period.ofMonths(1)));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusYears() {
     return ImmutableSet.of(
-        OffsetDateTime.MAX.minus(1, ChronoUnit.YEARS), OffsetDateTime.MAX.minus(Period.ofYears(1)));
+        OffsetDateTime.MAX.minus(1L, ChronoUnit.YEARS),
+        OffsetDateTime.MAX.minus(Period.ofYears(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusNanos() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.NANOS), ZONED_DATE_TIME.plus(Duration.ofNanos(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.NANOS), ZONED_DATE_TIME.plus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusSeconds() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.SECONDS), ZONED_DATE_TIME.plus(Duration.ofSeconds(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.SECONDS), ZONED_DATE_TIME.plus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusMinutes() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.MINUTES), ZONED_DATE_TIME.plus(Duration.ofMinutes(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.MINUTES), ZONED_DATE_TIME.plus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusHours() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.HOURS), ZONED_DATE_TIME.plus(Duration.ofHours(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.HOURS), ZONED_DATE_TIME.plus(Duration.ofHours(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusDays() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.DAYS), ZONED_DATE_TIME.plus(Period.ofDays(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.DAYS), ZONED_DATE_TIME.plus(Period.ofDays(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusWeeks() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.WEEKS), ZONED_DATE_TIME.plus(Period.ofWeeks(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.WEEKS), ZONED_DATE_TIME.plus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusMonths() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.MONTHS), ZONED_DATE_TIME.plus(Period.ofMonths(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.MONTHS), ZONED_DATE_TIME.plus(Period.ofMonths(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusYears() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.plus(1, ChronoUnit.YEARS), ZONED_DATE_TIME.plus(Period.ofYears(1)));
+        ZONED_DATE_TIME.plus(1L, ChronoUnit.YEARS), ZONED_DATE_TIME.plus(Period.ofYears(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusNanos() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.NANOS), ZONED_DATE_TIME.minus(Duration.ofNanos(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.NANOS), ZONED_DATE_TIME.minus(Duration.ofNanos(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusSeconds() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.SECONDS), ZONED_DATE_TIME.minus(Duration.ofSeconds(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.SECONDS),
+        ZONED_DATE_TIME.minus(Duration.ofSeconds(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMinutes() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.MINUTES), ZONED_DATE_TIME.minus(Duration.ofMinutes(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.MINUTES),
+        ZONED_DATE_TIME.minus(Duration.ofMinutes(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusHours() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.HOURS), ZONED_DATE_TIME.minus(Duration.ofHours(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.HOURS), ZONED_DATE_TIME.minus(Duration.ofHours(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusDays() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.DAYS), ZONED_DATE_TIME.minus(Period.ofDays(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.DAYS), ZONED_DATE_TIME.minus(Period.ofDays(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusWeeks() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.WEEKS), ZONED_DATE_TIME.minus(Period.ofWeeks(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.WEEKS), ZONED_DATE_TIME.minus(Period.ofWeeks(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMonths() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.MONTHS), ZONED_DATE_TIME.minus(Period.ofMonths(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.MONTHS), ZONED_DATE_TIME.minus(Period.ofMonths(1)));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusYears() {
     return ImmutableSet.of(
-        ZONED_DATE_TIME.minus(1, ChronoUnit.YEARS), ZONED_DATE_TIME.minus(Period.ofYears(1)));
+        ZONED_DATE_TIME.minus(1L, ChronoUnit.YEARS), ZONED_DATE_TIME.minus(Period.ofYears(1)));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
@@ -17,6 +17,8 @@ import java.time.temporal.ChronoUnit;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class TimeRulesTest implements RefasterRuleCollectionTestCase {
+  private static final ZonedDateTime ZONED_DATE_TIME = Instant.EPOCH.atZone(ZoneOffset.UTC);
+
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(ChronoUnit.class);
@@ -511,9 +513,6 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         OffsetDateTime.MAX.minus(1, ChronoUnit.YEARS), OffsetDateTime.MAX.minus(Period.ofYears(1)));
   }
-
-  private static final ZonedDateTime ZONED_DATE_TIME =
-      ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusNanos() {
     return ImmutableSet.of(

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
@@ -220,4 +220,378 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
         Period.ofYears(0),
         Period.of(0, 0, 0));
   }
+
+  ImmutableSet<LocalDate> testLocalDatePlusDays() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.plus(1, ChronoUnit.DAYS), LocalDate.EPOCH.plus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<LocalDate> testLocalDatePlusWeeks() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.plus(1, ChronoUnit.WEEKS), LocalDate.EPOCH.plus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<LocalDate> testLocalDatePlusMonths() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.plus(1, ChronoUnit.MONTHS), LocalDate.EPOCH.plus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<LocalDate> testLocalDatePlusYears() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.plus(1, ChronoUnit.YEARS), LocalDate.EPOCH.plus(Period.ofYears(1)));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusDays() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.minus(1, ChronoUnit.DAYS), LocalDate.EPOCH.minus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusWeeks() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.minus(1, ChronoUnit.WEEKS), LocalDate.EPOCH.minus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusMonths() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.minus(1, ChronoUnit.MONTHS), LocalDate.EPOCH.minus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusYears() {
+    return ImmutableSet.of(
+        LocalDate.EPOCH.minus(1, ChronoUnit.YEARS), LocalDate.EPOCH.minus(Period.ofYears(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusNanos() {
+    return ImmutableSet.of(
+        LocalTime.NOON.plus(1, ChronoUnit.NANOS), LocalTime.NOON.plus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusSeconds() {
+    return ImmutableSet.of(
+        LocalTime.NOON.plus(1, ChronoUnit.SECONDS), LocalTime.NOON.plus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusMinutes() {
+    return ImmutableSet.of(
+        LocalTime.NOON.plus(1, ChronoUnit.MINUTES), LocalTime.NOON.plus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusHours() {
+    return ImmutableSet.of(
+        LocalTime.NOON.plus(1, ChronoUnit.HOURS), LocalTime.NOON.plus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusNanos() {
+    return ImmutableSet.of(
+        LocalTime.NOON.minus(1, ChronoUnit.NANOS), LocalTime.NOON.minus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusSeconds() {
+    return ImmutableSet.of(
+        LocalTime.NOON.minus(1, ChronoUnit.SECONDS), LocalTime.NOON.minus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusMinutes() {
+    return ImmutableSet.of(
+        LocalTime.NOON.minus(1, ChronoUnit.MINUTES), LocalTime.NOON.minus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusHours() {
+    return ImmutableSet.of(
+        LocalTime.NOON.minus(1, ChronoUnit.HOURS), LocalTime.NOON.minus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusNanos() {
+    return ImmutableSet.of(
+        OffsetTime.MIN.plus(1, ChronoUnit.NANOS), OffsetTime.MIN.plus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusSeconds() {
+    return ImmutableSet.of(
+        OffsetTime.MIN.plus(1, ChronoUnit.SECONDS), OffsetTime.MIN.plus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusMinutes() {
+    return ImmutableSet.of(
+        OffsetTime.MIN.plus(1, ChronoUnit.MINUTES), OffsetTime.MIN.plus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusHours() {
+    return ImmutableSet.of(
+        OffsetTime.MIN.plus(1, ChronoUnit.HOURS), OffsetTime.MIN.plus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusNanos() {
+    return ImmutableSet.of(
+        OffsetTime.MAX.minus(1, ChronoUnit.NANOS), OffsetTime.MAX.minus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusSeconds() {
+    return ImmutableSet.of(
+        OffsetTime.MAX.minus(1, ChronoUnit.SECONDS), OffsetTime.MAX.minus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusMinutes() {
+    return ImmutableSet.of(
+        OffsetTime.MAX.minus(1, ChronoUnit.MINUTES), OffsetTime.MAX.minus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusHours() {
+    return ImmutableSet.of(
+        OffsetTime.MAX.minus(1, ChronoUnit.HOURS), OffsetTime.MAX.minus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusNanos() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.NANOS), LocalDateTime.MIN.plus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusSeconds() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.SECONDS),
+        LocalDateTime.MIN.plus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusMinutes() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.MINUTES),
+        LocalDateTime.MIN.plus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusHours() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.HOURS), LocalDateTime.MIN.plus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusDays() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.DAYS), LocalDateTime.MIN.plus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusWeeks() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.WEEKS), LocalDateTime.MIN.plus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusMonths() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.MONTHS), LocalDateTime.MIN.plus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusYears() {
+    return ImmutableSet.of(
+        LocalDateTime.MIN.plus(1, ChronoUnit.YEARS), LocalDateTime.MIN.plus(Period.ofYears(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusNanos() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.NANOS), LocalDateTime.MAX.minus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusSeconds() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.SECONDS),
+        LocalDateTime.MAX.minus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusMinutes() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.MINUTES),
+        LocalDateTime.MAX.minus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusHours() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.HOURS), LocalDateTime.MAX.minus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusDays() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.DAYS), LocalDateTime.MAX.minus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusWeeks() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.WEEKS), LocalDateTime.MAX.minus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusMonths() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.MONTHS), LocalDateTime.MAX.minus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusYears() {
+    return ImmutableSet.of(
+        LocalDateTime.MAX.minus(1, ChronoUnit.YEARS), LocalDateTime.MAX.minus(Period.ofYears(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusNanos() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.NANOS), OffsetDateTime.MIN.plus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusSeconds() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.SECONDS),
+        OffsetDateTime.MIN.plus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMinutes() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.MINUTES),
+        OffsetDateTime.MIN.plus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusHours() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.HOURS), OffsetDateTime.MIN.plus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusDays() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.DAYS), OffsetDateTime.MIN.plus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusWeeks() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.WEEKS), OffsetDateTime.MIN.plus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMonths() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.MONTHS), OffsetDateTime.MIN.plus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusYears() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.plus(1, ChronoUnit.YEARS), OffsetDateTime.MIN.plus(Period.ofYears(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusNanos() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.NANOS),
+        OffsetDateTime.MAX.minus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusSeconds() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.SECONDS),
+        OffsetDateTime.MAX.minus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMinutes() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.MINUTES),
+        OffsetDateTime.MAX.minus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusHours() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.HOURS),
+        OffsetDateTime.MAX.minus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusDays() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.DAYS), OffsetDateTime.MAX.minus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusWeeks() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.WEEKS), OffsetDateTime.MAX.minus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMonths() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.MONTHS),
+        OffsetDateTime.MAX.minus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusYears() {
+    return ImmutableSet.of(
+        OffsetDateTime.MAX.minus(1, ChronoUnit.YEARS), OffsetDateTime.MAX.minus(Period.ofYears(1)));
+  }
+
+  private static final ZonedDateTime ZONED_DATE_TIME =
+      ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusNanos() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.NANOS), ZONED_DATE_TIME.plus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusSeconds() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.SECONDS), ZONED_DATE_TIME.plus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusMinutes() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.MINUTES), ZONED_DATE_TIME.plus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusHours() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.HOURS), ZONED_DATE_TIME.plus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusDays() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.DAYS), ZONED_DATE_TIME.plus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusWeeks() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.WEEKS), ZONED_DATE_TIME.plus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusMonths() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.MONTHS), ZONED_DATE_TIME.plus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusYears() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.plus(1, ChronoUnit.YEARS), ZONED_DATE_TIME.plus(Period.ofYears(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusNanos() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.NANOS), ZONED_DATE_TIME.minus(Duration.ofNanos(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusSeconds() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.SECONDS), ZONED_DATE_TIME.minus(Duration.ofSeconds(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMinutes() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.MINUTES), ZONED_DATE_TIME.minus(Duration.ofMinutes(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusHours() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.HOURS), ZONED_DATE_TIME.minus(Duration.ofHours(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusDays() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.DAYS), ZONED_DATE_TIME.minus(Period.ofDays(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusWeeks() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.WEEKS), ZONED_DATE_TIME.minus(Period.ofWeeks(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMonths() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.MONTHS), ZONED_DATE_TIME.minus(Period.ofMonths(1)));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusYears() {
+    return ImmutableSet.of(
+        ZONED_DATE_TIME.minus(1, ChronoUnit.YEARS), ZONED_DATE_TIME.minus(Period.ofYears(1)));
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
@@ -205,290 +205,290 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<LocalDate> testLocalDatePlusDays() {
-    return ImmutableSet.of(LocalDate.EPOCH.plusDays(1), LocalDate.EPOCH.plusDays(1));
+    return ImmutableSet.of(LocalDate.EPOCH.plusDays(1L), LocalDate.EPOCH.plusDays(1));
   }
 
   ImmutableSet<LocalDate> testLocalDatePlusWeeks() {
-    return ImmutableSet.of(LocalDate.EPOCH.plusWeeks(1), LocalDate.EPOCH.plusWeeks(1));
+    return ImmutableSet.of(LocalDate.EPOCH.plusWeeks(1L), LocalDate.EPOCH.plusWeeks(1));
   }
 
   ImmutableSet<LocalDate> testLocalDatePlusMonths() {
-    return ImmutableSet.of(LocalDate.EPOCH.plusMonths(1), LocalDate.EPOCH.plusMonths(1));
+    return ImmutableSet.of(LocalDate.EPOCH.plusMonths(1L), LocalDate.EPOCH.plusMonths(1));
   }
 
   ImmutableSet<LocalDate> testLocalDatePlusYears() {
-    return ImmutableSet.of(LocalDate.EPOCH.plusYears(1), LocalDate.EPOCH.plusYears(1));
+    return ImmutableSet.of(LocalDate.EPOCH.plusYears(1L), LocalDate.EPOCH.plusYears(1));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusDays() {
-    return ImmutableSet.of(LocalDate.EPOCH.minusDays(1), LocalDate.EPOCH.minusDays(1));
+    return ImmutableSet.of(LocalDate.EPOCH.minusDays(1L), LocalDate.EPOCH.minusDays(1));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusWeeks() {
-    return ImmutableSet.of(LocalDate.EPOCH.minusWeeks(1), LocalDate.EPOCH.minusWeeks(1));
+    return ImmutableSet.of(LocalDate.EPOCH.minusWeeks(1L), LocalDate.EPOCH.minusWeeks(1));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusMonths() {
-    return ImmutableSet.of(LocalDate.EPOCH.minusMonths(1), LocalDate.EPOCH.minusMonths(1));
+    return ImmutableSet.of(LocalDate.EPOCH.minusMonths(1L), LocalDate.EPOCH.minusMonths(1));
   }
 
   ImmutableSet<LocalDate> testLocalDateMinusYears() {
-    return ImmutableSet.of(LocalDate.EPOCH.minusYears(1), LocalDate.EPOCH.minusYears(1));
+    return ImmutableSet.of(LocalDate.EPOCH.minusYears(1L), LocalDate.EPOCH.minusYears(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusNanos() {
-    return ImmutableSet.of(LocalTime.NOON.plusNanos(1), LocalTime.NOON.plusNanos(1));
+    return ImmutableSet.of(LocalTime.NOON.plusNanos(1L), LocalTime.NOON.plusNanos(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusSeconds() {
-    return ImmutableSet.of(LocalTime.NOON.plusSeconds(1), LocalTime.NOON.plusSeconds(1));
+    return ImmutableSet.of(LocalTime.NOON.plusSeconds(1L), LocalTime.NOON.plusSeconds(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusMinutes() {
-    return ImmutableSet.of(LocalTime.NOON.plusMinutes(1), LocalTime.NOON.plusMinutes(1));
+    return ImmutableSet.of(LocalTime.NOON.plusMinutes(1L), LocalTime.NOON.plusMinutes(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimePlusHours() {
-    return ImmutableSet.of(LocalTime.NOON.plusHours(1), LocalTime.NOON.plusHours(1));
+    return ImmutableSet.of(LocalTime.NOON.plusHours(1L), LocalTime.NOON.plusHours(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusNanos() {
-    return ImmutableSet.of(LocalTime.NOON.minusNanos(1), LocalTime.NOON.minusNanos(1));
+    return ImmutableSet.of(LocalTime.NOON.minusNanos(1L), LocalTime.NOON.minusNanos(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusSeconds() {
-    return ImmutableSet.of(LocalTime.NOON.minusSeconds(1), LocalTime.NOON.minusSeconds(1));
+    return ImmutableSet.of(LocalTime.NOON.minusSeconds(1L), LocalTime.NOON.minusSeconds(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusMinutes() {
-    return ImmutableSet.of(LocalTime.NOON.minusMinutes(1), LocalTime.NOON.minusMinutes(1));
+    return ImmutableSet.of(LocalTime.NOON.minusMinutes(1L), LocalTime.NOON.minusMinutes(1));
   }
 
   ImmutableSet<LocalTime> testLocalTimeMinusHours() {
-    return ImmutableSet.of(LocalTime.NOON.minusHours(1), LocalTime.NOON.minusHours(1));
+    return ImmutableSet.of(LocalTime.NOON.minusHours(1L), LocalTime.NOON.minusHours(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusNanos() {
-    return ImmutableSet.of(OffsetTime.MIN.plusNanos(1), OffsetTime.MIN.plusNanos(1));
+    return ImmutableSet.of(OffsetTime.MIN.plusNanos(1L), OffsetTime.MIN.plusNanos(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusSeconds() {
-    return ImmutableSet.of(OffsetTime.MIN.plusSeconds(1), OffsetTime.MIN.plusSeconds(1));
+    return ImmutableSet.of(OffsetTime.MIN.plusSeconds(1L), OffsetTime.MIN.plusSeconds(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusMinutes() {
-    return ImmutableSet.of(OffsetTime.MIN.plusMinutes(1), OffsetTime.MIN.plusMinutes(1));
+    return ImmutableSet.of(OffsetTime.MIN.plusMinutes(1L), OffsetTime.MIN.plusMinutes(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimePlusHours() {
-    return ImmutableSet.of(OffsetTime.MIN.plusHours(1), OffsetTime.MIN.plusHours(1));
+    return ImmutableSet.of(OffsetTime.MIN.plusHours(1L), OffsetTime.MIN.plusHours(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusNanos() {
-    return ImmutableSet.of(OffsetTime.MAX.minusNanos(1), OffsetTime.MAX.minusNanos(1));
+    return ImmutableSet.of(OffsetTime.MAX.minusNanos(1L), OffsetTime.MAX.minusNanos(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusSeconds() {
-    return ImmutableSet.of(OffsetTime.MAX.minusSeconds(1), OffsetTime.MAX.minusSeconds(1));
+    return ImmutableSet.of(OffsetTime.MAX.minusSeconds(1L), OffsetTime.MAX.minusSeconds(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusMinutes() {
-    return ImmutableSet.of(OffsetTime.MAX.minusMinutes(1), OffsetTime.MAX.minusMinutes(1));
+    return ImmutableSet.of(OffsetTime.MAX.minusMinutes(1L), OffsetTime.MAX.minusMinutes(1));
   }
 
   ImmutableSet<OffsetTime> testOffsetTimeMinusHours() {
-    return ImmutableSet.of(OffsetTime.MAX.minusHours(1), OffsetTime.MAX.minusHours(1));
+    return ImmutableSet.of(OffsetTime.MAX.minusHours(1L), OffsetTime.MAX.minusHours(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusNanos() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusNanos(1), LocalDateTime.MIN.plusNanos(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusNanos(1L), LocalDateTime.MIN.plusNanos(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusSeconds() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusSeconds(1), LocalDateTime.MIN.plusSeconds(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusSeconds(1L), LocalDateTime.MIN.plusSeconds(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusMinutes() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusMinutes(1), LocalDateTime.MIN.plusMinutes(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusMinutes(1L), LocalDateTime.MIN.plusMinutes(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusHours() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusHours(1), LocalDateTime.MIN.plusHours(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusHours(1L), LocalDateTime.MIN.plusHours(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusDays() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusDays(1), LocalDateTime.MIN.plusDays(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusDays(1L), LocalDateTime.MIN.plusDays(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusWeeks() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusWeeks(1), LocalDateTime.MIN.plusWeeks(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusWeeks(1L), LocalDateTime.MIN.plusWeeks(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusMonths() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusMonths(1), LocalDateTime.MIN.plusMonths(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusMonths(1L), LocalDateTime.MIN.plusMonths(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimePlusYears() {
-    return ImmutableSet.of(LocalDateTime.MIN.plusYears(1), LocalDateTime.MIN.plusYears(1));
+    return ImmutableSet.of(LocalDateTime.MIN.plusYears(1L), LocalDateTime.MIN.plusYears(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusNanos() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusNanos(1), LocalDateTime.MAX.minusNanos(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusNanos(1L), LocalDateTime.MAX.minusNanos(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusSeconds() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusSeconds(1), LocalDateTime.MAX.minusSeconds(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusSeconds(1L), LocalDateTime.MAX.minusSeconds(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusMinutes() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusMinutes(1), LocalDateTime.MAX.minusMinutes(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusMinutes(1L), LocalDateTime.MAX.minusMinutes(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusHours() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusHours(1), LocalDateTime.MAX.minusHours(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusHours(1L), LocalDateTime.MAX.minusHours(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusDays() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusDays(1), LocalDateTime.MAX.minusDays(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusDays(1L), LocalDateTime.MAX.minusDays(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusWeeks() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusWeeks(1), LocalDateTime.MAX.minusWeeks(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusWeeks(1L), LocalDateTime.MAX.minusWeeks(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusMonths() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusMonths(1), LocalDateTime.MAX.minusMonths(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusMonths(1L), LocalDateTime.MAX.minusMonths(1));
   }
 
   ImmutableSet<LocalDateTime> testLocalDateTimeMinusYears() {
-    return ImmutableSet.of(LocalDateTime.MAX.minusYears(1), LocalDateTime.MAX.minusYears(1));
+    return ImmutableSet.of(LocalDateTime.MAX.minusYears(1L), LocalDateTime.MAX.minusYears(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusNanos() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusNanos(1), OffsetDateTime.MIN.plusNanos(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusNanos(1L), OffsetDateTime.MIN.plusNanos(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusSeconds() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusSeconds(1), OffsetDateTime.MIN.plusSeconds(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusSeconds(1L), OffsetDateTime.MIN.plusSeconds(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMinutes() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusMinutes(1), OffsetDateTime.MIN.plusMinutes(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusMinutes(1L), OffsetDateTime.MIN.plusMinutes(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusHours() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusHours(1), OffsetDateTime.MIN.plusHours(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusHours(1L), OffsetDateTime.MIN.plusHours(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusDays() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusDays(1), OffsetDateTime.MIN.plusDays(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusDays(1L), OffsetDateTime.MIN.plusDays(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusWeeks() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusWeeks(1), OffsetDateTime.MIN.plusWeeks(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusWeeks(1L), OffsetDateTime.MIN.plusWeeks(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMonths() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusMonths(1), OffsetDateTime.MIN.plusMonths(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusMonths(1L), OffsetDateTime.MIN.plusMonths(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimePlusYears() {
-    return ImmutableSet.of(OffsetDateTime.MIN.plusYears(1), OffsetDateTime.MIN.plusYears(1));
+    return ImmutableSet.of(OffsetDateTime.MIN.plusYears(1L), OffsetDateTime.MIN.plusYears(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusNanos() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusNanos(1), OffsetDateTime.MAX.minusNanos(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusNanos(1L), OffsetDateTime.MAX.minusNanos(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusSeconds() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusSeconds(1), OffsetDateTime.MAX.minusSeconds(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusSeconds(1L), OffsetDateTime.MAX.minusSeconds(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMinutes() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusMinutes(1), OffsetDateTime.MAX.minusMinutes(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusMinutes(1L), OffsetDateTime.MAX.minusMinutes(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusHours() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusHours(1), OffsetDateTime.MAX.minusHours(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusHours(1L), OffsetDateTime.MAX.minusHours(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusDays() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusDays(1), OffsetDateTime.MAX.minusDays(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusDays(1L), OffsetDateTime.MAX.minusDays(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusWeeks() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusWeeks(1), OffsetDateTime.MAX.minusWeeks(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusWeeks(1L), OffsetDateTime.MAX.minusWeeks(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMonths() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusMonths(1), OffsetDateTime.MAX.minusMonths(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusMonths(1L), OffsetDateTime.MAX.minusMonths(1));
   }
 
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusYears() {
-    return ImmutableSet.of(OffsetDateTime.MAX.minusYears(1), OffsetDateTime.MAX.minusYears(1));
+    return ImmutableSet.of(OffsetDateTime.MAX.minusYears(1L), OffsetDateTime.MAX.minusYears(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusNanos() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusNanos(1), ZONED_DATE_TIME.plusNanos(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusNanos(1L), ZONED_DATE_TIME.plusNanos(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusSeconds() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusSeconds(1), ZONED_DATE_TIME.plusSeconds(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusSeconds(1L), ZONED_DATE_TIME.plusSeconds(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusMinutes() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusMinutes(1), ZONED_DATE_TIME.plusMinutes(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusMinutes(1L), ZONED_DATE_TIME.plusMinutes(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusHours() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusHours(1), ZONED_DATE_TIME.plusHours(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusHours(1L), ZONED_DATE_TIME.plusHours(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusDays() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusDays(1), ZONED_DATE_TIME.plusDays(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusDays(1L), ZONED_DATE_TIME.plusDays(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusWeeks() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusWeeks(1), ZONED_DATE_TIME.plusWeeks(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusWeeks(1L), ZONED_DATE_TIME.plusWeeks(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusMonths() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusMonths(1), ZONED_DATE_TIME.plusMonths(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusMonths(1L), ZONED_DATE_TIME.plusMonths(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusYears() {
-    return ImmutableSet.of(ZONED_DATE_TIME.plusYears(1), ZONED_DATE_TIME.plusYears(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.plusYears(1L), ZONED_DATE_TIME.plusYears(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusNanos() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusNanos(1), ZONED_DATE_TIME.minusNanos(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusNanos(1L), ZONED_DATE_TIME.minusNanos(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusSeconds() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusSeconds(1), ZONED_DATE_TIME.minusSeconds(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusSeconds(1L), ZONED_DATE_TIME.minusSeconds(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMinutes() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusMinutes(1), ZONED_DATE_TIME.minusMinutes(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusMinutes(1L), ZONED_DATE_TIME.minusMinutes(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusHours() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusHours(1), ZONED_DATE_TIME.minusHours(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusHours(1L), ZONED_DATE_TIME.minusHours(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusDays() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusDays(1), ZONED_DATE_TIME.minusDays(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusDays(1L), ZONED_DATE_TIME.minusDays(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusWeeks() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusWeeks(1), ZONED_DATE_TIME.minusWeeks(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusWeeks(1L), ZONED_DATE_TIME.minusWeeks(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMonths() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusMonths(1), ZONED_DATE_TIME.minusMonths(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusMonths(1L), ZONED_DATE_TIME.minusMonths(1));
   }
 
   ImmutableSet<ZonedDateTime> testZonedDateTimeMinusYears() {
-    return ImmutableSet.of(ZONED_DATE_TIME.minusYears(1), ZONED_DATE_TIME.minusYears(1));
+    return ImmutableSet.of(ZONED_DATE_TIME.minusYears(1L), ZONED_DATE_TIME.minusYears(1));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
@@ -17,6 +17,8 @@ import java.time.temporal.ChronoUnit;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class TimeRulesTest implements RefasterRuleCollectionTestCase {
+  private static final ZonedDateTime ZONED_DATE_TIME = Instant.EPOCH.atZone(ZoneOffset.UTC);
+
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(ChronoUnit.class);
@@ -425,9 +427,6 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusYears() {
     return ImmutableSet.of(OffsetDateTime.MAX.minusYears(1), OffsetDateTime.MAX.minusYears(1));
   }
-
-  private static final ZonedDateTime ZONED_DATE_TIME =
-      ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
 
   ImmutableSet<ZonedDateTime> testZonedDateTimePlusNanos() {
     return ImmutableSet.of(ZONED_DATE_TIME.plusNanos(1), ZONED_DATE_TIME.plusNanos(1));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
@@ -201,4 +201,295 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Period> testZeroPeriod() {
     return ImmutableSet.of(Period.ZERO, Period.ZERO, Period.ZERO, Period.ZERO, Period.ZERO);
   }
+
+  ImmutableSet<LocalDate> testLocalDatePlusDays() {
+    return ImmutableSet.of(LocalDate.EPOCH.plusDays(1), LocalDate.EPOCH.plusDays(1));
+  }
+
+  ImmutableSet<LocalDate> testLocalDatePlusWeeks() {
+    return ImmutableSet.of(LocalDate.EPOCH.plusWeeks(1), LocalDate.EPOCH.plusWeeks(1));
+  }
+
+  ImmutableSet<LocalDate> testLocalDatePlusMonths() {
+    return ImmutableSet.of(LocalDate.EPOCH.plusMonths(1), LocalDate.EPOCH.plusMonths(1));
+  }
+
+  ImmutableSet<LocalDate> testLocalDatePlusYears() {
+    return ImmutableSet.of(LocalDate.EPOCH.plusYears(1), LocalDate.EPOCH.plusYears(1));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusDays() {
+    return ImmutableSet.of(LocalDate.EPOCH.minusDays(1), LocalDate.EPOCH.minusDays(1));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusWeeks() {
+    return ImmutableSet.of(LocalDate.EPOCH.minusWeeks(1), LocalDate.EPOCH.minusWeeks(1));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusMonths() {
+    return ImmutableSet.of(LocalDate.EPOCH.minusMonths(1), LocalDate.EPOCH.minusMonths(1));
+  }
+
+  ImmutableSet<LocalDate> testLocalDateMinusYears() {
+    return ImmutableSet.of(LocalDate.EPOCH.minusYears(1), LocalDate.EPOCH.minusYears(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusNanos() {
+    return ImmutableSet.of(LocalTime.NOON.plusNanos(1), LocalTime.NOON.plusNanos(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusSeconds() {
+    return ImmutableSet.of(LocalTime.NOON.plusSeconds(1), LocalTime.NOON.plusSeconds(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusMinutes() {
+    return ImmutableSet.of(LocalTime.NOON.plusMinutes(1), LocalTime.NOON.plusMinutes(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimePlusHours() {
+    return ImmutableSet.of(LocalTime.NOON.plusHours(1), LocalTime.NOON.plusHours(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusNanos() {
+    return ImmutableSet.of(LocalTime.NOON.minusNanos(1), LocalTime.NOON.minusNanos(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusSeconds() {
+    return ImmutableSet.of(LocalTime.NOON.minusSeconds(1), LocalTime.NOON.minusSeconds(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusMinutes() {
+    return ImmutableSet.of(LocalTime.NOON.minusMinutes(1), LocalTime.NOON.minusMinutes(1));
+  }
+
+  ImmutableSet<LocalTime> testLocalTimeMinusHours() {
+    return ImmutableSet.of(LocalTime.NOON.minusHours(1), LocalTime.NOON.minusHours(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusNanos() {
+    return ImmutableSet.of(OffsetTime.MIN.plusNanos(1), OffsetTime.MIN.plusNanos(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusSeconds() {
+    return ImmutableSet.of(OffsetTime.MIN.plusSeconds(1), OffsetTime.MIN.plusSeconds(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusMinutes() {
+    return ImmutableSet.of(OffsetTime.MIN.plusMinutes(1), OffsetTime.MIN.plusMinutes(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimePlusHours() {
+    return ImmutableSet.of(OffsetTime.MIN.plusHours(1), OffsetTime.MIN.plusHours(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusNanos() {
+    return ImmutableSet.of(OffsetTime.MAX.minusNanos(1), OffsetTime.MAX.minusNanos(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusSeconds() {
+    return ImmutableSet.of(OffsetTime.MAX.minusSeconds(1), OffsetTime.MAX.minusSeconds(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusMinutes() {
+    return ImmutableSet.of(OffsetTime.MAX.minusMinutes(1), OffsetTime.MAX.minusMinutes(1));
+  }
+
+  ImmutableSet<OffsetTime> testOffsetTimeMinusHours() {
+    return ImmutableSet.of(OffsetTime.MAX.minusHours(1), OffsetTime.MAX.minusHours(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusNanos() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusNanos(1), LocalDateTime.MIN.plusNanos(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusSeconds() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusSeconds(1), LocalDateTime.MIN.plusSeconds(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusMinutes() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusMinutes(1), LocalDateTime.MIN.plusMinutes(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusHours() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusHours(1), LocalDateTime.MIN.plusHours(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusDays() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusDays(1), LocalDateTime.MIN.plusDays(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusWeeks() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusWeeks(1), LocalDateTime.MIN.plusWeeks(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusMonths() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusMonths(1), LocalDateTime.MIN.plusMonths(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimePlusYears() {
+    return ImmutableSet.of(LocalDateTime.MIN.plusYears(1), LocalDateTime.MIN.plusYears(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusNanos() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusNanos(1), LocalDateTime.MAX.minusNanos(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusSeconds() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusSeconds(1), LocalDateTime.MAX.minusSeconds(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusMinutes() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusMinutes(1), LocalDateTime.MAX.minusMinutes(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusHours() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusHours(1), LocalDateTime.MAX.minusHours(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusDays() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusDays(1), LocalDateTime.MAX.minusDays(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusWeeks() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusWeeks(1), LocalDateTime.MAX.minusWeeks(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusMonths() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusMonths(1), LocalDateTime.MAX.minusMonths(1));
+  }
+
+  ImmutableSet<LocalDateTime> testLocalDateTimeMinusYears() {
+    return ImmutableSet.of(LocalDateTime.MAX.minusYears(1), LocalDateTime.MAX.minusYears(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusNanos() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusNanos(1), OffsetDateTime.MIN.plusNanos(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusSeconds() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusSeconds(1), OffsetDateTime.MIN.plusSeconds(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMinutes() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusMinutes(1), OffsetDateTime.MIN.plusMinutes(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusHours() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusHours(1), OffsetDateTime.MIN.plusHours(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusDays() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusDays(1), OffsetDateTime.MIN.plusDays(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusWeeks() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusWeeks(1), OffsetDateTime.MIN.plusWeeks(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusMonths() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusMonths(1), OffsetDateTime.MIN.plusMonths(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimePlusYears() {
+    return ImmutableSet.of(OffsetDateTime.MIN.plusYears(1), OffsetDateTime.MIN.plusYears(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusNanos() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusNanos(1), OffsetDateTime.MAX.minusNanos(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusSeconds() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusSeconds(1), OffsetDateTime.MAX.minusSeconds(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMinutes() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusMinutes(1), OffsetDateTime.MAX.minusMinutes(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusHours() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusHours(1), OffsetDateTime.MAX.minusHours(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusDays() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusDays(1), OffsetDateTime.MAX.minusDays(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusWeeks() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusWeeks(1), OffsetDateTime.MAX.minusWeeks(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusMonths() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusMonths(1), OffsetDateTime.MAX.minusMonths(1));
+  }
+
+  ImmutableSet<OffsetDateTime> testOffsetDateTimeMinusYears() {
+    return ImmutableSet.of(OffsetDateTime.MAX.minusYears(1), OffsetDateTime.MAX.minusYears(1));
+  }
+
+  private static final ZonedDateTime ZONED_DATE_TIME =
+      ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusNanos() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusNanos(1), ZONED_DATE_TIME.plusNanos(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusSeconds() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusSeconds(1), ZONED_DATE_TIME.plusSeconds(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusMinutes() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusMinutes(1), ZONED_DATE_TIME.plusMinutes(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusHours() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusHours(1), ZONED_DATE_TIME.plusHours(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusDays() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusDays(1), ZONED_DATE_TIME.plusDays(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusWeeks() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusWeeks(1), ZONED_DATE_TIME.plusWeeks(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusMonths() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusMonths(1), ZONED_DATE_TIME.plusMonths(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimePlusYears() {
+    return ImmutableSet.of(ZONED_DATE_TIME.plusYears(1), ZONED_DATE_TIME.plusYears(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusNanos() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusNanos(1), ZONED_DATE_TIME.minusNanos(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusSeconds() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusSeconds(1), ZONED_DATE_TIME.minusSeconds(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMinutes() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusMinutes(1), ZONED_DATE_TIME.minusMinutes(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusHours() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusHours(1), ZONED_DATE_TIME.minusHours(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusDays() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusDays(1), ZONED_DATE_TIME.minusDays(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusWeeks() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusWeeks(1), ZONED_DATE_TIME.minusWeeks(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusMonths() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusMonths(1), ZONED_DATE_TIME.minusMonths(1));
+  }
+
+  ImmutableSet<ZonedDateTime> testZonedDateTimeMinusYears() {
+    return ImmutableSet.of(ZONED_DATE_TIME.minusYears(1), ZONED_DATE_TIME.minusYears(1));
+  }
 }


### PR DESCRIPTION
Uses e.g. `LocalDate#plusDays` instead of more contrived alternatives.
Quite a big PR as sadly none of the involved classes share a common interface for the shorthand methods.