### PR TITLE
Introduce `MonoFromFutureSupplier{,Boolean}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1906,8 +1906,13 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Mono#fromFuture(Supplier)} over {@link Mono#fromFuture(CompletableFuture)}. */
-  static final class MonoFromFuture<T> {
+  /**
+   * Prefer {@link Mono#fromFuture(Supplier)} over {@link Mono#fromFuture(CompletableFuture)}, as
+   * the former may defer initiation of the asynchornous computation until subscription.
+   */
+  static final class MonoFromFutureSupplier<T> {
+    // XXX: Constrain the `future` parameter using `@NotMatches(IsIdentityOperation.class)` once
+    // `IsIdentityOperation` no longer matches nullary method invocations.
     @BeforeTemplate
     Mono<T> before(CompletableFuture<T> future) {
       return Mono.fromFuture(future);
@@ -1921,9 +1926,12 @@ final class ReactorRules {
 
   /**
    * Prefer {@link Mono#fromFuture(Supplier, boolean)} over {@link
-   * Mono#fromFuture(CompletableFuture, boolean)}.
+   * Mono#fromFuture(CompletableFuture, boolean)}, as the former may defer initiation of the
+   * asynchornous computation until subscription.
    */
-  static final class MonoFromFutureSuppressCancel<T> {
+  static final class MonoFromFutureSupplierBoolean<T> {
+    // XXX: Constrain the `future` parameter using `@NotMatches(IsIdentityOperation.class)` once
+    // `IsIdentityOperation` no longer matches nullary method invocations.
     @BeforeTemplate
     Mono<T> before(CompletableFuture<T> future, boolean suppressCancel) {
       return Mono.fromFuture(future, suppressCancel);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -33,6 +33,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.BiConsumer;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
@@ -1902,6 +1903,35 @@ final class ReactorRules {
     @AfterTemplate
     Duration after(StepVerifier.LastStep step, Duration duration) {
       return step.verifyTimeout(duration);
+    }
+  }
+
+  /** Prefer {@link Mono#fromFuture(Supplier)} over {@link Mono#fromFuture(CompletableFuture)}. */
+  static final class MonoFromFuture<T> {
+    @BeforeTemplate
+    Mono<T> before(CompletableFuture<T> future) {
+      return Mono.fromFuture(future);
+    }
+
+    @AfterTemplate
+    Mono<T> after(CompletableFuture<T> future) {
+      return Mono.fromFuture(() -> future);
+    }
+  }
+
+  /**
+   * Prefer {@link Mono#fromFuture(Supplier, boolean)} over {@link
+   * Mono#fromFuture(CompletableFuture, boolean)}.
+   */
+  static final class MonoFromFutureSuppressCancel<T> {
+    @BeforeTemplate
+    Mono<T> before(CompletableFuture<T> future, boolean suppressCancel) {
+      return Mono.fromFuture(future, suppressCancel);
+    }
+
+    @AfterTemplate
+    Mono<T> after(CompletableFuture<T> future, boolean suppressCancel) {
+      return Mono.fromFuture(() -> future, suppressCancel);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -650,5 +651,13 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Duration testStepVerifierLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).expectTimeout(Duration.ZERO).verify();
+  }
+
+  Mono<Void> testMonoFromFuture() {
+    return Mono.fromFuture(CompletableFuture.completedFuture(null));
+  }
+
+  Mono<Void> testMonoFromFutureSuppressCancel() {
+    return Mono.fromFuture(CompletableFuture.completedFuture(null), true);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -653,11 +653,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).expectTimeout(Duration.ZERO).verify();
   }
 
-  Mono<Void> testMonoFromFuture() {
+  Mono<Void> testMonoFromFutureSupplier() {
     return Mono.fromFuture(CompletableFuture.completedFuture(null));
   }
 
-  Mono<Void> testMonoFromFutureSuppressCancel() {
+  Mono<Void> testMonoFromFutureSupplierBoolean() {
     return Mono.fromFuture(CompletableFuture.completedFuture(null), true);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.Callable;
+import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -631,5 +632,13 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   Duration testStepVerifierLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).verifyTimeout(Duration.ZERO);
+  }
+
+  Mono<Void> testMonoFromFuture() {
+    return Mono.fromFuture(() -> CompletableFuture.completedFuture(null));
+  }
+
+  Mono<Void> testMonoFromFutureSuppressCancel() {
+    return Mono.fromFuture(() -> CompletableFuture.completedFuture(null), true);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -634,11 +634,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).verifyTimeout(Duration.ZERO);
   }
 
-  Mono<Void> testMonoFromFuture() {
+  Mono<Void> testMonoFromFutureSupplier() {
     return Mono.fromFuture(() -> CompletableFuture.completedFuture(null));
   }
 
-  Mono<Void> testMonoFromFutureSuppressCancel() {
+  Mono<Void> testMonoFromFutureSupplierBoolean() {
     return Mono.fromFuture(() -> CompletableFuture.completedFuture(null), true);
   }
 }


### PR DESCRIPTION
Futures subscribe eagerly. This means that `Mono#fromFuture(CompletableFuture)` already executes the contents of the future on assembly time (even when that `Future` is constructed from a `Mono` as we do in our reactive Caffeine caches).

I therefore suggest instead to always use `Mono#fromFuture(Supplier)`, which will only instantiate (and thus execute) the future on subscription, i.e. much closer to how we usually do everything 😄 