### PR TITLE
Disable `ClassLiteralCast` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
@@ -73,23 +73,25 @@ final class ClassRules {
     }
   }
 
-  /**
-   * Prefer {@link Class#cast(Object)} method references over lambda expressions that require naming
-   * a variable.
-   */
+  // XXX: This rule is temporarily disabled due to false positives with generic casts.
+  /// **
+  // * Prefer {@link Class#cast(Object)} method references over lambda expressions that require
+  // naming
+  // * a variable.
+  // */
   // XXX: Once the `ClassReferenceCast` rule is dropped, rename this rule to just `ClassCast`.
-  static final class ClassLiteralCast<T, S> {
-    @BeforeTemplate
-    @SuppressWarnings("unchecked")
-    Function<T, S> before() {
-      return t -> (S) t;
-    }
-
-    @AfterTemplate
-    Function<T, S> after() {
-      return Refaster.<S>clazz()::cast;
-    }
-  }
+  //  static final class ClassLiteralCast<T, S> {
+  //    @BeforeTemplate
+  //    @SuppressWarnings("unchecked")
+  //    Function<T, S> before() {
+  //      return t -> (S) t;
+  //    }
+  //
+  //    @AfterTemplate
+  //    Function<T, S> after() {
+  //      return Refaster.<S>clazz()::cast;
+  //    }
+  //  }
 
   /**
    * Prefer {@link Class#cast(Object)} method references over lambda expressions that require naming

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
@@ -24,10 +24,6 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
     return s -> clazz.isInstance(s);
   }
 
-  Function<Number, Integer> testClassLiteralCast() {
-    return i -> (Integer) i;
-  }
-
   Function<Number, Integer> testClassReferenceCast() {
     return i -> Integer.class.cast(i);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
@@ -24,10 +24,6 @@ final class ClassRulesTest implements RefasterRuleCollectionTestCase {
     return clazz::isInstance;
   }
 
-  Function<Number, Integer> testClassLiteralCast() {
-    return Integer.class::cast;
-  }
-
   Function<Number, Integer> testClassReferenceCast() {
     return Integer.class::cast;
   }


### PR DESCRIPTION
Temporarily disable the `ClassRules#ClassLiteralCast` Refaster rule. We want to do a release and fixing this won't make it in time for the release probably.