### PR TITLE
Introduce `Check{Argument,State}WithMessageAndArguments` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -9,8 +9,11 @@ import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Objects.requireNonNull;
 
 import com.google.common.base.Preconditions;
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Objects;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -49,6 +52,26 @@ final class PreconditionsRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(boolean condition, String message) {
       checkArgument(!condition, message);
+    }
+  }
+
+  /**
+   * Prefer {@link Preconditions#checkArgument(boolean, String, Object...)} over more verbose
+   * alternatives.
+   */
+  // XXX: This check assumes that the format string only uses `%s` placeholders.
+  static final class CheckArgumentWithMessageAndArguments {
+    @BeforeTemplate
+    @FormatMethod
+    void before(boolean condition, String message, @Repeated Object... args) {
+      checkArgument(
+          condition, Refaster.anyOf(String.format(message, args), message.formatted(args)));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition, String message, @Repeated Object... args) {
+      checkArgument(condition, message, args);
     }
   }
 
@@ -203,6 +226,25 @@ final class PreconditionsRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(boolean condition, String message) {
       checkState(!condition, message);
+    }
+  }
+
+  /**
+   * Prefer {@link Preconditions#checkState(boolean, String, Object...)} over more verbose
+   * alternatives.
+   */
+  // XXX: This check assumes that the format string only uses `%s` placeholders.
+  static final class CheckStateWithMessageAndArguments {
+    @BeforeTemplate
+    @FormatMethod
+    void before(boolean condition, String message, @Repeated Object... args) {
+      checkState(condition, Refaster.anyOf(String.format(message, args), message.formatted(args)));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean condition, String message, @Repeated Object... args) {
+      checkState(condition, message, args);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -1,6 +1,8 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.common.base.Preconditions.checkNotNull;
+import static com.google.common.base.Preconditions.checkState;
 
 import com.google.common.collect.ImmutableSet;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
@@ -22,6 +24,11 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     if ("foo".isEmpty()) {
       throw new IllegalArgumentException("The string is empty");
     }
+  }
+
+  void testCheckArgumentWithMessageAndArguments() {
+    checkArgument("foo".isEmpty(), String.format("The %s is empty", 1));
+    checkArgument("bar".isEmpty(), "The %s is %s".formatted(2.0, false));
   }
 
   void testCheckElementIndexWithMessage() {
@@ -72,5 +79,10 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     if ("foo".isEmpty()) {
       throw new IllegalStateException("The string is empty");
     }
+  }
+
+  void testCheckStateWithMessageAndArguments() {
+    checkState("foo".isEmpty(), String.format("The %s is empty", 1));
+    checkState("bar".isEmpty(), "The %s is %s".formatted(2.0, false));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -25,6 +25,11 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     checkArgument(!"foo".isEmpty(), "The string is empty");
   }
 
+  void testCheckArgumentWithMessageAndArguments() {
+    checkArgument("foo".isEmpty(), "The %s is empty", 1);
+    checkArgument("bar".isEmpty(), "The %s is %s", 2.0, false);
+  }
+
   void testCheckElementIndexWithMessage() {
     checkElementIndex(1, 2, "My index");
   }
@@ -59,5 +64,10 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
 
   void testCheckStateWithMessage() {
     checkState(!"foo".isEmpty(), "The string is empty");
+  }
+
+  void testCheckStateWithMessageAndArguments() {
+    checkState("foo".isEmpty(), "The %s is empty", 1);
+    checkState("bar".isEmpty(), "The %s is %s", 2.0, false);
   }
 }


### PR DESCRIPTION
Suggested commit message:
```
Introduce `Check{Argument,State}WithMessageAndArguments` Refaster rules
```

The tests pass, but when I run this against an internal code base relevant violations aren't replaced. Requires a deeper look.