### PR TITLE
Introduce `{Max,Min}Of{Array,Collection}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -24,6 +24,7 @@ import com.google.errorprone.refaster.annotation.Placeholder;
 import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.Optional;
@@ -247,6 +248,38 @@ final class ComparatorRules {
    * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
    * of values.
    */
+  static final class MinOfArray<T> {
+    @BeforeTemplate
+    T before(T[] array, Comparator<T> cmp) {
+      return Arrays.stream(array).min(cmp).orElseThrow();
+    }
+
+    @AfterTemplate
+    T after(T[] array, Comparator<T> cmp) {
+      return Collections.min(Arrays.asList(array), cmp);
+    }
+  }
+
+  /**
+   * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
+   * of values.
+   */
+  static final class MinOfCollection<T> {
+    @BeforeTemplate
+    T before(Collection<T> collection, Comparator<T> cmp) {
+      return collection.stream().min(cmp).orElseThrow();
+    }
+
+    @AfterTemplate
+    T after(Collection<T> collection, Comparator<T> cmp) {
+      return Collections.min(collection, cmp);
+    }
+  }
+
+  /**
+   * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
+   * of values.
+   */
   static final class MinOfVarargs<T> {
     @BeforeTemplate
     T before(@Repeated T value, Comparator<T> cmp) {
@@ -307,6 +340,38 @@ final class ComparatorRules {
     @AfterTemplate
     T after(T value1, T value2, Comparator<? super T> cmp) {
       return Comparators.min(value1, value2, cmp);
+    }
+  }
+
+  /**
+   * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
+   * of values.
+   */
+  static final class MaxOfArray<T> {
+    @BeforeTemplate
+    T before(T[] array, Comparator<T> cmp) {
+      return Arrays.stream(array).max(cmp).orElseThrow();
+    }
+
+    @AfterTemplate
+    T after(T[] array, Comparator<T> cmp) {
+      return Collections.max(Arrays.asList(array), cmp);
+    }
+  }
+
+  /**
+   * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
+   * of values.
+   */
+  static final class MaxOfCollection<T> {
+    @BeforeTemplate
+    T before(Collection<T> collection, Comparator<T> cmp) {
+      return collection.stream().max(cmp).orElseThrow();
+    }
+
+    @AfterTemplate
+    T after(Collection<T> collection, Comparator<T> cmp) {
+      return Collections.max(collection, cmp);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -248,14 +248,14 @@ final class ComparatorRules {
    * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
    * of values.
    */
-  static final class MinOfArray<T> {
+  static final class MinOfArray<S, T extends S> {
     @BeforeTemplate
-    T before(T[] array, Comparator<T> cmp) {
+    T before(T[] array, Comparator<S> cmp) {
       return Arrays.stream(array).min(cmp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(T[] array, Comparator<T> cmp) {
+    T after(T[] array, Comparator<S> cmp) {
       return Collections.min(Arrays.asList(array), cmp);
     }
   }
@@ -264,14 +264,14 @@ final class ComparatorRules {
    * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
    * of values.
    */
-  static final class MinOfCollection<T> {
+  static final class MinOfCollection<S, T extends S> {
     @BeforeTemplate
-    T before(Collection<T> collection, Comparator<T> cmp) {
+    T before(Collection<T> collection, Comparator<S> cmp) {
       return collection.stream().min(cmp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(Collection<T> collection, Comparator<T> cmp) {
+    T after(Collection<T> collection, Comparator<S> cmp) {
       return Collections.min(collection, cmp);
     }
   }
@@ -280,14 +280,14 @@ final class ComparatorRules {
    * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
    * of values.
    */
-  static final class MinOfVarargs<T> {
+  static final class MinOfVarargs<S, T extends S> {
     @BeforeTemplate
-    T before(@Repeated T value, Comparator<T> cmp) {
+    T before(@Repeated T value, Comparator<S> cmp) {
       return Stream.of(Refaster.asVarargs(value)).min(cmp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(@Repeated T value, Comparator<T> cmp) {
+    T after(@Repeated T value, Comparator<S> cmp) {
       return Collections.min(Arrays.asList(value), cmp);
     }
   }
@@ -347,14 +347,14 @@ final class ComparatorRules {
    * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
    * of values.
    */
-  static final class MaxOfArray<T> {
+  static final class MaxOfArray<S, T extends S> {
     @BeforeTemplate
-    T before(T[] array, Comparator<T> cmp) {
+    T before(T[] array, Comparator<S> cmp) {
       return Arrays.stream(array).max(cmp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(T[] array, Comparator<T> cmp) {
+    T after(T[] array, Comparator<S> cmp) {
       return Collections.max(Arrays.asList(array), cmp);
     }
   }
@@ -363,14 +363,14 @@ final class ComparatorRules {
    * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
    * of values.
    */
-  static final class MaxOfCollection<T> {
+  static final class MaxOfCollection<S, T extends S> {
     @BeforeTemplate
-    T before(Collection<T> collection, Comparator<T> cmp) {
+    T before(Collection<T> collection, Comparator<S> cmp) {
       return collection.stream().max(cmp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(Collection<T> collection, Comparator<T> cmp) {
+    T after(Collection<T> collection, Comparator<S> cmp) {
       return Collections.max(collection, cmp);
     }
   }
@@ -379,14 +379,14 @@ final class ComparatorRules {
    * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
    * of values.
    */
-  static final class MaxOfVarargs<T> {
+  static final class MaxOfVarargs<S, T extends S> {
     @BeforeTemplate
-    T before(@Repeated T value, Comparator<T> cmp) {
+    T before(@Repeated T value, Comparator<S> cmp) {
       return Stream.of(Refaster.asVarargs(value)).max(cmp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(@Repeated T value, Comparator<T> cmp) {
+    T after(@Repeated T value, Comparator<S> cmp) {
       return Collections.max(Arrays.asList(value), cmp);
     }
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
@@ -107,6 +107,14 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Comparator.<String>reverseOrder().compare("baz", "qux"));
   }
 
+  String testMinOfArray() {
+    return Arrays.stream(new String[0]).min(naturalOrder()).orElseThrow();
+  }
+
+  String testMinOfCollection() {
+    return ImmutableSet.of("foo", "bar").stream().min(naturalOrder()).orElseThrow();
+  }
+
   int testMinOfVarargs() {
     return Stream.of(1, 2).min(naturalOrder()).orElseThrow();
   }
@@ -133,6 +141,14 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Collections.min(Arrays.asList("a", "b"), (a, b) -> -1),
         Collections.min(ImmutableList.of("a", "b"), (a, b) -> 0),
         Collections.min(ImmutableSet.of("a", "b"), (a, b) -> 1));
+  }
+
+  String testMaxOfArray() {
+    return Arrays.stream(new String[0]).max(naturalOrder()).orElseThrow();
+  }
+
+  String testMaxOfCollection() {
+    return ImmutableSet.of("foo", "bar").stream().max(naturalOrder()).orElseThrow();
   }
 
   int testMaxOfVarargs() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
@@ -98,6 +98,14 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of("foo".compareTo("bar"), "qux".compareTo("baz"));
   }
 
+  String testMinOfArray() {
+    return Collections.min(Arrays.asList(new String[0]), naturalOrder());
+  }
+
+  String testMinOfCollection() {
+    return Collections.min(ImmutableSet.of("foo", "bar"), naturalOrder());
+  }
+
   int testMinOfVarargs() {
     return Collections.min(Arrays.asList(1, 2), naturalOrder());
   }
@@ -124,6 +132,14 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Comparators.min("a", "b", (a, b) -> -1),
         Comparators.min("a", "b", (a, b) -> 0),
         Comparators.min("a", "b", (a, b) -> 1));
+  }
+
+  String testMaxOfArray() {
+    return Collections.max(Arrays.asList(new String[0]), naturalOrder());
+  }
+
+  String testMaxOfCollection() {
+    return Collections.max(ImmutableSet.of("foo", "bar"), naturalOrder());
   }
 
   int testMaxOfVarargs() {


### PR DESCRIPTION
Suggested commit message:
```
Introduce `{Max,Min}Of{Array,Collection}` Refaster rules (#1276)

While there, generalize the `{Max,Min}OfVarargs` rules.
```