### PR TITLE
Introduce `Class{Literal,Reference}Cast` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
@@ -38,7 +38,12 @@ final class ClassRules {
     }
   }
 
-  /** Prefer {@link Class#isInstance(Object)} method references over more verbose alternatives. */
+  /**
+   * Prefer {@link Class#isInstance(Object)} method references over lambda expressions that require
+   * naming a variable.
+   */
+  // XXX: Once the `ClassReferenceIsInstancePredicate` rule is dropped, rename this rule to just
+  // `ClassIsInstancePredicate`.
   static final class ClassLiteralIsInstancePredicate<T, S> {
     @BeforeTemplate
     Predicate<S> before() {
@@ -51,7 +56,11 @@ final class ClassRules {
     }
   }
 
-  /** Prefer {@link Class#isInstance(Object)} method references over more verbose alternatives. */
+  /**
+   * Prefer {@link Class#isInstance(Object)} method references over lambda expressions that require
+   * naming a variable.
+   */
+  // XXX: Drop this rule once the `MethodReferenceUsage` rule is enabled by default.
   static final class ClassReferenceIsInstancePredicate<T, S> {
     @BeforeTemplate
     Predicate<S> before(Class<T> clazz) {
@@ -64,7 +73,11 @@ final class ClassRules {
     }
   }
 
-  /** Prefer {@link Class#cast(Object)} method references over more verbose alternatives. */
+  /**
+   * Prefer {@link Class#cast(Object)} method references over lambda expressions that require naming
+   * a variable.
+   */
+  // XXX: Once the `ClassReferenceCast` rule is dropped, rename this rule to just `ClassCast`.
   static final class ClassLiteralCast<T, S> {
     @BeforeTemplate
     @SuppressWarnings("unchecked")
@@ -78,7 +91,11 @@ final class ClassRules {
     }
   }
 
-  /** Prefer {@link Class#cast(Object)} method references over more verbose alternatives. */
+  /**
+   * Prefer {@link Class#cast(Object)} method references over lambda expressions that require naming
+   * a variable.
+   */
+  // XXX: Drop this rule once the `MethodReferenceUsage` rule is enabled by default.
   static final class ClassReferenceCast<T, S> {
     @BeforeTemplate
     Function<T, S> before(Class<? extends S> clazz) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
@@ -3,6 +3,7 @@ package tech.picnic.errorprone.refasterrules;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
@@ -60,6 +61,20 @@ final class ClassRules {
     @AfterTemplate
     Predicate<S> after(Class<T> clazz) {
       return clazz::isInstance;
+    }
+  }
+
+  /** Prefer {@link Class#cast(Object)} method references over more verbose alternatives. */
+  static final class ClassLiteralCast<T, S> {
+    @BeforeTemplate
+    @SuppressWarnings("unchecked")
+    Function<T, S> before() {
+      return t -> (S) t;
+    }
+
+    @AfterTemplate
+    Function<T, S> after() {
+      return Refaster.<S>clazz()::cast;
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
@@ -77,4 +77,17 @@ final class ClassRules {
       return Refaster.<S>clazz()::cast;
     }
   }
+
+  /** Prefer {@link Class#cast(Object)} method references over more verbose alternatives. */
+  static final class ClassReferenceCast<T, S> {
+    @BeforeTemplate
+    Function<T, S> before(Class<? extends S> clazz) {
+      return o -> clazz.cast(o);
+    }
+
+    @AfterTemplate
+    Function<T, S> after(Class<? extends S> clazz) {
+      return clazz::cast;
+    }
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
@@ -2,6 +2,7 @@ package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
@@ -22,5 +23,9 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
   Predicate<String> testClassReferenceIsInstancePredicate() throws IOException {
     Class<?> clazz = CharSequence.class;
     return s -> clazz.isInstance(s);
+  }
+
+  Function<Number, Integer> testClassLiteralCast() {
+    return i -> (Integer) i;
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
@@ -1,26 +1,25 @@
 package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class ClassRulesTest implements RefasterRuleCollectionTestCase {
-  boolean testClassIsInstance() throws IOException {
+  boolean testClassIsInstance() {
     return CharSequence.class.isAssignableFrom("foo".getClass());
   }
 
-  ImmutableSet<Boolean> testInstanceof() throws IOException {
+  ImmutableSet<Boolean> testInstanceof() {
     Class<?> clazz = CharSequence.class;
     return ImmutableSet.of(CharSequence.class.isInstance("foo"), clazz.isInstance("bar"));
   }
 
-  Predicate<String> testClassLiteralIsInstancePredicate() throws IOException {
+  Predicate<String> testClassLiteralIsInstancePredicate() {
     return s -> s instanceof CharSequence;
   }
 
-  Predicate<String> testClassReferenceIsInstancePredicate() throws IOException {
+  Predicate<String> testClassReferenceIsInstancePredicate() {
     Class<?> clazz = CharSequence.class;
     return s -> clazz.isInstance(s);
   }
@@ -30,7 +29,6 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Function<Number, Integer> testClassReferenceCast() {
-    Class<? extends Integer> clazz = Integer.class;
-    return i -> clazz.cast(i);
+    return i -> Integer.class.cast(i);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
@@ -28,4 +28,9 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
   Function<Number, Integer> testClassLiteralCast() {
     return i -> (Integer) i;
   }
+
+  Function<Number, Integer> testClassReferenceCast() {
+    Class<? extends Integer> clazz = Integer.class;
+    return i -> clazz.cast(i);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
@@ -28,4 +28,9 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
   Function<Number, Integer> testClassLiteralCast() {
     return Integer.class::cast;
   }
+
+  Function<Number, Integer> testClassReferenceCast() {
+    Class<? extends Integer> clazz = Integer.class;
+    return clazz::cast;
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
@@ -1,26 +1,25 @@
 package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
-import java.io.IOException;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class ClassRulesTest implements RefasterRuleCollectionTestCase {
-  boolean testClassIsInstance() throws IOException {
+  boolean testClassIsInstance() {
     return CharSequence.class.isInstance("foo");
   }
 
-  ImmutableSet<Boolean> testInstanceof() throws IOException {
+  ImmutableSet<Boolean> testInstanceof() {
     Class<?> clazz = CharSequence.class;
     return ImmutableSet.of("foo" instanceof CharSequence, clazz.isInstance("bar"));
   }
 
-  Predicate<String> testClassLiteralIsInstancePredicate() throws IOException {
+  Predicate<String> testClassLiteralIsInstancePredicate() {
     return CharSequence.class::isInstance;
   }
 
-  Predicate<String> testClassReferenceIsInstancePredicate() throws IOException {
+  Predicate<String> testClassReferenceIsInstancePredicate() {
     Class<?> clazz = CharSequence.class;
     return clazz::isInstance;
   }
@@ -30,7 +29,6 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Function<Number, Integer> testClassReferenceCast() {
-    Class<? extends Integer> clazz = Integer.class;
-    return clazz::cast;
+    return Integer.class::cast;
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
@@ -2,6 +2,7 @@ package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
+import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
@@ -22,5 +23,9 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
   Predicate<String> testClassReferenceIsInstancePredicate() throws IOException {
     Class<?> clazz = CharSequence.class;
     return clazz::isInstance;
+  }
+
+  Function<Number, Integer> testClassLiteralCast() {
+    return Integer.class::cast;
   }
 }


### PR DESCRIPTION
* Perhaps opinionated, but personally, I find the `Class.class:cast` alternative more readable, especially when working with _Streams_.
* One downside to this rule, is that we lose the compile-time cast checks in exchange for runtime checks.

What are your guys thoughts?


Suggested commit message
```
Introduce `Class(Reference|Literal)Cast` class rules
```