### PR TITLE
Introduce `OptionalEmpty` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -27,6 +27,19 @@ import tech.picnic.errorprone.refaster.matchers.IsLikelyTrivialComputation;
 final class OptionalRules {
   private OptionalRules() {}
 
+  /** Prefer {@link Optional#empty()} over the more contrived alternative. */
+  static final class OptionalEmpty<T> {
+    @BeforeTemplate
+    Optional<T> before() {
+      return Optional.ofNullable(null);
+    }
+
+    @AfterTemplate
+    Optional<T> after() {
+      return Optional.empty();
+    }
+  }
+
   static final class OptionalOfNullable<T> {
     // XXX: Refaster should be smart enough to also rewrite occurrences in which there are
     // parentheses around the null check, but that's currently not the case. Try to fix that.

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
@@ -13,6 +13,10 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
+  Optional<String> testOptionalEmpty() {
+    return Optional.ofNullable(null);
+  }
+
   ImmutableSet<Optional<String>> testOptionalOfNullable() {
     return ImmutableSet.of(
         toString() == null ? Optional.empty() : Optional.of(toString()),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
@@ -15,6 +15,10 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
+  Optional<String> testOptionalEmpty() {
+    return Optional.empty();
+  }
+
   ImmutableSet<Optional<String>> testOptionalOfNullable() {
     return ImmutableSet.of(Optional.ofNullable(toString()), Optional.ofNullable(toString()));
   }


### PR DESCRIPTION
I spotted the following interesting piece of code:
```java
Optional.ofNullable(null)
```
which should obviously always be:
```java
Optional.empty()
```
---
### Suggested commit message:
```
Introduce `OptionalEmpty` Refaster rule (#1156)
```
