### PR TITLE
Introduce assorted Reactor `StepVerifier` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1774,13 +1774,13 @@ final class ReactorRules {
    */
   static final class StepVerifierVerify {
     @BeforeTemplate
-    void before(StepVerifier stepVerifier) {
-      stepVerifier.verifyThenAssertThat();
+    StepVerifier.Assertions before(StepVerifier stepVerifier) {
+      return stepVerifier.verifyThenAssertThat();
     }
 
     @AfterTemplate
-    void after(StepVerifier stepVerifier) {
-      stepVerifier.verify();
+    Duration after(StepVerifier stepVerifier) {
+      return stepVerifier.verify();
     }
   }
 
@@ -1790,13 +1790,13 @@ final class ReactorRules {
    */
   static final class StepVerifierVerifyDuration {
     @BeforeTemplate
-    void before(StepVerifier stepVerifier, Duration duration) {
-      stepVerifier.verifyThenAssertThat(duration);
+    StepVerifier.Assertions before(StepVerifier stepVerifier, Duration duration) {
+      return stepVerifier.verifyThenAssertThat(duration);
     }
 
     @AfterTemplate
-    void after(StepVerifier stepVerifier, Duration duration) {
-      stepVerifier.verify(duration);
+    Duration after(StepVerifier stepVerifier, Duration duration) {
+      return stepVerifier.verify(duration);
     }
   }
 
@@ -1913,25 +1913,15 @@ final class ReactorRules {
       return step.expectErrorMatches(predicate).verify();
     }
 
+    @BeforeTemplate
+    @SuppressWarnings("StepVerifierVerify" /* This is a more specific template. */)
+    StepVerifier.Assertions before2(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
+      return step.expectError().verifyThenAssertThat().hasOperatorErrorMatching(predicate);
+    }
+
     @AfterTemplate
     Duration after(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
       return step.verifyErrorMatches(predicate);
-    }
-  }
-
-  /**
-   * Prefer {@link StepVerifier.LastStep#verifyErrorMatches(Predicate)} over more verbose
-   * alternatives.
-   */
-  static final class StepVerifierLastStepVerifyErrorMatchesAssertions {
-    @BeforeTemplate
-    void before(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
-      step.expectError().verifyThenAssertThat().hasOperatorErrorMatching(predicate);
-    }
-
-    @AfterTemplate
-    void after(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
-      step.verifyErrorMatches(predicate);
     }
   }
 
@@ -1955,10 +1945,11 @@ final class ReactorRules {
    * Prefer {@link StepVerifier.LastStep#verifyErrorSatisfies(Consumer)} with AssertJ over more
    * contrived alternatives.
    */
-  static final class StepVerifierLastStepVerifyErrorSatisfiesAssertJ {
+  static final class StepVerifierLastStepVerifyErrorSatisfiesAssertJ<T extends Throwable> {
     @BeforeTemplate
-    void before(StepVerifier.LastStep step, Class<? extends Throwable> clazz, String message) {
-      Refaster.anyOf(
+    @SuppressWarnings("StepVerifierVerify" /* This is a more specific template. */)
+    StepVerifier.Assertions before(StepVerifier.LastStep step, Class<T> clazz, String message) {
+      return Refaster.anyOf(
           step.expectError()
               .verifyThenAssertThat()
               .hasOperatorErrorOfType(clazz)
@@ -1969,8 +1960,8 @@ final class ReactorRules {
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(StepVerifier.LastStep step, Class<? extends Throwable> clazz, String message) {
-      step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz).hasMessage(message));
+    Duration after(StepVerifier.LastStep step, Class<T> clazz, String message) {
+      return step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz).hasMessage(message));
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -43,7 +43,6 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
-import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -1971,8 +1970,7 @@ final class ReactorRules {
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(StepVerifier.LastStep step, Class<? extends Throwable> clazz, String message) {
-      step.verifyErrorSatisfies(
-          t -> Assertions.assertThat(t).isInstanceOf(clazz).hasMessage(message));
+      step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz).hasMessage(message));
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1769,7 +1769,7 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link StepVerifier.LastStep#verify()} over a dangling {@link
+   * Prefer {@link StepVerifier#verify()} over a dangling {@link
    * StepVerifier#verifyThenAssertThat()}.
    */
   // XXX: Application of this rule (and several others in this class) will cause invalid code if the
@@ -1794,7 +1794,7 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link StepVerifier.LastStep#verify(Duration)} over a dangling {@link
+   * Prefer {@link StepVerifier#verify(Duration)} over a dangling {@link
    * StepVerifier#verifyThenAssertThat(Duration)}.
    */
   static final class StepVerifierVerifyDuration {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1772,9 +1772,15 @@ final class ReactorRules {
    * Prefer {@link StepVerifier.LastStep#verify()} over a dangling {@link
    * StepVerifier#verifyThenAssertThat()}.
    */
-  // XXX: This rule may break existing code. We want to explicitly nudge towards using {@link
-  // StepVerifier.Step#assertNext(Consumer)} or {@link StepVerifier.Step#expectNext(Object)}
-  // together with {@link Step#verifyComplete()}.
+  // XXX: Application of this rule (and several others in this class) will cause invalid code if the
+  // result of the rewritten expression is dereferenced. Consider introducing a bug checker that
+  // identifies rules that change the return type of an expression and annotates them accordingly.
+  // The associated annotation can then be used to instruct an annotation processor to generate
+  // corresponding `void` rules that match only statements. This would allow the `Refaster` check to
+  // conditionally skip "not fully safe" rules. This allows conditionally flagging more dubious
+  // code, at the risk of compilation failures. With this rule, for example, we want to explicitly
+  // nudge users towards `StepVerifier.Step#assertNext(Consumer)` or
+  // `StepVerifier.Step#expectNext(Object)`, together with `Step#verifyComplete()`.
   static final class StepVerifierVerify {
     @BeforeTemplate
     StepVerifier.Assertions before(StepVerifier stepVerifier) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1921,6 +1921,22 @@ final class ReactorRules {
   }
 
   /**
+   * Prefer {@link StepVerifier.LastStep#verifyErrorMatches(Predicate)} over more verbose
+   * alternatives.
+   */
+  static final class StepVerifierLastStepVerifyErrorMatchesAssertions {
+    @BeforeTemplate
+    void before(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
+      step.expectError().verifyThenAssertThat().hasOperatorErrorMatching(predicate);
+    }
+
+    @AfterTemplate
+    void after(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
+      step.verifyErrorMatches(predicate);
+    }
+  }
+
+  /**
    * Prefer {@link StepVerifier.LastStep#verifyErrorSatisfies(Consumer)} over more verbose
    * alternatives.
    */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1768,6 +1768,19 @@ final class ReactorRules {
     }
   }
 
+  /** Don't unnecessarily invoke {@link StepVerifier#verifyLater()} multiple times. */
+  static final class StepVerifierVerifyLater {
+    @BeforeTemplate
+    StepVerifier before(StepVerifier stepVerifier) {
+      return stepVerifier.verifyLater().verifyLater();
+    }
+
+    @AfterTemplate
+    StepVerifier after(StepVerifier stepVerifier) {
+      return stepVerifier.verifyLater();
+    }
+  }
+
   /** Don't unnecessarily have {@link StepVerifier.Step} expect no elements. */
   static final class StepVerifierStepIdentity<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1772,6 +1772,9 @@ final class ReactorRules {
    * Prefer {@link StepVerifier.LastStep#verify()} over a dangling {@link
    * StepVerifier#verifyThenAssertThat()}.
    */
+  // XXX: This rule may break existing code. We want to explicitly nudge towards using {@link
+  // StepVerifier.Step#assertNext(Consumer)} or {@link StepVerifier.Step#expectNext(Object)}
+  // together with {@link Step#verifyComplete()}.
   static final class StepVerifierVerify {
     @BeforeTemplate
     StepVerifier.Assertions before(StepVerifier stepVerifier) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1768,6 +1768,38 @@ final class ReactorRules {
     }
   }
 
+  /**
+   * Prefer {@link StepVerifier.LastStep#verify()} over a dangling {@link
+   * StepVerifier#verifyThenAssertThat()}.
+   */
+  static final class StepVerifierVerify {
+    @BeforeTemplate
+    void before(StepVerifier stepVerifier) {
+      stepVerifier.verifyThenAssertThat();
+    }
+
+    @AfterTemplate
+    void after(StepVerifier stepVerifier) {
+      stepVerifier.verify();
+    }
+  }
+
+  /**
+   * Prefer {@link StepVerifier.LastStep#verify(Duration)} over a dangling {@link
+   * StepVerifier#verifyThenAssertThat(Duration)}.
+   */
+  static final class StepVerifierVerifyDuration {
+    @BeforeTemplate
+    void before(StepVerifier stepVerifier, Duration duration) {
+      stepVerifier.verifyThenAssertThat(duration);
+    }
+
+    @AfterTemplate
+    void after(StepVerifier stepVerifier, Duration duration) {
+      stepVerifier.verify(duration);
+    }
+  }
+
   /** Don't unnecessarily invoke {@link StepVerifier#verifyLater()} multiple times. */
   static final class StepVerifierVerifyLater {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -598,12 +598,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return StepVerifier.create(Flux.just(1));
   }
 
-  void testStepVerifierVerify() {
-    Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat();
+  Object testStepVerifierVerify() {
+    return Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat();
   }
 
-  void testStepVerifierVerifyDuration() {
-    Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat(Duration.ZERO);
+  Object testStepVerifierVerifyDuration() {
+    return Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat(Duration.ZERO);
   }
 
   StepVerifier testStepVerifierVerifyLater() {
@@ -650,42 +650,41 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
             .verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(AssertionError.class)));
   }
 
-  Duration testStepVerifierLastStepVerifyErrorMatches() {
-    return Mono.empty()
-        .as(StepVerifier::create)
-        .expectErrorMatches(IllegalArgumentException.class::equals)
-        .verify();
-  }
-
-  void testStepVerifierLastStepVerifyErrorMatchesAssertions() {
-    Mono.empty()
-        .as(StepVerifier::create)
-        .expectError()
-        .verifyThenAssertThat()
-        .hasOperatorErrorMatching(IllegalArgumentException.class::equals);
+  ImmutableSet<?> testStepVerifierLastStepVerifyErrorMatches() {
+    return ImmutableSet.of(
+        Mono.empty()
+            .as(StepVerifier::create)
+            .expectErrorMatches(IllegalArgumentException.class::equals)
+            .verify(),
+        Mono.empty()
+            .as(StepVerifier::create)
+            .expectError()
+            .verifyThenAssertThat()
+            .hasOperatorErrorMatching(IllegalStateException.class::equals));
   }
 
   Duration testStepVerifierLastStepVerifyErrorSatisfies() {
     return Mono.empty().as(StepVerifier::create).expectErrorSatisfies(t -> {}).verify();
   }
 
-  void testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
-    Mono.empty()
-        .as(StepVerifier::create)
-        .expectError()
-        .verifyThenAssertThat()
-        .hasOperatorErrorOfType(IllegalStateException.class)
-        .hasOperatorErrorWithMessage("foo");
-    Mono.empty()
-        .as(StepVerifier::create)
-        .expectError(IllegalStateException.class)
-        .verifyThenAssertThat()
-        .hasOperatorErrorWithMessage("bar");
-    Mono.empty()
-        .as(StepVerifier::create)
-        .expectErrorMessage("baz")
-        .verifyThenAssertThat()
-        .hasOperatorErrorOfType(IllegalStateException.class);
+  ImmutableSet<?> testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
+    return ImmutableSet.of(
+        Mono.empty()
+            .as(StepVerifier::create)
+            .expectError()
+            .verifyThenAssertThat()
+            .hasOperatorErrorOfType(IllegalArgumentException.class)
+            .hasOperatorErrorWithMessage("foo"),
+        Mono.empty()
+            .as(StepVerifier::create)
+            .expectError(IllegalStateException.class)
+            .verifyThenAssertThat()
+            .hasOperatorErrorWithMessage("bar"),
+        Mono.empty()
+            .as(StepVerifier::create)
+            .expectErrorMessage("baz")
+            .verifyThenAssertThat()
+            .hasOperatorErrorOfType(AssertionError.class));
   }
 
   Duration testStepVerifierLastStepVerifyErrorMessage() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -598,6 +598,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return StepVerifier.create(Flux.just(1));
   }
 
+  void testStepVerifierVerify() {
+    Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat();
+  }
+
+  void testStepVerifierVerifyDuration() {
+    Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat(Duration.ZERO);
+  }
+
   StepVerifier testStepVerifierVerifyLater() {
     return Mono.empty().as(StepVerifier::create).expectError().verifyLater().verifyLater();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -657,6 +657,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         .verify();
   }
 
+  void testStepVerifierLastStepVerifyErrorMatchesAssertions() {
+    Mono.empty()
+        .as(StepVerifier::create)
+        .expectError()
+        .verifyThenAssertThat()
+        .hasOperatorErrorMatching(IllegalArgumentException.class::equals);
+  }
+
   Duration testStepVerifierLastStepVerifyErrorSatisfies() {
     return Mono.empty().as(StepVerifier::create).expectErrorSatisfies(t -> {}).verify();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -598,6 +598,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return StepVerifier.create(Flux.just(1));
   }
 
+  StepVerifier testStepVerifierVerifyLater() {
+    return Mono.empty().as(StepVerifier::create).expectError().verifyLater().verifyLater();
+  }
+
   ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create).expectNext(),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -661,6 +661,25 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).expectErrorSatisfies(t -> {}).verify();
   }
 
+  void testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
+    Mono.empty()
+        .as(StepVerifier::create)
+        .expectError()
+        .verifyThenAssertThat()
+        .hasOperatorErrorOfType(IllegalStateException.class)
+        .hasOperatorErrorWithMessage("foo");
+    Mono.empty()
+        .as(StepVerifier::create)
+        .expectError(IllegalStateException.class)
+        .verifyThenAssertThat()
+        .hasOperatorErrorWithMessage("bar");
+    Mono.empty()
+        .as(StepVerifier::create)
+        .expectErrorMessage("baz")
+        .verifyThenAssertThat()
+        .hasOperatorErrorOfType(IllegalStateException.class);
+  }
+
   Duration testStepVerifierLastStepVerifyErrorMessage() {
     return Mono.empty().as(StepVerifier::create).expectErrorMessage("foo").verify();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -586,6 +586,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).as(StepVerifier::create);
   }
 
+  void testStepVerifierVerify() {
+    Mono.empty().as(StepVerifier::create).expectError().verify();
+  }
+
+  void testStepVerifierVerifyDuration() {
+    Mono.empty().as(StepVerifier::create).expectError().verify(Duration.ZERO);
+  }
+
   StepVerifier testStepVerifierVerifyLater() {
     return Mono.empty().as(StepVerifier::create).expectError().verifyLater();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -586,6 +586,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).as(StepVerifier::create);
   }
 
+  StepVerifier testStepVerifierVerifyLater() {
+    return Mono.empty().as(StepVerifier::create).expectError().verifyLater();
+  }
+
   ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -637,6 +637,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         .verifyErrorMatches(IllegalArgumentException.class::equals);
   }
 
+  void testStepVerifierLastStepVerifyErrorMatchesAssertions() {
+    Mono.empty()
+        .as(StepVerifier::create)
+        .verifyErrorMatches(IllegalArgumentException.class::equals);
+  }
+
   Duration testStepVerifierLastStepVerifyErrorSatisfies() {
     return Mono.empty().as(StepVerifier::create).verifyErrorSatisfies(t -> {});
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -586,12 +586,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).as(StepVerifier::create);
   }
 
-  void testStepVerifierVerify() {
-    Mono.empty().as(StepVerifier::create).expectError().verify();
+  Object testStepVerifierVerify() {
+    return Mono.empty().as(StepVerifier::create).expectError().verify();
   }
 
-  void testStepVerifierVerifyDuration() {
-    Mono.empty().as(StepVerifier::create).expectError().verify(Duration.ZERO);
+  Object testStepVerifierVerifyDuration() {
+    return Mono.empty().as(StepVerifier::create).expectError().verify(Duration.ZERO);
   }
 
   StepVerifier testStepVerifierVerifyLater() {
@@ -631,35 +631,34 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.empty().as(StepVerifier::create).verifyError(AssertionError.class));
   }
 
-  Duration testStepVerifierLastStepVerifyErrorMatches() {
-    return Mono.empty()
-        .as(StepVerifier::create)
-        .verifyErrorMatches(IllegalArgumentException.class::equals);
-  }
-
-  void testStepVerifierLastStepVerifyErrorMatchesAssertions() {
-    Mono.empty()
-        .as(StepVerifier::create)
-        .verifyErrorMatches(IllegalArgumentException.class::equals);
+  ImmutableSet<?> testStepVerifierLastStepVerifyErrorMatches() {
+    return ImmutableSet.of(
+        Mono.empty()
+            .as(StepVerifier::create)
+            .verifyErrorMatches(IllegalArgumentException.class::equals),
+        Mono.empty()
+            .as(StepVerifier::create)
+            .verifyErrorMatches(IllegalStateException.class::equals));
   }
 
   Duration testStepVerifierLastStepVerifyErrorSatisfies() {
     return Mono.empty().as(StepVerifier::create).verifyErrorSatisfies(t -> {});
   }
 
-  void testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
-    Mono.empty()
-        .as(StepVerifier::create)
-        .verifyErrorSatisfies(
-            t -> assertThat(t).isInstanceOf(IllegalStateException.class).hasMessage("foo"));
-    Mono.empty()
-        .as(StepVerifier::create)
-        .verifyErrorSatisfies(
-            t -> assertThat(t).isInstanceOf(IllegalStateException.class).hasMessage("bar"));
-    Mono.empty()
-        .as(StepVerifier::create)
-        .verifyErrorSatisfies(
-            t -> assertThat(t).isInstanceOf(IllegalStateException.class).hasMessage("baz"));
+  ImmutableSet<?> testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
+    return ImmutableSet.of(
+        Mono.empty()
+            .as(StepVerifier::create)
+            .verifyErrorSatisfies(
+                t -> assertThat(t).isInstanceOf(IllegalArgumentException.class).hasMessage("foo")),
+        Mono.empty()
+            .as(StepVerifier::create)
+            .verifyErrorSatisfies(
+                t -> assertThat(t).isInstanceOf(IllegalStateException.class).hasMessage("bar")),
+        Mono.empty()
+            .as(StepVerifier::create)
+            .verifyErrorSatisfies(
+                t -> assertThat(t).isInstanceOf(AssertionError.class).hasMessage("baz")));
   }
 
   Duration testStepVerifierLastStepVerifyErrorMessage() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -641,6 +641,21 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).verifyErrorSatisfies(t -> {});
   }
 
+  void testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
+    Mono.empty()
+        .as(StepVerifier::create)
+        .verifyErrorSatisfies(
+            t -> assertThat(t).isInstanceOf(IllegalStateException.class).hasMessage("foo"));
+    Mono.empty()
+        .as(StepVerifier::create)
+        .verifyErrorSatisfies(
+            t -> assertThat(t).isInstanceOf(IllegalStateException.class).hasMessage("bar"));
+    Mono.empty()
+        .as(StepVerifier::create)
+        .verifyErrorSatisfies(
+            t -> assertThat(t).isInstanceOf(IllegalStateException.class).hasMessage("baz"));
+  }
+
   Duration testStepVerifierLastStepVerifyErrorMessage() {
     return Mono.empty().as(StepVerifier::create).verifyErrorMessage("foo");
   }


### PR DESCRIPTION
### Summary
This PR introduces a bunch of rules associated to `StepVerifier.Asserations` and a trivial `StepVerifier` rule.

---
### Example
I spotted the following interesting pattern:
```java
Mono.empty()
    .as(StepVerifier::create)
    .expectError(SpecificException.class)
    .verifyThenAssertThat()
    .hasOperatorErrorWithMessage("msg");
```
Which made me find the interesting `StepVerifier#Assertions` API. It's quite low-level, and IMO not as straightforward to read and write.

The example itself is most often represented in our code-base using AssertJ's richer API:
```java
Mono.empty()
    .as(StepVerifier::create)
    .verifyErrorSatisfies(t ->
        assertThat(t)
        .isInstanceOf(SpecificException.class)
        .hasMessage("msg"));
```
---
### Suggested commit message:
```
Introduce assorted Reactor `StepVerifier` Refaster rules (#1132)
```
