### PR TITLE
Update `step-security/harden-runner` configuration

### DIFF
--- a/.github/workflows/openssf-scorecard.yml
+++ b/.github/workflows/openssf-scorecard.yml
@@ -26,6 +26,7 @@ jobs:
           disable-sudo: true
           egress-policy: block
           allowed-endpoints: >
+            api.deps.dev:443
             api.github.com:443
             api.osv.dev:443
             api.scorecard.dev:443


### PR DESCRIPTION
Suggested commit message:
```
Update `step-security/harden-runner` configuration (#1412)

By allowing access to Open Source Insights.
```

See the [report](https://app.stepsecurity.io/github/PicnicSupermarket/error-prone-support/actions/runs/11773530035?jobid=32790589274&tab=network-events). Given the check's function, it makes sense to contact [Open Source Insights](https://deps.dev).

