### PR TITLE
Introduce Refaster rules for Sonar's java:S4635 rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -244,4 +244,72 @@ final class StringRules {
       return Utf8.encodedLength(str);
     }
   }
+
+  /** Prefer {@link String#indexOf(int, int)} over less efficient alternatives. */
+  static final class StringIndexOfChar {
+    @BeforeTemplate
+    int before(String string, int ch, int fromIndex) {
+      return string.substring(fromIndex).indexOf(ch);
+    }
+
+    @AfterTemplate
+    int after(String string, int ch, int fromIndex) {
+      return string.indexOf(ch, fromIndex);
+    }
+  }
+
+  /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
+  static final class StringIndexOfString {
+    @BeforeTemplate
+    int before(String string, String substring, int fromIndex) {
+      return string.substring(fromIndex).indexOf(substring);
+    }
+
+    @AfterTemplate
+    int after(String string, String substring, int fromIndex) {
+      return string.indexOf(substring, fromIndex);
+    }
+  }
+
+  // XXX: Once we compile Refaster templates with JDK 21 also suggest `String#indexOf(int, int,
+  // int)` and `String#indexOf(String, int, int)`.
+
+  /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
+  static final class StringLastIndexOfChar {
+    @BeforeTemplate
+    int before(String string, int ch, int fromIndex) {
+      return string.substring(fromIndex).lastIndexOf(ch);
+    }
+
+    @AfterTemplate
+    int after(String string, int ch, int fromIndex) {
+      return string.lastIndexOf(ch, fromIndex);
+    }
+  }
+
+  /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
+  static final class StringLastIndexOfString {
+    @BeforeTemplate
+    int before(String string, String substring, int fromIndex) {
+      return string.substring(fromIndex).lastIndexOf(substring);
+    }
+
+    @AfterTemplate
+    int after(String string, String substring, int fromIndex) {
+      return string.lastIndexOf(substring, fromIndex);
+    }
+  }
+
+  /** Prefer {@link String#startsWith(String, int)} over less efficient alternatives. */
+  static final class StringStartsWith {
+    @BeforeTemplate
+    boolean before(String string, String prefix, int fromIndex) {
+      return string.substring(fromIndex).startsWith(prefix);
+    }
+
+    @AfterTemplate
+    boolean after(String string, String prefix, int fromIndex) {
+      return string.startsWith(prefix, fromIndex);
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -279,6 +279,34 @@ final class StringRules {
   /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
   static final class StringLastIndexOfChar {
     @BeforeTemplate
+    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
+    int before(String string, int ch, int fromIndex) {
+      return string.substring(fromIndex).lastIndexOf(ch);
+    }
+
+    @AfterTemplate
+    int after(String string, int ch, int fromIndex) {
+      return Math.max(-1, string.lastIndexOf(ch) - fromIndex);
+    }
+  }
+
+  /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
+  static final class StringLastIndexOfString {
+    @BeforeTemplate
+    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
+    int before(String string, String substring, int fromIndex) {
+      return string.substring(fromIndex).lastIndexOf(substring);
+    }
+
+    @AfterTemplate
+    int after(String string, String substring, int fromIndex) {
+      return Math.max(-1, string.lastIndexOf(substring) - fromIndex);
+    }
+  }
+
+  /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
+  static final class StringLastIndexOfCharWithIndex {
+    @BeforeTemplate
     int before(String string, int ch, int fromIndex) {
       return string.substring(0, fromIndex).lastIndexOf(ch);
     }
@@ -292,7 +320,7 @@ final class StringRules {
   /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
   // XXX: The replacement expression isn't fully equivalent: in case `substring` is empty, then
   // the replacement yields `fromIndex - 1` rather than `fromIndex`.
-  static final class StringLastIndexOfString {
+  static final class StringLastIndexOfStringWithIndex {
     @BeforeTemplate
     int before(String string, String substring, int fromIndex) {
       return string.substring(0, fromIndex).lastIndexOf(substring);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -246,6 +246,7 @@ final class StringRules {
   }
 
   /** Prefer {@link String#indexOf(int, int)} over less efficient alternatives. */
+  // XXX: The suggested alternative may yield a result less than -1.
   static final class StringIndexOfChar {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
@@ -255,11 +256,12 @@ final class StringRules {
 
     @AfterTemplate
     int after(String string, int ch, int fromIndex) {
-      return string.indexOf(ch, fromIndex);
+      return string.indexOf(ch, fromIndex) - fromIndex;
     }
   }
 
   /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
+  // XXX: The suggested alternative may yield a result less than -1.
   static final class StringIndexOfString {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
@@ -269,7 +271,7 @@ final class StringRules {
 
     @AfterTemplate
     int after(String string, String substring, int fromIndex) {
-      return string.indexOf(substring, fromIndex);
+      return string.indexOf(substring, fromIndex) - fromIndex;
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -246,7 +246,6 @@ final class StringRules {
   }
 
   /** Prefer {@link String#indexOf(int, int)} over less efficient alternatives. */
-  // XXX: The suggested alternative may yield a result less than -1.
   static final class StringIndexOfChar {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
@@ -256,12 +255,11 @@ final class StringRules {
 
     @AfterTemplate
     int after(String string, int ch, int fromIndex) {
-      return string.indexOf(ch, fromIndex) - fromIndex;
+      return Math.max(-1, string.indexOf(ch, fromIndex) - fromIndex);
     }
   }
 
   /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
-  // XXX: The suggested alternative may yield a result less than -1.
   static final class StringIndexOfString {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
@@ -271,7 +269,7 @@ final class StringRules {
 
     @AfterTemplate
     int after(String string, String substring, int fromIndex) {
-      return string.indexOf(substring, fromIndex) - fromIndex;
+      return Math.max(-1, string.indexOf(substring, fromIndex) - fromIndex);
     }
   }
 
@@ -287,11 +285,13 @@ final class StringRules {
 
     @AfterTemplate
     int after(String string, int ch, int fromIndex) {
-      return string.lastIndexOf(ch, fromIndex);
+      return string.lastIndexOf(ch, fromIndex - 1);
     }
   }
 
   /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
+  // XXX: The replacement expression isn't fully equivalent: in case `substring` is empty, then
+  // the replacement yields `fromIndex - 1` rather than `fromIndex`.
   static final class StringLastIndexOfString {
     @BeforeTemplate
     int before(String string, String substring, int fromIndex) {
@@ -300,7 +300,7 @@ final class StringRules {
 
     @AfterTemplate
     int after(String string, String substring, int fromIndex) {
-      return string.lastIndexOf(substring, fromIndex);
+      return string.lastIndexOf(substring, fromIndex - 1);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -279,7 +279,6 @@ final class StringRules {
   /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
   static final class StringLastIndexOfChar {
     @BeforeTemplate
-    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, int ch, int fromIndex) {
       return string.substring(0, fromIndex).lastIndexOf(ch);
     }
@@ -293,7 +292,6 @@ final class StringRules {
   /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
   static final class StringLastIndexOfString {
     @BeforeTemplate
-    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, String substring, int fromIndex) {
       return string.substring(0, fromIndex).lastIndexOf(substring);
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -248,6 +248,7 @@ final class StringRules {
   /** Prefer {@link String#indexOf(int, int)} over less efficient alternatives. */
   static final class StringIndexOfChar {
     @BeforeTemplate
+    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, int ch, int fromIndex) {
       return string.substring(fromIndex).indexOf(ch);
     }
@@ -261,6 +262,7 @@ final class StringRules {
   /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
   static final class StringIndexOfString {
     @BeforeTemplate
+    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, String substring, int fromIndex) {
       return string.substring(fromIndex).indexOf(substring);
     }
@@ -277,8 +279,9 @@ final class StringRules {
   /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
   static final class StringLastIndexOfChar {
     @BeforeTemplate
+    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, int ch, int fromIndex) {
-      return string.substring(fromIndex).lastIndexOf(ch);
+      return string.substring(0, fromIndex).lastIndexOf(ch);
     }
 
     @AfterTemplate
@@ -290,8 +293,9 @@ final class StringRules {
   /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
   static final class StringLastIndexOfString {
     @BeforeTemplate
+    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, String substring, int fromIndex) {
-      return string.substring(fromIndex).lastIndexOf(substring);
+      return string.substring(0, fromIndex).lastIndexOf(substring);
     }
 
     @AfterTemplate
@@ -303,6 +307,7 @@ final class StringRules {
   /** Prefer {@link String#startsWith(String, int)} over less efficient alternatives. */
   static final class StringStartsWith {
     @BeforeTemplate
+    @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     boolean before(String string, String prefix, int fromIndex) {
       return string.substring(fromIndex).startsWith(prefix);
     }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -96,4 +96,24 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   int testUtf8EncodedLength() {
     return "foo".getBytes(UTF_8).length;
   }
+
+  int testStringIndexOfChar() {
+    return "foo".substring(1).indexOf('a');
+  }
+
+  int testStringIndexOfString() {
+    return "foo".substring(1).indexOf("bar");
+  }
+
+  int testStringLastIndexOfChar() {
+    return "foo".substring(1).lastIndexOf('a');
+  }
+
+  int testStringLastIndexOfString() {
+    return "foo".substring(1).lastIndexOf("bar");
+  }
+
+  boolean testStringStartsWith() {
+    return "foo".substring(1).startsWith("bar");
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -106,11 +106,11 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   int testStringLastIndexOfChar() {
-    return "foo".substring(0, 1).lastIndexOf('a');
+    return "foo".substring(0, 2).lastIndexOf('a');
   }
 
   int testStringLastIndexOfString() {
-    return "foo".substring(0, 1).lastIndexOf("bar");
+    return "foo".substring(0, 2).lastIndexOf("bar");
   }
 
   boolean testStringStartsWith() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -106,11 +106,11 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   int testStringLastIndexOfChar() {
-    return "foo".substring(1).lastIndexOf('a');
+    return "foo".substring(0, 1).lastIndexOf('a');
   }
 
   int testStringLastIndexOfString() {
-    return "foo".substring(1).lastIndexOf("bar");
+    return "foo".substring(0, 1).lastIndexOf("bar");
   }
 
   boolean testStringStartsWith() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -106,10 +106,18 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   int testStringLastIndexOfChar() {
-    return "foo".substring(0, 2).lastIndexOf('a');
+    return "foo".substring(1).lastIndexOf('a');
   }
 
   int testStringLastIndexOfString() {
+    return "foo".substring(1).lastIndexOf("bar");
+  }
+
+  int testStringLastIndexOfCharWithIndex() {
+    return "foo".substring(0, 2).lastIndexOf('a');
+  }
+
+  int testStringLastIndexOfStringWithIndex() {
     return "foo".substring(0, 2).lastIndexOf("bar");
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -98,11 +98,11 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   int testStringIndexOfChar() {
-    return "foo".indexOf('a', 1);
+    return "foo".indexOf('a', 1) - 1;
   }
 
   int testStringIndexOfString() {
-    return "foo".indexOf("bar", 1);
+    return "foo".indexOf("bar", 1) - 1;
   }
 
   int testStringLastIndexOfChar() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -96,4 +96,24 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   int testUtf8EncodedLength() {
     return Utf8.encodedLength("foo");
   }
+
+  int testStringIndexOfChar() {
+    return "foo".indexOf('a', 1);
+  }
+
+  int testStringIndexOfString() {
+    return "foo".indexOf("bar", 1);
+  }
+
+  int testStringLastIndexOfChar() {
+    return "foo".lastIndexOf('a', 1);
+  }
+
+  int testStringLastIndexOfString() {
+    return "foo".lastIndexOf("bar", 1);
+  }
+
+  boolean testStringStartsWith() {
+    return "foo".startsWith("bar", 1);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -98,19 +98,19 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   int testStringIndexOfChar() {
-    return "foo".indexOf('a', 1) - 1;
+    return Math.max(-1, "foo".indexOf('a', 1) - 1);
   }
 
   int testStringIndexOfString() {
-    return "foo".indexOf("bar", 1) - 1;
+    return Math.max(-1, "foo".indexOf("bar", 1) - 1);
   }
 
   int testStringLastIndexOfChar() {
-    return "foo".lastIndexOf('a', 1);
+    return "foo".lastIndexOf('a', 2 - 1);
   }
 
   int testStringLastIndexOfString() {
-    return "foo".lastIndexOf("bar", 1);
+    return "foo".lastIndexOf("bar", 2 - 1);
   }
 
   boolean testStringStartsWith() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -106,10 +106,18 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   int testStringLastIndexOfChar() {
-    return "foo".lastIndexOf('a', 2 - 1);
+    return Math.max(-1, "foo".lastIndexOf('a') - 1);
   }
 
   int testStringLastIndexOfString() {
+    return Math.max(-1, "foo".lastIndexOf("bar") - 1);
+  }
+
+  int testStringLastIndexOfCharWithIndex() {
+    return "foo".lastIndexOf('a', 2 - 1);
+  }
+
+  int testStringLastIndexOfStringWithIndex() {
     return "foo".lastIndexOf("bar", 2 - 1);
   }
 


### PR DESCRIPTION
Suggested commit message:
```
Introduce Refaster rules for Sonar's java:S4635 rule (#1320)

As well as two related expressions that can be optimized.

See:
- https://sonarcloud.io/organizations/picnic-technologies/rules?open=java%3AS4635&rule_key=java%3AS4635
- https://github.com/SonarSource/sonar-java/blob/26157927314eed0105449e8c7bc7e86c34148a83/java-checks/src/main/java/org/sonar/java/checks/StringOffsetMethodsCheck.java
```