### PR TITLE
Extend `StreamIsEmpty` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -4,6 +4,7 @@ import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.filtering;
 import static java.util.stream.Collectors.flatMapping;
@@ -20,6 +21,8 @@ import static java.util.stream.Collectors.summingInt;
 import static java.util.stream.Collectors.summingLong;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.refaster.Refaster;
@@ -36,9 +39,12 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
+import java.util.List;
 import java.util.LongSummaryStatistics;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.BinaryOperator;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -247,6 +253,103 @@ final class StreamRules {
     @AfterTemplate
     Optional<S> after(Stream<T> stream, Function<? super T, S> function) {
       return stream.findFirst().map(function);
+    }
+  }
+
+  // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
+  static final class StreamCollectingAndThenCollectionIsEmpty<T> {
+    @BeforeTemplate
+    boolean before(Stream<T> stream, Collector<? super T, ?, ? extends Collection<?>> collector) {
+      return stream.collect(collectingAndThen(collector, Collection::isEmpty));
+    }
+
+    @AfterTemplate
+    boolean after(Stream<T> stream) {
+      return stream.findAny().isEmpty();
+    }
+  }
+
+  // cannot fit the @BeforeTemplates in the same rule, since they have the same signature (only
+  // difference
+  // is reduction type of the collector)
+
+  // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
+  static final class StreamCollectingAndThenImmutableListIsEmpty<T> {
+    @BeforeTemplate
+    boolean before(
+        Stream<T> stream, Collector<? super T, ?, ? extends ImmutableList<?>> collector) {
+      return stream.collect(collectingAndThen(collector, ImmutableList::isEmpty));
+    }
+
+    @AfterTemplate
+    boolean after(Stream<T> stream) {
+      return stream.findAny().isEmpty();
+    }
+  }
+
+  // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
+  static final class StreamCollectingAndThenListIsEmpty<T> {
+    @BeforeTemplate
+    boolean before(Stream<T> stream, Collector<? super T, ?, ? extends List<?>> collector) {
+      return stream.collect(collectingAndThen(collector, List::isEmpty));
+    }
+
+    @AfterTemplate
+    boolean after(Stream<T> stream) {
+      return stream.findAny().isEmpty();
+    }
+  }
+
+  // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
+  static final class StreamCollectingAndThenImmutableSetIsEmpty<T> {
+    @BeforeTemplate
+    boolean before(Stream<T> stream, Collector<? super T, ?, ? extends ImmutableSet<?>> collector) {
+      return stream.collect(collectingAndThen(collector, ImmutableSet::isEmpty));
+    }
+
+    @AfterTemplate
+    boolean after(Stream<T> stream) {
+      return stream.findAny().isEmpty();
+    }
+  }
+
+  // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
+  static final class StreamCollectingAndThenSetIsEmpty<T> {
+    @BeforeTemplate
+    boolean before(Stream<T> stream, Collector<? super T, ?, ? extends Set<?>> collector) {
+      return stream.collect(collectingAndThen(collector, Set::isEmpty));
+    }
+
+    @AfterTemplate
+    boolean after(Stream<T> stream) {
+      return stream.findAny().isEmpty();
+    }
+  }
+
+  // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
+  static final class StreamCollectingAndThenImmutableMapIsEmpty<T> {
+    @BeforeTemplate
+    boolean before(
+        Stream<T> stream, Collector<? super T, ?, ? extends ImmutableMap<?, ?>> collector) {
+      return stream.collect(collectingAndThen(collector, ImmutableMap::isEmpty));
+    }
+
+    @AfterTemplate
+    boolean after(Stream<T> stream) {
+      return stream.findAny().isEmpty();
+    }
+  }
+
+  // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
+  static final class StreamCollectingAndThenMapIsEmpty<T> {
+    @BeforeTemplate
+    boolean before(Stream<T> stream, Collector<? super T, ?, ? extends Map<?, ?>> collector) {
+      return stream.collect(collectingAndThen(collector, Map::isEmpty));
+    }
+
+    @AfterTemplate
+    boolean after(Stream<T> stream) {
+      return stream.findAny().isEmpty();
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -269,10 +269,6 @@ final class StreamRules {
     }
   }
 
-  // cannot fit the @BeforeTemplates in the same rule, since they have the same signature (only
-  // difference
-  // is reduction type of the collector)
-
   // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
   static final class StreamCollectingAndThenImmutableListIsEmpty<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -1,10 +1,13 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Comparator.comparingInt;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Function.identity;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.filtering;
 import static java.util.stream.Collectors.flatMapping;
@@ -19,15 +22,23 @@ import static java.util.stream.Collectors.summarizingLong;
 import static java.util.stream.Collectors.summingDouble;
 import static java.util.stream.Collectors.summingInt;
 import static java.util.stream.Collectors.summingLong;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static java.util.stream.Collectors.toSet;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
+import java.util.Collection;
 import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
+import java.util.List;
 import java.util.LongSummaryStatistics;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -106,6 +117,36 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Stream.of("foo").map(s -> s.length()).findFirst(),
         Stream.of("bar").map(String::length).findFirst());
+  }
+
+  Boolean testStreamCollectingAndThenCollectionIsEmpty() {
+    return Stream.of(1).collect(collectingAndThen(toList(), Collection::isEmpty));
+  }
+
+  Boolean testStreamCollectingAndThenImmutableListIsEmpty() {
+    return Stream.of(1).collect(collectingAndThen(toImmutableList(), ImmutableList::isEmpty));
+  }
+
+  Boolean testStreamCollectingAndThenListIsEmpty() {
+    return Stream.of(1).collect(collectingAndThen(toList(), List::isEmpty));
+  }
+
+  Boolean testStreamCollectingAndThenImmutableSetIsEmpty() {
+    return Stream.of(1).collect(collectingAndThen(toImmutableSet(), ImmutableSet::isEmpty));
+  }
+
+  Boolean testStreamCollectingAndThenSetIsEmpty() {
+    return Stream.of(1).collect(collectingAndThen(toSet(), Set::isEmpty));
+  }
+
+  Boolean testStreamCollectingAndThenImmutableMapIsEmpty() {
+    return Stream.of(1)
+        .collect(
+            collectingAndThen(toImmutableMap(key -> key, value -> value), ImmutableMap::isEmpty));
+  }
+
+  Boolean testStreamCollectingAndThenMapIsEmpty() {
+    return Stream.of(1).collect(collectingAndThen(toMap(key -> key, value -> value), Map::isEmpty));
   }
 
   ImmutableSet<Boolean> testStreamIsEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -22,15 +22,11 @@ import static java.util.stream.Collectors.summarizingLong;
 import static java.util.stream.Collectors.summingDouble;
 import static java.util.stream.Collectors.summingInt;
 import static java.util.stream.Collectors.summingLong;
-import static java.util.stream.Collectors.toList;
-import static java.util.stream.Collectors.toMap;
-import static java.util.stream.Collectors.toSet;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
-import java.util.Collection;
 import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
 import java.util.List;
@@ -38,7 +34,6 @@ import java.util.LongSummaryStatistics;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -49,8 +44,12 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
         ImmutableList.class,
+        ImmutableMap.class,
+        List.class,
+        Map.class,
         Objects.class,
         Streams.class,
+        collectingAndThen(null, null),
         counting(),
         filtering(null, null),
         flatMapping(null, null),
@@ -65,7 +64,9 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         summarizingLong(null),
         summingDouble(null),
         summingInt(null),
-        summingLong(null));
+        summingLong(null),
+        toImmutableList(),
+        toImmutableMap(null, null));
   }
 
   String testJoining() {
@@ -119,43 +120,18 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("bar").map(String::length).findFirst());
   }
 
-  Boolean testStreamCollectingAndThenCollectionIsEmpty() {
-    return Stream.of(1).collect(collectingAndThen(toList(), Collection::isEmpty));
-  }
-
-  Boolean testStreamCollectingAndThenImmutableListIsEmpty() {
-    return Stream.of(1).collect(collectingAndThen(toImmutableList(), ImmutableList::isEmpty));
-  }
-
-  Boolean testStreamCollectingAndThenListIsEmpty() {
-    return Stream.of(1).collect(collectingAndThen(toList(), List::isEmpty));
-  }
-
-  Boolean testStreamCollectingAndThenImmutableSetIsEmpty() {
-    return Stream.of(1).collect(collectingAndThen(toImmutableSet(), ImmutableSet::isEmpty));
-  }
-
-  Boolean testStreamCollectingAndThenSetIsEmpty() {
-    return Stream.of(1).collect(collectingAndThen(toSet(), Set::isEmpty));
-  }
-
-  Boolean testStreamCollectingAndThenImmutableMapIsEmpty() {
-    return Stream.of(1)
-        .collect(
-            collectingAndThen(toImmutableMap(key -> key, value -> value), ImmutableMap::isEmpty));
-  }
-
-  Boolean testStreamCollectingAndThenMapIsEmpty() {
-    return Stream.of(1).collect(collectingAndThen(toMap(key -> key, value -> value), Map::isEmpty));
-  }
-
   ImmutableSet<Boolean> testStreamIsEmpty() {
     return ImmutableSet.of(
         Stream.of(1).count() == 0,
         Stream.of(2).count() <= 0,
         Stream.of(3).count() < 1,
         Stream.of(4).findFirst().isEmpty(),
-        Stream.of(5).collect(toImmutableSet()).isEmpty());
+        Stream.of(5).collect(toImmutableSet()).isEmpty(),
+        Stream.of(6).collect(collectingAndThen(toImmutableList(), List::isEmpty)),
+        Stream.of(7).collect(collectingAndThen(toImmutableList(), ImmutableList::isEmpty)),
+        Stream.of(8).collect(collectingAndThen(toImmutableMap(k -> k, v -> v), Map::isEmpty)),
+        Stream.of(9)
+            .collect(collectingAndThen(toImmutableMap(k -> k, v -> v), ImmutableMap::isEmpty)));
   }
 
   ImmutableSet<Boolean> testStreamIsNotEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -1,11 +1,14 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.common.collect.ImmutableMap.toImmutableMap;
 import static com.google.common.collect.ImmutableSet.toImmutableSet;
 import static java.util.Comparator.comparingInt;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Function.identity;
 import static java.util.function.Predicate.not;
+import static java.util.stream.Collectors.collectingAndThen;
 import static java.util.stream.Collectors.counting;
 import static java.util.stream.Collectors.filtering;
 import static java.util.stream.Collectors.flatMapping;
@@ -22,12 +25,15 @@ import static java.util.stream.Collectors.summingInt;
 import static java.util.stream.Collectors.summingLong;
 
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
 import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
+import java.util.List;
 import java.util.LongSummaryStatistics;
+import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Function;
@@ -40,8 +46,12 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
         ImmutableList.class,
+        ImmutableMap.class,
+        List.class,
+        Map.class,
         Objects.class,
         Streams.class,
+        collectingAndThen(null, null),
         counting(),
         filtering(null, null),
         flatMapping(null, null),
@@ -56,7 +66,9 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         summarizingLong(null),
         summingDouble(null),
         summingInt(null),
-        summingLong(null));
+        summingLong(null),
+        toImmutableList(),
+        toImmutableMap(null, null));
   }
 
   String testJoining() {
@@ -109,41 +121,17 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("bar").findFirst().map(String::length));
   }
 
-  Boolean testStreamCollectingAndThenCollectionIsEmpty() {
-    return Stream.of(1).findAny().isEmpty();
-  }
-
-  Boolean testStreamCollectingAndThenImmutableListIsEmpty() {
-    return Stream.of(1).findAny().isEmpty();
-  }
-
-  Boolean testStreamCollectingAndThenListIsEmpty() {
-    return Stream.of(1).findAny().isEmpty();
-  }
-
-  Boolean testStreamCollectingAndThenImmutableSetIsEmpty() {
-    return Stream.of(1).findAny().isEmpty();
-  }
-
-  Boolean testStreamCollectingAndThenSetIsEmpty() {
-    return Stream.of(1).findAny().isEmpty();
-  }
-
-  Boolean testStreamCollectingAndThenImmutableMapIsEmpty() {
-    return Stream.of(1).findAny().isEmpty();
-  }
-
-  Boolean testStreamCollectingAndThenMapIsEmpty() {
-    return Stream.of(1).findAny().isEmpty();
-  }
-
   ImmutableSet<Boolean> testStreamIsEmpty() {
     return ImmutableSet.of(
         Stream.of(1).findAny().isEmpty(),
         Stream.of(2).findAny().isEmpty(),
         Stream.of(3).findAny().isEmpty(),
         Stream.of(4).findAny().isEmpty(),
-        Stream.of(5).findAny().isEmpty());
+        Stream.of(5).findAny().isEmpty(),
+        Stream.of(6).findAny().isEmpty(),
+        Stream.of(7).findAny().isEmpty(),
+        Stream.of(8).findAny().isEmpty(),
+        Stream.of(9).findAny().isEmpty());
   }
 
   ImmutableSet<Boolean> testStreamIsNotEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -109,6 +109,34 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("bar").findFirst().map(String::length));
   }
 
+  Boolean testStreamCollectingAndThenCollectionIsEmpty() {
+    return Stream.of(1).findAny().isEmpty();
+  }
+
+  Boolean testStreamCollectingAndThenImmutableListIsEmpty() {
+    return Stream.of(1).findAny().isEmpty();
+  }
+
+  Boolean testStreamCollectingAndThenListIsEmpty() {
+    return Stream.of(1).findAny().isEmpty();
+  }
+
+  Boolean testStreamCollectingAndThenImmutableSetIsEmpty() {
+    return Stream.of(1).findAny().isEmpty();
+  }
+
+  Boolean testStreamCollectingAndThenSetIsEmpty() {
+    return Stream.of(1).findAny().isEmpty();
+  }
+
+  Boolean testStreamCollectingAndThenImmutableMapIsEmpty() {
+    return Stream.of(1).findAny().isEmpty();
+  }
+
+  Boolean testStreamCollectingAndThenMapIsEmpty() {
+    return Stream.of(1).findAny().isEmpty();
+  }
+
   ImmutableSet<Boolean> testStreamIsEmpty() {
     return ImmutableSet.of(
         Stream.of(1).findAny().isEmpty(),


### PR DESCRIPTION
Introduces Refaster rule(s) that avoid unnecessary collections when checking whether a stream is empty.

Quick peek at the extension introduced:
`stream.collect(collectingAndThen(collector, Collection::isEmpty));` ➡️ `stream.findAny().isEmpty();`

1. ✅ see https://github.com/PicnicSupermarket/error-prone-support/pull/1025#discussion_r1485240560 ~~Tests currently are not passing because of the errors in Snippet 3 (import statements are different in `StreamRulesTestOutput` wrt. the ones in `StreamRulesTestInput`). If I add them manually, the tests pass but then the build fails because the imports are unused. Once I format, the tests fail again for the same reason. This never happened to me previously~~ 
2. ✅ thank you @Stephan202! Looks much cleaner now ~~I could not find a way to group the rules inside of a single template/rule.~~
	1. ~~Let's say we want to have the `@BeforeTemplate` in Snippet 1: this does not work, because the result type of the collector is a `Collection`, and therefore only accepts `Collection::isEmpty`~~
	2. ~~Let's say we want to have multiple `@BeforeTemplate` inside the same rule, in order to not repeat the `@AfterTemplate`, as Snippet 2. This does not work, since the two functions have the same signature.~~
	3. ~~Very happy to hear suggestions on how to improve this!~~
3. ✅  irrelevant now ~~I'm pretty sure the name of the rules has to be changed to follow the naming algorithm: I couldn't find what the algorithm is~~

<details>
<summary>Snippet 1</summary>

```java
@BeforeTemplate
boolean before(Stream<T> stream, Collector<? super T, ?, ? extends Collection<?>> collector) {
  return stream.collect(
      collectingAndThen(
          collector,
          Refaster.anyOf(
              Collection::isEmpty,
              ImmutableList::isEmpty,
              ImmutableSet::isEmpty,
              List::isEmpty,
              Set::isEmpty)));
```

</details>

<details>
<summary>Snippet 2</summary>

```java
static final class StreamCollectingAndThenCollectionIsEmpty<T> {
  @BeforeTemplate
  boolean before(Stream<T> stream, Collector<? super T, ?, ? extends Collection<?>> collector) {
    return stream.collect(collectingAndThen(collector, Collection::isEmpty));
  }

  @BeforeTemplate
  boolean before(Stream<T> stream, Collector<? super T, ?, ? extends Set<?>> collector) {
    return stream.collect(collectingAndThen(collector, Set::isEmpty));
  }

  @AfterTemplate
  boolean after(Stream<T> stream) {
    return stream.findAny().isEmpty();
  }
}
```

</details>

<details>
<summary>Snippet 3</summary>

```
[ERROR] Failures:
[ERROR]   RefasterRulesTest.validateRuleCollection:90 value of:
    maybeFormat(...)
diff (-expected +actual):
    @@ -1,11 +1,14 @@
     package tech.picnic.errorprone.refasterrules;

    +import static com.google.common.collect.ImmutableList.toImmutableList;
    +import static com.google.common.collect.ImmutableMap.toImmutableMap;
     import static com.google.common.collect.ImmutableSet.toImmutableSet;
     import static java.util.Comparator.comparingInt;
     import static java.util.Comparator.naturalOrder;
     import static java.util.Comparator.reverseOrder;
     import static java.util.function.Function.identity;
     import static java.util.function.Predicate.not;
    +import static java.util.stream.Collectors.collectingAndThen;
     import static java.util.stream.Collectors.counting;
     import static java.util.stream.Collectors.filtering;
     import static java.util.stream.Collectors.flatMapping;
    @@ -20,16 +23,24 @@
     import static java.util.stream.Collectors.summingDouble;
     import static java.util.stream.Collectors.summingInt;
     import static java.util.stream.Collectors.summingLong;
    +import static java.util.stream.Collectors.toList;
    +import static java.util.stream.Collectors.toMap;
    +import static java.util.stream.Collectors.toSet;

     import com.google.common.collect.ImmutableList;
    +import com.google.common.collect.ImmutableMap;
     import com.google.common.collect.ImmutableSet;
     import com.google.common.collect.Streams;
     import java.util.Arrays;
    +import java.util.Collection;
     import java.util.DoubleSummaryStatistics;
     import java.util.IntSummaryStatistics;
    +import java.util.List;
     import java.util.LongSummaryStatistics;
    +import java.util.Map;
     import java.util.Objects;
     import java.util.Optional;
    +import java.util.Set;
     import java.util.function.Function;
     import java.util.function.Predicate;
     import java.util.stream.Stream;
```

</details>