### PR TITLE
Extend `CollectionIsEmpty` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
@@ -51,6 +51,9 @@ import tech.picnic.errorprone.utils.SourceCode;
  * <p>The idea behind this checker is that maintaining a sorted sequence simplifies conflict
  * resolution, and can even avoid it if two branches add the same entry.
  */
+// XXX: In some places we declare a `@SuppressWarnings` annotation with a final value of
+// `key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict`. That entry must stay
+// last. Consider adding (generic?) support for such cases.
 @AutoService(BugChecker.class)
 @BugPattern(
     summary = "Where possible, sort annotation array attributes lexicographically",

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -35,14 +35,21 @@ final class CollectionRules {
    */
   static final class CollectionIsEmpty<T> {
     @BeforeTemplate
-    @SuppressWarnings("java:S1155" /* This violation will be rewritten. */)
+    @SuppressWarnings({
+      "java:S1155" /* This violation will be rewritten. */,
+      "LexicographicalAnnotationAttributeListing" /* `key-*` entry must remain last. */,
+      "OptionalFirstCollectionElement" /* This is a more specific template. */,
+      "StreamIsEmpty" /* This is a more specific template. */,
+      "key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
+    })
     boolean before(Collection<T> collection) {
       return Refaster.anyOf(
           collection.size() == 0,
           collection.size() <= 0,
           collection.size() < 1,
           Iterables.isEmpty(collection),
-          collection.stream().findAny().isEmpty());
+          collection.stream().findAny().isEmpty(),
+          collection.stream().findFirst().isEmpty());
     }
 
     @BeforeTemplate
@@ -338,7 +345,9 @@ final class CollectionRules {
 
   /**
    * Don't use the ternary operator to extract the first element of a possibly-empty {@link
-   * Collection} as an {@link Optional}.
+   * Collection} as an {@link Optional}, and (when applicable) prefer {@link Stream#findFirst()}
+   * over {@link Stream#findAny()} to communicate that the collection's first element (if any,
+   * according to iteration order) will be returned.
    */
   static final class OptionalFirstCollectionElement<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -41,7 +41,8 @@ final class CollectionRules {
           collection.size() == 0,
           collection.size() <= 0,
           collection.size() < 1,
-          Iterables.isEmpty(collection));
+          Iterables.isEmpty(collection),
+          collection.stream().findAny().isEmpty());
     }
 
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
@@ -29,7 +29,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableSet.of(5).size() > 0,
         ImmutableSet.of(6).size() >= 1,
         Iterables.isEmpty(ImmutableSet.of(7)),
-        ImmutableSet.of(8).asList().isEmpty());
+        ImmutableSet.of(8).stream().findAny().isEmpty(),
+        ImmutableSet.of(9).asList().isEmpty());
   }
 
   ImmutableSet<Integer> testCollectionSize() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
@@ -30,7 +30,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableSet.of(6).size() >= 1,
         Iterables.isEmpty(ImmutableSet.of(7)),
         ImmutableSet.of(8).stream().findAny().isEmpty(),
-        ImmutableSet.of(9).asList().isEmpty());
+        ImmutableSet.of(9).stream().findFirst().isEmpty(),
+        ImmutableSet.of(10).asList().isEmpty());
   }
 
   ImmutableSet<Integer> testCollectionSize() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
@@ -29,7 +29,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         !ImmutableSet.of(5).isEmpty(),
         !ImmutableSet.of(6).isEmpty(),
         ImmutableSet.of(7).isEmpty(),
-        ImmutableSet.of(8).isEmpty());
+        ImmutableSet.of(8).isEmpty(),
+        ImmutableSet.of(9).isEmpty());
   }
 
   ImmutableSet<Integer> testCollectionSize() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
@@ -30,7 +30,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         !ImmutableSet.of(6).isEmpty(),
         ImmutableSet.of(7).isEmpty(),
         ImmutableSet.of(8).isEmpty(),
-        ImmutableSet.of(9).isEmpty());
+        ImmutableSet.of(9).isEmpty(),
+        ImmutableSet.of(10).isEmpty());
   }
 
   ImmutableSet<Integer> testCollectionSize() {


### PR DESCRIPTION
Add the following expression to `CollectionIsEmpty`: `collection.stream().findAny().isEmpty()`.

### Clashing issue
Currently, this rule clashes with the rule `OptionalFirstCollectionElement`, which is matching `collection.stream().findAny()`, rewriting it to `collection.stream().findFirst()`. Not sure what's the best way to solve this issue, both use cases seem valid 🤔
1. Suppressing the suggestion to rewrite `collection.stream().findAny().isEmpty()` to `collection.stream().findFirst().isEmpty()` leads to a loop since `stream().findFirst().isEmpty()` is rewritten to `stream().findAny().isEmpty()`

### Benefits 
This acts as a useful partner to `StreamIsEmpty`: expressions that match the one introduced in this PR can result as a consequence of applying the `StreamIsEmpty` rule: this allows for refactors like the following to be applied in multiple steps:

```
1. collection.stream().collect(collectingAndThen(toImmutableList(), List::isEmpty))
3. collection.stream().findAny().isEmpty()
4. collection.isEmpty()
```
