### PR TITLE
Update `step-security/harden-runner` configuration

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -25,6 +25,7 @@ jobs:
           egress-policy: block
           allowed-endpoints: >
             api.adoptium.net:443
+            api.sonarcloud.io:443
             ea6ne4j2sb.execute-api.eu-central-1.amazonaws.com:443
             github.com:443
             objects.githubusercontent.com:443


### PR DESCRIPTION
Based on [this report](https://app.stepsecurity.io/github/PicnicSupermarket/error-prone-support/actions/runs/9879856511?jobid=27287029146&tab=network-events).

Suggested commit message:
```
Update `step-security/harden-runner` configuration (#1246)

While apparently the build doesn't fail without this, it is reasonable
for SonarCloud analysis to access the `api.sonarcloud.io` domain.
```