### PR TITLE
Allow static imports of `{ZERO,ONE}` identifiers

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -136,10 +136,8 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
           "newBuilder",
           "newInstance",
           "of",
-          "ONE",
           "parse",
-          "valueOf",
-          "ZERO");
+          "valueOf");
 
   /** Instantiates a new {@link NonStaticImport} instance. */
   public NonStaticImport() {}

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NonStaticImportTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NonStaticImportTest.java
@@ -72,7 +72,7 @@ final class NonStaticImportTest {
             "import java.time.ZoneOffset;",
             "import java.util.Locale;",
             "import java.util.Map;",
-            "import pkg.A.Wrapper.ZERO;",
+            "import pkg.A.Wrapper.INSTANCE;",
             "",
             "class A {",
             "  private Integer MIN_VALUE = 12;",
@@ -92,7 +92,7 @@ final class NonStaticImportTest {
             "    empty();",
             "",
             "    list();",
-            "    new ZERO();",
+            "    new INSTANCE();",
             "  }",
             "",
             "  static final class WithMethodThatIsSelectivelyFlagged {",
@@ -102,7 +102,7 @@ final class NonStaticImportTest {
             "  }",
             "",
             "  static final class Wrapper {",
-            "    static final class ZERO {}",
+            "    static final class INSTANCE {}",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
We think that in the contexts where this happen it usually _does_ make sense to statically import these identifiers.