### PR TITLE
Update `FluxTake` Refaster rule for Reactor 3.5.0+

### DIFF
--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -142,7 +142,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Flux<Integer> testFluxTake() {
-    return Flux.just(1, 2, 3).take(1);
+    return Flux.just(1, 2, 3).take(1, true);
   }
 
   Mono<String> testMonoDefaultIfEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -147,7 +147,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Flux<Integer> testFluxTake() {
-    return Flux.just(1, 2, 3).take(1, true);
+    return Flux.just(1, 2, 3).take(1);
   }
 
   Mono<String> testMonoDefaultIfEmpty() {


### PR DESCRIPTION
Something I noticed while going over the internal code base.

Suggested commit message:
```
Update `FluxTake` Refaster rule for Reactor 3.5.0+ (#1128)
```