### PR TITLE
Introduce `SetStream` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -184,7 +184,12 @@ final class CollectionRules {
     }
   }
 
-  /** Rely on Set's property to preserve distinct elements. */
+  /** Don't unnecessarily call {@link Stream#distinct()} on an already-unique stream of elements. */
+  // XXX: This rule assumes that the `Set` relies on `Object#equals`, rather than a custom
+  // equivalence relation.
+  // XXX: Expressions that drop or reorder elements from the stream, such as `.filter`, `.skip` and
+  // `sorted`, can similarly be simplified. Covering all cases is better done using an Error Prone
+  // check.
   static final class SetStream<T> {
     @BeforeTemplate
     Stream<?> before(Set<T> set) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -184,6 +184,19 @@ final class CollectionRules {
     }
   }
 
+  /** Rely on Set's property to preserve distinct elements. */
+  static final class SetStream<T> {
+    @BeforeTemplate
+    Stream<?> before(Set<T> set) {
+      return set.stream().distinct();
+    }
+
+    @AfterTemplate
+    Stream<?> after(Set<T> set) {
+      return set.stream();
+    }
+  }
+
   /** Prefer {@link ArrayList#ArrayList(Collection)} over the Guava alternative. */
   @SuppressWarnings(
       "NonApiType" /* Matching against `List` would unnecessarily constrain the rule. */)

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
@@ -70,6 +70,10 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
+  Stream<Integer> testSetStream() {
+    return ImmutableSet.of(1).stream().distinct();
+  }
+
   ArrayList<String> testNewArrayListFromCollection() {
     return Lists.newArrayList(ImmutableList.of("foo"));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
@@ -62,6 +62,10 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     new HashSet<Number>().removeAll(ImmutableSet.of(2));
   }
 
+  Stream<Integer> testSetStream() {
+    return ImmutableSet.of(1).stream();
+  }
+
   ArrayList<String> testNewArrayListFromCollection() {
     return new ArrayList<>(ImmutableList.of("foo"));
   }


### PR DESCRIPTION
I think this is a candidate for "combinations of operators that don't make sense".

I tried to extend the rule with rules like 
```
  static final class SetStreamFilter<T> {
    @BeforeTemplate
    Stream<?> before(Set<T> set, Predicate<T> predicate) {
      return set.stream().filter(predicate).distinct();
    }

    @AfterTemplate
    Stream<?> after(Set<T> set, Predicate<T> predicate) {
      return set.stream().filter(predicate);
    }
  }
```

But the number of permutations of different operators before using `#distinct` is a lot.

Suggested commit message
```
Rely on Set's property to preserve distinct elements when streaming
```