### PR TITLE
Have `step-security/harden-runner` audit the OpenSSF Scorecard update workflow

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -23,12 +23,8 @@ jobs:
       - name: Install Harden-Runner
         uses: step-security/harden-runner@63c24ba6bd7ba022e95695ff85de572c04a18142 # v2.7.0
         with:
-          disable-sudo: true
-          egress-policy: block
-          allowed-endpoints: >
-            api.github.com:443
-            api.osv.dev:443
-            github.com:443
+          # XXX: Replace with `block` policy.
+          egress-policy: audit
       - name: Check out code
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
         with:


### PR DESCRIPTION
Suggested commit message:
```
Have `step-security/harden-runner` audit the OpenSSF Scorecard update workflow (#1076)

When executed on `master` this workflow requires additional permissions;
let's find out what they are.
```