### PR TITLE
Use `rewrite-java-17` rather than `rewrite-java-11`

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -201,7 +201,7 @@
         </dependency>
         <dependency>
             <groupId>org.openrewrite</groupId>
-            <artifactId>rewrite-java-11</artifactId>
+            <artifactId>rewrite-java-17</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>


### PR DESCRIPTION
Suggested commit message:
```
Use `rewrite-java-17` rather than `rewrite-java-11` (#1330)
```

See [this comment](https://github.com/PicnicSupermarket/error-prone-support/pull/1329#issuecomment-2350934389).