### PR TITLE
Start release notes with "Update considerations and deprecations" section

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -3,16 +3,16 @@ changelog:
     labels:
       - "ignore-changelog"
   categories:
+    - title: ":warning: Update considerations and deprecations"
+      labels:
+        - "breaking change"
+        - "deprecation"
     - title: ":rocket: New Error Prone checks and Refaster rules"
       labels:
         - "new feature"
     - title: ":sparkles: Improvements"
       labels:
         - "improvement"
-    - title: ":warning: Update considerations and deprecations"
-      labels:
-        - "breaking change"
-        - "deprecation"
     - title: ":bug: Bug fixes"
       labels:
         - "bug"


### PR DESCRIPTION
Discussed this offline with @Stephan202. 

When we have an update consideration or deprecation, it's usually quite important, so we want to have it at the top of the release notes. An example is the release notes from `v0.16.0`: https://github.com/PicnicSupermarket/error-prone-support/releases/tag/v0.16.0.