### PR TITLE
Upgrade JDKs used by GitHub Actions builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,9 +42,9 @@ Please replace this sentence with log output, if applicable.
 <!-- Please complete the following information: -->
 
 - Operating system (e.g. MacOS Monterey).
-- Java version (i.e. `java --version`, e.g. `17.0.8`).
-- Error Prone version (e.g. `2.18.0`).
-- Error Prone Support version (e.g. `0.9.0`).
+- Java version (i.e. `java --version`, e.g. `17.0.10`).
+- Error Prone version (e.g. `2.25.0`).
+- Error Prone Support version (e.g. `0.15.0`).
 
 ### Additional context
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,16 +10,16 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        jdk: [ 17.0.8, 21.0.0 ]
+        jdk: [ 17.0.10, 21.0.2 ]
         distribution: [ temurin ]
         experimental: [ false ]
         include:
           - os: macos-14
-            jdk: 17.0.8
+            jdk: 17.0.10
             distribution: temurin
             experimental: false
           - os: windows-2022
-            jdk: 17.0.8
+            jdk: 17.0.10
             distribution: temurin
             experimental: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -24,7 +24,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:
-          java-version: 17.0.8
+          java-version: 17.0.10
           java-distribution: temurin
           maven-version: 3.9.6
       - name: Initialize CodeQL

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -15,7 +15,7 @@ jobs:
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:
           checkout-fetch-depth: 2
-          java-version: 17.0.8
+          java-version: 17.0.10
           java-distribution: temurin
           maven-version: 3.9.6
       - name: Run Pitest

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:
-          java-version: 17.0.8
+          java-version: 17.0.10
           java-distribution: temurin
           maven-version: 3.9.6
       - name: Download Pitest analysis artifact

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -22,7 +22,7 @@ jobs:
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:
           checkout-ref: "refs/pull/${{ github.event.issue.number }}/head"
-          java-version: 17.0.8
+          java-version: 17.0.10
           java-distribution: temurin
           maven-version: 3.9.6
       - name: Install project to local Maven repository

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -22,7 +22,7 @@ jobs:
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:
           checkout-fetch-depth: 0
-          java-version: 17.0.8
+          java-version: 17.0.10
           java-distribution: temurin
           maven-version: 3.9.6
       - name: Create missing `test` directory


### PR DESCRIPTION
Suggested commit message:
```
Upgrade JDKs used by GitHub Actions builds (#1043)

Summary of changes:
- Use JDK 17.0.10 instead of 17.0.8.
- Use JDK 21.0.2 instead of 21.0.0.
- Have GitHub issue template reference more recent version numbers.

See:
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.9+9
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.10+7
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.1+12
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.2+13
```