### PR TITLE
Actually skip test failures during SonarCloud analysis

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1981,6 +1981,11 @@
         </profile>
         <profile>
             <id>sonar</id>
+            <activation>
+                <property>
+                    <name>sonar.projectKey</name>
+                </property>
+            </activation>
             <properties>
                 <maven.test.failure.ignore>true</maven.test.failure.ignore>
             </properties>


### PR DESCRIPTION
Extracted from #603.

Suggested commit message:
```
Actually skip test failures during SonarCloud analysis (#986)
```

To test, run:
```sh
vimdiff \
  <(mvn help:effective-pom) \
  <(mvn help:effective-pom -Dsonar.projectKey=PicnicSupermarket_error-prone-support)
```