### PR TITLE
Fix `error-prone-contrib` runtime classpath

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -55,7 +55,12 @@
         <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>refaster-support</artifactId>
-            <scope>provided</scope>
+            <!-- XXX: One would expect this to be a `provided` dependency (as
+            Refaster rules are interpreted by the `refaster-runner` module),
+            but the `OptionalOrElseGet` bug checker defined by this module
+            depends on the `RequiresComputation` matcher that
+            `refaster-support` primarily exposes for use by Refaster rules.
+            Review this setup. (Should the matchers be moved elsewhere?) -->
         </dependency>
         <dependency>
             <groupId>${project.groupId}</groupId>


### PR DESCRIPTION
This change resolves an issue caused by #1283, and flagged by @pzygielo [here](https://github.com/PicnicSupermarket/error-prone-support/pull/1283#issuecomment-2451777445). Thanks Piotrek!

(The bug didn't manifest while testing the release, as in all relevant contexts we also have `refaster-runner` on the annotation processor classpath, and that module has a _runtime_ dependency on `refaster-support`.)

Suggested commit message:
```
Fix `error-prone-contrib` runtime classpath (#1387)
```

We should cut a new release with this fix.