### PR TITLE
Track `StreamFlatMapOptional` Refaster rule caveat

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -279,6 +279,9 @@ final class OptionalRules {
    */
   // XXX: Do we need the `.filter(Optional::isPresent)`? If it's absent the caller probably assumed
   // that the values are present. (If we drop it, we should rewrite vacuous filter steps.)
+  // XXX: The rewritten `filter`/`map` expression may be more performant than its replacement. See
+  // https://github.com/palantir/gradle-baseline/pull/2946. (There are plans to pair Refaster rules
+  // with JMH benchmarks; this would be a great use case.)
   static final class StreamFlatMapOptional<T> {
     @BeforeTemplate
     Stream<T> before(Stream<Optional<T>> stream) {


### PR DESCRIPTION
Suggested commit message:
```
Track `StreamFlatMapOptional` Refaster rule caveat (#1410)
```

(I often track notes like these locally, but perhaps making it explicit here motivates me to finalize a [JMH benchmark generation doodle](https://github.com/PicnicSupermarket/error-prone-support/compare/master...sschroevers/reactor-optimizations) I started on long aog.)