### PR TITLE
Introduce `FluxFromIterable` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1207,6 +1207,21 @@ final class ReactorRules {
   }
 
   /**
+   * Don't unnecessarily convert {@link Collection} to {@link Stream} before creating {@link Flux}.
+   */
+  static final class FluxFromIterable<T> {
+    @BeforeTemplate
+    Flux<T> before(Collection<T> c) {
+      return Flux.fromStream(c.stream());
+    }
+
+    @AfterTemplate
+    Flux<T> after(Collection<T> c) {
+      return Flux.fromIterable(c);
+    }
+  }
+
+  /**
    * Prefer {@link Flux#count()} followed by a conversion from {@code long} to {@code int} over
    * collecting into a list and counting its elements.
    */
@@ -1898,21 +1913,6 @@ final class ReactorRules {
     @AfterTemplate
     Duration after(StepVerifier.LastStep step, Duration duration) {
       return step.verifyTimeout(duration);
-    }
-  }
-
-  /**
-   * Don't unnecessarily convert {@link Collection} to {@link Stream} before creating {@link Flux}.
-   */
-  static final class FluxFromIterable<T> {
-    @BeforeTemplate
-    Flux<T> before(Collection<T> c) {
-      return Flux.fromStream(c.stream());
-    }
-
-    @AfterTemplate
-    Flux<T> after(Collection<T> c) {
-      return Flux.fromIterable(c);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -41,7 +41,6 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
-import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -1206,10 +1205,7 @@ final class ReactorRules {
     }
   }
 
-  /**
-   * Don't unnecessarily convert a {@link Collection} to a {@link Stream} before creating a {@link
-   * Flux}.
-   */
+  /** Prefer {@link Flux#fromIterable(Iterable)} over less efficient alternatives. */
   static final class FluxFromIterable<T> {
     @BeforeTemplate
     Flux<T> before(Collection<T> collection) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1207,17 +1207,18 @@ final class ReactorRules {
   }
 
   /**
-   * Don't unnecessarily convert {@link Collection} to {@link Stream} before creating {@link Flux}.
+   * Don't unnecessarily convert a {@link Collection} to a {@link Stream} before creating a {@link
+   * Flux}.
    */
   static final class FluxFromIterable<T> {
     @BeforeTemplate
-    Flux<T> before(Collection<T> c) {
-      return Flux.fromStream(c.stream());
+    Flux<T> before(Collection<T> collection) {
+      return Flux.fromStream(collection.stream());
     }
 
     @AfterTemplate
-    Flux<T> after(Collection<T> c) {
-      return Flux.fromIterable(c);
+    Flux<T> after(Collection<T> collection) {
+      return Flux.fromIterable(collection);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -221,19 +221,6 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily convert {@link Collection} to {@link Stream} before creating {@link Flux}. */
-  static final class FluxFromIterable<T> {
-    @BeforeTemplate
-    Flux<T> before(Collection<T> c) {
-      return Flux.fromStream(c.stream());
-    }
-
-    @AfterTemplate
-    Flux<T> after(Collection<T> c) {
-      return Flux.fromIterable(c);
-    }
-  }
-
   /**
    * Prefer {@link Flux#zip(Publisher, Publisher)} over a chained {@link Flux#zipWith(Publisher)},
    * as the former better conveys that the {@link Publisher}s may be subscribed to concurrently, and
@@ -1911,6 +1898,21 @@ final class ReactorRules {
     @AfterTemplate
     Duration after(StepVerifier.LastStep step, Duration duration) {
       return step.verifyTimeout(duration);
+    }
+  }
+
+  /**
+   * Don't unnecessarily convert {@link Collection} to {@link Stream} before creating {@link Flux}.
+   */
+  static final class FluxFromIterable<T> {
+    @BeforeTemplate
+    Flux<T> before(Collection<T> c) {
+      return Flux.fromStream(c.stream());
+    }
+
+    @AfterTemplate
+    Flux<T> after(Collection<T> c) {
+      return Flux.fromIterable(c);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -41,6 +41,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
+import java.util.stream.Stream;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -217,6 +218,19 @@ final class ReactorRules {
     @AfterTemplate
     Mono<R> after(Mono<T> mono, Mono<S> other, BiFunction<T, S, R> combinator) {
       return Mono.zip(mono, other).map(function(combinator));
+    }
+  }
+
+  /** Don't unnecessarily convert {@link Collection} to {@link Stream} before creating {@link Flux}. */
+  static final class FluxFromIterable<T> {
+    @BeforeTemplate
+    Flux<T> before(Collection<T> c) {
+      return Flux.fromStream(c.stream());
+    }
+
+    @AfterTemplate
+    Flux<T> after(Collection<T> c) {
+      return Flux.fromIterable(c);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -646,4 +646,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   Duration testStepVerifierLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).expectTimeout(Duration.ZERO).verify();
   }
+
+  Flux<String> testFluxFromIterable() {
+    return Flux.fromStream(ImmutableList.of("foo").stream());
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -432,6 +432,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(ImmutableList.of("bar")).concatMap(Flux::fromIterable, 2));
   }
 
+  Flux<String> testFluxFromIterable() {
+    return Flux.fromStream(ImmutableList.of("foo").stream());
+  }
+
   ImmutableSet<Mono<Integer>> testFluxCountMapMathToIntExact() {
     return ImmutableSet.of(
         Flux.just(1).collect(toImmutableList()).map(Collection::size),
@@ -645,9 +649,5 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Duration testStepVerifierLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).expectTimeout(Duration.ZERO).verify();
-  }
-
-  Flux<String> testFluxFromIterable() {
-    return Flux.fromStream(ImmutableList.of("foo").stream());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -627,4 +627,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   Duration testStepVerifierLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).verifyTimeout(Duration.ZERO);
   }
+
+  Flux<String> testFluxFromIterable() {
+    return Flux.fromIterable(ImmutableList.of("foo"));
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -427,6 +427,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(ImmutableList.of("bar")).concatMapIterable(identity(), 2));
   }
 
+  Flux<String> testFluxFromIterable() {
+    return Flux.fromIterable(ImmutableList.of("foo"));
+  }
+
   ImmutableSet<Mono<Integer>> testFluxCountMapMathToIntExact() {
     return ImmutableSet.of(
         Flux.just(1).count().map(Math::toIntExact),
@@ -626,9 +630,5 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Duration testStepVerifierLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).verifyTimeout(Duration.ZERO);
-  }
-
-  Flux<String> testFluxFromIterable() {
-    return Flux.fromIterable(ImmutableList.of("foo"));
   }
 }


### PR DESCRIPTION
Based on an internal discussion, we found this case for a Refaster rule;

we can omit `.stream()` on a `Collection` and directly use `Flux.fromIterable`.

I wasn't sure about the order of rules and tests, so I placed them at the end, LMK if they need to move. :)