### PR TITLE
PSM-2580 Simplify Renovate matchers

### DIFF
--- a/.renovaterc.json
+++ b/.renovaterc.json
@@ -12,7 +12,7 @@
       "separateMinorPatch": true
     },
     {
-      "matchDepNames": [
+      "matchPackageNames": [
         "dawidd6/action-download-artifact",
         "github/codeql-action",
         "ruby/setup-ruby"


### PR DESCRIPTION

This automated PR simplifies the matchers in the package rules by migrating to `packageName` matchers as opposed to `depName` matchers. It furthermore may remove some human-readable strings to match on as this is obsolete with the new `packageName` matchers.