### PR TITLE
Prevent `ExplicitEnumOrdering` from throwing an NPE

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrdering.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrdering.java
@@ -72,7 +72,7 @@ public final class ExplicitEnumOrdering extends BugChecker implements MethodInvo
       List<? extends ExpressionTree> expressions) {
     return expressions.stream()
         .map(ASTHelpers::getSymbol)
-        .filter(Symbol::isEnum)
+        .filter(s -> s != null && s.isEnum())
         .collect(
             collectingAndThen(
                 toImmutableSetMultimap(Symbol::asType, Symbol::toString),

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrderingTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/ExplicitEnumOrderingTest.java
@@ -75,6 +75,8 @@ final class ExplicitEnumOrderingTest {
             "    Ordering.explicit(IsoEra.BCE, SOURCE, RetentionPolicy.CLASS);",
             "    // BUG: Diagnostic contains: RetentionPolicy.SOURCE, IsoEra.BCE",
             "    Ordering.explicit(CLASS, RUNTIME, CE);",
+            "",
+            "    Ordering.explicit(BCE, null, CE);",
             "  }",
             "}")
         .doTest();


### PR DESCRIPTION
Suggested commit message:
```
Prevent `ExplicitEnumOrdering` from throwing an NPE (#998)
```

Found while evaluating Qodana.