### PR TITLE
Replace deprecated `build-helper:remove-project-artifact` goal

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,6 @@ jobs:
       - name: Build project with self-check against Error Prone fork
         run: mvn -T1C clean verify -Perror-prone-fork -Pnon-maven-central -Pself-check -s settings.xml
       - name: Remove installed project artifacts
-        run: mvn build-helper:remove-project-artifact
+        run: mvn dependency:purge-local-repository -DmanualInclude='${project.groupId}' -DresolutionFuzziness=groupId
 
 # XXX: Enable Codecov once we "go public".

--- a/.github/workflows/run-integration-tests.yml
+++ b/.github/workflows/run-integration-tests.yml
@@ -50,4 +50,4 @@ jobs:
           name: integration-test-checkstyle
           path: "${{ runner.temp }}/artifacts"
       - name: Remove installed project artifacts
-        run: mvn build-helper:remove-project-artifact
+        run: mvn dependency:purge-local-repository -DmanualInclude='${project.groupId}' -DresolutionFuzziness=groupId

--- a/pom.xml
+++ b/pom.xml
@@ -1312,11 +1312,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
-                    <artifactId>build-helper-maven-plugin</artifactId>
-                    <version>3.6.0</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.codehaus.mojo</groupId>
                     <artifactId>license-maven-plugin</artifactId>
                     <version>2.4.0</version>
                     <configuration>


### PR DESCRIPTION
Suggested commit message:
```
Replace deprecated `build-helper:remove-project-artifact` goal (#1413)
```

This resolves the following warning:
```
 [WARNING]  Goal 'remove-project-artifact' is deprecated: There is a similar goal: dependency:purge-local-repository <https://maven.apache.org/plugins/maven-dependency-plugin/purge-local-repository-mojo.html> By the way such goal should by not used with Maven 3/4 anymore.
```

(As for whether such a goal should not be used at all: (a) there's no point in caching these artifacts, and (b) we know from internal projects that keeping such SNAPSHOTs around can hide project cycles. Not likely to happen with our simple Maven build setup, but still.)

Tested as follows:
```sh
# Install project into local repository.
$ mvn clean install -DskipTests -Dverification.skip
# ...
# Validate that artifacts are now present.
$ find ~/.m2/repository/tech/picnic/error-prone-support | wc -l
88
# Run new artifact removal command.
$ mvn dependency:purge-local-repository -DmanualInclude='${project.groupId}' -DresolutionFuzziness=groupId
# ...
# Validate that artifacts are now gone.
$ ls ~/.m2/repository/tech/picnic/error-prone-support
ls: cannot access '/home/myusername/.m2/repository/tech/picnic/error-prone-support': No such file or directory
```
