### PR TITLE
Introduce Refaster rules that resolve `EnumOrdinal` violations

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -16,8 +16,11 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Matches;
+import com.google.errorprone.refaster.annotation.MayOptionallyUse;
+import com.google.errorprone.refaster.annotation.Placeholder;
 import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Arrays;
@@ -89,6 +92,24 @@ final class ComparatorRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     Comparator<T> after(Comparator<T> cmp) {
       return cmp;
+    }
+  }
+
+  /** Don't explicitly compare enums by their ordinal. */
+  abstract static class ComparingEnum<E extends Enum<E>, T> {
+    @Placeholder(allowsIdentity = true)
+    abstract E toEnumFunction(@MayOptionallyUse T value);
+
+    @BeforeTemplate
+    @SuppressWarnings("EnumOrdinal" /* This violation will be rewritten. */)
+    Comparator<T> before() {
+      return comparingInt(v -> toEnumFunction(v).ordinal());
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    Comparator<T> after() {
+      return comparing(v -> toEnumFunction(v));
     }
   }
 
@@ -417,6 +438,36 @@ final class ComparatorRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     Collector<T, ?, Optional<T>> after() {
       return maxBy(naturalOrder());
+    }
+  }
+
+  /** Don't explicitly compare enums by their ordinal. */
+  static final class IsLessThan<E extends Enum<E>> {
+    @BeforeTemplate
+    @SuppressWarnings("EnumOrdinal" /* This violation will be rewritten. */)
+    boolean before(E value1, E value2) {
+      return value1.ordinal() < value2.ordinal();
+    }
+
+    @AfterTemplate
+    @AlsoNegation
+    boolean after(E value1, E value2) {
+      return value1.compareTo(value2) < 0;
+    }
+  }
+
+  /** Don't explicitly compare enums by their ordinal. */
+  static final class IsLessThanOrEqualTo<E extends Enum<E>> {
+    @BeforeTemplate
+    @SuppressWarnings("EnumOrdinal" /* This violation will be rewritten. */)
+    boolean before(E value1, E value2) {
+      return value1.ordinal() <= value2.ordinal();
+    }
+
+    @AfterTemplate
+    @AlsoNegation
+    boolean after(E value1, E value2) {
+      return value1.compareTo(value2) <= 0;
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/EqualityRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/EqualityRules.java
@@ -30,8 +30,9 @@ final class EqualityRules {
     // XXX: This Refaster rule is the topic of https://github.com/google/error-prone/issues/559. We
     // work around the issue by selecting the "largest replacements". See the `Refaster` check.
     @BeforeTemplate
+    @SuppressWarnings("EnumOrdinal" /* This violation will be rewritten. */)
     boolean before(T a, T b) {
-      return Refaster.anyOf(a.equals(b), Objects.equals(a, b));
+      return Refaster.anyOf(a.equals(b), Objects.equals(a, b), a.ordinal() == b.ordinal());
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
@@ -9,6 +9,7 @@ import static java.util.stream.Collectors.minBy;
 import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -52,6 +53,10 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Comparator.comparing(identity(), Comparator.comparingInt(String::length)),
         Comparator.comparing(s -> s, Comparator.comparingInt(String::length)),
         Comparator.comparing(s -> "foo", Comparator.comparingInt(String::length)));
+  }
+
+  Comparator<String> testComparingEnum() {
+    return Comparator.comparingInt(s -> RoundingMode.valueOf(s).ordinal());
   }
 
   Comparator<String> testThenComparing() {
@@ -172,5 +177,17 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
 
   Collector<Integer, ?, Optional<Integer>> testMaxByNaturalOrder() {
     return minBy(reverseOrder());
+  }
+
+  ImmutableSet<Boolean> testIsLessThan() {
+    return ImmutableSet.of(
+        RoundingMode.UP.ordinal() < RoundingMode.DOWN.ordinal(),
+        RoundingMode.UP.ordinal() >= RoundingMode.DOWN.ordinal());
+  }
+
+  ImmutableSet<Boolean> testIsLessThanOrEqualTo() {
+    return ImmutableSet.of(
+        RoundingMode.UP.ordinal() <= RoundingMode.DOWN.ordinal(),
+        RoundingMode.UP.ordinal() > RoundingMode.DOWN.ordinal());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
@@ -1,5 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static java.util.Comparator.comparing;
 import static java.util.Comparator.naturalOrder;
 import static java.util.Comparator.reverseOrder;
 import static java.util.function.Function.identity;
@@ -9,6 +10,7 @@ import static java.util.stream.Collectors.minBy;
 import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
+import java.math.RoundingMode;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -50,6 +52,10 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Comparator.comparingInt(String::length),
         Comparator.comparingInt(String::length),
         Comparator.comparing(s -> "foo", Comparator.comparingInt(String::length)));
+  }
+
+  Comparator<String> testComparingEnum() {
+    return comparing(s -> RoundingMode.valueOf(s));
   }
 
   Comparator<String> testThenComparing() {
@@ -162,5 +168,17 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
 
   Collector<Integer, ?, Optional<Integer>> testMaxByNaturalOrder() {
     return maxBy(naturalOrder());
+  }
+
+  ImmutableSet<Boolean> testIsLessThan() {
+    return ImmutableSet.of(
+        RoundingMode.UP.compareTo(RoundingMode.DOWN) < 0,
+        RoundingMode.UP.compareTo(RoundingMode.DOWN) >= 0);
+  }
+
+  ImmutableSet<Boolean> testIsLessThanOrEqualTo() {
+    return ImmutableSet.of(
+        RoundingMode.UP.compareTo(RoundingMode.DOWN) <= 0,
+        RoundingMode.UP.compareTo(RoundingMode.DOWN) > 0);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestInput.java
@@ -21,8 +21,10 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         RoundingMode.UP.equals(RoundingMode.DOWN),
         Objects.equals(RoundingMode.UP, RoundingMode.DOWN),
+        RoundingMode.UP.ordinal() == RoundingMode.DOWN.ordinal(),
         !RoundingMode.UP.equals(RoundingMode.DOWN),
-        !Objects.equals(RoundingMode.UP, RoundingMode.DOWN));
+        !Objects.equals(RoundingMode.UP, RoundingMode.DOWN),
+        RoundingMode.UP.ordinal() != RoundingMode.DOWN.ordinal());
   }
 
   boolean testEqualsPredicate() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestOutput.java
@@ -21,6 +21,8 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         RoundingMode.UP == RoundingMode.DOWN,
         RoundingMode.UP == RoundingMode.DOWN,
+        RoundingMode.UP == RoundingMode.DOWN,
+        RoundingMode.UP != RoundingMode.DOWN,
         RoundingMode.UP != RoundingMode.DOWN,
         RoundingMode.UP != RoundingMode.DOWN);
   }


### PR DESCRIPTION
Suggested commit message:
```
Introduce Refaster rules that resolve `EnumOrdinal` violations (#1104)
```

These rules resolve some of the violations reported by the [EnumOrdinal](https://errorprone.info/bugpattern/EnumOrdinal) check new in Error Prone [2.26.0](https://github.com/google/error-prone/releases/tag/v2.26.0).