### PR TITLE
Have Renovate file `action-download-artifact` PRs once every four weeks

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -13,6 +13,7 @@
     },
     {
       "matchDepNames": [
+        "dawidd6/action-download-artifact",
         "github/codeql-action",
         "ruby/setup-ruby"
       ],


### PR DESCRIPTION
Wanted to omit `dawidd6` to fit the PR description.

As suggested here: https://github.com/PicnicSupermarket/error-prone-support/pull/1039#issuecomment-1951878345.