### PR TITLE
Re-enable SonarCloud analysis on default branch

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -13,7 +13,7 @@ jobs:
   analyze:
     # Analysis of code in forked repositories is skipped, as such workflow runs
     # do not have access to the requisite secrets.
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: read
     runs-on: ubuntu-22.04


### PR DESCRIPTION
SonarCloud reports that the `master` branch was [last analyzed](https://sonarcloud.io/summary/new_code?id=PicnicSupermarket_error-prone-support) for revision 7c2078b771f218269534f4c34966e170049d53d8, i.e. just before #926. I noticed that something was off when all new PRs started to report the issue resolved by #1023. The current fix is based on [this SO answer](https://stackoverflow.com/a/66206183).

Suggested commit message:
```
Re-enable SonarCloud analysis on default branch (#1029)

This analysis was accidentally disabled by
ff3be8ae3fc23072976c601e73a2b46d0792d7e9.
```