### PR TITLE
Allow OpenSSF Scorecard analysis to access `api.scorecard.dev`

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -28,6 +28,7 @@ jobs:
           allowed-endpoints: >
             api.github.com:443
             api.osv.dev:443
+            api.scorecard.dev:443
             api.securityscorecards.dev:443
             fulcio.sigstore.dev:443
             github.com:443


### PR DESCRIPTION
Suggested commit message:
```
Allow OpenSSF Scorecard analysis to access `api.scorecard.dev` (#1193)
```