### PR TITLE
Upgrade JDKs used by GitHub Actions builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,9 +42,9 @@ Please replace this sentence with log output, if applicable.
 <!-- Please complete the following information: -->
 
 - Operating system (e.g. MacOS Monterey).
-- Java version (i.e. `java --version`, e.g. `17.0.10`).
-- Error Prone version (e.g. `2.25.0`).
-- Error Prone Support version (e.g. `0.15.0`).
+- Java version (i.e. `java --version`, e.g. `17.0.13`).
+- Error Prone version (e.g. `2.35.1`).
+- Error Prone Support version (e.g. `0.18.0`).
 
 ### Additional context
 

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -44,7 +44,7 @@ Please replace this sentence with log output, if applicable.
 - Operating system (e.g. MacOS Monterey).
 - Java version (i.e. `java --version`, e.g. `17.0.13`).
 - Error Prone version (e.g. `2.35.1`).
-- Error Prone Support version (e.g. `0.18.0`).
+- Error Prone Support version (e.g. `0.19.0`).
 
 ### Additional context
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        jdk: [ 17.0.10, 21.0.2, 22.0.2 ]
+        jdk: [ 17.0.10, 21.0.2, 22.0.2, 23-ea ]
         distribution: [ temurin ]
         experimental: [ false ]
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,11 @@ jobs:
         experimental: [ false ]
         include:
           - os: macos-14
-            jdk: 17.0.10
+            jdk: 17.0.13
             distribution: temurin
             experimental: false
           - os: windows-2022
-            jdk: 17.0.10
+            jdk: 17.0.13
             distribution: temurin
             experimental: false
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-22.04 ]
-        jdk: [ 17.0.10, 21.0.2, 22.0.2, 23-ea ]
+        jdk: [ 17.0.13, 21.0.5, 23.0.1 ]
         distribution: [ temurin ]
         experimental: [ false ]
         include:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@489441643219d2b93ee2a127b2402eb640a1b947 # v1.13.0
         with:
-          java-version: 17.0.10
+          java-version: 17.0.13
           java-distribution: temurin
           maven-version: 3.9.9
       - name: Initialize CodeQL

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -25,7 +25,7 @@ jobs:
         uses: s4u/setup-maven-action@489441643219d2b93ee2a127b2402eb640a1b947 # v1.13.0
         with:
           checkout-fetch-depth: 2
-          java-version: 17.0.10
+          java-version: 17.0.13
           java-distribution: temurin
           maven-version: 3.9.9
       - name: Run Pitest

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -33,7 +33,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@489441643219d2b93ee2a127b2402eb640a1b947 # v1.13.0
         with:
-          java-version: 17.0.10
+          java-version: 17.0.13
           java-distribution: temurin
           maven-version: 3.9.9
       - name: Download Pitest analysis artifact

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -36,7 +36,7 @@ jobs:
         uses: s4u/setup-maven-action@489441643219d2b93ee2a127b2402eb640a1b947 # v1.13.0
         with:
           checkout-ref: "refs/pull/${{ github.event.issue.number }}/head"
-          java-version: 17.0.10
+          java-version: 17.0.13
           java-distribution: temurin
           maven-version: 3.9.9
       - name: Install project to local Maven repository

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -38,7 +38,7 @@ jobs:
         uses: s4u/setup-maven-action@489441643219d2b93ee2a127b2402eb640a1b947 # v1.13.0
         with:
           checkout-fetch-depth: 0
-          java-version: 17.0.10
+          java-version: 17.0.13
           java-distribution: temurin
           maven-version: 3.9.9
       - name: Create missing `test` directory

--- a/pom.xml
+++ b/pom.xml
@@ -486,6 +486,13 @@
                 <artifactId>mongodb-driver-core</artifactId>
                 <version>5.2.0</version>
             </dependency>
+            <!-- XXX: Drop this `rewrite-java-17` version declaration once
+            `rewrite-recipe-bom` pulls in version 8.39.1 or greater. -->
+            <dependency>
+                <groupId>org.openrewrite</groupId>
+                <artifactId>rewrite-java-17</artifactId>
+                <version>8.38.1</version>
+            </dependency>
             <dependency>
                 <groupId>org.openrewrite</groupId>
                 <artifactId>rewrite-templating</artifactId>

--- a/website/generate-version-compatibility-overview.sh
+++ b/website/generate-version-compatibility-overview.sh
@@ -12,7 +12,7 @@ set -e -u -o pipefail
 
 # Currently all released Error Prone Support versions are compatible with Java
 # 17.
-java_version=17.0.10-tem
+java_version=17.0.13-tem
 (set +u && echo n | sdk install java "${java_version}")
 sdk use java "${java_version}"
 


### PR DESCRIPTION
Suggested commit message:
```
Upgrade JDKs used by GitHub Actions builds (#1329)

Summary of changes:
- Use JDK 17.0.13 instead of 17.0.10.
- Use JDK 21.0.5 instead of 21.0.2.
- Use JDK 23.0.1 instead of 22.0.2.
- Have GitHub issue template reference more recent version numbers.

See:
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.11+9
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.12+7
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.13+11
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.3+9
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.4+7
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.5+11
- https://adoptium.net/temurin/release-notes/?version=jdk-23+37
- https://adoptium.net/temurin/release-notes/?version=jdk-23.0.1+11
```