### PR TITLE
Run builds on macOS 14 rather than macOS 12

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         distribution: [ temurin ]
         experimental: [ false ]
         include:
-          - os: macos-12
+          - os: macos-14
             jdk: 17.0.8
             distribution: temurin
             experimental: false


### PR DESCRIPTION
Suggested commit message:
```
Run builds on macOS 14 rather than macOS 12 (#1011)

See https://github.blog/changelog/2024-01-30-github-actions-introducing-the-new-m1-macos-runner-available-to-open-source/
```