### PR TITLE
Exempt `picocli.CommandLine.Option#names` annotation attribute from reordering

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/LexicographicalAnnotationAttributeListing.java
@@ -67,14 +67,15 @@ public final class LexicographicalAnnotationAttributeListing extends BugChecker
   private static final long serialVersionUID = 1L;
   private static final ImmutableSet<String> BLACKLISTED_ANNOTATIONS =
       ImmutableSet.of(
-          // XXX: unless JsonPropertyOrder#alphabetic is true...
+          // XXX: Unless `JsonPropertyOrder#alphabetic` is true...
           "com.fasterxml.jackson.annotation.JsonPropertyOrder#value",
           "io.swagger.annotations.ApiImplicitParams#value",
           "io.swagger.v3.oas.annotations.Parameters#value",
           "javax.xml.bind.annotation.XmlType#propOrder",
           "org.springframework.context.annotation.PropertySource#value",
           "org.springframework.test.context.TestPropertySource#locations",
-          "org.springframework.test.context.TestPropertySource#value");
+          "org.springframework.test.context.TestPropertySource#value",
+          "picocli.CommandLine.Option#names");
   private static final String FLAG_PREFIX = "LexicographicalAnnotationAttributeListing:";
   private static final String INCLUDED_ANNOTATIONS_FLAG = FLAG_PREFIX + "Includes";
   private static final String EXCLUDED_ANNOTATIONS_FLAG = FLAG_PREFIX + "Excludes";


### PR DESCRIPTION
As part of https://github.com/checkstyle/checkstyle/issues/14137 I'm enabling the `LexicographicalAnnotationAttributeListing` check. I encountered a problem related to this: https://github.com/PicnicSupermarket/error-prone-support/blob/master/integration-tests/checkstyle-init.patch#L78. 

Therefore I'm filing this PR.