### PR TITLE
Introduce `NameContentEquals` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ConstantNaming.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ConstantNaming.java
@@ -112,7 +112,7 @@ public final class ConstantNaming extends BugChecker implements VariableTreeMatc
         new TreeScanner<Boolean, @Nullable Void>() {
           @Override
           public Boolean visitVariable(VariableTree tree, @Nullable Void unused) {
-            return ASTHelpers.getSymbol(tree).getSimpleName().toString().equals(name)
+            return ASTHelpers.getSymbol(tree).getSimpleName().contentEquals(name)
                 || super.visitVariable(tree, null);
           }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
@@ -9,6 +9,7 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.sun.tools.javac.util.Constants;
 import com.sun.tools.javac.util.Convert;
+import javax.lang.model.element.Name;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to {@link com.google.errorprone.bugpatterns.BugChecker} classes. */
@@ -65,6 +66,24 @@ final class BugCheckerRules {
     @AfterTemplate
     String after(String value) {
       return Constants.format(value);
+    }
+  }
+
+  /** Prefer {@link Name#contentEquals(CharSequence)} over more verbose alternatives. */
+  static final class NameContentEquals {
+    @BeforeTemplate
+    boolean before(Name name, CharSequence string) {
+      return name.toString().equals(string.toString());
+    }
+
+    @BeforeTemplate
+    boolean before(Name name, String string) {
+      return name.toString().equals(string);
+    }
+
+    @AfterTemplate
+    boolean after(Name name, CharSequence string) {
+      return name.contentEquals(string);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestInput.java
@@ -5,6 +5,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.sun.tools.javac.util.Convert;
+import javax.lang.model.element.Name;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
@@ -30,5 +31,11 @@ final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
 
   String testConstantsFormat() {
     return String.format("\"%s\"", Convert.quote("foo"));
+  }
+
+  ImmutableSet<Boolean> testNameContentEquals() {
+    return ImmutableSet.of(
+        ((Name) null).toString().equals("foo".subSequence(0, 1).toString()),
+        ((com.sun.tools.javac.util.Name) null).toString().equals("bar"));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestOutput.java
@@ -6,6 +6,7 @@ import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.sun.tools.javac.util.Constants;
 import com.sun.tools.javac.util.Convert;
+import javax.lang.model.element.Name;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
@@ -29,5 +30,11 @@ final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
 
   String testConstantsFormat() {
     return Constants.format("foo");
+  }
+
+  ImmutableSet<Boolean> testNameContentEquals() {
+    return ImmutableSet.of(
+        ((Name) null).contentEquals("foo".subSequence(0, 1)),
+        ((com.sun.tools.javac.util.Name) null).contentEquals("bar"));
   }
 }


### PR DESCRIPTION
As also flagged [here](https://github.com/PicnicSupermarket/error-prone-support/pull/783#discussion_r1502274717) and [here](https://github.com/PicnicSupermarket/error-prone-support/pull/794#discussion_r1818105009).

Suggested commit message:
```
Introduce `NameContentEquals` Refaster rule (#1379)
```