### PR TITLE
Introduce `RefasterRuleTestExtractor` for documentation generation

### DIFF
--- a/documentation-support/pom.xml
+++ b/documentation-support/pom.xml
@@ -34,6 +34,15 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>error-prone-utils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>${project.groupId}</groupId>
+            <artifactId>refaster-test-support</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
         </dependency>

--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
@@ -1,0 +1,176 @@
+package tech.picnic.errorprone.documentation;
+
+import static com.google.common.collect.ImmutableList.toImmutableList;
+import static com.google.errorprone.matchers.Matchers.isSubtypeOf;
+import static java.util.stream.Collectors.joining;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.google.auto.service.AutoService;
+import com.google.auto.value.AutoValue;
+import com.google.common.base.Splitter;
+import com.google.common.base.Supplier;
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.annotations.FormatMethod;
+import com.google.errorprone.annotations.Immutable;
+import com.google.errorprone.matchers.Matcher;
+import com.sun.source.tree.ClassTree;
+import com.sun.source.tree.MethodTree;
+import java.net.URI;
+import java.util.Optional;
+import java.util.regex.Pattern;
+import tech.picnic.errorprone.documentation.RefasterRuleCollectionTestExtractor.RefasterTestCases;
+import tech.picnic.errorprone.utils.SourceCode;
+
+/**
+ * An {@link Extractor} that describes how to extract data from Refaster rule input and output test
+ * classes.
+ */
+// XXX: Drop this extractor if/when the Refaster test framework is reimlemented such that tests can
+// be located alongside rules, rather than in two additional resource files as currently required by
+// `RefasterRuleCollection`.
+@Immutable
+@AutoService(Extractor.class)
+@SuppressWarnings("rawtypes" /* See https://github.com/google/auto/issues/870. */)
+public final class RefasterRuleCollectionTestExtractor implements Extractor<RefasterTestCases> {
+  private static final Matcher<ClassTree> IS_REFASTER_RULE_COLLECTION_TEST_CASE =
+      isSubtypeOf("tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase");
+  private static final Pattern TEST_CLASS_NAME_PATTERN = Pattern.compile("(.*)Test");
+  private static final Pattern TEST_CLASS_FILE_NAME_PATTERN =
+      Pattern.compile(".*(Input|Output)\\.java");
+  private static final Pattern TEST_METHOD_NAME_PATTERN = Pattern.compile("test(.*)");
+  private static final String LINE_SEPARATOR = "\n";
+  private static final Splitter LINE_SPLITTER = Splitter.on(LINE_SEPARATOR);
+
+  /** Instantiates a new {@link RefasterRuleCollectionTestExtractor} instance. */
+  public RefasterRuleCollectionTestExtractor() {}
+
+  @Override
+  public String identifier() {
+    return "refaster-rule-collection-test";
+  }
+
+  @Override
+  public Optional<RefasterTestCases> tryExtract(ClassTree tree, VisitorState state) {
+    if (!IS_REFASTER_RULE_COLLECTION_TEST_CASE.matches(tree, state)) {
+      return Optional.empty();
+    }
+
+    URI sourceFile = state.getPath().getCompilationUnit().getSourceFile().toUri();
+    return Optional.of(
+        RefasterTestCases.create(
+            sourceFile,
+            getRuleCollectionName(tree),
+            isInputFile(sourceFile),
+            getRefasterTestCases(tree, state)));
+  }
+
+  private static String getRuleCollectionName(ClassTree tree) {
+    String className = tree.getSimpleName().toString();
+
+    // XXX: Instead of throwing an error here, it'd be nicer to have a bug checker validate key
+    // aspects of `RefasterRuleCollectionRefasterTestCase` subtypes.
+    return tryExtractPatternGroup(className, TEST_CLASS_NAME_PATTERN)
+        .orElseThrow(
+            violation(
+                "Refaster rule collection test class name '%s' does not match '%s'",
+                className, TEST_CLASS_NAME_PATTERN));
+  }
+
+  private static boolean isInputFile(URI sourceFile) {
+    String path = sourceFile.getPath();
+
+    // XXX: Instead of throwing an error here, it'd be nicer to have a bug checker validate key
+    // aspects of `RefasterRuleCollectionRefasterTestCase` subtypes.
+    return "Input"
+        .equals(
+            tryExtractPatternGroup(path, TEST_CLASS_FILE_NAME_PATTERN)
+                .orElseThrow(
+                    violation(
+                        "Refaster rule collection test file name '%s' does not match '%s'",
+                        path, TEST_CLASS_FILE_NAME_PATTERN)));
+  }
+
+  private static ImmutableList<RefasterTestCase> getRefasterTestCases(
+      ClassTree tree, VisitorState state) {
+    return tree.getMembers().stream()
+        .filter(MethodTree.class::isInstance)
+        .map(MethodTree.class::cast)
+        .flatMap(m -> tryExtractRefasterTestCase(m, state).stream())
+        .collect(toImmutableList());
+  }
+
+  private static Optional<RefasterTestCase> tryExtractRefasterTestCase(
+      MethodTree method, VisitorState state) {
+    return tryExtractPatternGroup(method.getName().toString(), TEST_METHOD_NAME_PATTERN)
+        .map(name -> RefasterTestCase.create(name, getFormattedSource(method, state)));
+  }
+
+  /**
+   * Returns the source code for the specified method.
+   *
+   * @implNote This operation attempts to trim leading whitespace, such that the start and end of
+   *     the method declaration are aligned. The implemented heuristic assumes that the code is
+   *     formatted using Google Java Format.
+   */
+  // XXX: Leading Javadoc and other comments are currently not extracted. Consider fixing this.
+  private static String getFormattedSource(MethodTree method, VisitorState state) {
+    String source = SourceCode.treeToString(method, state);
+    int finalNewline = source.lastIndexOf(LINE_SEPARATOR);
+    if (finalNewline < 0) {
+      return source;
+    }
+
+    int indentation = source.substring(finalNewline).lastIndexOf(' ');
+    String prefixToStrip = " ".repeat(indentation);
+
+    return LINE_SPLITTER
+        .splitToStream(source)
+        .map(line -> line.startsWith(prefixToStrip) ? line.substring(indentation) : line)
+        .collect(joining(LINE_SEPARATOR));
+  }
+
+  private static Optional<String> tryExtractPatternGroup(String input, Pattern pattern) {
+    java.util.regex.Matcher matcher = pattern.matcher(input);
+    return matcher.matches() ? Optional.of(matcher.group(1)) : Optional.empty();
+  }
+
+  @FormatMethod
+  private static Supplier<VerifyException> violation(String format, Object... args) {
+    return () -> new VerifyException(String.format(format, args));
+  }
+
+  @AutoValue
+  @JsonDeserialize(as = AutoValue_RefasterRuleCollectionTestExtractor_RefasterTestCases.class)
+  abstract static class RefasterTestCases {
+    static RefasterTestCases create(
+        URI source,
+        String ruleCollection,
+        boolean isInput,
+        ImmutableList<RefasterTestCase> testCases) {
+      return new AutoValue_RefasterRuleCollectionTestExtractor_RefasterTestCases(
+          source, ruleCollection, isInput, testCases);
+    }
+
+    abstract URI source();
+
+    abstract String ruleCollection();
+
+    abstract boolean isInput();
+
+    abstract ImmutableList<RefasterTestCase> testCases();
+  }
+
+  @AutoValue
+  @JsonDeserialize(as = AutoValue_RefasterRuleCollectionTestExtractor_RefasterTestCase.class)
+  abstract static class RefasterTestCase {
+    static RefasterTestCase create(String name, String content) {
+      return new AutoValue_RefasterRuleCollectionTestExtractor_RefasterTestCase(name, content);
+    }
+
+    abstract String name();
+
+    abstract String content();
+  }
+}

--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
@@ -27,7 +27,7 @@ import tech.picnic.errorprone.utils.SourceCode;
  * An {@link Extractor} that describes how to extract data from Refaster rule input and output test
  * classes.
  */
-// XXX: Drop this extractor if/when the Refaster test framework is reimlemented such that tests can
+// XXX: Drop this extractor if/when the Refaster test framework is reimplemented such that tests can
 // be located alongside rules, rather than in two additional resource files as currently required by
 // `RefasterRuleCollection`.
 @Immutable

--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
@@ -118,7 +118,7 @@ public final class RefasterRuleCollectionTestExtractor implements Extractor<Refa
   private static String getFormattedSource(MethodTree method, VisitorState state) {
     String source = SourceCode.treeToString(method, state);
     int finalNewline = source.lastIndexOf(LINE_SEPARATOR);
-    if (finalNewline == -1) {
+    if (finalNewline < 0) {
       return source;
     }
 

--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
@@ -122,7 +122,7 @@ public final class RefasterRuleCollectionTestExtractor implements Extractor<Refa
       return source;
     }
 
-    int indentation = source.substring(finalNewline).lastIndexOf(' ');
+    int indentation = Math.max(0, source.lastIndexOf(' ') - finalNewline);
     String prefixToStrip = " ".repeat(indentation);
 
     return LINE_SPLITTER

--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractor.java
@@ -70,7 +70,7 @@ public final class RefasterRuleCollectionTestExtractor implements Extractor<Refa
     String className = tree.getSimpleName().toString();
 
     // XXX: Instead of throwing an error here, it'd be nicer to have a bug checker validate key
-    // aspects of `RefasterRuleCollectionRefasterTestCase` subtypes.
+    // aspects of `RefasterRuleCollectionTestCase` subtypes.
     return tryExtractPatternGroup(className, TEST_CLASS_NAME_PATTERN)
         .orElseThrow(
             violation(
@@ -82,7 +82,7 @@ public final class RefasterRuleCollectionTestExtractor implements Extractor<Refa
     String path = sourceFile.getPath();
 
     // XXX: Instead of throwing an error here, it'd be nicer to have a bug checker validate key
-    // aspects of `RefasterRuleCollectionRefasterTestCase` subtypes.
+    // aspects of `RefasterRuleCollectionTestCase` subtypes.
     return "Input"
         .equals(
             tryExtractPatternGroup(path, TEST_CLASS_FILE_NAME_PATTERN)
@@ -118,7 +118,7 @@ public final class RefasterRuleCollectionTestExtractor implements Extractor<Refa
   private static String getFormattedSource(MethodTree method, VisitorState state) {
     String source = SourceCode.treeToString(method, state);
     int finalNewline = source.lastIndexOf(LINE_SEPARATOR);
-    if (finalNewline < 0) {
+    if (finalNewline == -1) {
       return source;
     }
 

--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/BugPatternTestExtractorTest.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/BugPatternTestExtractorTest.java
@@ -7,10 +7,10 @@ import java.net.URI;
 import java.nio.file.Path;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import tech.picnic.errorprone.documentation.BugPatternTestExtractor.BugPatternTestCase;
+import tech.picnic.errorprone.documentation.BugPatternTestExtractor.BugPatternTestCases;
 import tech.picnic.errorprone.documentation.BugPatternTestExtractor.IdentificationTestEntry;
 import tech.picnic.errorprone.documentation.BugPatternTestExtractor.ReplacementTestEntry;
-import tech.picnic.errorprone.documentation.BugPatternTestExtractor.TestCase;
-import tech.picnic.errorprone.documentation.BugPatternTestExtractor.TestCases;
 
 final class BugPatternTestExtractorTest {
   @Test
@@ -269,11 +269,11 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "SingleFileCompilationTestHelperTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create("file:///SingleFileCompilationTestHelperTest.java"),
             "SingleFileCompilationTestHelperTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "SingleFileCompilationTestHelperTest.TestChecker",
                     ImmutableList.of(
                         IdentificationTestEntry.create(
@@ -302,11 +302,11 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "SingleFileCompilationTestHelperWithSetArgsTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create("file:///SingleFileCompilationTestHelperWithSetArgsTest.java"),
             "SingleFileCompilationTestHelperWithSetArgsTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "SingleFileCompilationTestHelperWithSetArgsTest.TestChecker",
                     ImmutableList.of(
                         IdentificationTestEntry.create(
@@ -335,11 +335,11 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "MultiFileCompilationTestHelperTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create("file:///MultiFileCompilationTestHelperTest.java"),
             "MultiFileCompilationTestHelperTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "MultiFileCompilationTestHelperTest.TestChecker",
                     ImmutableList.of(
                         IdentificationTestEntry.create(
@@ -370,11 +370,11 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "SingleFileBugCheckerRefactoringTestHelperTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create("file:///SingleFileBugCheckerRefactoringTestHelperTest.java"),
             "SingleFileBugCheckerRefactoringTestHelperTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "SingleFileBugCheckerRefactoringTestHelperTest.TestChecker",
                     ImmutableList.of(
                         ReplacementTestEntry.create(
@@ -408,12 +408,12 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "SingleFileBugCheckerRefactoringTestHelperWithSetArgsFixChooserAndCustomTestModeTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create(
                 "file:///SingleFileBugCheckerRefactoringTestHelperWithSetArgsFixChooserAndCustomTestModeTest.java"),
             "SingleFileBugCheckerRefactoringTestHelperWithSetArgsFixChooserAndCustomTestModeTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "SingleFileBugCheckerRefactoringTestHelperWithSetArgsFixChooserAndCustomTestModeTest.TestChecker",
                     ImmutableList.of(
                         ReplacementTestEntry.create(
@@ -444,11 +444,11 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "MultiFileBugCheckerRefactoringTestHelperTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create("file:///MultiFileBugCheckerRefactoringTestHelperTest.java"),
             "MultiFileBugCheckerRefactoringTestHelperTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "MultiFileBugCheckerRefactoringTestHelperTest.TestChecker",
                     ImmutableList.of(
                         ReplacementTestEntry.create(
@@ -484,16 +484,16 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "CompilationAndBugCheckerRefactoringTestHelpersTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create("file:///CompilationAndBugCheckerRefactoringTestHelpersTest.java"),
             "CompilationAndBugCheckerRefactoringTestHelpersTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "CompilationAndBugCheckerRefactoringTestHelpersTest.TestChecker",
                     ImmutableList.of(
                         IdentificationTestEntry.create(
                             "A.java", "// BUG: Diagnostic contains:\nclass A {}\n"))),
-                TestCase.create(
+                BugPatternTestCase.create(
                     "CompilationAndBugCheckerRefactoringTestHelpersTest.TestChecker",
                     ImmutableList.of(
                         ReplacementTestEntry.create(
@@ -532,17 +532,17 @@ final class BugPatternTestExtractorTest {
     verifyGeneratedFileContent(
         outputDirectory,
         "CompilationAndBugCheckerRefactoringTestHelpersWithCustomCheckerPackageAndNamesTest",
-        TestCases.create(
+        BugPatternTestCases.create(
             URI.create(
                 "file:///CompilationAndBugCheckerRefactoringTestHelpersWithCustomCheckerPackageAndNamesTest.java"),
             "pkg.CompilationAndBugCheckerRefactoringTestHelpersWithCustomCheckerPackageAndNamesTest",
             ImmutableList.of(
-                TestCase.create(
+                BugPatternTestCase.create(
                     "pkg.CompilationAndBugCheckerRefactoringTestHelpersWithCustomCheckerPackageAndNamesTest.CustomTestChecker",
                     ImmutableList.of(
                         IdentificationTestEntry.create(
                             "A.java", "// BUG: Diagnostic contains:\nclass A {}\n"))),
-                TestCase.create(
+                BugPatternTestCase.create(
                     "pkg.CompilationAndBugCheckerRefactoringTestHelpersWithCustomCheckerPackageAndNamesTest.CustomTestChecker2",
                     ImmutableList.of(
                         ReplacementTestEntry.create(
@@ -550,9 +550,9 @@ final class BugPatternTestExtractorTest {
   }
 
   private static void verifyGeneratedFileContent(
-      Path outputDirectory, String testClass, TestCases expected) {
+      Path outputDirectory, String testClass, BugPatternTestCases expected) {
     assertThat(outputDirectory.resolve(String.format("bugpattern-test-%s.json", testClass)))
         .exists()
-        .returns(expected, path -> Json.read(path, TestCases.class));
+        .returns(expected, path -> Json.read(path, BugPatternTestCases.class));
   }
 }

--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractorTest.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/RefasterRuleCollectionTestExtractorTest.java
@@ -1,0 +1,166 @@
+package tech.picnic.errorprone.documentation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.google.common.base.VerifyException;
+import com.google.common.collect.ImmutableList;
+import java.net.URI;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import tech.picnic.errorprone.documentation.RefasterRuleCollectionTestExtractor.RefasterTestCase;
+import tech.picnic.errorprone.documentation.RefasterRuleCollectionTestExtractor.RefasterTestCases;
+
+final class RefasterRuleCollectionTestExtractorTest {
+  @Test
+  void noRefasterRuleTest(@TempDir Path outputDirectory) {
+    Compilation.compileWithDocumentationGenerator(
+        outputDirectory, "NoRefasterRuleTest.java", "public final class NoRefasterRuleTest {}");
+
+    assertThat(outputDirectory.toAbsolutePath()).isEmptyDirectory();
+  }
+
+  @Test
+  void invalidTestClassName(@TempDir Path outputDirectory) {
+    assertThatThrownBy(
+            () ->
+                Compilation.compileWithDocumentationGenerator(
+                    outputDirectory,
+                    "InvalidTestClassNameInput.java",
+                    "import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;",
+                    "",
+                    "final class InvalidTestClassName implements RefasterRuleCollectionTestCase {}"))
+        .cause()
+        .isInstanceOf(VerifyException.class)
+        .hasMessage(
+            "Refaster rule collection test class name 'InvalidTestClassName' does not match '(.*)Test'");
+  }
+
+  @Test
+  void invalidFileName(@TempDir Path outputDirectory) {
+    assertThatThrownBy(
+            () ->
+                Compilation.compileWithDocumentationGenerator(
+                    outputDirectory,
+                    "InvalidFileNameTest.java",
+                    "import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;",
+                    "",
+                    "final class InvalidFileNameTest implements RefasterRuleCollectionTestCase {}"))
+        .cause()
+        .isInstanceOf(VerifyException.class)
+        .hasMessage(
+            "Refaster rule collection test file name '/InvalidFileNameTest.java' does not match '.*(Input|Output)\\.java'");
+  }
+
+  @Test
+  void emptyRefasterRuleCollectionTestInput(@TempDir Path outputDirectory) {
+    Compilation.compileWithDocumentationGenerator(
+        outputDirectory,
+        "EmptyRefasterRuleCollectionTestInput.java",
+        "import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;",
+        "",
+        "final class EmptyRefasterRuleCollectionTest implements RefasterRuleCollectionTestCase {}");
+
+    verifyGeneratedFileContent(
+        outputDirectory,
+        "EmptyRefasterRuleCollectionTestInput",
+        RefasterTestCases.create(
+            URI.create("file:///EmptyRefasterRuleCollectionTestInput.java"),
+            "EmptyRefasterRuleCollection",
+            /* isInput= */ true,
+            ImmutableList.of()));
+  }
+
+  @Test
+  void singletonRefasterRuleCollectionTestOutput(@TempDir Path outputDirectory) {
+    Compilation.compileWithDocumentationGenerator(
+        outputDirectory,
+        "SingletonRefasterRuleCollectionTestOutput.java",
+        "import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;",
+        "",
+        "final class SingletonRefasterRuleCollectionTest implements RefasterRuleCollectionTestCase {",
+        "  int testMyRule() {",
+        "    return 42;",
+        "  }",
+        "}");
+
+    verifyGeneratedFileContent(
+        outputDirectory,
+        "SingletonRefasterRuleCollectionTestOutput",
+        RefasterTestCases.create(
+            URI.create("file:///SingletonRefasterRuleCollectionTestOutput.java"),
+            "SingletonRefasterRuleCollection",
+            /* isInput= */ false,
+            ImmutableList.of(
+                RefasterTestCase.create(
+                    "MyRule",
+                    """
+                    int testMyRule() {
+                      return 42;
+                    }"""))));
+  }
+
+  @Test
+  void complexRefasterRuleCollectionTestOutput(@TempDir Path outputDirectory) {
+    Compilation.compileWithDocumentationGenerator(
+        outputDirectory,
+        "pkg/ComplexRefasterRuleCollectionTestInput.java",
+        "package pkg;",
+        "",
+        "import com.google.common.collect.ImmutableSet;",
+        "import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;",
+        "",
+        "final class ComplexRefasterRuleCollectionTest implements RefasterRuleCollectionTestCase {",
+        "  private static final String IGNORED_CONSTANT = \"constant\";",
+        "",
+        "  @Override",
+        "  public ImmutableSet<Object> elidedTypesAndStaticImports() {",
+        "    return ImmutableSet.of();",
+        "  }",
+        "",
+        "  /** Javadoc. */",
+        "  String testFirstRule() {",
+        "    return \"Don't panic\";",
+        "  }",
+        "",
+        "  // Comment.",
+        "  String testSecondRule() {",
+        "    return \"Carry a towel\";",
+        "  }",
+        "",
+        "  void testEmptyRule() {}",
+        "}");
+
+    verifyGeneratedFileContent(
+        outputDirectory,
+        "ComplexRefasterRuleCollectionTestInput",
+        RefasterTestCases.create(
+            URI.create("file:///pkg/ComplexRefasterRuleCollectionTestInput.java"),
+            "ComplexRefasterRuleCollection",
+            /* isInput= */ true,
+            ImmutableList.of(
+                RefasterTestCase.create(
+                    "FirstRule",
+                    """
+                    String testFirstRule() {
+                      return "Don't panic";
+                    }"""),
+                RefasterTestCase.create(
+                    "SecondRule",
+                    """
+                    String testSecondRule() {
+                      return "Carry a towel";
+                    }"""),
+                RefasterTestCase.create("EmptyRule", "void testEmptyRule() {}"))));
+  }
+
+  private static void verifyGeneratedFileContent(
+      Path outputDirectory, String testIdentifier, RefasterTestCases expected) {
+    assertThat(
+            outputDirectory.resolve(
+                String.format("refaster-rule-collection-test-%s.json", testIdentifier)))
+        .exists()
+        .returns(expected, path -> Json.read(path, RefasterTestCases.class));
+  }
+}

--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -305,7 +305,7 @@
                         separately and to distinct output directories, as they
                         define the same set of class names. -->
                         <!-- XXX: Drop these executions if/when the Refaster
-                        test framework is reimlemented such that tests can be
+                        test framework is reimplemented such that tests can be
                         located alongside rules, rather than in two additional
                         resource files. -->
                         <execution>

--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -292,6 +292,55 @@
                             <arg>-Xplugin:DocumentationGenerator -XoutputDirectory=${project.build.directory}/docs</arg>
                         </compilerArgs>
                     </configuration>
+                    <executions>
+                        <!-- The Refaster input/output test classes used by
+                        `RefasterRuleCollection` are modelled as classpath
+                        resources, and thus not subject to the default test
+                        compilation step. These two custom compilation steps
+                        serve two purposes:
+                        - To provide early feedback in case of syntax errors.
+                        - To enable the `DocumentationGenerator` compiler
+                        plugin to extract documentation metadata from them.
+                        Note that the input and output files must be compiled
+                        separately and to distinct output directories, as they
+                        define the same set of class names. -->
+                        <!-- XXX: Drop these executions if/when the Refaster
+                        test framework is reimlemented such that tests can be
+                        located alongside rules, rather than in two additional
+                        resource files. -->
+                        <execution>
+                            <id>compile-refaster-test-input</id>
+                            <goals>
+                                <goal>testCompile</goal>
+                            </goals>
+                            <phase>process-test-resources</phase>
+                            <configuration>
+                                <compileSourceRoots>
+                                    <compileSourceRoot>${project.basedir}/src/test/resources</compileSourceRoot>
+                                </compileSourceRoots>
+                                <testIncludes>
+                                    <testInclude>**/*Input.java</testInclude>
+                                </testIncludes>
+                                <outputDirectory>${project.build.directory}/refaster-test-input</outputDirectory>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>compile-refaster-test-output</id>
+                            <goals>
+                                <goal>testCompile</goal>
+                            </goals>
+                            <phase>process-test-resources</phase>
+                            <configuration>
+                                <compileSourceRoots>
+                                    <compileSourceRoot>${project.basedir}/src/test/resources</compileSourceRoot>
+                                </compileSourceRoots>
+                                <testIncludes>
+                                    <testInclude>**/*Output.java</testInclude>
+                                </testIncludes>
+                                <outputDirectory>${project.build.directory}/refaster-test-output</outputDirectory>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
             </plugins>
         </pluginManagement>

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestInput.java
@@ -26,6 +26,7 @@ final class ImmutableMultisetRulesTest implements RefasterRuleCollectionTestCase
         Stream.<Integer>empty().collect(toImmutableMultiset()));
   }
 
+  @SuppressWarnings("unchecked")
   ImmutableMultiset<ImmutableMultiset<Integer>> testIterableToImmutableMultiset() {
     return ImmutableMultiset.of(
         ImmutableList.of(1).stream().collect(toImmutableMultiset()),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestOutput.java
@@ -24,6 +24,7 @@ final class ImmutableMultisetRulesTest implements RefasterRuleCollectionTestCase
     return ImmutableMultiset.of(ImmutableMultiset.of(), ImmutableMultiset.of());
   }
 
+  @SuppressWarnings("unchecked")
   ImmutableMultiset<ImmutableMultiset<Integer>> testIterableToImmutableMultiset() {
     return ImmutableMultiset.of(
         ImmutableMultiset.copyOf(ImmutableList.of(1)),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestInput.java
@@ -37,6 +37,7 @@ final class ImmutableSortedMultisetRulesTest implements RefasterRuleCollectionTe
         Stream.<Integer>empty().collect(toImmutableSortedMultiset(naturalOrder())));
   }
 
+  @SuppressWarnings("unchecked")
   ImmutableMultiset<ImmutableSortedMultiset<Integer>> testIterableToImmutableSortedMultiset() {
     return ImmutableMultiset.of(
         ImmutableSortedMultiset.copyOf(naturalOrder(), ImmutableList.of(1)),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestOutput.java
@@ -35,6 +35,7 @@ final class ImmutableSortedMultisetRulesTest implements RefasterRuleCollectionTe
     return ImmutableMultiset.of(ImmutableSortedMultiset.of(), ImmutableSortedMultiset.of());
   }
 
+  @SuppressWarnings("unchecked")
   ImmutableMultiset<ImmutableSortedMultiset<Integer>> testIterableToImmutableSortedMultiset() {
     return ImmutableMultiset.of(
         ImmutableSortedMultiset.copyOf(ImmutableList.of(1)),

--- a/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
+++ b/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
@@ -61,6 +61,9 @@ import tech.picnic.errorprone.refaster.runner.Refaster;
 // XXX: This check currently only validates that one `Refaster.anyOf` branch in one
 // `@BeforeTemplate` method is covered by a test. Review how we can make sure that _all_
 // `@BeforeTemplate` methods and `Refaster.anyOf` branches are covered.
+// XXX: Look into replacing this setup with another that allows test cases to be co-located
+// with/nested within the rules. This way any rule change only requires modifications in a single
+// place, rather than in three.
 @BugPattern(summary = "Exercises a Refaster rule collection", linkType = NONE, severity = ERROR)
 @SuppressWarnings("java:S2160" /* Super class equality definition suffices. */)
 public final class RefasterRuleCollection extends BugChecker implements CompilationUnitTreeMatcher {


### PR DESCRIPTION
Suggested commit message:
```
Introduce `RefasterRuleTestExtractor` for documentation generation (#1317)

This new `Extractor` implementation collects Refaster example input and 
output code from rule collection tests.

This change also introduces explicit compilation steps for the test
code. As a side-effect this produces faster feedback in case of invalid
input or output code.
```

After this PR, approximately one more PR remains to port the remainder of the logic on the `website` branch to `master`. After that we can configure the build such that any change on `master` is nearly immediately reflected on https://error-prone.picnic.tech.

(The build will fail because of [this issue](https://github.com/PicnicSupermarket/error-prone-support/pull/1069#issuecomment-2322956932); will try to address that separately.)