### PR TITLE
Introduce `PublisherProbeAssertWas{,Not}{Subscribed,Cancelled,Requested}` Refaster rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ Other highly relevant commands:
 - `mvn fmt:format` formats the code using
   [`google-java-format`][google-java-format].
 - [`./run-full-build.sh`][script-run-full-build] builds the project twice,
-  where the second pass validates compatbility with Picnic's [Error Prone
+  where the second pass validates compatibility with Picnic's [Error Prone
   fork][error-prone-fork-repo] and compliance of the code with any rules
   defined within this project. (Consider running this before [opening a pull
   request][contributing-pull-request], as the PR checks also perform this

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1801,6 +1801,32 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link PublisherProbe#assertWasRequested()} over more verbose alternatives. */
+  static final class PublisherProbeAssertWasRequested<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe) {
+      assertThat(probe.wasRequested()).isTrue();
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe) {
+      probe.assertWasRequested();
+    }
+  }
+
+  /** Prefer {@link PublisherProbe#assertWasNotRequested()} over more verbose alternatives. */
+  static final class PublisherProbeAssertWasNotRequested<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe) {
+      assertThat(probe.wasRequested()).isFalse();
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe) {
+      probe.assertWasNotRequested();
+    }
+  }
+
   /** Prefer {@link Mono#as(Function)} when creating a {@link StepVerifier}. */
   static final class StepVerifierFromMono<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1742,6 +1742,39 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link PublisherProbe#assertWasSubscribed()} over more verbose alternatives. */
+  static final class PublisherProbeAssertWasSubscribed<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe) {
+      Refaster.anyOf(
+          assertThat(probe.wasSubscribed()).isTrue(),
+          assertThat(probe.subscribeCount()).isNotNegative(),
+          assertThat(probe.subscribeCount()).isNotZero(),
+          assertThat(probe.subscribeCount()).isPositive());
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe) {
+      probe.assertWasSubscribed();
+    }
+  }
+
+  /** Prefer {@link PublisherProbe#assertWasNotSubscribed()} over more verbose alternatives. */
+  static final class PublisherProbeAssertWasNotSubscribed<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe) {
+      Refaster.anyOf(
+          assertThat(probe.wasSubscribed()).isFalse(),
+          assertThat(probe.subscribeCount()).isZero(),
+          assertThat(probe.subscribeCount()).isNotPositive());
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe) {
+      probe.assertWasNotSubscribed();
+    }
+  }
+
   /** Prefer {@link Mono#as(Function)} when creating a {@link StepVerifier}. */
   static final class StepVerifierFromMono<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1775,6 +1775,32 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link PublisherProbe#assertWasCancelled()} over more verbose alternatives. */
+  static final class PublisherProbeAssertWasCancelled<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe) {
+      assertThat(probe.wasCancelled()).isTrue();
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe) {
+      probe.assertWasCancelled();
+    }
+  }
+
+  /** Prefer {@link PublisherProbe#assertWasNotCancelled()} over more verbose alternatives. */
+  static final class PublisherProbeAssertWasNotCancelled<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe) {
+      assertThat(probe.wasCancelled()).isFalse();
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe) {
+      probe.assertWasNotCancelled();
+    }
+  }
+
   /** Prefer {@link Mono#as(Function)} when creating a {@link StepVerifier}. */
   static final class StepVerifierFromMono<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1749,7 +1749,7 @@ final class ReactorRules {
       Refaster.anyOf(
           assertThat(probe.wasSubscribed()).isTrue(),
           assertThat(probe.subscribeCount()).isNotNegative(),
-          assertThat(probe.subscribeCount()).isNotZero(),
+          assertThat(probe.subscribeCount()).isNotEqualTo(0),
           assertThat(probe.subscribeCount()).isPositive());
     }
 
@@ -1765,7 +1765,7 @@ final class ReactorRules {
     void before(PublisherProbe<T> probe) {
       Refaster.anyOf(
           assertThat(probe.wasSubscribed()).isFalse(),
-          assertThat(probe.subscribeCount()).isZero(),
+          assertThat(probe.subscribeCount()).isEqualTo(0),
           assertThat(probe.subscribeCount()).isNotPositive());
     }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -603,6 +603,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(PublisherProbe.of(Mono.just(3)).subscribeCount()).isNotPositive();
   }
 
+  void testPublisherProbeAssertWasCancelled() {
+    assertThat(PublisherProbe.empty().wasCancelled()).isTrue();
+  }
+
+  void testPublisherProbeAssertWasNotCancelled() {
+    assertThat(PublisherProbe.empty().wasCancelled()).isFalse();
+  }
+
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.just(1)), Mono.just(2).flux().as(StepVerifier::create));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -593,13 +593,13 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   void testPublisherProbeAssertWasSubscribed() {
     assertThat(PublisherProbe.of(Mono.just(1)).wasSubscribed()).isTrue();
     assertThat(PublisherProbe.of(Mono.just(2)).subscribeCount()).isNotNegative();
-    assertThat(PublisherProbe.of(Mono.just(3)).subscribeCount()).isNotZero();
+    assertThat(PublisherProbe.of(Mono.just(3)).subscribeCount()).isNotEqualTo(0);
     assertThat(PublisherProbe.of(Mono.just(4)).subscribeCount()).isPositive();
   }
 
   void testPublisherProbeAssertWasNotSubscribed() {
     assertThat(PublisherProbe.of(Mono.just(1)).wasSubscribed()).isFalse();
-    assertThat(PublisherProbe.of(Mono.just(2)).subscribeCount()).isZero();
+    assertThat(PublisherProbe.of(Mono.just(2)).subscribeCount()).isEqualTo(0);
     assertThat(PublisherProbe.of(Mono.just(3)).subscribeCount()).isNotPositive();
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -611,6 +611,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(PublisherProbe.empty().wasCancelled()).isFalse();
   }
 
+  void testPublisherProbeAssertWasRequested() {
+    assertThat(PublisherProbe.empty().wasRequested()).isTrue();
+  }
+
+  void testPublisherProbeAssertWasNotRequested() {
+    assertThat(PublisherProbe.empty().wasRequested()).isFalse();
+  }
+
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.just(1)), Mono.just(2).flux().as(StepVerifier::create));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -44,6 +44,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         List.class,
         ImmutableCollection.class,
         ImmutableMap.class,
+        assertThat(false),
         assertThat(0),
         maxBy(null),
         minBy(null),
@@ -587,6 +588,19 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {
     return ImmutableSet.of(PublisherProbe.of(Mono.empty()), PublisherProbe.of(Flux.empty()));
+  }
+
+  void testPublisherProbeAssertWasSubscribed() {
+    assertThat(PublisherProbe.of(Mono.just(1)).wasSubscribed()).isTrue();
+    assertThat(PublisherProbe.of(Mono.just(2)).subscribeCount()).isNotNegative();
+    assertThat(PublisherProbe.of(Mono.just(3)).subscribeCount()).isNotZero();
+    assertThat(PublisherProbe.of(Mono.just(4)).subscribeCount()).isPositive();
+  }
+
+  void testPublisherProbeAssertWasNotSubscribed() {
+    assertThat(PublisherProbe.of(Mono.just(1)).wasSubscribed()).isFalse();
+    assertThat(PublisherProbe.of(Mono.just(2)).subscribeCount()).isZero();
+    assertThat(PublisherProbe.of(Mono.just(3)).subscribeCount()).isNotPositive();
   }
 
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -47,6 +47,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         List.class,
         ImmutableCollection.class,
         ImmutableMap.class,
+        assertThat(false),
         assertThat(0),
         maxBy(null),
         minBy(null),
@@ -575,6 +576,19 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {
     return ImmutableSet.of(PublisherProbe.empty(), PublisherProbe.empty());
+  }
+
+  void testPublisherProbeAssertWasSubscribed() {
+    PublisherProbe.of(Mono.just(1)).assertWasSubscribed();
+    PublisherProbe.of(Mono.just(2)).assertWasSubscribed();
+    PublisherProbe.of(Mono.just(3)).assertWasSubscribed();
+    PublisherProbe.of(Mono.just(4)).assertWasSubscribed();
+  }
+
+  void testPublisherProbeAssertWasNotSubscribed() {
+    PublisherProbe.of(Mono.just(1)).assertWasNotSubscribed();
+    PublisherProbe.of(Mono.just(2)).assertWasNotSubscribed();
+    PublisherProbe.of(Mono.just(3)).assertWasNotSubscribed();
   }
 
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -591,6 +591,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     PublisherProbe.of(Mono.just(3)).assertWasNotSubscribed();
   }
 
+  void testPublisherProbeAssertWasCancelled() {
+    PublisherProbe.empty().assertWasCancelled();
+  }
+
+  void testPublisherProbeAssertWasNotCancelled() {
+    PublisherProbe.empty().assertWasNotCancelled();
+  }
+
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create), Mono.just(2).as(StepVerifier::create));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -599,6 +599,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     PublisherProbe.empty().assertWasNotCancelled();
   }
 
+  void testPublisherProbeAssertWasRequested() {
+    PublisherProbe.empty().assertWasRequested();
+  }
+
+  void testPublisherProbeAssertWasNotRequested() {
+    PublisherProbe.empty().assertWasNotRequested();
+  }
+
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create), Mono.just(2).as(StepVerifier::create));


### PR DESCRIPTION
Another set of trivial Reactor Refaster rules.

Suggested commit message:
```
Introduce `PublisherProbeAssertWas{,Not}{Subscribed,Cancelled,Requested}` Refaster rules (#1423)

While there, fix a typo in `README.md`.
```