### PR TITLE
Compact and replace `StreamIs{,Not}Empty` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -39,7 +39,7 @@ final class CollectionRules {
       "java:S1155" /* This violation will be rewritten. */,
       "LexicographicalAnnotationAttributeListing" /* `key-*` entry must remain last. */,
       "OptionalFirstCollectionElement" /* This is a more specific template. */,
-      "StreamIsEmpty" /* This is a more specific template. */,
+      "StreamFindAnyIsEmpty" /* This is a more specific template. */,
       "key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
     })
     boolean before(Collection<T> collection) {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -120,7 +120,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("bar").map(String::length).findFirst());
   }
 
-  ImmutableSet<Boolean> testStreamIsEmpty() {
+  ImmutableSet<Boolean> testStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         Stream.of(1).count() == 0,
         Stream.of(2).count() <= 0,
@@ -131,15 +131,14 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of(7).collect(collectingAndThen(toImmutableList(), ImmutableList::isEmpty)),
         Stream.of(8).collect(collectingAndThen(toImmutableMap(k -> k, v -> v), Map::isEmpty)),
         Stream.of(9)
-            .collect(collectingAndThen(toImmutableMap(k -> k, v -> v), ImmutableMap::isEmpty)));
+            .collect(collectingAndThen(toImmutableMap(k -> k, v -> v), ImmutableMap::isEmpty)),
+        Stream.of(10).count() != 0,
+        Stream.of(11).count() > 0,
+        Stream.of(12).count() >= 1);
   }
 
-  ImmutableSet<Boolean> testStreamIsNotEmpty() {
-    return ImmutableSet.of(
-        Stream.of(1).count() != 0,
-        Stream.of(2).count() > 0,
-        Stream.of(3).count() >= 1,
-        Stream.of(4).findFirst().isPresent());
+  boolean testStreamFindAnyIsPresent() {
+    return Stream.of(1).findFirst().isPresent();
   }
 
   ImmutableSet<Optional<String>> testStreamMin() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -121,7 +121,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("bar").findFirst().map(String::length));
   }
 
-  ImmutableSet<Boolean> testStreamIsEmpty() {
+  ImmutableSet<Boolean> testStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         Stream.of(1).findAny().isEmpty(),
         Stream.of(2).findAny().isEmpty(),
@@ -131,15 +131,14 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of(6).findAny().isEmpty(),
         Stream.of(7).findAny().isEmpty(),
         Stream.of(8).findAny().isEmpty(),
-        Stream.of(9).findAny().isEmpty());
+        Stream.of(9).findAny().isEmpty(),
+        !Stream.of(10).findAny().isEmpty(),
+        !Stream.of(11).findAny().isEmpty(),
+        !Stream.of(12).findAny().isEmpty());
   }
 
-  ImmutableSet<Boolean> testStreamIsNotEmpty() {
-    return ImmutableSet.of(
-        Stream.of(1).findAny().isPresent(),
-        Stream.of(2).findAny().isPresent(),
-        Stream.of(3).findAny().isPresent(),
-        Stream.of(4).findAny().isPresent());
+  boolean testStreamFindAnyIsPresent() {
+    return Stream.of(1).findAny().isPresent();
   }
 
   ImmutableSet<Optional<String>> testStreamMin() {


### PR DESCRIPTION
~:exclamation: This PR is on top of #1025. :exclamation:~

Suggested commit message:
```
Compact and replace `StreamIs{,Not}Empty` Refaster rules (#1028)

The new `StreamFindAnyIs{Empty,Present}` rules are simpler thanks to the
use of `@AlsoNegation`. In some cases an additional application of the
`OptionalIsEmpty` rule will be required.
```