### PR TITLE
Extend `FluxConcatMap` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -557,6 +557,7 @@ final class ReactorRules {
         @Matches(IsIdentityOperation.class)
             Function<? super P, ? extends Publisher<? extends S>> identityOperation) {
       return Refaster.anyOf(
+          flux.concatMap(function, 0),
           flux.flatMap(function, 1),
           flux.flatMapSequential(function, 1),
           flux.map(function).concatMap(identityOperation));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -207,11 +207,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Flux<Integer>> testFluxConcatMap() {
     return ImmutableSet.of(
-        Flux.just(1).flatMap(Mono::just, 1),
-        Flux.just(2).flatMapSequential(Mono::just, 1),
-        Flux.just(3).map(Mono::just).concatMap(identity()),
-        Flux.just(4).map(Mono::just).concatMap(v -> v),
-        Flux.just(5).map(Mono::just).concatMap(v -> Mono.empty()));
+        Flux.just(1).concatMap(Mono::just, 0),
+        Flux.just(2).flatMap(Mono::just, 1),
+        Flux.just(3).flatMapSequential(Mono::just, 1),
+        Flux.just(4).map(Mono::just).concatMap(identity()),
+        Flux.just(5).map(Mono::just).concatMap(v -> v),
+        Flux.just(6).map(Mono::just).concatMap(v -> Mono.empty()));
   }
 
   ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -214,7 +214,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(2).concatMap(Mono::just),
         Flux.just(3).concatMap(Mono::just),
         Flux.just(4).concatMap(Mono::just),
-        Flux.just(5).map(Mono::just).concatMap(v -> Mono.empty()));
+        Flux.just(5).concatMap(Mono::just),
+        Flux.just(6).map(Mono::just).concatMap(v -> Mono.empty()));
   }
 
   ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {


### PR DESCRIPTION
As discussed during PR review with @werli.

Suggested commit message:
```
Extend `FluxConcatMap` Refaster rule (#1213)
```