### PR TITLE
Extend `ImmutableCollectionIterator` refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -365,15 +365,20 @@ final class CollectionRules {
     }
   }
 
-  /** Prefer {@link ImmutableCollection#iterator()} over more contrived alternatives. */
-  static final class ImmutableCollectionIterator<T> {
+  /** Prefer {@link Collection#iterator()} over more contrived or less efficient alternatives. */
+  static final class CollectionIterator<T> {
+    @BeforeTemplate
+    Iterator<T> before(Collection<T> collection) {
+      return collection.stream().iterator();
+    }
+
     @BeforeTemplate
     Iterator<T> before(ImmutableCollection<T> collection) {
-      return Refaster.anyOf(collection.stream().iterator(), collection.asList().iterator());
+      return collection.asList().iterator();
     }
 
     @AfterTemplate
-    Iterator<T> after(ImmutableCollection<T> collection) {
+    Iterator<T> after(Collection<T> collection) {
       return collection.iterator();
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -365,14 +365,11 @@ final class CollectionRules {
     }
   }
 
-  /**
-   * Don't call {@link ImmutableCollection#asList()} if {@link ImmutableCollection#iterator()} is
-   * called on the result; call it directly.
-   */
+  /** Prefer {@link ImmutableCollection#iterator()} over more contrived alternatives. */
   static final class ImmutableCollectionIterator<T> {
     @BeforeTemplate
     Iterator<T> before(ImmutableCollection<T> collection) {
-      return collection.asList().iterator();
+      return Refaster.anyOf(collection.stream().iterator(), collection.asList().iterator());
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
@@ -119,9 +119,9 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1).asList().toArray(Integer[]::new);
   }
 
-  ImmutableSet<Iterator<Integer>> testImmutableCollectionIterator() {
+  ImmutableSet<Iterator<Integer>> testCollectionIterator() {
     return ImmutableSet.of(
-        ImmutableSet.of(1).stream().iterator(), ImmutableSet.of(1).asList().iterator());
+        ImmutableSet.of(1).stream().iterator(), ImmutableSet.of(2).asList().iterator());
   }
 
   ImmutableSet<Optional<Integer>> testOptionalFirstCollectionElement() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
@@ -119,8 +119,9 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1).asList().toArray(Integer[]::new);
   }
 
-  Iterator<Integer> testImmutableCollectionIterator() {
-    return ImmutableSet.of(1).asList().iterator();
+  ImmutableSet<Iterator<Integer>> testImmutableCollectionIterator() {
+    return ImmutableSet.of(
+        ImmutableSet.of(1).stream().iterator(), ImmutableSet.of(1).asList().iterator());
   }
 
   ImmutableSet<Optional<Integer>> testOptionalFirstCollectionElement() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
@@ -109,8 +109,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1).toArray(Integer[]::new);
   }
 
-  Iterator<Integer> testImmutableCollectionIterator() {
-    return ImmutableSet.of(1).iterator();
+  ImmutableSet<Iterator<Integer>> testImmutableCollectionIterator() {
+    return ImmutableSet.of(ImmutableSet.of(1).iterator(), ImmutableSet.of(1).iterator());
   }
 
   ImmutableSet<Optional<Integer>> testOptionalFirstCollectionElement() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
@@ -109,8 +109,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1).toArray(Integer[]::new);
   }
 
-  ImmutableSet<Iterator<Integer>> testImmutableCollectionIterator() {
-    return ImmutableSet.of(ImmutableSet.of(1).iterator(), ImmutableSet.of(1).iterator());
+  ImmutableSet<Iterator<Integer>> testCollectionIterator() {
+    return ImmutableSet.of(ImmutableSet.of(1).iterator(), ImmutableSet.of(2).iterator());
   }
 
   ImmutableSet<Optional<Integer>> testOptionalFirstCollectionElement() {


### PR DESCRIPTION
Suggested commit message
```
Introduce `CollectionIterator` Refaster rule (#1347)

This rule supersedes the more specific `ImmutableCollectionIterator` rule.
```