### PR TITLE
Introduce GitHub Actions `step-security/harden-runner` step

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,6 +25,15 @@ jobs:
     runs-on: ${{ matrix.os }}
     continue-on-error: ${{ matrix.experimental }}
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            jitpack.io:443
+            repo.maven.apache.org:443
       # We run the build twice for each supported JDK: once against the
       # original Error Prone release, using only Error Prone checks available
       # on Maven Central, and once against the Picnic Error Prone fork,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,6 +21,15 @@ jobs:
       security-events: write
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            github.com:443
+            repo.maven.apache.org:443
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -11,6 +11,33 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.adoptium.net:443
+            api.github.com:443
+            bestpractices.coreinfrastructure.org:443
+            blog.picnic.nl:443
+            errorprone.info:443
+            github.com:443
+            img.shields.io:443
+            index.rubygems.org:443
+            jitpack.io:443
+            maven.apache.org:443
+            objects.githubusercontent.com:443
+            pitest.org:443
+            repo.maven.apache.org:443
+            rubygems.org:443
+            search.maven.org:443
+            securityscorecards.dev:443
+            sonarcloud.io:443
+            www.baeldung.com:443
+            www.bestpractices.dev:443
+            www.youtube.com:443
+            youtrack.jetbrains.com:443
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:
@@ -46,6 +73,13 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@decdde0ac072f6dcbe43649d82d9c635fff5b4e4 # v4.0.4

--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -20,6 +20,15 @@ jobs:
       id-token: write
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.github.com:443
+            api.osv.dev:443
+            github.com:443
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -11,6 +11,14 @@ jobs:
   analyze-pr:
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            github.com:443
+            repo.maven.apache.org:443
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -19,6 +19,11 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          # XXX: Replace with `block` policy.
+          egress-policy: audit
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -18,6 +18,11 @@ jobs:
       github.event.issue.pull_request && contains(github.event.comment.body, '/integration-test')
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          # XXX: Replace with `block` policy.
+          egress-policy: audit
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -18,6 +18,18 @@ jobs:
       contents: read
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
+        with:
+          disable-sudo: true
+          egress-policy: block
+          allowed-endpoints: >
+            ea6ne4j2sb.execute-api.eu-central-1.amazonaws.com:443
+            github.com:443
+            repo.maven.apache.org:443
+            sc-cleancode-sensorcache-eu-central-1-prod.s3.amazonaws.com:443
+            scanner.sonarcloud.io:443
+            sonarcloud.io:443
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@6d44c18d67d9e1549907b8815efa5e4dada1801b # v1.12.0
         with:


### PR DESCRIPTION
See [these steps](https://github.com/step-security/harden-runner?tab=readme-ov-file#github-hosted-runners) for context. I noticed this feature when checking the [Byte Buddy GHA setup](https://github.com/raphw/byte-buddy/blob/3b4ed21c97a960ddd8196cdd76c62810f9a6cfd2/.github/workflows/main.yml).

Suggested commit message:
```
Introduce GitHub Actions `step-security/harden-runner` step (#1063)
```