### PR TITLE
Update `step-security/harden-runner` configuration

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -31,7 +31,9 @@ jobs:
             api.scorecard.dev:443
             api.securityscorecards.dev:443
             github.com:443
+            index.docker.io:443
             oss-fuzz-build-logs.storage.googleapis.com:443
+            repo.maven.apache.org:443
             *.sigstore.dev:443
             www.bestpractices.dev:443
       - name: Check out code


### PR DESCRIPTION
Suggested commit message:
```
Update `step-security/harden-runner` configuration (#1411)

By allowing Docker Hub and Maven Central access.
```

Next to this there's also a [report](https://app.stepsecurity.io/github/PicnicSupermarket/error-prone-support/actions/runs/11755278196?jobid=32750165843&tab=network-events) of some process `provjobd` attempting to access `api.ipify.org`, but I'm not sure what that's about, so prefer not to whitelist it.