### PR TITLE
Upgrade Error Prone fork v2.25.0-picnic-1 -> v2.25.0-picnic-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -207,7 +207,7 @@
         <version.auto-service>1.1.1</version.auto-service>
         <version.auto-value>1.10.4</version.auto-value>
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
-        <version.error-prone-fork>v${version.error-prone-orig}-picnic-1</version.error-prone-fork>
+        <version.error-prone-fork>v${version.error-prone-orig}-picnic-2</version.error-prone-fork>
         <version.error-prone-orig>2.25.0</version.error-prone-orig>
         <version.error-prone-slf4j>0.1.22</version.error-prone-slf4j>
         <version.guava-beta-checker>1.0</version.guava-beta-checker>


### PR DESCRIPTION
Suggested commit message:
```
Upgrade Error Prone fork v2.25.0-picnic-1 -> v2.25.0-picnic-2 (#1065)

See:
- https://github.com/PicnicSupermarket/error-prone/releases/tag/v2.25.0-picnic-2
- https://github.com/PicnicSupermarket/error-prone/compare/v2.25.0-picnic-1...v2.25.0-picnic-2
```