### PR TITLE
Update Checkstyle integration test

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -93,6 +93,12 @@ final class FileRules {
   /**
    * Prefer {@link Files#createTempFile(String, String, FileAttribute[])} over alternatives that
    * create files with more liberal permissions.
+   *
+   * <p>Note that {@link File#createTempFile} treats the given prefix as a path, and ignores all but
+   * its file name. That is, the actual prefix used is derived from all characters following the
+   * final file separator (if any). This is not the case with {@link Files#createTempFile}, which
+   * will instead throw an {@link IllegalArgumentException} if the prefix contains any file
+   * separators.
    */
   static final class FilesCreateTempFileToFile {
     @BeforeTemplate
@@ -117,6 +123,12 @@ final class FileRules {
   /**
    * Prefer {@link Files#createTempFile(Path, String, String, FileAttribute[])} over alternatives
    * that create files with more liberal permissions.
+   *
+   * <p>Note that {@link File#createTempFile} treats the given prefix as a path, and ignores all but
+   * its file name. That is, the actual prefix used is derived from all characters following the
+   * final file separator (if any). This is not the case with {@link Files#createTempFile}, which
+   * will instead throw an {@link IllegalArgumentException} if the prefix contains any file
+   * separators.
    */
   static final class FilesCreateTempFileInCustomDirectoryToFile {
     @BeforeTemplate

--- a/integration-tests/checkstyle-expected-changes.patch
+++ b/integration-tests/checkstyle-expected-changes.patch
@@ -1,6 +1,6 @@
 --- a/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
 +++ b/src/it/java/com/google/checkstyle/test/base/AbstractIndentationTestSupport.java
-@@ -19,10 +19,12 @@
+@@ -19,12 +19,14 @@
  
  package com.google.checkstyle.test.base;
  
@@ -12,15 +12,18 @@
  import java.io.IOException;
 -import java.nio.charset.StandardCharsets;
  import java.nio.file.Files;
- import java.nio.file.Paths;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
  import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.List;
 @@ -71,8 +73,7 @@ public abstract class AbstractIndentationTestSupport extends AbstractGoogleModul
    private static Integer[] getLinesWithWarnAndCheckComments(String aFileName, final int tabWidth)
        throws IOException {
      final List<Integer> result = new ArrayList<>();
 -    try (BufferedReader br =
 -        Files.newBufferedReader(Paths.get(aFileName), StandardCharsets.UTF_8)) {
-+    try (BufferedReader br = Files.newBufferedReader(Paths.get(aFileName), UTF_8)) {
++    try (BufferedReader br = Files.newBufferedReader(Path.of(aFileName), UTF_8)) {
        int lineNumber = 1;
        for (String line = br.readLine(); line != null; line = br.readLine()) {
          final Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);
@@ -2085,6 +2088,15 @@
  
  import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
  import com.puppycrawl.tools.checkstyle.Checker;
+@@ -39,7 +40,7 @@ import java.io.InputStreamReader;
+ import java.io.LineNumberReader;
+ import java.nio.charset.StandardCharsets;
+ import java.nio.file.Files;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
+ import java.text.MessageFormat;
+ import java.util.ArrayList;
+ import java.util.Collections;
 @@ -397,8 +398,7 @@ public abstract class AbstractItModuleTestSupport extends AbstractPathTestSuppor
  
      // process each of the lines
@@ -2100,7 +2112,7 @@
    protected Integer[] getLinesWithWarn(String fileName) throws IOException {
      final List<Integer> result = new ArrayList<>();
 -    try (BufferedReader br = Files.newBufferedReader(Paths.get(fileName), StandardCharsets.UTF_8)) {
-+    try (BufferedReader br = Files.newBufferedReader(Paths.get(fileName), UTF_8)) {
++    try (BufferedReader br = Files.newBufferedReader(Path.of(fileName), UTF_8)) {
        int lineNumber = 1;
        while (true) {
          final String line = br.readLine();
@@ -11082,7 +11094,15 @@
  import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  import com.puppycrawl.tools.checkstyle.api.Configuration;
  import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
-@@ -94,12 +96,8 @@ public final class PropertyCacheFile {
+@@ -33,7 +35,6 @@ import java.math.BigInteger;
+ import java.net.URI;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.security.MessageDigest;
+ import java.security.NoSuchAlgorithmException;
+ import java.util.HashSet;
+@@ -94,12 +95,8 @@ public final class PropertyCacheFile {
     * @throws IllegalArgumentException when either arguments are null
     */
    public PropertyCacheFile(Configuration config, String fileName) {
@@ -11097,6 +11117,15 @@
      this.config = config;
      this.fileName = fileName;
    }
+@@ -135,7 +132,7 @@ public final class PropertyCacheFile {
+    * @throws IOException when there is a problems with file save
+    */
+   public void persist() throws IOException {
+-    final Path path = Paths.get(fileName);
++    final Path path = Path.of(fileName);
+     final Path directory = path.getParent();
+ 
+     if (directory != null) {
 --- a/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
 +++ b/src/main/java/com/puppycrawl/tools/checkstyle/SarifLogger.java
 @@ -19,6 +19,9 @@
@@ -13149,15 +13178,27 @@
  import com.puppycrawl.tools.checkstyle.AbstractAutomaticBean.OutputStreamOptions;
  import com.puppycrawl.tools.checkstyle.Checker;
  import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-@@ -34,7 +36,6 @@ import java.nio.file.Path;
- import java.nio.file.Paths;
+@@ -31,10 +33,8 @@ import java.io.OutputStream;
+ import java.nio.charset.StandardCharsets;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
  import java.util.ArrayList;
  import java.util.List;
 -import java.util.stream.Collectors;
  import java.util.stream.Stream;
  
  /** Class which handles all the metadata generation and writing calls. */
-@@ -98,7 +99,7 @@ public final class MetadataGeneratorUtil {
+@@ -87,7 +87,7 @@ public final class MetadataGeneratorUtil {
+       throws IOException {
+     final List<File> validFiles = new ArrayList<>();
+     for (String folder : moduleFolders) {
+-      try (Stream<Path> files = Files.walk(Paths.get(path + "/" + folder))) {
++      try (Stream<Path> files = Files.walk(Path.of(path + "/" + folder))) {
+         validFiles.addAll(
+             files
+                 .map(Path::toFile)
+@@ -98,7 +98,7 @@ public final class MetadataGeneratorUtil {
                            || fileName.endsWith("Check.java")
                            || fileName.endsWith("Filter.java");
                      })
@@ -13262,6 +13303,25 @@
    }
  
    /**
+--- a/src/main/java/com/puppycrawl/tools/checkstyle/site/ParentModuleMacro.java
++++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/ParentModuleMacro.java
+@@ -20,7 +20,6 @@
+ package com.puppycrawl.tools.checkstyle.site;
+ 
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.Locale;
+ import org.apache.maven.doxia.macro.AbstractMacro;
+ import org.apache.maven.doxia.macro.Macro;
+@@ -91,7 +90,7 @@ public class ParentModuleMacro extends AbstractMacro {
+       throw new MacroExecutionException("Failed to get parent path for " + templatePath);
+     }
+     return templatePathParent
+-            .relativize(Paths.get("src", "xdocs", "config.xml"))
++            .relativize(Path.of("src", "xdocs", "config.xml"))
+             .toString()
+             .replace(".xml", ".html")
+             .replace('\\', '/')
 --- a/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
 +++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/PropertiesMacro.java
 @@ -19,6 +19,10 @@
@@ -13369,7 +13429,15 @@
  import com.google.common.collect.Lists;
  import com.puppycrawl.tools.checkstyle.Checker;
  import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-@@ -72,7 +80,6 @@ import java.util.Optional;
+@@ -55,7 +63,6 @@ import java.net.URI;
+ import java.nio.charset.StandardCharsets;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.ArrayDeque;
+ import java.util.ArrayList;
+ import java.util.Arrays;
+@@ -72,7 +79,6 @@ import java.util.Optional;
  import java.util.Set;
  import java.util.TreeSet;
  import java.util.regex.Pattern;
@@ -13377,7 +13445,7 @@
  import java.util.stream.IntStream;
  import java.util.stream.Stream;
  import javax.annotation.Nullable;
-@@ -156,7 +163,7 @@ public final class SiteUtil {
+@@ -156,7 +162,7 @@ public final class SiteUtil {
  
    /** Set of properties that are undocumented. Those are internal properties. */
    private static final Set<String> UNDOCUMENTED_PROPERTIES =
@@ -13386,7 +13454,52 @@
            "SuppressWithNearbyCommentFilter.fileContents", "SuppressionCommentFilter.fileContents");
  
    /** Properties that can not be gathered from class instance. */
-@@ -480,7 +487,7 @@ public final class SiteUtil {
+@@ -291,27 +297,25 @@ public final class SiteUtil {
+ 
+   /** Path to main source code folder. */
+   private static final String MAIN_FOLDER_PATH =
+-      Paths.get(SRC, "main", "java", "com", "puppycrawl", "tools", "checkstyle").toString();
++      Path.of(SRC, "main", "java", "com", "puppycrawl", "tools", "checkstyle").toString();
+ 
+   /** List of files who are superclasses and contain certain properties that checks inherit. */
+   private static final List<File> MODULE_SUPER_CLASS_FILES =
+       List.of(
+           new File(
+-              Paths.get(MAIN_FOLDER_PATH, CHECKS, NAMING, "AbstractAccessControlNameCheck.java")
++              Path.of(MAIN_FOLDER_PATH, CHECKS, NAMING, "AbstractAccessControlNameCheck.java")
+                   .toString()),
++          new File(Path.of(MAIN_FOLDER_PATH, CHECKS, NAMING, "AbstractNameCheck.java").toString()),
+           new File(
+-              Paths.get(MAIN_FOLDER_PATH, CHECKS, NAMING, "AbstractNameCheck.java").toString()),
+-          new File(
+-              Paths.get(MAIN_FOLDER_PATH, CHECKS, "javadoc", "AbstractJavadocCheck.java")
+-                  .toString()),
+-          new File(Paths.get(MAIN_FOLDER_PATH, "api", "AbstractFileSetCheck.java").toString()),
++              Path.of(MAIN_FOLDER_PATH, CHECKS, "javadoc", "AbstractJavadocCheck.java").toString()),
++          new File(Path.of(MAIN_FOLDER_PATH, "api", "AbstractFileSetCheck.java").toString()),
+           new File(
+-              Paths.get(MAIN_FOLDER_PATH, CHECKS, "header", "AbstractHeaderCheck.java").toString()),
++              Path.of(MAIN_FOLDER_PATH, CHECKS, "header", "AbstractHeaderCheck.java").toString()),
+           new File(
+-              Paths.get(MAIN_FOLDER_PATH, CHECKS, "metrics", "AbstractClassCouplingCheck.java")
++              Path.of(MAIN_FOLDER_PATH, CHECKS, "metrics", "AbstractClassCouplingCheck.java")
+                   .toString()),
+           new File(
+-              Paths.get(MAIN_FOLDER_PATH, CHECKS, "whitespace", "AbstractParenPadCheck.java")
++              Path.of(MAIN_FOLDER_PATH, CHECKS, "whitespace", "AbstractParenPadCheck.java")
+                   .toString()));
+ 
+   /** Private utility constructor. */
+@@ -472,7 +476,7 @@ public final class SiteUtil {
+    * @throws MacroExecutionException if an I/O error occurs.
+    */
+   public static Set<Path> getXdocsTemplatesFilePaths() throws MacroExecutionException {
+-    final Path directory = Paths.get("src/xdocs");
++    final Path directory = Path.of("src/xdocs");
+     try (Stream<Path> stream =
+         Files.find(
+             directory,
+@@ -480,7 +484,7 @@ public final class SiteUtil {
              (path, attr) -> {
                return attr.isRegularFile() && path.toString().endsWith(".xml.template");
              })) {
@@ -13395,7 +13508,7 @@
      } catch (IOException ioException) {
        throw new MacroExecutionException("Failed to find xdocs templates", ioException);
      }
-@@ -507,7 +514,7 @@ public final class SiteUtil {
+@@ -507,7 +511,7 @@ public final class SiteUtil {
      }
  
      // If parent class is not found, check interfaces
@@ -13404,7 +13517,7 @@
        final Class<?>[] interfaces = moduleClass.getInterfaces();
        for (Class<?> interfaceClass : interfaces) {
          parentModuleName = CLASS_TO_PARENT_MODULE.get(interfaceClass);
-@@ -517,7 +524,7 @@ public final class SiteUtil {
+@@ -517,7 +521,7 @@ public final class SiteUtil {
        }
      }
  
@@ -13413,7 +13526,7 @@
        final String message =
            String.format(
                Locale.ROOT, "Failed to find parent module for %s", moduleClass.getSimpleName());
-@@ -541,7 +548,7 @@ public final class SiteUtil {
+@@ -541,7 +545,7 @@ public final class SiteUtil {
                  prop -> {
                    return !isGlobalProperty(clss, prop) && !isUndocumentedProperty(clss, prop);
                  })
@@ -13422,7 +13535,7 @@
      properties.addAll(getNonExplicitProperties(instance, clss));
      return new TreeSet<>(properties);
    }
-@@ -660,7 +667,7 @@ public final class SiteUtil {
+@@ -660,7 +664,7 @@ public final class SiteUtil {
      treeWalkerConfig.addChild(scraperCheckConfig);
      try {
        checker.configure(defaultConfiguration);
@@ -13431,7 +13544,7 @@
        checker.process(filesToProcess);
        checker.destroy();
      } catch (CheckstyleException checkstyleException) {
-@@ -983,9 +990,7 @@ public final class SiteUtil {
+@@ -983,9 +987,7 @@ public final class SiteUtil {
      if (value != null && Array.getLength(value) > 0) {
        result =
            removeSquareBrackets(
@@ -13442,7 +13555,7 @@
      }
  
      if (result.isEmpty()) {
-@@ -1017,8 +1022,7 @@ public final class SiteUtil {
+@@ -1017,8 +1019,7 @@ public final class SiteUtil {
        result = "";
      } else {
        try (Stream<?> valuesStream = getValuesStream(value)) {
@@ -13452,7 +13565,7 @@
        }
      }
  
-@@ -1059,10 +1063,7 @@ public final class SiteUtil {
+@@ -1059,10 +1060,7 @@ public final class SiteUtil {
    private static String getIntArrayPropertyValue(Object value) {
      try (IntStream stream = getIntStream(value)) {
        String result =
@@ -13464,7 +13577,7 @@
        if (result.isEmpty()) {
          result = CURLY_BRACKETS;
        }
-@@ -1168,11 +1169,11 @@ public final class SiteUtil {
+@@ -1168,11 +1166,11 @@ public final class SiteUtil {
     */
    public static List<Integer> getDifference(int[] tokens, int... subtractions) {
      final Set<Integer> subtractionsSet =
@@ -13478,6 +13591,15 @@
    }
  
    /**
+@@ -1219,7 +1217,7 @@ public final class SiteUtil {
+       throw new MacroExecutionException("Failed to get parent path for " + templatePath);
+     }
+     return templatePathParent
+-        .relativize(Paths.get(SRC, "xdocs", document))
++        .relativize(Path.of(SRC, "xdocs", document))
+         .toString()
+         .replace(".xml", ".html")
+         .replace('\\', '/');
 --- a/src/main/java/com/puppycrawl/tools/checkstyle/site/XdocsTemplateParser.java
 +++ b/src/main/java/com/puppycrawl/tools/checkstyle/site/XdocsTemplateParser.java
 @@ -19,6 +19,7 @@
@@ -13627,15 +13749,37 @@
    /**
 --- a/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
 +++ b/src/main/java/com/puppycrawl/tools/checkstyle/utils/CommonUtil.java
-@@ -32,7 +32,6 @@ import java.net.URL;
+@@ -30,9 +30,7 @@ import java.net.URI;
+ import java.net.URISyntaxException;
+ import java.net.URL;
  import java.nio.file.Path;
- import java.nio.file.Paths;
+-import java.nio.file.Paths;
  import java.util.BitSet;
 -import java.util.Objects;
  import java.util.regex.Matcher;
  import java.util.regex.Pattern;
  import java.util.regex.PatternSyntaxException;
-@@ -506,7 +505,7 @@ public final class CommonUtil {
+@@ -235,8 +233,8 @@ public final class CommonUtil {
+     if (baseDirectory == null) {
+       resultPath = path;
+     } else {
+-      final Path pathAbsolute = Paths.get(path);
+-      final Path pathBase = Paths.get(baseDirectory);
++      final Path pathAbsolute = Path.of(path);
++      final Path pathBase = Path.of(baseDirectory);
+       resultPath = pathBase.relativize(pathAbsolute).toString();
+     }
+     return resultPath;
+@@ -447,7 +445,7 @@ public final class CommonUtil {
+    *     extension.
+    */
+   public static String getFileExtension(String fileNameWithExtension) {
+-    final String fileName = Paths.get(fileNameWithExtension).toString();
++    final String fileName = Path.of(fileNameWithExtension).toString();
+     final int dotIndex = fileName.lastIndexOf('.');
+     final String extension;
+     if (dotIndex == -1) {
+@@ -506,7 +504,7 @@ public final class CommonUtil {
     * @return true if the arg is blank.
     */
    public static boolean isBlank(String value) {
@@ -14148,7 +14292,8 @@
  import java.io.File;
  import java.io.IOException;
  import java.nio.file.Files;
- import java.nio.file.Paths;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
 +import java.util.Arrays;
  import java.util.Locale;
 -import java.util.stream.Collectors;
@@ -14156,6 +14301,15 @@
  import org.junit.jupiter.api.BeforeEach;
  
  public abstract class AbstractPathTestSupport {
+@@ -93,7 +94,7 @@ public abstract class AbstractPathTestSupport {
+    * @noinspectionreason RedundantThrows - false positive
+    */
+   protected static String readFile(String filename) throws IOException {
+-    return toLfLineEnding(Files.readString(Paths.get(filename)));
++    return toLfLineEnding(Files.readString(Path.of(filename)));
+   }
+ 
+   /**
 @@ -103,7 +104,7 @@ public abstract class AbstractPathTestSupport {
     * @return joined strings
     */
@@ -14190,8 +14344,12 @@
    }
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/AstTreeStringPrinterTest.java
-@@ -32,7 +32,7 @@ import java.nio.file.Files;
- import java.nio.file.Paths;
+@@ -29,10 +29,10 @@ import com.puppycrawl.tools.checkstyle.api.TokenTypes;
+ import java.io.File;
+ import java.nio.charset.StandardCharsets;
+ import java.nio.file.Files;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
  import org.junit.jupiter.api.Test;
  
 -public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
@@ -14243,7 +14401,14 @@
      final FileText text =
          new FileText(
              new File(getPath("InputAstTreeStringPrinterComments.java")).getAbsoluteFile(),
-@@ -103,7 +103,7 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
+@@ -97,13 +97,13 @@ public class AstTreeStringPrinterTest extends AbstractTreeTestSupport {
+     final String actual =
+         toLfLineEnding(AstTreeStringPrinter.printAst(text, JavaParser.Options.WITHOUT_COMMENTS));
+     final String expected =
+-        toLfLineEnding(Files.readString(Paths.get(getPath("ExpectedAstTreeStringPrinter.txt"))));
++        toLfLineEnding(Files.readString(Path.of(getPath("ExpectedAstTreeStringPrinter.txt"))));
+ 
+     assertWithMessage("Print AST output is invalid").that(actual).isEqualTo(expected);
    }
  
    @Test
@@ -14401,11 +14566,13 @@
      final Checker checker = new Checker();
      final DebugAuditAdapter auditAdapter = new DebugAuditAdapter();
      checker.addListener(auditAdapter);
-@@ -132,7 +134,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -131,8 +133,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     // should remove all listeners, file sets, and filters
      checker.destroy();
  
-     final File tempFile = File.createTempFile("junit", null, temporaryFolder);
+-    final File tempFile = File.createTempFile("junit", null, temporaryFolder);
 -    checker.process(Collections.singletonList(tempFile));
++    final File tempFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
 +    checker.process(ImmutableList.of(tempFile));
      final SortedSet<Violation> violations = new TreeSet<>();
      violations.add(
@@ -14480,7 +14647,7 @@
      final Checker checker = new Checker();
      final DebugFilter filter = new DebugFilter();
      final DebugFilter f2 = new DebugFilter();
-@@ -337,7 +339,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -337,11 +339,12 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14489,7 +14656,23 @@
      final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
      checkerConfig.addProperty("charset", StandardCharsets.UTF_8.name());
      checkerConfig.addProperty(
-@@ -378,7 +380,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+-        "cacheFile", File.createTempFile("junit", null, temporaryFolder).getPath());
++        "cacheFile",
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath());
+ 
+     final Checker checker = new Checker();
+     checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+@@ -357,7 +360,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     files.add(otherFile);
+     final String[] fileExtensions = {"java", "xml", "properties"};
+     checker.setFileExtensions(fileExtensions);
+-    checker.setCacheFile(File.createTempFile("junit", null, temporaryFolder).getPath());
++    checker.setCacheFile(
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath());
+     final int counter = checker.process(files);
+ 
+     // comparing to 1 as there is only one legal file in input
+@@ -378,10 +382,10 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14497,8 +14680,22 @@
 +  void ignoredFileExtensions() throws Exception {
      final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
      checkerConfig.addProperty("charset", StandardCharsets.UTF_8.name());
-     final File tempFile = File.createTempFile("junit", null, temporaryFolder);
-@@ -413,7 +415,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+-    final File tempFile = File.createTempFile("junit", null, temporaryFolder);
++    final File tempFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", tempFile.getPath());
+ 
+     final Checker checker = new Checker();
+@@ -396,7 +400,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     allIgnoredFiles.add(ignoredFile);
+     final String[] fileExtensions = {"java", "xml", "properties"};
+     checker.setFileExtensions(fileExtensions);
+-    checker.setCacheFile(File.createTempFile("junit", null, temporaryFolder).getPath());
++    checker.setCacheFile(
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath());
+     final int counter = checker.process(allIgnoredFiles);
+ 
+     // comparing to 0 as there is no legal file in input
+@@ -413,7 +418,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14507,7 +14704,7 @@
      // all  that is set by reflection, so just make code coverage be happy
      final Checker checker = new Checker();
      checker.setBasedir("some");
-@@ -437,7 +439,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -437,7 +442,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14516,7 +14713,7 @@
      final Checker checker = new Checker();
  
      try {
-@@ -451,7 +453,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -451,7 +456,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14525,7 +14722,7 @@
      final Checker checker = new Checker();
      final ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
  
-@@ -465,7 +467,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -465,7 +470,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14534,7 +14731,7 @@
      final Checker checker = new Checker();
      final ClassLoader contextClassLoader = Thread.currentThread().getContextClassLoader();
      checker.setModuleClassLoader(contextClassLoader);
-@@ -496,7 +498,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -496,7 +501,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14543,7 +14740,7 @@
      final Checker checker = new Checker();
      final PackageObjectFactory factory =
          new PackageObjectFactory(new HashSet<>(), Thread.currentThread().getContextClassLoader());
-@@ -514,7 +516,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -514,7 +519,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14552,7 +14749,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
      checkConfig.addProperty("$$No such property", null);
      try {
-@@ -533,7 +535,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -533,7 +538,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14561,7 +14758,7 @@
      final Checker checker = new Checker();
      final PackageObjectFactory factory =
          new PackageObjectFactory(new HashSet<>(), Thread.currentThread().getContextClassLoader());
-@@ -550,7 +552,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -550,7 +555,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14570,7 +14767,7 @@
      final Checker checker = new Checker();
      final PackageObjectFactory factory =
          new PackageObjectFactory(new HashSet<>(), Thread.currentThread().getContextClassLoader());
-@@ -572,8 +574,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -572,8 +577,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
  
    /** It is OK to have long test method name here as it describes the test purpose. */
    @Test
@@ -14580,7 +14777,20 @@
      assertWithMessage("ExternalResourceHolder has changed his parent")
          .that(ExternalResourceHolder.class.isAssignableFrom(HiddenFieldCheck.class))
          .isFalse();
-@@ -609,7 +610,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -585,10 +589,10 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+     checkerConfig.addProperty("charset", StandardCharsets.UTF_8.name());
+ 
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+-    final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
++    final File tmpFile = Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile();
+ 
+     execute(checkerConfig, tmpFile.getPath());
+     final Properties cacheAfterFirstRun = new Properties();
+@@ -609,18 +613,18 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14589,7 +14799,20 @@
      final Checker checker = new Checker();
      final PackageObjectFactory factory =
          new PackageObjectFactory(new HashSet<>(), Thread.currentThread().getContextClassLoader());
-@@ -650,7 +651,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     checker.setModuleFactory(factory);
+     checker.configure(createModuleConfig(TranslationCheck.class));
+ 
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checker.setCacheFile(cacheFile.getPath());
+ 
+     checker.setupChild(createModuleConfig(TranslationCheck.class));
+-    final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
++    final File tmpFile = Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile();
+     final List<File> files = new ArrayList<>(1);
+     files.add(tmpFile);
+     checker.process(files);
+@@ -650,10 +654,10 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14597,8 +14820,22 @@
 +  void clearExistingCache() throws Exception {
      final DefaultConfiguration checkerConfig = createRootConfig(null);
      checkerConfig.addProperty("charset", StandardCharsets.UTF_8.name());
-     final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
-@@ -698,7 +699,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+     final Checker checker = new Checker();
+@@ -675,7 +679,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
+         .that(cacheAfterClear.getProperty(PropertyCacheFile.CONFIG_HASH_KEY))
+         .isNotNull();
+ 
+-    final String pathToEmptyFile = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String pathToEmptyFile =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+ 
+     // file that should be audited is not in cache
+     execute(checkerConfig, pathToEmptyFile);
+@@ -698,12 +703,12 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14607,7 +14844,13 @@
      final DefaultConfiguration violationCheck =
          createModuleConfig(DummyFileSetViolationCheck.class);
      final DefaultConfiguration checkerConfig = new DefaultConfiguration("myConfig");
-@@ -711,7 +712,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     checkerConfig.addProperty("charset", "UTF-8");
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+     checkerConfig.addChild(violationCheck);
+     final Checker checker = new Checker();
+@@ -711,7 +716,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
      checker.configure(checkerConfig);
      checker.addListener(getBriefUtLogger());
  
@@ -14616,7 +14859,7 @@
      checker.clearCache();
      // invoke destroy to persist cache
      final PropertyCacheFile cache = TestUtil.getInternalState(checker, "cacheFile");
-@@ -726,7 +727,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -726,7 +731,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14625,7 +14868,7 @@
      final Checker checker = new Checker();
      checker.setFileExtensions(".test1", "test2");
      final String[] actual = TestUtil.getInternalState(checker, "fileExtensions");
-@@ -736,7 +737,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -736,7 +741,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14634,7 +14877,7 @@
      // The idea of the test is to check that when cache file is not set,
      // the invocation of clearCache method does not throw an exception.
      final Checker checker = new Checker();
-@@ -755,7 +756,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -755,7 +760,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     *     does not require serialization
     */
    @Test
@@ -14643,7 +14886,7 @@
      // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
      final String errorMessage =
          "Java Virtual Machine is broken"
-@@ -811,7 +812,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -811,7 +816,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     *     does not require serialization
     */
    @Test
@@ -14652,7 +14895,7 @@
      // Assume that I/O error is happened when we try to invoke 'lastModified()' method.
      final String errorMessage =
          "Java Virtual Machine is broken"
-@@ -869,8 +870,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -869,18 +874,18 @@ public class CheckerTest extends AbstractModuleTestSupport {
  
    /** It is OK to have long test method name here as it describes the test purpose. */
    @Test
@@ -14662,7 +14905,20 @@
      assertWithMessage("ExternalResourceHolder has changed its parent")
          .that(ExternalResourceHolder.class.isAssignableFrom(DummyFilter.class))
          .isFalse();
-@@ -915,8 +915,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     final DefaultConfiguration filterConfig = createModuleConfig(DummyFilter.class);
+ 
+     final DefaultConfiguration checkerConfig = createRootConfig(filterConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+-    final String pathToEmptyFile = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String pathToEmptyFile =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+ 
+     execute(checkerConfig, pathToEmptyFile);
+     final Properties cacheAfterFirstRun = new Properties();
+@@ -915,8 +920,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    /** It is OK to have long test method name here as it describes the test purpose. */
    // -@cs[ExecutableStatementCount] This test needs to verify many things.
    @Test
@@ -14672,7 +14928,26 @@
      // Use case (https://github.com/checkstyle/checkstyle/pull/3092#issuecomment-218162436):
      // Imagine that cache exists in a file. New version of Checkstyle appear.
      // New release contains update to a some check to have additional external resource.
-@@ -996,7 +995,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -930,7 +934,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     check.setFirstExternalResourceLocation(firstExternalResourceLocation);
+ 
+     final DefaultConfiguration checkerConfig = createRootConfig(null);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+     final Checker checker = new Checker();
+@@ -940,7 +944,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     checker.configure(checkerConfig);
+     checker.addListener(getBriefUtLogger());
+ 
+-    final String pathToEmptyFile = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String pathToEmptyFile =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+ 
+     execute(checker, pathToEmptyFile);
+     final Properties cacheAfterFirstRun = new Properties();
+@@ -996,7 +1001,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14681,16 +14956,27 @@
      final DefaultConfiguration checkConfig1 =
          createModuleConfig(CheckWhichDoesNotRequireCommentNodes.class);
      final DefaultConfiguration checkConfig2 =
-@@ -1015,7 +1014,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1015,8 +1020,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
 -  public void testCacheOnViolationSuppression() throws Exception {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 +  void cacheOnViolationSuppression() throws Exception {
-     final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
      final DefaultConfiguration violationCheck =
          createModuleConfig(DummyFileSetViolationCheck.class);
-@@ -1043,7 +1042,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+ 
+@@ -1028,7 +1033,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     checkerConfig.addChild(filterConfig);
+ 
+     final String fileViolationPath =
+-        File.createTempFile("ViolationFile", ".java", temporaryFolder).getPath();
++        Files.createTempFile(temporaryFolder.toPath(), "ViolationFile", ".java").toFile().getPath();
+ 
+     execute(checkerConfig, fileViolationPath);
+ 
+@@ -1043,7 +1048,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14699,16 +14985,18 @@
      final DefaultConfiguration checkConfig = createModuleConfig(CheckWhichThrowsError.class);
      final String filePath = getPath("InputChecker.java");
      try {
-@@ -1057,7 +1056,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1057,8 +1062,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
 -  public void testExceptionWithCache() throws Exception {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 +  void exceptionWithCache() throws Exception {
-     final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
  
      final DefaultConfiguration checkConfig = createModuleConfig(CheckWhichThrowsError.class);
-@@ -1074,7 +1073,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+ 
+@@ -1074,7 +1079,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
  
      final String filePath = getPath("InputChecker.java");
      try {
@@ -14717,25 +15005,29 @@
        assertWithMessage("Exception is expected").fail();
      } catch (CheckstyleException ex) {
        assertWithMessage("Error message is not expected")
-@@ -1102,7 +1101,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1102,8 +1107,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     *     does not require serialization
     */
    @Test
 -  public void testCatchErrorWithCache() throws Exception {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 +  void catchErrorWithCache() throws Exception {
-     final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
  
      final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
-@@ -1178,7 +1177,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     checkerConfig.addProperty("charset", StandardCharsets.UTF_8.name());
+@@ -1178,8 +1183,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     *     does not require serialization
     */
    @Test
 -  public void testCatchErrorWithCacheWithNoFileName() throws Exception {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 +  void catchErrorWithCacheWithNoFileName() throws Exception {
-     final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
  
      final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
-@@ -1249,7 +1248,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     checkerConfig.addProperty("charset", StandardCharsets.UTF_8.name());
+@@ -1249,7 +1254,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
     *     does not require serialization
     */
    @Test
@@ -14744,16 +15036,18 @@
      final String errorMessage = "Security Exception";
      final RuntimeException expectedError = new SecurityException(errorMessage);
  
-@@ -1297,7 +1296,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1297,8 +1302,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
     *     does not require serialization
     */
    @Test
 -  public void testExceptionWithCacheAndNoFileName() throws Exception {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 +  void exceptionWithCacheAndNoFileName() throws Exception {
-     final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
  
      final DefaultConfiguration checkerConfig = new DefaultConfiguration("configuration");
-@@ -1356,7 +1355,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+     checkerConfig.addProperty("charset", StandardCharsets.UTF_8.name());
+@@ -1356,7 +1361,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14762,7 +15056,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(CheckWhichThrowsError.class);
  
      final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
-@@ -1376,7 +1375,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1376,7 +1381,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14771,7 +15065,7 @@
      final String[] expected = {
        "10:17: violation", "13:33: violation",
      };
-@@ -1384,7 +1383,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1384,7 +1389,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14780,7 +15074,7 @@
      final DefaultConfiguration checkConfig =
          createModuleConfig(VerifyPositionAfterTabFileSet.class);
      final DefaultConfiguration checkerConfig = createRootConfig(checkConfig);
-@@ -1396,11 +1395,11 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1396,11 +1401,11 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14794,7 +15088,7 @@
      final List<String> expected = Arrays.asList("beginProcessing", "finishProcessing", "destroy");
      assertWithMessage("Method calls were not expected")
          .that(fileSet.getMethodCalls())
-@@ -1408,7 +1407,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1408,7 +1413,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14803,7 +15097,7 @@
      final DummyFileSet fileSet = new DummyFileSet();
      final Checker checker = new Checker();
      checker.addFileSetCheck(fileSet);
-@@ -1418,7 +1417,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1418,7 +1423,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14812,7 +15106,7 @@
      final Checker checker = new Checker();
      final DebugAuditAdapter auditAdapter = new DebugAuditAdapter();
      final PackageObjectFactory factory =
-@@ -1435,14 +1434,14 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1435,14 +1440,14 @@ public class CheckerTest extends AbstractModuleTestSupport {
      checker.setModuleFactory(factory);
      checker.setupChild(createModuleConfig(DebugAuditAdapter.class));
      // Let's try fire some events
@@ -14829,7 +15123,7 @@
      final Checker checker = new Checker();
      final TestBeforeExecutionFileFilter fileFilter = new TestBeforeExecutionFileFilter();
      final PackageObjectFactory factory =
-@@ -1458,14 +1457,14 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1458,14 +1463,14 @@ public class CheckerTest extends AbstractModuleTestSupport {
          };
      checker.setModuleFactory(factory);
      checker.setupChild(createModuleConfig(TestBeforeExecutionFileFilter.class));
@@ -14846,7 +15140,7 @@
      final Checker checker = new Checker();
      final DummyFileSet fileSet = new DummyFileSet();
      final PackageObjectFactory factory =
-@@ -1487,7 +1486,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1487,7 +1492,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
  
    // -@cs[CheckstyleTestMakeup] must use raw class to directly initialize DefaultLogger
    @Test
@@ -14855,7 +15149,16 @@
      final Checker checker = new Checker();
      try (CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
              new CloseAndFlushTestByteArrayOutputStream();
-@@ -1522,7 +1521,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1501,7 +1506,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+               testErrorOutputStream,
+               OutputStreamOptions.CLOSE));
+ 
+-      final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
++      final File tmpFile = Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile();
+ 
+       execute(checker, tmpFile.getPath());
+ 
+@@ -1522,14 +1527,14 @@ public class CheckerTest extends AbstractModuleTestSupport {
  
    // -@cs[CheckstyleTestMakeup] must use raw class to directly initialize DefaultLogger
    @Test
@@ -14864,7 +15167,15 @@
      final Checker checker = new Checker();
      try (CloseAndFlushTestByteArrayOutputStream testInfoOutputStream =
          new CloseAndFlushTestByteArrayOutputStream()) {
-@@ -1543,7 +1542,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+       checker.setModuleClassLoader(Thread.currentThread().getContextClassLoader());
+       checker.addListener(new XMLLogger(testInfoOutputStream, OutputStreamOptions.CLOSE));
+ 
+-      final File tmpFile = File.createTempFile("file", ".java", temporaryFolder);
++      final File tmpFile = Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile();
+ 
+       execute(checker, tmpFile.getPath(), tmpFile.getPath());
+ 
+@@ -1543,7 +1548,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14873,7 +15184,17 @@
      // we need to test a module with two instances, one with id and the other not
      final DefaultConfiguration moduleConfig1 = createModuleConfig(NewlineAtEndOfFileCheck.class);
      final DefaultConfiguration moduleConfig2 = createModuleConfig(NewlineAtEndOfFileCheck.class);
-@@ -1575,10 +1574,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1566,7 +1571,8 @@ public class CheckerTest extends AbstractModuleTestSupport {
+             new AuditEventDefaultFormatter());
+     checker.addListener(logger);
+ 
+-    final String path = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String path =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+     final String violationMessage =
+         getCheckMessage(NewlineAtEndOfFileCheck.class, MSG_KEY_NO_NEWLINE_EOF);
+     final String[] expected = {
+@@ -1575,10 +1581,9 @@ public class CheckerTest extends AbstractModuleTestSupport {
  
      // super.verify does not work here, for we change the logger
      out.flush();
@@ -14886,7 +15207,7 @@
        // we need to ignore the unrelated lines
        final List<String> actual =
            lnr.lines()
-@@ -1586,7 +1584,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1586,7 +1591,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
                .filter(line -> !getCheckMessage(AUDIT_FINISHED_MESSAGE).equals(line))
                .limit(expected.length)
                .sorted()
@@ -14895,7 +15216,7 @@
        Arrays.sort(expected);
  
        for (int i = 0; i < expected.length; i++) {
-@@ -1603,7 +1601,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1603,7 +1608,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14904,16 +15225,24 @@
      final Checker checker = createChecker(createModuleConfig(TranslationCheck.class));
      final OutputStream infoStream = new ByteArrayOutputStream();
      final OutputStream errorStream = new ByteArrayOutputStream();
-@@ -1616,7 +1614,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1612,11 +1617,13 @@ public class CheckerTest extends AbstractModuleTestSupport {
+             infoStream, OutputStreamOptions.CLOSE,
+             errorStream, OutputStreamOptions.CLOSE);
+     checker.addListener(loggerWithCounter);
+-    final File cacheFile = File.createTempFile("cacheFile", ".txt", temporaryFolder);
++    final File cacheFile =
++        Files.createTempFile(temporaryFolder.toPath(), "cacheFile", ".txt").toFile();
      checker.setCacheFile(cacheFile.getAbsolutePath());
  
-     final File testFile = File.createTempFile("testFile", ".java", temporaryFolder);
+-    final File testFile = File.createTempFile("testFile", ".java", temporaryFolder);
 -    final List<File> files = List.of(testFile, testFile);
++    final File testFile =
++        Files.createTempFile(temporaryFolder.toPath(), "testFile", ".java").toFile();
 +    final List<File> files = ImmutableList.of(testFile, testFile);
      checker.process(files);
  
      assertWithMessage("Cached file should not be processed twice")
-@@ -1628,7 +1626,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1628,7 +1635,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
  
    @SuppressForbidden
    @Test
@@ -14922,7 +15251,7 @@
      final String[] expected = {
        "4: " + getCheckMessage(LineLengthCheck.class, MSG_KEY, 75, 238),
      };
-@@ -1643,7 +1641,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1643,7 +1650,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -14931,7 +15260,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(CheckWhichThrowsError.class);
  
      final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
-@@ -1930,7 +1928,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
+@@ -1930,7 +1937,7 @@ public class CheckerTest extends AbstractModuleTestSupport {
      }
  
      public List<String> getMethodCalls() {
@@ -14950,9 +15279,12 @@
  import com.puppycrawl.tools.checkstyle.ConfigurationLoader.IgnoredModulesOptions;
  import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  import com.puppycrawl.tools.checkstyle.api.Configuration;
-@@ -34,7 +35,6 @@ import java.lang.reflect.Method;
+@@ -32,9 +33,8 @@ import java.io.File;
+ import java.lang.reflect.Constructor;
+ import java.lang.reflect.Method;
  import java.nio.file.Files;
- import java.nio.file.Paths;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
  import java.util.ArrayList;
 -import java.util.Collections;
  import java.util.List;
@@ -15201,7 +15533,7 @@
      try {
        ConfigurationLoader.loadConfiguration(
            ";InputConfigurationLoaderModuleIgnoreSeverity.xml",
-@@ -585,7 +584,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
+@@ -585,13 +584,13 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
    }
  
    @Test
@@ -15210,6 +15542,13 @@
      final DefaultConfiguration config =
          (DefaultConfiguration)
              ConfigurationLoader.loadConfiguration(
+                 new InputSource(
+                     Files.newInputStream(
+-                        Paths.get(getPath("InputConfigurationLoaderModuleIgnoreSeverity.xml")))),
++                        Path.of(getPath("InputConfigurationLoaderModuleIgnoreSeverity.xml")))),
+                 new PropertiesExpander(new Properties()),
+                 IgnoredModulesOptions.OMIT);
+ 
 @@ -601,7 +600,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
    }
  
@@ -15246,6 +15585,15 @@
      final Properties props = new Properties();
      props.setProperty("checkstyle.basedir", "basedir");
      final String fName = getPath("InputConfigurationLoaderChecks.xml");
+@@ -653,7 +652,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
+             ConfigurationLoader.loadConfiguration(
+                 new InputSource(
+                     Files.newInputStream(
+-                        Paths.get(getPath("InputConfigurationLoaderModuleIgnoreSeverity.xml")))),
++                        Path.of(getPath("InputConfigurationLoaderModuleIgnoreSeverity.xml")))),
+                 new PropertiesExpander(new Properties()),
+                 ConfigurationLoader.IgnoredModulesOptions.EXECUTE);
+ 
 @@ -663,7 +662,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
    }
  
@@ -15264,6 +15612,15 @@
      final String[] configFiles = {
        "InputConfigurationLoaderOldConfig0.xml",
        "InputConfigurationLoaderOldConfig1.xml",
+@@ -707,7 +706,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
+       final DefaultConfiguration config =
+           (DefaultConfiguration)
+               ConfigurationLoader.loadConfiguration(
+-                  new InputSource(Files.newInputStream(Paths.get(getPath(configFile)))),
++                  new InputSource(Files.newInputStream(Path.of(getPath(configFile)))),
+                   new PropertiesExpander(new Properties()),
+                   IgnoredModulesOptions.OMIT);
+ 
 @@ -739,7 +738,7 @@ public class ConfigurationLoaderTest extends AbstractPathTestSupport {
    }
  
@@ -16191,8 +16548,12 @@
      };
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocDetailNodeParserTest.java
-@@ -27,7 +27,7 @@ import java.nio.file.Files;
- import java.nio.file.Paths;
+@@ -24,10 +24,10 @@ import static com.google.common.truth.Truth.assertWithMessage;
+ import com.puppycrawl.tools.checkstyle.api.DetailAST;
+ import java.io.File;
+ import java.nio.file.Files;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
  import org.junit.jupiter.api.Test;
  
 -public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
@@ -16209,6 +16570,15 @@
      final DetailAST ast =
          JavaParser.parseFile(
                  new File(getPath("InputJavadocDetailNodeParser.java")),
+@@ -49,7 +49,7 @@ public class JavadocDetailNodeParserTest extends AbstractModuleTestSupport {
+     final String actual =
+         toLfLineEnding(DetailNodeTreeStringPrinter.printTree(status.getTree(), "", ""));
+     final String expected =
+-        toLfLineEnding(Files.readString(Paths.get(getPath("ExpectedJavadocDetailNodeParser.txt"))));
++        toLfLineEnding(Files.readString(Path.of(getPath("ExpectedJavadocDetailNodeParser.txt"))));
+     assertWithMessage("Invalid parse result").that(actual).isEqualTo(expected);
+   }
+ }
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/JavadocPropertiesGeneratorTest.java
 @@ -20,13 +20,13 @@
@@ -16520,15 +16890,18 @@
  import static org.junit.jupiter.api.Assumptions.assumeTrue;
  import static org.mockito.Mockito.mock;
  import static org.mockito.Mockito.mockStatic;
-@@ -40,7 +42,6 @@ import java.io.File;
+@@ -40,10 +42,8 @@ import java.io.File;
  import java.io.IOException;
  import java.io.PrintStream;
  import java.lang.reflect.Method;
 -import java.nio.charset.StandardCharsets;
  import java.nio.file.Files;
  import java.nio.file.Path;
- import java.nio.file.Paths;
-@@ -51,7 +52,6 @@ import java.util.logging.Handler;
+-import java.nio.file.Paths;
+ import java.util.ArrayList;
+ import java.util.List;
+ import java.util.Locale;
+@@ -51,7 +51,6 @@ import java.util.logging.Handler;
  import java.util.logging.Level;
  import java.util.logging.Logger;
  import java.util.regex.Pattern;
@@ -16536,7 +16909,7 @@
  import org.itsallcode.io.Capturable;
  import org.itsallcode.junit.sysextensions.SystemErrGuard;
  import org.itsallcode.junit.sysextensions.SystemErrGuard.SysErr;
-@@ -65,7 +65,7 @@ import org.mockito.MockedStatic;
+@@ -65,7 +64,7 @@ import org.mockito.MockedStatic;
  import org.mockito.Mockito;
  
  @ExtendWith({SystemErrGuard.class, SystemOutGuard.class})
@@ -16545,7 +16918,7 @@
  
    private static final String SHORT_USAGE =
        String.format(
-@@ -222,7 +222,7 @@ public class MainTest {
+@@ -222,7 +221,7 @@ public class MainTest {
     * @param systemOut wrapper for {@code System.out}
     */
    @BeforeEach
@@ -16554,7 +16927,7 @@
      systemErr.captureMuted();
      systemOut.captureMuted();
  
-@@ -247,14 +247,14 @@ public class MainTest {
+@@ -247,14 +246,14 @@ public class MainTest {
    }
  
    @Test
@@ -16571,7 +16944,7 @@
      assertMainReturnCode(0, "-V");
      assertWithMessage("Unexpected output log")
          .that(systemOut.getCapturedData())
-@@ -265,7 +265,7 @@ public class MainTest {
+@@ -265,7 +264,7 @@ public class MainTest {
    }
  
    @Test
@@ -16580,7 +16953,7 @@
      assertMainReturnCode(0, "-h");
      assertWithMessage("Unexpected output log").that(systemOut.getCapturedData()).isEqualTo(USAGE);
      assertWithMessage("Unexpected system error log")
-@@ -274,7 +274,7 @@ public class MainTest {
+@@ -274,7 +273,7 @@ public class MainTest {
    }
  
    @Test
@@ -16589,7 +16962,7 @@
      // need to specify a file:
      // <files> is defined as a required positional param;
      // picocli verifies required parameters before checking unknown options
-@@ -287,8 +287,7 @@ public class MainTest {
+@@ -287,8 +286,7 @@ public class MainTest {
    }
  
    @Test
@@ -16599,7 +16972,7 @@
      assertMainReturnCode(-1, "-q");
      // files is defined as a required positional param;
      // picocli verifies required parameters before checking unknown options
-@@ -300,7 +299,7 @@ public class MainTest {
+@@ -300,7 +298,7 @@ public class MainTest {
    }
  
    @Test
@@ -16608,7 +16981,7 @@
      assertMainReturnCode(-1, getPath("InputMain.java"));
      assertWithMessage("Unexpected output log")
          .that(systemOut.getCapturedData())
-@@ -311,8 +310,7 @@ public class MainTest {
+@@ -311,8 +309,7 @@ public class MainTest {
    }
  
    @Test
@@ -16618,7 +16991,7 @@
      assertMainReturnCode(-1, "-c", "/google_checks.xml", "NonExistentFile.java");
      assertWithMessage("Unexpected output log")
          .that(systemOut.getCapturedData())
-@@ -323,7 +321,7 @@ public class MainTest {
+@@ -323,10 +320,12 @@ public class MainTest {
    }
  
    @Test
@@ -16626,8 +16999,14 @@
 +  void existingTargetFileButWithoutReadAccess(
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) throws IOException {
      final File file =
-         File.createTempFile("testExistingTargetFileButWithoutReadAccess", null, temporaryFolder);
-@@ -342,8 +340,7 @@ public class MainTest {
+-        File.createTempFile("testExistingTargetFileButWithoutReadAccess", null, temporaryFolder);
++        Files.createTempFile(
++                temporaryFolder.toPath(), "testExistingTargetFileButWithoutReadAccess", null)
++            .toFile();
+     // skip execution if file is still readable, it is possible on some Windows machines
+     // see https://github.com/checkstyle/checkstyle/issues/7032 for details
+     assumeTrue(file.setReadable(false), "file is still readable");
+@@ -342,8 +341,7 @@ public class MainTest {
    }
  
    @Test
@@ -16637,7 +17016,7 @@
      assertMainReturnCode(
          -1, "-c", "src/main/resources/non_existent_config.xml", getPath("InputMain.java"));
      assertWithMessage("Unexpected output log")
-@@ -358,8 +355,7 @@ public class MainTest {
+@@ -358,8 +356,7 @@ public class MainTest {
    }
  
    @Test
@@ -16647,7 +17026,7 @@
      assertMainReturnCode(-1, "-c", "/google_checks.xml", "-f", "xmlp", getPath("InputMain.java"));
      assertWithMessage("Unexpected output log").that(systemOut.getCapturedData()).isEqualTo("");
      assertWithMessage("Unexpected system error log")
-@@ -372,7 +368,7 @@ public class MainTest {
+@@ -372,7 +369,7 @@ public class MainTest {
    }
  
    @Test
@@ -16656,7 +17035,7 @@
      assertMainReturnCode(
          -2, "-c", getPath("InputMainConfig-non-existent-classname.xml"), getPath("InputMain.java"));
      final String cause =
-@@ -384,7 +380,7 @@ public class MainTest {
+@@ -384,7 +381,7 @@ public class MainTest {
    }
  
    @Test
@@ -16665,7 +17044,7 @@
      assertMainReturnCode(
          0, "-c", getPath("InputMainConfig-classname.xml"), getPath("InputMain.java"));
      assertWithMessage("Unexpected output log")
-@@ -396,8 +392,8 @@ public class MainTest {
+@@ -396,8 +393,8 @@ public class MainTest {
    }
  
    @Test
@@ -16676,7 +17055,7 @@
      assertMainReturnCode(
          0, "-c", getPath("InputMainConfig-classname.xml"), "-f", "xml", getPath("InputMain.java"));
      final String expectedPath = getFilePath("InputMain.java");
-@@ -425,8 +421,7 @@ public class MainTest {
+@@ -425,8 +422,7 @@ public class MainTest {
     * @param systemOut the system output stream
     */
    @Test
@@ -16686,7 +17065,7 @@
      try (ShouldNotBeClosedStream stream = new ShouldNotBeClosedStream()) {
        System.setOut(stream);
        System.setErr(stream);
-@@ -456,7 +451,7 @@ public class MainTest {
+@@ -456,7 +452,7 @@ public class MainTest {
     * @throws Exception if there is an error.
     */
    @Test
@@ -16695,7 +17074,7 @@
      final Path path = new File(getPath("InputMain.java")).toPath();
      final OutputStreamOptions option =
          TestUtil.invokeStaticMethod(Main.class, "getOutputStreamOptions", path);
-@@ -466,8 +461,7 @@ public class MainTest {
+@@ -466,8 +462,7 @@ public class MainTest {
    }
  
    @Test
@@ -16705,7 +17084,7 @@
      assertMainReturnCode(
          0,
          "-c",
-@@ -484,8 +478,8 @@ public class MainTest {
+@@ -484,8 +479,8 @@ public class MainTest {
    }
  
    @Test
@@ -16716,7 +17095,7 @@
      assertMainReturnCode(
          0, "-c", getPath("InputMainConfig-classname2.xml"), getPath("InputMain.java"));
      final Violation invalidPatternMessageMain =
-@@ -529,7 +523,7 @@ public class MainTest {
+@@ -529,7 +524,7 @@ public class MainTest {
    }
  
    @Test
@@ -16725,7 +17104,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      System.setProperty(
          "org.checkstyle.google.suppressionxpathfilter.config",
-@@ -545,7 +539,7 @@ public class MainTest {
+@@ -545,7 +540,7 @@ public class MainTest {
    }
  
    @Test
@@ -16734,7 +17113,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      System.setProperty(
          "org.checkstyle.google.suppressionfilter.config",
-@@ -561,8 +555,8 @@ public class MainTest {
+@@ -561,8 +556,8 @@ public class MainTest {
    }
  
    @Test
@@ -16745,7 +17124,7 @@
      assertMainReturnCode(
          2, "-c", getPath("InputMainConfig-classname2-error.xml"), getPath("InputMain.java"));
      final Violation errorCounterTwoMessage =
-@@ -622,8 +616,8 @@ public class MainTest {
+@@ -622,8 +617,8 @@ public class MainTest {
     * @throws Exception should not throw anything
     */
    @Test
@@ -16756,7 +17135,7 @@
      assertMainReturnCode(
          1, "-c", getPath("InputMainConfig-classname2-error.xml"), getPath("InputMain1.java"));
      final Violation errorCounterTwoMessage =
-@@ -662,7 +656,7 @@ public class MainTest {
+@@ -662,7 +657,7 @@ public class MainTest {
    }
  
    @Test
@@ -16765,7 +17144,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) throws Exception {
      assertMainReturnCode(1, "-c", "/sun_checks.xml", getPath("InputMain1.java"));
      final Violation errorCounterTwoMessage =
-@@ -697,7 +691,7 @@ public class MainTest {
+@@ -697,7 +692,7 @@ public class MainTest {
    }
  
    @Test
@@ -16774,7 +17153,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(
          0,
-@@ -715,7 +709,7 @@ public class MainTest {
+@@ -715,10 +710,12 @@ public class MainTest {
    }
  
    @Test
@@ -16782,8 +17161,14 @@
 +  void existingTargetFilePlainOutputToFile(
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) throws Exception {
      final String outputFile =
-         File.createTempFile("file", ".output", temporaryFolder).getCanonicalPath();
-@@ -736,7 +730,7 @@ public class MainTest {
+-        File.createTempFile("file", ".output", temporaryFolder).getCanonicalPath();
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".output")
++            .toFile()
++            .getCanonicalPath();
+     assertWithMessage("File must exist").that(new File(outputFile).exists()).isTrue();
+     assertMainReturnCode(
+         0,
+@@ -736,7 +733,7 @@ public class MainTest {
    }
  
    @Test
@@ -16792,7 +17177,7 @@
      final String outputFile = new File(temporaryFolder, "nonexistent.out").getCanonicalPath();
      assertWithMessage("File must not exist").that(new File(outputFile).exists()).isFalse();
      assertMainReturnCode(
-@@ -752,7 +746,7 @@ public class MainTest {
+@@ -752,7 +749,7 @@ public class MainTest {
    }
  
    @Test
@@ -16801,7 +17186,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(
          0,
-@@ -770,7 +764,7 @@ public class MainTest {
+@@ -770,7 +767,7 @@ public class MainTest {
    }
  
    @Test
@@ -16810,7 +17195,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(
          0,
-@@ -789,7 +783,7 @@ public class MainTest {
+@@ -789,7 +786,7 @@ public class MainTest {
    }
  
    @Test
@@ -16819,7 +17204,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(
          -2,
-@@ -806,7 +800,7 @@ public class MainTest {
+@@ -806,7 +803,7 @@ public class MainTest {
    }
  
    @Test
@@ -16828,7 +17213,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(
          -1,
-@@ -824,7 +818,7 @@ public class MainTest {
+@@ -824,7 +821,7 @@ public class MainTest {
    }
  
    @Test
@@ -16837,7 +17222,7 @@
      assertMainReturnCode(
          -2, "-c", getPath("InputMainConfig-Incorrect.xml"), getPath("InputMain.java"));
      final String errorOutput =
-@@ -836,7 +830,7 @@ public class MainTest {
+@@ -836,7 +833,7 @@ public class MainTest {
    }
  
    @Test
@@ -16846,7 +17231,7 @@
      assertMainReturnCode(
          -2, "-c", getPath("InputMainConfig-incorrectChildren.xml"), getPath("InputMain.java"));
      final String errorOutput =
-@@ -849,7 +843,7 @@ public class MainTest {
+@@ -849,7 +846,7 @@ public class MainTest {
    }
  
    @Test
@@ -16855,7 +17240,7 @@
      assertMainReturnCode(
          -2, "-c", getPath("InputMainConfig-incorrectChildren2.xml"), getPath("InputMain.java"));
      final String errorOutput =
-@@ -863,7 +857,7 @@ public class MainTest {
+@@ -863,7 +860,7 @@ public class MainTest {
    }
  
    @Test
@@ -16864,7 +17249,7 @@
      final Class<?>[] param = new Class<?>[1];
      param[0] = File.class;
      final Class<?> cliOptionsClass = Class.forName(Main.class.getName());
-@@ -905,8 +899,8 @@ public class MainTest {
+@@ -905,8 +902,8 @@ public class MainTest {
    }
  
    @Test
@@ -16875,7 +17260,7 @@
      // we just reference there all violations
      final String[][] outputValues = {
        {"InputMainComplexityOverflow", "1", "172"},
-@@ -953,7 +947,7 @@ public class MainTest {
+@@ -953,7 +950,7 @@ public class MainTest {
     *     does not require serialization
     */
    @Test
@@ -16884,7 +17269,7 @@
      final File fileMock =
          new File("") {
            private static final long serialVersionUID = 1L;
-@@ -987,7 +981,7 @@ public class MainTest {
+@@ -987,7 +984,7 @@ public class MainTest {
     *     does not require serialization
     */
    @Test
@@ -16893,7 +17278,7 @@
      final File[] nullResult = null;
      final File fileMock =
          new File("") {
-@@ -1015,7 +1009,7 @@ public class MainTest {
+@@ -1015,7 +1012,7 @@ public class MainTest {
    }
  
    @Test
@@ -16902,7 +17287,7 @@
      // We put xml as source to cause parse exception
      assertMainReturnCode(
          -2,
-@@ -1033,7 +1027,7 @@ public class MainTest {
+@@ -1033,7 +1030,7 @@ public class MainTest {
    }
  
    @Test
@@ -16911,7 +17296,7 @@
      assertMainReturnCode(-2, "-t", getNonCompilablePath("InputMainIncorrectClass.java"));
  
      assertWithMessage("First line of exception message should not contain lexer error.")
-@@ -1042,7 +1036,7 @@ public class MainTest {
+@@ -1042,7 +1039,7 @@ public class MainTest {
    }
  
    @Test
@@ -16920,7 +17305,7 @@
      assertMainReturnCode(-2, "-t", getNonCompilablePath("InputMainIncorrectClass.java"));
      final String capturedData = systemErr.getCapturedData();
  
-@@ -1057,8 +1051,7 @@ public class MainTest {
+@@ -1057,8 +1054,7 @@ public class MainTest {
    }
  
    @Test
@@ -16930,7 +17315,7 @@
      assertMainReturnCode(-1, "-t", getPath(""));
      assertWithMessage("Unexpected output log")
          .that(systemOut.getCapturedData())
-@@ -1069,7 +1062,7 @@ public class MainTest {
+@@ -1069,7 +1065,7 @@ public class MainTest {
    }
  
    @Test
@@ -16939,7 +17324,7 @@
      final String expected =
          addEndOfLine(
              "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
-@@ -1111,7 +1104,7 @@ public class MainTest {
+@@ -1111,7 +1107,7 @@ public class MainTest {
    }
  
    @Test
@@ -16948,7 +17333,7 @@
      final String expected =
          addEndOfLine(
              "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
-@@ -1136,8 +1129,7 @@ public class MainTest {
+@@ -1136,8 +1132,7 @@ public class MainTest {
    }
  
    @Test
@@ -16958,7 +17343,7 @@
      final String expected =
          addEndOfLine(
              "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
-@@ -1159,8 +1151,7 @@ public class MainTest {
+@@ -1159,8 +1154,7 @@ public class MainTest {
    }
  
    @Test
@@ -16968,7 +17353,7 @@
      final String expected = addEndOfLine("COMPILATION_UNIT -> COMPILATION_UNIT [1:0]");
      assertMainReturnCode(0, "-b", "/COMPILATION_UNIT", getPath("InputMainXPath.java"));
      assertWithMessage("Unexpected output log")
-@@ -1172,7 +1163,7 @@ public class MainTest {
+@@ -1172,7 +1166,7 @@ public class MainTest {
    }
  
    @Test
@@ -16977,7 +17362,7 @@
      final String expected =
          addEndOfLine(
              "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
-@@ -1194,7 +1185,7 @@ public class MainTest {
+@@ -1194,7 +1188,7 @@ public class MainTest {
    }
  
    @Test
@@ -16986,7 +17371,7 @@
      final String expected =
          addEndOfLine(
              "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
-@@ -1220,7 +1211,7 @@ public class MainTest {
+@@ -1220,7 +1214,7 @@ public class MainTest {
    }
  
    @Test
@@ -16995,7 +17380,7 @@
      final String invalidXpath =
          "\\/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='Two']]" + "//METHOD_DEF";
      final String filePath = getFilePath("InputMainXPath.java");
-@@ -1238,8 +1229,7 @@ public class MainTest {
+@@ -1238,8 +1232,7 @@ public class MainTest {
    }
  
    @Test
@@ -17005,7 +17390,7 @@
      final String expected =
          addEndOfLine(
              "COMPILATION_UNIT -> COMPILATION_UNIT [1:0]",
-@@ -1293,7 +1283,7 @@ public class MainTest {
+@@ -1293,10 +1286,10 @@ public class MainTest {
     * @noinspectionreason RedundantThrows - false positive
     */
    @Test
@@ -17013,8 +17398,12 @@
 +  void printTreeJavadocOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
        throws IOException {
      final String expected =
-         Files.readString(Paths.get(getPath("InputMainExpectedInputJavadocComment.txt")))
-@@ -1311,8 +1301,7 @@ public class MainTest {
+-        Files.readString(Paths.get(getPath("InputMainExpectedInputJavadocComment.txt")))
++        Files.readString(Path.of(getPath("InputMainExpectedInputJavadocComment.txt")))
+             .replaceAll("\\\\r\\\\n", "\\\\n")
+             .replaceAll("\r\n", "\n");
+ 
+@@ -1311,8 +1304,7 @@ public class MainTest {
    }
  
    @Test
@@ -17024,7 +17413,7 @@
      final String expected =
          addEndOfLine(
              "/COMPILATION_UNIT/CLASS_DEF[./IDENT[@text='InputMainSuppressionsStringPrinter']]",
-@@ -1331,7 +1320,7 @@ public class MainTest {
+@@ -1331,7 +1323,7 @@ public class MainTest {
    }
  
    @Test
@@ -17033,7 +17422,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      final String expected =
          addEndOfLine(
-@@ -1363,7 +1352,7 @@ public class MainTest {
+@@ -1363,7 +1355,7 @@ public class MainTest {
    }
  
    @Test
@@ -17042,7 +17431,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(-1, "-c", "/google_checks.xml", getPath(""), "-s", "2:4");
      assertWithMessage("Unexpected output log")
-@@ -1375,7 +1364,7 @@ public class MainTest {
+@@ -1375,7 +1367,7 @@ public class MainTest {
    }
  
    @Test
@@ -17051,7 +17440,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(
          -1, "-p", getPath("InputMainMycheckstyle.properties"), "-s", "2:4", getPath(""));
-@@ -1388,7 +1377,7 @@ public class MainTest {
+@@ -1388,7 +1380,7 @@ public class MainTest {
    }
  
    @Test
@@ -17060,7 +17449,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(-1, "-f", "plain", "-s", "2:4", getPath(""));
      assertWithMessage("Unexpected output log")
-@@ -1400,7 +1389,7 @@ public class MainTest {
+@@ -1400,7 +1392,7 @@ public class MainTest {
    }
  
    @Test
@@ -17069,7 +17458,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) throws IOException {
      final String outputPath = new File(temporaryFolder, "file.output").getCanonicalPath();
  
-@@ -1414,7 +1403,7 @@ public class MainTest {
+@@ -1414,7 +1406,7 @@ public class MainTest {
    }
  
    @Test
@@ -17078,7 +17467,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      assertMainReturnCode(-1, "-s", "2:4", getPath(""), getPath(""));
      assertWithMessage("Unexpected output log")
-@@ -1427,7 +1416,7 @@ public class MainTest {
+@@ -1427,7 +1419,7 @@ public class MainTest {
    }
  
    @Test
@@ -17087,7 +17476,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      final String expected =
          addEndOfLine(
-@@ -1546,7 +1535,7 @@ public class MainTest {
+@@ -1546,7 +1538,7 @@ public class MainTest {
    }
  
    @Test
@@ -17096,7 +17485,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      final String expected =
          addEndOfLine(
-@@ -1593,7 +1582,7 @@ public class MainTest {
+@@ -1593,7 +1585,7 @@ public class MainTest {
    }
  
    @Test
@@ -17105,7 +17494,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      final String expected = "";
  
-@@ -1612,8 +1601,7 @@ public class MainTest {
+@@ -1612,8 +1604,7 @@ public class MainTest {
    }
  
    @Test
@@ -17115,7 +17504,7 @@
      final String expected =
          addEndOfLine(
              "<?xml version=\"1.0\" encoding=\"UTF-8\"?>",
-@@ -1639,7 +1627,7 @@ public class MainTest {
+@@ -1639,7 +1630,7 @@ public class MainTest {
          "--generate-xpath-suppression",
          getPath("InputMainGenerateXpathSuppressionsTabWidth.java"));
      try (BufferedReader br = Files.newBufferedReader(file.toPath())) {
@@ -17124,7 +17513,7 @@
        assertWithMessage("Unexpected output log").that(fileContent).isEqualTo(expected);
        assertWithMessage("Unexpected system error log")
            .that(systemErr.getCapturedData())
-@@ -1648,7 +1636,7 @@ public class MainTest {
+@@ -1648,7 +1639,7 @@ public class MainTest {
    }
  
    @Test
@@ -17133,7 +17522,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      final String expected =
          addEndOfLine(
-@@ -1681,7 +1669,7 @@ public class MainTest {
+@@ -1681,7 +1672,7 @@ public class MainTest {
    }
  
    @Test
@@ -17142,7 +17531,7 @@
        @SysErr Capturable systemErr, @SysOut Capturable systemOut) {
      final String expected = "";
  
-@@ -1711,7 +1699,7 @@ public class MainTest {
+@@ -1711,11 +1702,10 @@ public class MainTest {
     * @noinspectionreason RedundantThrows - false positive
     */
    @Test
@@ -17150,8 +17539,13 @@
 +  void printFullTreeOption(@SysErr Capturable systemErr, @SysOut Capturable systemOut)
        throws IOException {
      final String expected =
-         Files.readString(
-@@ -1730,8 +1718,7 @@ public class MainTest {
+-        Files.readString(
+-                Paths.get(getPath("InputMainExpectedInputAstTreeStringPrinterJavadoc.txt")))
++        Files.readString(Path.of(getPath("InputMainExpectedInputAstTreeStringPrinterJavadoc.txt")))
+             .replaceAll("\\\\r\\\\n", "\\\\n")
+             .replaceAll("\r\n", "\n");
+ 
+@@ -1730,8 +1720,7 @@ public class MainTest {
    }
  
    @Test
@@ -17161,7 +17555,7 @@
      assertMainReturnCode(-1, "-c", "/google_checks.xml", "-t", getPath(""));
      assertWithMessage("Unexpected output log")
          .that(systemOut.getCapturedData())
-@@ -1742,8 +1729,7 @@ public class MainTest {
+@@ -1742,8 +1731,7 @@ public class MainTest {
    }
  
    @Test
@@ -17171,7 +17565,7 @@
      assertMainReturnCode(-1, "-p", getPath("InputMainMycheckstyle.properties"), "-t", getPath(""));
      assertWithMessage("Unexpected output log")
          .that(systemOut.getCapturedData())
-@@ -1754,8 +1740,7 @@ public class MainTest {
+@@ -1754,8 +1742,7 @@ public class MainTest {
    }
  
    @Test
@@ -17181,7 +17575,7 @@
      assertMainReturnCode(-1, "-f", "plain", "-t", getPath(""));
      assertWithMessage("Unexpected output log")
          .that(systemOut.getCapturedData())
-@@ -1766,7 +1751,7 @@ public class MainTest {
+@@ -1766,7 +1753,7 @@ public class MainTest {
    }
  
    @Test
@@ -17190,7 +17584,7 @@
        throws IOException {
      final String outputPath = new File(temporaryFolder, "file.output").getCanonicalPath();
  
-@@ -1780,7 +1765,7 @@ public class MainTest {
+@@ -1780,7 +1767,7 @@ public class MainTest {
    }
  
    @Test
@@ -17199,7 +17593,7 @@
        throws IOException {
      final String outputPath = new File(temporaryFolder, "file.output").getCanonicalPath();
  
-@@ -1794,7 +1779,7 @@ public class MainTest {
+@@ -1794,7 +1781,7 @@ public class MainTest {
    }
  
    @Test
@@ -17208,7 +17602,7 @@
      assertMainReturnCode(0, "-c", "/google_checks.xml", getPath("InputMain.java"), "-d");
      assertWithMessage("Unexpected system error log")
          .that(systemErr.getCapturedData())
-@@ -1802,7 +1787,7 @@ public class MainTest {
+@@ -1802,7 +1789,7 @@ public class MainTest {
    }
  
    @Test
@@ -17217,7 +17611,7 @@
        throws IOException {
      final String filePath = getFilePath("");
      assertMainReturnCode(-1, "-c", "/google_checks.xml", filePath, "-e", filePath);
-@@ -1815,7 +1800,7 @@ public class MainTest {
+@@ -1815,7 +1802,7 @@ public class MainTest {
    }
  
    @Test
@@ -17226,7 +17620,7 @@
        throws IOException {
      final String filePath = getFilePath("InputMain.java");
      assertMainReturnCode(-1, "-c", "/google_checks.xml", filePath, "-e", filePath);
-@@ -1828,7 +1813,7 @@ public class MainTest {
+@@ -1828,7 +1815,7 @@ public class MainTest {
    }
  
    @Test
@@ -17235,7 +17629,7 @@
        throws IOException {
      final String filePath = getFilePath("");
      assertMainReturnCode(-1, "-c", "/google_checks.xml", filePath, "-x", ".");
-@@ -1839,8 +1824,8 @@ public class MainTest {
+@@ -1839,8 +1826,8 @@ public class MainTest {
    }
  
    @Test
@@ -17246,7 +17640,7 @@
      final String filePath = getFilePath("InputMain.java");
      assertMainReturnCode(-1, "-c", "/google_checks.xml", filePath, "-x", ".");
      assertWithMessage("Unexpected output log")
-@@ -1849,9 +1834,9 @@ public class MainTest {
+@@ -1849,9 +1836,9 @@ public class MainTest {
      assertWithMessage("Unexpected output log").that(systemErr.getCapturedData()).isEqualTo("");
    }
  
@@ -17258,7 +17652,7 @@
      final Class<?> optionsClass = Class.forName(Main.class.getName());
      final Method method = optionsClass.getDeclaredMethod("listFiles", File.class, List.class);
      method.setAccessible(true);
-@@ -1863,7 +1848,7 @@ public class MainTest {
+@@ -1863,7 +1850,7 @@ public class MainTest {
    }
  
    @Test
@@ -17267,7 +17661,7 @@
      TestRootModuleChecker.reset();
  
      assertMainReturnCode(
-@@ -1879,7 +1864,7 @@ public class MainTest {
+@@ -1879,7 +1866,7 @@ public class MainTest {
    }
  
    @Test
@@ -17276,7 +17670,7 @@
      TestRootModuleChecker.reset();
      assertMainReturnCode(
          -2,
-@@ -1908,8 +1893,7 @@ public class MainTest {
+@@ -1908,8 +1895,7 @@ public class MainTest {
    }
  
    @Test
@@ -17286,7 +17680,7 @@
      assertMainReturnCode(
          -2,
          "-c",
-@@ -1925,8 +1909,7 @@ public class MainTest {
+@@ -1925,8 +1911,7 @@ public class MainTest {
    }
  
    @Test
@@ -17296,7 +17690,7 @@
      assertMainReturnCode(
          -2,
          "-c",
-@@ -1946,15 +1929,14 @@ public class MainTest {
+@@ -1946,15 +1931,14 @@ public class MainTest {
    }
  
    @Test
@@ -17314,7 +17708,7 @@
      assertMainReturnCode(-1);
      final String usage = "Missing required parameter: '<files>'" + EOL + SHORT_USAGE;
      assertWithMessage("Unexpected output log").that(systemOut.getCapturedData()).isEqualTo("");
-@@ -1964,13 +1946,13 @@ public class MainTest {
+@@ -1964,13 +1948,13 @@ public class MainTest {
    }
  
    @Test
@@ -17330,7 +17724,7 @@
      final ByteArrayOutputStream out = new ByteArrayOutputStream();
      final AuditListener listener =
          Main.OutputFormat.XML.createListener(out, OutputStreamOptions.CLOSE);
-@@ -1978,7 +1960,7 @@ public class MainTest {
+@@ -1978,7 +1962,7 @@ public class MainTest {
    }
  
    @Test
@@ -17339,7 +17733,7 @@
      final ByteArrayOutputStream out = new ByteArrayOutputStream();
      final AuditListener listener =
          Main.OutputFormat.SARIF.createListener(out, OutputStreamOptions.CLOSE);
-@@ -1986,7 +1968,7 @@ public class MainTest {
+@@ -1986,7 +1970,7 @@ public class MainTest {
    }
  
    @Test
@@ -17348,7 +17742,7 @@
      final ByteArrayOutputStream out = new ByteArrayOutputStream();
      final AuditListener listener =
          Main.OutputFormat.PLAIN.createListener(out, OutputStreamOptions.CLOSE);
-@@ -2025,7 +2007,7 @@ public class MainTest {
+@@ -2025,7 +2009,7 @@ public class MainTest {
      private boolean isClosed;
  
      private ShouldNotBeClosedStream() {
@@ -17920,7 +18314,15 @@
  import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
  import com.puppycrawl.tools.checkstyle.api.Configuration;
  import com.puppycrawl.tools.checkstyle.internal.utils.TestUtil;
-@@ -54,7 +53,7 @@ import org.junit.jupiter.params.ParameterizedTest;
+@@ -39,7 +38,6 @@ import java.io.ObjectOutputStream;
+ import java.net.URI;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.security.MessageDigest;
+ import java.security.NoSuchAlgorithmException;
+ import java.util.HashSet;
+@@ -54,7 +52,7 @@ import org.junit.jupiter.params.ParameterizedTest;
  import org.junit.jupiter.params.provider.ValueSource;
  import org.mockito.MockedStatic;
  
@@ -17929,7 +18331,7 @@
  
    @TempDir public File temporaryFolder;
  
-@@ -64,7 +63,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -64,7 +62,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
@@ -17938,15 +18340,19 @@
      try {
        final Object test = new PropertyCacheFile(null, "");
        assertWithMessage("exception expected but got " + test).fail();
-@@ -85,7 +84,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -85,9 +83,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testInCache() throws IOException {
 +  void inCache() throws IOException {
      final Configuration config = new DefaultConfiguration("myName");
-     final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
+-    final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
      final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+     cache.put("myFile", 1);
+     assertWithMessage("Should return true when file is in cache")
 @@ -102,7 +101,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
@@ -17965,25 +18371,33 @@
      final Configuration config = new DefaultConfiguration("myName");
      final PropertyCacheFile cache =
          new PropertyCacheFile(config, getPath("InputPropertyCacheFile"));
-@@ -136,7 +135,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -136,9 +135,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testConfigHashOnReset() throws IOException {
 +  void configHashOnReset() throws IOException {
      final Configuration config = new DefaultConfiguration("myName");
-     final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
+-    final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
      final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
-@@ -154,7 +153,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+ 
+     cache.load();
+@@ -154,9 +154,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testConfigHashRemainsOnResetExternalResources() throws IOException {
 +  void configHashRemainsOnResetExternalResources() throws IOException {
      final Configuration config = new DefaultConfiguration("myName");
-     final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
+-    final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
      final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
-@@ -180,7 +179,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+ 
+     // create cache with one file
+@@ -180,11 +181,12 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
@@ -17991,17 +18405,28 @@
 +  void cacheRemainsWhenExternalResourceTheSame() throws IOException {
      final Configuration config = new DefaultConfiguration("myName");
      final String externalResourcePath =
-         File.createTempFile("junit", null, temporaryFolder).getPath();
-@@ -209,7 +208,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+-        File.createTempFile("junit", null, temporaryFolder).getPath();
+-    final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
+     final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
+ 
+     // pre-populate with cache with resources
+@@ -209,9 +211,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testExternalResourceIsSavedInCache() throws Exception {
 +  void externalResourceIsSavedInCache() throws Exception {
      final Configuration config = new DefaultConfiguration("myName");
-     final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
+-    final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
      final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
-@@ -223,7 +222,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+ 
+     cache.load();
+@@ -223,7 +226,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
  
      final MessageDigest digest = MessageDigest.getInstance("SHA-1");
      final URI uri = CommonUtil.getUriByFilename(pathToResource);
@@ -18010,7 +18435,7 @@
      final ByteArrayOutputStream out = new ByteArrayOutputStream();
      try (ObjectOutputStream oos = new ObjectOutputStream(out)) {
        oos.writeObject(input);
-@@ -237,7 +236,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -237,7 +240,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
@@ -18019,7 +18444,7 @@
      final Configuration config = new DefaultConfiguration("myName");
      final String filePath =
          String.format(Locale.ENGLISH, "%s%2$stemp%2$scache.temp", temporaryFolder, File.separator);
-@@ -250,7 +249,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -250,10 +253,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
@@ -18027,8 +18452,12 @@
 +  void pathToCacheContainsOnlyFileName() throws IOException {
      final Configuration config = new DefaultConfiguration("myName");
      final String fileName = "temp.cache";
-     final Path filePath = Paths.get(fileName);
-@@ -263,9 +262,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+-    final Path filePath = Paths.get(fileName);
++    final Path filePath = Path.of(fileName);
+     final PropertyCacheFile cache = new PropertyCacheFile(config, fileName);
+ 
+     // no exception expected
+@@ -263,9 +266,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
      Files.delete(filePath);
    }
  
@@ -18040,7 +18469,7 @@
      final Path tempDirectory = temporaryFolder.toPath();
      final Path symbolicLinkDirectory = temporaryFolder.toPath().resolve("symbolicLink");
      Files.createSymbolicLink(symbolicLinkDirectory, tempDirectory);
-@@ -282,9 +281,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -282,9 +285,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
          .isTrue();
    }
  
@@ -18052,7 +18481,7 @@
      final Path tempDirectory = temporaryFolder.toPath();
      final Path symbolicLinkDirectory = temporaryFolder.toPath().resolve("symbolicLink");
      Files.createSymbolicLink(symbolicLinkDirectory, tempDirectory);
-@@ -301,9 +300,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -301,9 +304,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
          .isTrue();
    }
  
@@ -18064,7 +18493,7 @@
      final Path tempFile = Files.createTempFile("tempFile", null);
      final Path symbolicLinkDirectory = temporaryFolder.toPath();
      final Path symbolicLink = symbolicLinkDirectory.resolve("symbolicLink");
-@@ -323,9 +322,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -323,9 +326,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
          .contains(expectedMessage);
    }
  
@@ -18076,7 +18505,7 @@
      final Path actualDirectory = temporaryFolder.toPath();
      final Path firstSymbolicLink = temporaryFolder.toPath().resolve("firstLink");
      Files.createSymbolicLink(firstSymbolicLink, actualDirectory);
-@@ -346,7 +345,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+@@ -346,11 +349,11 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
@@ -18085,35 +18514,50 @@
      final DefaultConfiguration config = new DefaultConfiguration("myConfig");
      config.addProperty("attr", "value");
  
-@@ -392,7 +391,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     final PropertyCacheFile cache = new PropertyCacheFile(config, cacheFile.getPath());
+     cache.load();
+ 
+@@ -392,9 +395,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testNonExistentResource() throws IOException {
 +  void nonExistentResource() throws IOException {
      final Configuration config = new DefaultConfiguration("myName");
-     final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
+-    final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
      final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
-@@ -421,7 +420,7 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+ 
+     // create cache with one file
+@@ -421,9 +425,10 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testExceptionNoSuchAlgorithmException() throws Exception {
 +  void exceptionNoSuchAlgorithmException() throws Exception {
      final Configuration config = new DefaultConfiguration("myName");
-     final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
+-    final String filePath = File.createTempFile("junit", null, temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath();
      final PropertyCacheFile cache = new PropertyCacheFile(config, filePath);
-@@ -460,8 +459,8 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
+     cache.put("myFile", 1);
+ 
+@@ -460,9 +465,9 @@ public class PropertyCacheFileTest extends AbstractPathTestSupport {
     * @param rawMessages exception messages separated by ';'
     */
    @ParameterizedTest
 -  @ValueSource(strings = {"Same;Same", "First;Second"})
 -  public void testPutNonExistentExternalResource(String rawMessages) throws Exception {
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
 +  @ValueSource(strings = {"First;Second", "Same;Same"})
 +  void putNonExistentExternalResource(String rawMessages) throws Exception {
-     final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
      final String[] messages = rawMessages.split(";");
      // We mock getUriByFilename method of CommonUtil to guarantee that it will
+     // throw CheckstyleException with the specific content.
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/SarifLoggerTest.java
 @@ -20,6 +20,7 @@
@@ -18492,16 +18936,18 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
      checkConfig.addProperty("tokens", "VARIABLE_DEF, ENUM_DEF, CLASS_DEF, METHOD_DEF," + "IMPORT");
      try {
-@@ -225,7 +227,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -225,22 +227,22 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
 -  public void testOnEmptyFile() throws Exception {
 +  void onEmptyFile() throws Exception {
      final DefaultConfiguration checkConfig = createModuleConfig(HiddenFieldCheck.class);
-     final File emptyFile = File.createTempFile("file", ".java", temporaryFolder);
+-    final File emptyFile = File.createTempFile("file", ".java", temporaryFolder);
++    final File emptyFile = Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile();
      execute(checkConfig, emptyFile.getPath());
-@@ -234,7 +236,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+     final long fileSize = Files.size(emptyFile.toPath());
+     assertWithMessage("File should be empty").that(fileSize).isEqualTo(0);
    }
  
    @Test
@@ -18510,6 +18956,13 @@
      final DefaultConfiguration checkConfig = createModuleConfig(JavadocPackageCheck.class);
  
      try {
+       execute(
+           createTreeWalkerConfig(checkConfig),
+-          File.createTempFile("junit", null, temporaryFolder).getPath());
++          Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile().getPath());
+       assertWithMessage("CheckstyleException is expected").fail();
+     } catch (CheckstyleException exception) {
+       assertWithMessage("Error message is unexpected")
 @@ -250,7 +252,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
@@ -18528,16 +18981,20 @@
      final TreeWalker treeWalker = new TreeWalker();
      final DefaultConfiguration config = new DefaultConfiguration("default config");
      treeWalker.setTabWidth(1);
-@@ -284,7 +286,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -284,9 +286,10 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
 -  public void testForInvalidCheckImplementation() throws Exception {
 +  void forInvalidCheckImplementation() throws Exception {
      final DefaultConfiguration checkConfig = createModuleConfig(BadJavaDocCheck.class);
-     final String pathToEmptyFile = File.createTempFile("file", ".java", temporaryFolder).getPath();
+-    final String pathToEmptyFile = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String pathToEmptyFile =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
  
-@@ -307,7 +309,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+     try {
+       execute(checkConfig, pathToEmptyFile);
+@@ -307,7 +310,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18546,7 +19003,7 @@
      final TreeWalker treeWalker = new TreeWalker();
      final PackageObjectFactory factory =
          new PackageObjectFactory(new HashSet<>(), Thread.currentThread().getContextClassLoader());
-@@ -335,7 +337,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -335,7 +338,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18555,7 +19012,7 @@
      final TreeWalker treeWalker = new TreeWalker();
      treeWalker.setTabWidth(1);
      treeWalker.configure(new DefaultConfiguration("default config"));
-@@ -347,14 +349,14 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -347,14 +350,14 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18572,7 +19029,7 @@
      final TreeWalker treeWalker = new TreeWalker();
      treeWalker.configure(createModuleConfig(TypeNameCheck.class));
      final PackageObjectFactory factory =
-@@ -377,7 +379,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -377,7 +380,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18581,7 +19038,7 @@
      final TreeWalker treeWalker = new TreeWalker();
      treeWalker.configure(createModuleConfig(TypeNameCheck.class));
      final PackageObjectFactory factory =
-@@ -400,9 +402,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -400,9 +403,9 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18593,7 +19050,7 @@
        final String configComment =
            "/*\n"
                + "com.puppycrawl.tools.checkstyle.TreeWalkerTest"
-@@ -415,7 +417,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -415,7 +418,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18602,7 +19059,7 @@
      final TreeWalker treeWalker = new TreeWalker();
      final PackageObjectFactory factory =
          new PackageObjectFactory(new HashSet<>(), Thread.currentThread().getContextClassLoader());
-@@ -430,7 +432,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -430,7 +433,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18611,7 +19068,7 @@
      final TreeWalker treeWalker = new TreeWalker();
      treeWalker.configure(createModuleConfig(TypeNameCheck.class));
      treeWalker.configure(createModuleConfig(CommentsIndentationCheck.class));
-@@ -457,7 +459,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -457,7 +460,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18620,7 +19077,7 @@
      final TreeWalker treeWalker = new TreeWalker();
      final PackageObjectFactory factory =
          new PackageObjectFactory(new HashSet<>(), Thread.currentThread().getContextClassLoader());
-@@ -477,7 +479,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -477,7 +480,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18629,7 +19086,7 @@
  
      final String[] expected = {
        "17:17: "
-@@ -492,7 +494,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -492,7 +495,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18638,7 +19095,7 @@
  
      final String[] expected = {
        "13:9: " + getCheckMessage(WhitespaceAfterCheck.class, "ws.notFollowed", "if"),
-@@ -503,7 +505,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -503,7 +506,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18647,7 +19104,7 @@
  
      final String[] expected = {
        "15:28: "
-@@ -521,7 +523,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -521,7 +524,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18656,16 +19113,17 @@
      final TreeWalker treeWalker = new TreeWalker();
      treeWalker.setSeverity("error");
      treeWalker.setTabWidth(100);
-@@ -537,7 +539,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -537,18 +540,18 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
 -  public void testCheckInitIsCalledInTreeWalker() throws Exception {
 +  void checkInitIsCalledInTreeWalker() throws Exception {
      final DefaultConfiguration checkConfig = createModuleConfig(VerifyInitCheck.class);
-     final File file = File.createTempFile("file", ".pdf", temporaryFolder);
+-    final File file = File.createTempFile("file", ".pdf", temporaryFolder);
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "file", ".pdf").toFile();
      execute(checkConfig, file.getPath());
-@@ -545,7 +547,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+     assertWithMessage("Init was not called").that(VerifyInitCheck.isInitWasCalled()).isTrue();
    }
  
    @Test
@@ -18673,8 +19131,12 @@
 +  void checkDestroyIsCalledInTreeWalker() throws Exception {
      VerifyDestroyCheck.resetDestroyWasCalled();
      final DefaultConfiguration checkConfig = createModuleConfig(VerifyDestroyCheck.class);
-     final File file = File.createTempFile("file", ".pdf", temporaryFolder);
-@@ -556,7 +558,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+-    final File file = File.createTempFile("file", ".pdf", temporaryFolder);
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "file", ".pdf").toFile();
+     execute(checkConfig, file.getPath());
+     assertWithMessage("Destroy was not called")
+         .that(VerifyDestroyCheck.isDestroyWasCalled())
+@@ -556,10 +559,10 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18682,8 +19144,12 @@
 +  void commentCheckDestroyIsCalledInTreeWalker() throws Exception {
      VerifyDestroyCheck.resetDestroyWasCalled();
      final DefaultConfiguration checkConfig = createModuleConfig(VerifyDestroyCommentCheck.class);
-     final File file = File.createTempFile("file", ".pdf", temporaryFolder);
-@@ -567,7 +569,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+-    final File file = File.createTempFile("file", ".pdf", temporaryFolder);
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "file", ".pdf").toFile();
+     execute(checkConfig, file.getPath());
+     assertWithMessage("Destroy was not called")
+         .that(VerifyDestroyCheck.isDestroyWasCalled())
+@@ -567,17 +570,18 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18692,7 +19158,20 @@
      final DefaultConfiguration filterConfig = createModuleConfig(SuppressionXpathFilter.class);
      filterConfig.addProperty("file", getPath("InputTreeWalkerSuppressionXpathFilter.xml"));
      final DefaultConfiguration treeWalkerConfig = createModuleConfig(TreeWalker.class);
-@@ -589,7 +591,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+     treeWalkerConfig.addChild(filterConfig);
+ 
+     final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+-    final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+ 
+     execute(checkerConfig, filePath);
+     // One more time to use cache.
+@@ -589,7 +593,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18701,7 +19180,7 @@
      // test is only valid when relative paths are given
      final String filePath =
          "src/test/resources/"
-@@ -601,7 +603,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -601,7 +605,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -18710,7 +19189,20 @@
      final DefaultConfiguration checkConfig = createModuleConfig(EmptyStatementCheck.class);
      final DefaultConfiguration filterConfig =
          createModuleConfig(SuppressWithNearbyCommentFilter.class);
-@@ -626,7 +628,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -610,9 +614,10 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+     treeWalkerConfig.addChild(filterConfig);
+ 
+     final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+-    final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+ 
+     execute(checkerConfig, filePath);
+ 
+@@ -626,7 +631,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
     * @throws Exception if file is not found
     */
    @Test
@@ -18719,7 +19211,7 @@
  
      final DefaultConfiguration configuration1 = createModuleConfig(AaCheck.class);
      configuration1.addProperty("id", "2");
-@@ -637,7 +639,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
+@@ -637,7 +642,7 @@ public class TreeWalkerTest extends AbstractModuleTestSupport {
      treeWalkerConfig.addChild(configuration2);
      treeWalkerConfig.addChild(configuration1);
  
@@ -21293,7 +21785,15 @@
  import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
  import com.puppycrawl.tools.checkstyle.PropertiesExpander;
  import com.puppycrawl.tools.checkstyle.api.CheckstyleException;
-@@ -41,7 +43,6 @@ import java.util.Properties;
+@@ -29,7 +31,6 @@ import java.io.StringReader;
+ import java.lang.reflect.Modifier;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.Collections;
+@@ -41,7 +42,6 @@ import java.util.Properties;
  import java.util.Set;
  import java.util.regex.Matcher;
  import java.util.regex.Pattern;
@@ -21301,7 +21801,16 @@
  import org.xml.sax.InputSource;
  
  public final class InlineConfigParser {
-@@ -241,7 +242,7 @@ public final class InlineConfigParser {
+@@ -184,7 +184,7 @@ public final class InlineConfigParser {
+       throws Exception {
+     final TestInputConfiguration.Builder testInputConfigBuilder =
+         new TestInputConfiguration.Builder();
+-    final Path filePath = Paths.get(inputFilePath);
++    final Path filePath = Path.of(inputFilePath);
+     final List<String> lines = readFile(filePath);
+     try {
+       setModules(testInputConfigBuilder, inputFilePath, lines);
+@@ -241,7 +241,7 @@ public final class InlineConfigParser {
      return lines.stream()
          .skip(1)
          .takeWhile(line -> !line.startsWith("*/"))
@@ -31786,7 +32295,13 @@
          getNonCompilablePath("InputVisibilityModifierPackageClassName.java"), expected);
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/checks/header/HeaderCheckTest.java
-@@ -40,7 +40,7 @@ import org.junit.jupiter.api.Test;
+@@ -35,12 +35,13 @@ import java.io.File;
+ import java.io.IOException;
+ import java.io.LineNumberReader;
+ import java.net.URI;
++import java.nio.file.Files;
+ import java.util.Set;
+ import org.junit.jupiter.api.Test;
  import org.junit.jupiter.api.io.TempDir;
  import org.mockito.MockedConstruction;
  
@@ -31795,7 +32310,7 @@
  
    @TempDir public File temporaryFolder;
  
-@@ -50,7 +50,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -50,7 +51,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31804,7 +32319,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", getPath("InputHeaderjava.header"));
      checkConfig.addProperty("ignoreLines", "");
-@@ -61,7 +61,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -61,7 +62,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31813,7 +32328,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
  
      createChecker(checkConfig);
-@@ -70,7 +70,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -70,7 +71,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31822,7 +32337,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("header", "\n    \n");
  
-@@ -80,7 +80,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -80,7 +81,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31831,7 +32346,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", getPath("nonExistent.file"));
      final CheckstyleException ex =
-@@ -106,7 +106,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -106,7 +107,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31840,7 +32355,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", getPath("InputHeaderjava.header"));
      checkConfig.addProperty("charset", "XSO-8859-1");
-@@ -133,7 +133,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -133,7 +134,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31849,7 +32364,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", "");
      final CheckstyleException ex =
-@@ -161,7 +161,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -161,7 +162,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31858,7 +32373,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", null);
      final CheckstyleException ex =
-@@ -180,7 +180,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -180,7 +181,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31867,7 +32382,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", getPath("InputHeaderjava.header"));
      checkConfig.addProperty("ignoreLines", "");
-@@ -195,7 +195,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -195,7 +196,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31876,7 +32391,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", getPath("InputHeaderjava.header"));
      checkConfig.addProperty("ignoreLines", "2");
-@@ -204,7 +204,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -204,7 +205,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31885,7 +32400,7 @@
      final HeaderCheck check = new HeaderCheck();
      check.setHeader("Header");
      final IllegalArgumentException ex =
-@@ -220,7 +220,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -220,7 +221,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31894,7 +32409,7 @@
      final HeaderCheck check = new HeaderCheck();
      check.setHeaderFile(new URI("test://bad"));
  
-@@ -236,7 +236,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -236,12 +237,12 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31903,7 +32418,13 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", getPath("InputHeaderjava.header"));
  
-@@ -254,7 +254,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+     final DefaultConfiguration checkerConfig = createRootConfig(checkConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+     final String[] expected = {
+@@ -254,12 +255,12 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31912,7 +32433,13 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("header", "Test");
  
-@@ -270,7 +270,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+     final DefaultConfiguration checkerConfig = createRootConfig(checkConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+     final String[] expected = {
+@@ -270,7 +271,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31921,7 +32448,7 @@
      final DefaultConfiguration checkConfig = createModuleConfig(HeaderCheck.class);
      checkConfig.addProperty("headerFile", getPath("InputHeaderjava.header"));
      checkConfig.addProperty("ignoreLines", "4,2,3");
-@@ -279,7 +279,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -279,7 +280,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31930,7 +32457,7 @@
      final HeaderCheck check = new HeaderCheck();
      check.setHeader("Header");
      final ReflectiveOperationException ex =
-@@ -294,21 +294,21 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -294,21 +295,21 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -31955,7 +32482,7 @@
      final HeaderCheck check = new HeaderCheck();
      final URI uri = CommonUtil.getUriByFilename(getPath("InputHeaderjava.header"));
      check.setHeaderFile(uri);
-@@ -320,7 +320,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
+@@ -320,7 +321,7 @@ public class HeaderCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -33249,7 +33776,21 @@
      final DefaultConfiguration checkConfig = createModuleConfig(ImportControlCheck.class);
      checkConfig.addProperty("file", getPath("InputImportControlOneRegExp.xml"));
  
-@@ -322,35 +322,35 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+@@ -306,10 +306,11 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+     treeWalkerConfig.addChild(checkConfig);
+ 
+     final DefaultConfiguration checkerConfig = createRootConfig(treeWalkerConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+-    final String filePath = File.createTempFile("empty", ".java", temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "empty", ".java").toFile().getPath();
+ 
+     execute(checkerConfig, filePath);
+     // One more time to use cache.
+@@ -322,35 +323,35 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -33290,7 +33831,7 @@
      final String[] expected = {
        "12:1: " + getCheckMessage(MSG_DISALLOWED, "java.util.Date"),
      };
-@@ -360,7 +360,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+@@ -360,7 +361,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -33299,7 +33840,7 @@
      final String[] expected = {
        "11:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
      };
-@@ -369,7 +369,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+@@ -369,7 +370,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -33308,7 +33849,7 @@
      final String[] expected = {
        "11:1: " + getCheckMessage(MSG_DISALLOWED, "java.io.File"),
      };
-@@ -378,7 +378,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+@@ -378,7 +379,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -33317,7 +33858,7 @@
      final String[] expected = {
        "13:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
      };
-@@ -387,7 +387,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+@@ -387,7 +388,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -33326,7 +33867,7 @@
      final String file1 = getPath("InputImportControlBeginTree1.java");
      final String file2 = getPath("InputImportControlBeginTree2.java");
      final List<String> expectedFirstInput =
-@@ -399,7 +399,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+@@ -399,7 +400,7 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -33335,7 +33876,7 @@
      final String[] expected = {
        "11:1: " + getCheckMessage(MSG_DISALLOWED, "java.awt.Image"),
      };
-@@ -408,14 +408,14 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
+@@ -408,14 +409,14 @@ public class ImportControlCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -34757,14 +35298,17 @@
  
  import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
  import com.puppycrawl.tools.checkstyle.Checker;
-@@ -34,7 +36,6 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
+@@ -34,9 +36,8 @@ import com.puppycrawl.tools.checkstyle.api.Configuration;
  import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
  import java.io.BufferedReader;
  import java.io.IOException;
 -import java.nio.charset.StandardCharsets;
  import java.nio.file.Files;
- import java.nio.file.Paths;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
  import java.util.ArrayList;
+ import java.util.Arrays;
+ import java.util.List;
 @@ -46,7 +47,7 @@ import java.util.regex.Pattern;
  import org.junit.jupiter.api.Test;
  
@@ -34780,7 +35324,7 @@
      final List<IndentComment> result = new ArrayList<>();
 -    try (BufferedReader br =
 -        Files.newBufferedReader(Paths.get(aFileName), StandardCharsets.UTF_8)) {
-+    try (BufferedReader br = Files.newBufferedReader(Paths.get(aFileName), UTF_8)) {
++    try (BufferedReader br = Files.newBufferedReader(Path.of(aFileName), UTF_8)) {
        int lineNumber = 1;
        for (String line = br.readLine(); line != null; line = br.readLine()) {
          final Matcher match = LINE_WITH_COMMENT_REGEX.matcher(line);
@@ -36009,7 +36553,15 @@
  
  import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
  import com.puppycrawl.tools.checkstyle.DefaultConfiguration;
-@@ -44,7 +44,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
+@@ -35,6 +35,7 @@ import com.puppycrawl.tools.checkstyle.api.JavadocTokenTypes;
+ import com.puppycrawl.tools.checkstyle.utils.CommonUtil;
+ import com.puppycrawl.tools.checkstyle.utils.JavadocUtil;
+ import java.io.File;
++import java.nio.file.Files;
+ import org.itsallcode.io.Capturable;
+ import org.itsallcode.junit.sysextensions.SystemErrGuard;
+ import org.itsallcode.junit.sysextensions.SystemErrGuard.SysErr;
+@@ -44,7 +45,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
  import org.junit.jupiter.api.io.TempDir;
  
  @ExtendWith(SystemErrGuard.class)
@@ -36018,7 +36570,7 @@
  
    @TempDir public File temporaryFolder;
  
-@@ -63,12 +63,12 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -63,12 +64,12 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
     * @param systemErr wrapper for {@code System.err}
     */
    @BeforeEach
@@ -36033,7 +36585,7 @@
      final String[] expected = {
        "16: "
            + getCheckMessage(
-@@ -109,7 +109,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -109,7 +110,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36042,7 +36594,7 @@
      final String[] expected = {
        "8: "
            + getCheckMessage(
-@@ -123,13 +123,13 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -123,13 +124,13 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36058,7 +36610,7 @@
      final String[] expected = {
        "9: " + getCheckMessage(MSG_JAVADOC_MISSED_HTML_CLOSE, 4, "unclosedTag"),
        "16: " + getCheckMessage(MSG_JAVADOC_WRONG_SINGLETON_TAG, 35, "img"),
-@@ -139,19 +139,19 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -139,19 +140,19 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36081,7 +36633,7 @@
      final String[] expected = {
        "9: "
            + getCheckMessage(
-@@ -163,8 +163,8 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -163,8 +164,8 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36092,7 +36644,7 @@
      final String[] expectedMessagesForFile1 = {
        "9: " + getCheckMessage(MSG_JAVADOC_MISSED_HTML_CLOSE, 4, "unclosedTag"),
        "16: " + getCheckMessage(MSG_JAVADOC_WRONG_SINGLETON_TAG, 35, "img"),
-@@ -184,7 +184,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -184,7 +185,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36101,7 +36653,7 @@
      final String[] expected = {
        "9: " + getCheckMessage(MSG_JAVADOC_MISSED_HTML_CLOSE, 4, "unclosedTag"),
        "16: "
-@@ -196,7 +196,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -196,7 +197,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36110,7 +36662,7 @@
      final String[] expected = {
        "12: " + getCheckMessage(SummaryJavadocCheck.class, MSG_SUMMARY_FIRST_SENTENCE),
      };
-@@ -207,7 +207,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -207,7 +208,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36119,7 +36671,7 @@
      JavadocCatchCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(getPath("InputAbstractJavadocPositionOne.java"), expected);
-@@ -219,7 +219,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -219,7 +220,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36128,7 +36680,7 @@
      JavadocCatchCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(getPath("InputAbstractJavadocPositionTwo.java"), expected);
-@@ -231,7 +231,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -231,7 +232,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36137,7 +36689,7 @@
      JavadocCatchCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(getPath("InputAbstractJavadocPositionThree.java"), expected);
-@@ -243,7 +243,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -243,7 +244,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36146,7 +36698,7 @@
      JavadocCatchCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(
-@@ -256,7 +256,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -256,7 +257,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36155,7 +36707,7 @@
      JavadocCatchCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(
-@@ -269,7 +269,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -269,7 +270,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36164,7 +36716,7 @@
      JavadocCatchCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(
-@@ -282,7 +282,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -282,7 +283,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36173,7 +36725,7 @@
      JavadocCatchCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(
-@@ -293,7 +293,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -293,7 +294,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36182,7 +36734,7 @@
      final int[] defaultJavadocTokens = {JavadocTokenTypes.JAVADOC};
      final AbstractJavadocCheck check =
          new AbstractJavadocCheck() {
-@@ -329,7 +329,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -329,7 +330,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36191,7 +36743,7 @@
      final int[] defaultJavadocTokens = {
        JavadocTokenTypes.JAVADOC,
        JavadocTokenTypes.AREA_HTML_TAG_NAME,
-@@ -351,11 +351,11 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -351,11 +352,11 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
            }
          };
      check.setJavadocTokens("RETURN_LITERAL");
@@ -36205,7 +36757,7 @@
      final String path = getPath("InputAbstractJavadocTokensFail.java");
      try {
        final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
-@@ -374,13 +374,13 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -374,16 +375,17 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36220,8 +36772,13 @@
 +  void requiredTokenIsNotInDefaultTokens() throws Exception {
      final DefaultConfiguration checkConfig =
          createModuleConfig(RequiredTokenIsNotInDefaultsJavadocCheck.class);
-     final String pathToEmptyFile = File.createTempFile("empty", ".java", temporaryFolder).getPath();
-@@ -402,7 +402,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+-    final String pathToEmptyFile = File.createTempFile("empty", ".java", temporaryFolder).getPath();
++    final String pathToEmptyFile =
++        Files.createTempFile(temporaryFolder.toPath(), "empty", ".java").toFile().getPath();
+ 
+     try {
+       execute(checkConfig, pathToEmptyFile);
+@@ -402,7 +404,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36230,7 +36787,7 @@
      JavadocVisitLeaveCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(getPath("InputAbstractJavadocLeaveTokenOne.java"), expected);
-@@ -415,7 +415,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -415,7 +417,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36239,7 +36796,7 @@
      JavadocVisitLeaveCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(getPath("InputAbstractJavadocLeaveTokenTwo.java"), expected);
-@@ -428,7 +428,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -428,7 +430,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36248,7 +36805,7 @@
      JavadocVisitLeaveCheck.clearCounter();
      final String[] expected = CommonUtil.EMPTY_STRING_ARRAY;
      verifyWithInlineConfigParser(getPath("InputAbstractJavadocLeaveTokenThree.java"), expected);
-@@ -441,7 +441,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -441,7 +443,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36257,7 +36814,7 @@
      final String[] expected = {
        "18: "
            + getCheckMessage(
-@@ -491,7 +491,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -491,7 +493,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36266,7 +36823,7 @@
      final String[] expected = {
        "10: " + getCheckMessage(MSG_JAVADOC_WRONG_SINGLETON_TAG, 9, "embed"),
        "17: " + getCheckMessage(MSG_JAVADOC_WRONG_SINGLETON_TAG, 9, "keygen"),
-@@ -504,7 +504,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -504,7 +506,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36275,7 +36832,7 @@
      final String[] expected = {
        "12: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
        "19: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
-@@ -518,7 +518,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -518,7 +520,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36284,7 +36841,7 @@
      final String[] expected = {
        "12: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
        "19: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
-@@ -530,21 +530,21 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -530,21 +532,21 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36309,7 +36866,7 @@
      final String[] expected = {
        "13: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
        "20: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
-@@ -560,7 +560,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -560,7 +562,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36318,7 +36875,7 @@
      final String[] expected = {
        "13: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
        "20: " + getCheckMessage(MSG_UNCLOSED_HTML_TAG, "p"),
-@@ -577,7 +577,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -577,7 +579,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -36327,7 +36884,7 @@
      final String[] expected = {
        "11:4: " + getCheckMessage(NonTightHtmlTagCheck.MSG_KEY, "BODY_TAG_START"),
        "12:4: " + getCheckMessage(NonTightHtmlTagCheck.MSG_KEY, "P_TAG_START"),
-@@ -619,7 +619,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
+@@ -619,7 +621,7 @@ public class AbstractJavadocCheckTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -43407,13 +43964,15 @@
      final DefaultConfiguration checkConfig = createModuleConfig(RegexpMultilineCheck.class);
      checkConfig.addProperty("format", "\\r");
      checkConfig.addProperty("maximum", "0");
-@@ -96,15 +97,13 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+@@ -95,16 +96,14 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+       "3: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "\\r"),
      };
  
-     final File file = File.createTempFile("junit", null, temporaryFolder);
+-    final File file = File.createTempFile("junit", null, temporaryFolder);
 -    Files.write(
 -        file.toPath(),
 -        "first line \r\n second line \n\r third line".getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), "first line \r\n second line \n\r third line".getBytes(UTF_8));
  
      verify(checkConfig, file.getPath(), expected);
@@ -43425,13 +43984,15 @@
      final DefaultConfiguration checkConfig = createModuleConfig(RegexpMultilineCheck.class);
      checkConfig.addProperty("format", "\\r");
      checkConfig.addProperty("maximum", "1");
-@@ -113,9 +112,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+@@ -112,10 +111,8 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+       "3: " + getCheckMessage(MSG_REGEXP_EXCEEDED, "\\r"),
      };
  
-     final File file = File.createTempFile("junit", null, temporaryFolder);
+-    final File file = File.createTempFile("junit", null, temporaryFolder);
 -    Files.write(
 -        file.toPath(),
 -        "first line \r\n second line \n\r third line".getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), "first line \r\n second line \n\r third line".getBytes(UTF_8));
  
      verify(checkConfig, file.getPath(), expected);
@@ -43447,10 +44008,11 @@
          DetectorOptions.newBuilder().reporter(reporter).format("\\r").maximum(1).build();
  
      final MultilineDetector detector = new MultilineDetector(detectorOptions);
-     final File file = File.createTempFile("junit", null, temporaryFolder);
+-    final File file = File.createTempFile("junit", null, temporaryFolder);
 -    Files.write(
 -        file.toPath(),
 -        "first line \r\n second line \n\r third line".getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), "first line \r\n second line \n\r third line".getBytes(UTF_8));
  
      detector.processLines(new FileText(file, StandardCharsets.UTF_8.name()));
@@ -43489,11 +44051,13 @@
      final DefaultConfiguration checkConfig = createModuleConfig(RegexpMultilineCheck.class);
      // http://madbean.com/2004/mb2004-20/
      checkConfig.addProperty("format", "(x|y)*");
-@@ -177,13 +172,13 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+@@ -176,14 +171,14 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+       "1: " + getCheckMessage(MSG_STACKOVERFLOW, "(x|y)*"),
      };
  
-     final File file = File.createTempFile("junit", null, temporaryFolder);
+-    final File file = File.createTempFile("junit", null, temporaryFolder);
 -    Files.write(file.toPath(), makeLargeXyString().toString().getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), makeLargeXyString().toString().getBytes(UTF_8));
  
      verify(checkConfig, file.getPath(), expected);
@@ -43505,11 +44069,13 @@
      final DefaultConfiguration checkConfig = createModuleConfig(RegexpMultilineCheck.class);
      checkConfig.addProperty("format", "\\r");
      checkConfig.addProperty("minimum", "5");
-@@ -192,13 +187,13 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+@@ -191,14 +186,14 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+       "1: " + getCheckMessage(MSG_REGEXP_MINIMUM, "5", "\\r"),
      };
  
-     final File file = File.createTempFile("junit", null, temporaryFolder);
+-    final File file = File.createTempFile("junit", null, temporaryFolder);
 -    Files.write(file.toPath(), "".getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), "".getBytes(UTF_8));
  
      verify(checkConfig, file.getPath(), expected);
@@ -43521,11 +44087,13 @@
      final DefaultConfiguration checkConfig = createModuleConfig(RegexpMultilineCheck.class);
      checkConfig.addProperty("format", "\\r");
      checkConfig.addProperty("minimum", "5");
-@@ -208,7 +203,7 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+@@ -207,8 +202,8 @@ public class RegexpMultilineCheckTest extends AbstractModuleTestSupport {
+       "1: some message",
      };
  
-     final File file = File.createTempFile("junit", null, temporaryFolder);
+-    final File file = File.createTempFile("junit", null, temporaryFolder);
 -    Files.write(file.toPath(), "".getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), "".getBytes(UTF_8));
  
      verify(checkConfig, file.getPath(), expected);
@@ -48652,7 +49220,11 @@
      final DetailAST rootAst = JavaParser.parseFile(file, JavaParser.Options.WITH_COMMENTS);
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/filters/SuppressionFilterTest.java
-@@ -39,7 +39,7 @@ import java.net.URL;
+@@ -36,10 +36,11 @@ import java.io.IOException;
+ import java.io.InputStream;
+ import java.net.HttpURLConnection;
+ import java.net.URL;
++import java.nio.file.Files;
  import org.junit.jupiter.api.Test;
  import org.junit.jupiter.api.io.TempDir;
  
@@ -48661,7 +49233,7 @@
  
    @TempDir public File temporaryFolder;
  
-@@ -49,7 +49,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -49,7 +50,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48670,7 +49242,7 @@
      final String fileName = getPath("InputSuppressionFilterNone.xml");
      final boolean optional = false;
      final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
-@@ -62,7 +62,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -62,7 +63,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48679,7 +49251,7 @@
      final String fileName = getPath("InputSuppressionFilterSuppress.xml");
      final boolean optional = false;
      final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
-@@ -77,7 +77,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -77,7 +78,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48688,7 +49260,7 @@
      final String fileName = null;
      final boolean optional = false;
      final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
-@@ -89,7 +89,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -89,7 +90,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48697,7 +49269,7 @@
      final String fileName = "non_existent_suppression_file.xml";
      try {
        final boolean optional = false;
-@@ -103,7 +103,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -103,7 +104,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48706,7 +49278,7 @@
      final String fileName = getPath("InputSuppressionFilterInvalidFile.xml");
      try {
        final boolean optional = true;
-@@ -118,7 +118,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -118,7 +119,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48715,7 +49287,7 @@
      final String fileName = getPath("InputSuppressionFilterNone.xml");
      final boolean optional = true;
      final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
-@@ -131,7 +131,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -131,7 +132,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48724,7 +49296,7 @@
      final String fileName = "non_existent_suppression_file.xml";
      final boolean optional = true;
      final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
-@@ -144,7 +144,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -144,7 +145,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48733,7 +49305,7 @@
      final String fileName = "https://checkstyle.org/non_existent_suppression.xml";
      final boolean optional = true;
      final SuppressionFilter filter = createSuppressionFilter(fileName, optional);
-@@ -157,7 +157,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -157,15 +158,16 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48742,7 +49314,18 @@
      final DefaultConfiguration filterConfig = createModuleConfig(SuppressionFilter.class);
      filterConfig.addProperty("file", getPath("InputSuppressionFilterNone.xml"));
  
-@@ -173,7 +173,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+     final DefaultConfiguration checkerConfig = createRootConfig(filterConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     checkerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+-    final String filePath = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String filePath =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+ 
+     execute(checkerConfig, filePath);
+     // One more time to use cache.
+@@ -173,7 +175,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48751,7 +49334,21 @@
      final String[] urlCandidates = {
        "https://checkstyle.org/files/suppressions_none.xml",
        "https://raw.githubusercontent.com/checkstyle/checkstyle/master/src/site/resources/"
-@@ -262,7 +262,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -194,10 +196,11 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+     firstFilterConfig.addProperty("file", urlForTest);
+ 
+     final DefaultConfiguration firstCheckerConfig = createRootConfig(firstFilterConfig);
+-    final File cacheFile = File.createTempFile("junit", null, temporaryFolder);
++    final File cacheFile = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
+     firstCheckerConfig.addProperty("cacheFile", cacheFile.getPath());
+ 
+-    final String pathToEmptyFile = File.createTempFile("file", ".java", temporaryFolder).getPath();
++    final String pathToEmptyFile =
++        Files.createTempFile(temporaryFolder.toPath(), "file", ".java").toFile().getPath();
+ 
+     execute(firstCheckerConfig, pathToEmptyFile);
+ 
+@@ -262,7 +265,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48760,7 +49357,7 @@
      for (int test = 1; test <= 6; test++) {
        final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
        final String[] expected = {
-@@ -280,7 +280,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -280,7 +283,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -48769,7 +49366,7 @@
      final String pattern = "^[A-Z][A-Z0-9]*(_[A-Z0-9]+)*$";
      final String[] expected = {
        "19:29: "
-@@ -295,7 +295,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
+@@ -295,7 +298,7 @@ public class SuppressionFilterTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -53147,7 +53744,15 @@
      // test validity of messages from modules
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/AllTestsTest.java
-@@ -42,10 +42,10 @@ import org.junit.jupiter.api.Test;
+@@ -25,7 +25,6 @@ import java.io.File;
+ import java.io.IOException;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.ArrayList;
+ import java.util.HashMap;
+ import java.util.List;
+@@ -42,14 +41,14 @@ import org.junit.jupiter.api.Test;
   * @noinspectionreason ClassIndependentOfModule - architecture of test modules requires this
   *     structure
   */
@@ -53160,7 +53765,26 @@
      final Map<String, List<String>> allTests = new HashMap<>();
  
      walk(
-@@ -69,7 +69,7 @@ public class AllTestsTest {
+-        Paths.get("src/test/java"),
++        Path.of("src/test/java"),
+         filePath -> {
+           grabAllTests(allTests, filePath.toFile());
+         });
+@@ -57,23 +56,23 @@ public class AllTestsTest {
+     assertWithMessage("found tests").that(allTests.keySet()).isNotEmpty();
+ 
+     walk(
+-        Paths.get("src/test/resources/com/puppycrawl"),
++        Path.of("src/test/resources/com/puppycrawl"),
+         filePath -> {
+           verifyInputFile(allTests, filePath.toFile());
+         });
+     walk(
+-        Paths.get("src/test/resources-noncompilable/com/puppycrawl"),
++        Path.of("src/test/resources-noncompilable/com/puppycrawl"),
+         filePath -> {
+           verifyInputFile(allTests, filePath.toFile());
+         });
    }
  
    @Test
@@ -53169,6 +53793,20 @@
      final Map<String, List<String>> allTests = new HashMap<>();
  
      walk(
+-        Paths.get("src/main/java"),
++        Path.of("src/main/java"),
+         filePath -> {
+           grabAllFiles(allTests, filePath.toFile());
+         });
+@@ -81,7 +80,7 @@ public class AllTestsTest {
+     assertWithMessage("found tests").that(allTests.keySet()).isNotEmpty();
+ 
+     walk(
+-        Paths.get("src/test/java"),
++        Path.of("src/test/java"),
+         filePath -> {
+           verifyHasProductionFile(allTests, filePath.toFile());
+         });
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitSuperClassTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/ArchUnitSuperClassTest.java
 @@ -41,7 +41,7 @@ import java.util.Optional;
@@ -53229,7 +53867,7 @@
              .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/CliOptionsXdocsSyncTest.java
-@@ -20,6 +20,7 @@
+@@ -20,11 +20,11 @@
  package com.puppycrawl.tools.checkstyle.internal;
  
  import static com.google.common.truth.Truth.assertWithMessage;
@@ -53237,7 +53875,12 @@
  
  import com.puppycrawl.tools.checkstyle.internal.utils.XmlUtil;
  import java.nio.file.Files;
-@@ -32,7 +33,6 @@ import java.util.Map;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.HashMap;
+ import java.util.HashSet;
+ import java.util.List;
+@@ -32,7 +32,6 @@ import java.util.Map;
  import java.util.Set;
  import java.util.regex.Matcher;
  import java.util.regex.Pattern;
@@ -53245,7 +53888,7 @@
  import org.junit.jupiter.api.Test;
  import org.w3c.dom.Document;
  import org.w3c.dom.Node;
-@@ -40,10 +40,10 @@ import org.w3c.dom.NodeList;
+@@ -40,10 +39,10 @@ import org.w3c.dom.NodeList;
  import picocli.CommandLine;
  import picocli.CommandLine.Model.OptionSpec;
  
@@ -53258,7 +53901,7 @@
      final Map<String, String> cmdDesc = new HashMap<>();
  
      final NodeList sections = getSectionsFromXdoc("src/xdocs/cmdline.xml.vm");
-@@ -85,7 +85,7 @@ public class CliOptionsXdocsSyncTest {
+@@ -85,7 +84,7 @@ public class CliOptionsXdocsSyncTest {
    }
  
    @Test
@@ -53267,7 +53910,7 @@
      final NodeList sections = getSectionsFromXdoc("src/xdocs/cmdline.xml.vm");
      final Node usageSource = XmlUtil.getFirstChildElement(sections.item(2));
      final String usageText = XmlUtil.getFirstChildElement(usageSource).getTextContent();
-@@ -99,12 +99,12 @@ public class CliOptionsXdocsSyncTest {
+@@ -99,12 +98,12 @@ public class CliOptionsXdocsSyncTest {
      final Set<String> shortParamsMain =
          commandLine.getCommandSpec().options().stream()
              .map(OptionSpec::shortestName)
@@ -53282,7 +53925,16 @@
  
      assertWithMessage("Short parameters in Main.java and cmdline" + ".xml.vm should match")
          .that(shortParamsMain)
-@@ -138,7 +138,7 @@ public class CliOptionsXdocsSyncTest {
+@@ -125,7 +124,7 @@ public class CliOptionsXdocsSyncTest {
+   }
+ 
+   private static NodeList getSectionsFromXdoc(String xdocPath) throws Exception {
+-    final Path path = Paths.get(xdocPath);
++    final Path path = Path.of(xdocPath);
+     final String input = Files.readString(path);
+     final Document document = XmlUtil.getRawXml(path.getFileName().toString(), input, input);
+     return document.getElementsByTagName("section");
+@@ -138,7 +137,7 @@ public class CliOptionsXdocsSyncTest {
        result =
            XmlUtil.getChildrenElements(node).stream()
                .map(Node::getTextContent)
@@ -53497,7 +54149,15 @@
  
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsJavaDocsTest.java
-@@ -68,7 +68,7 @@ import org.w3c.dom.NamedNodeMap;
+@@ -54,7 +54,6 @@ import java.io.File;
+ import java.net.URI;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.ArrayList;
+ import java.util.HashMap;
+ import java.util.List;
+@@ -68,7 +67,7 @@ import org.w3c.dom.NamedNodeMap;
  import org.w3c.dom.Node;
  import org.w3c.dom.NodeList;
  
@@ -53506,7 +54166,7 @@
    private static final Map<String, Class<?>> FULLY_QUALIFIED_CLASS_NAMES =
        ImmutableMap.<String, Class<?>>builder()
            .put("int", int.class)
-@@ -115,7 +115,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
+@@ -115,7 +114,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
    }
  
    @BeforeEach
@@ -53515,7 +54175,7 @@
      final DefaultConfiguration checkConfig =
          new DefaultConfiguration(JavaDocCapture.class.getName());
      checker = createChecker(checkConfig);
-@@ -129,7 +129,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
+@@ -129,7 +128,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
     *     method
     */
    @Test
@@ -53524,6 +54184,15 @@
      final ModuleFactory moduleFactory = TestUtil.getPackageObjectFactory();
  
      for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
+@@ -532,7 +531,7 @@ public class XdocsJavaDocsTest extends AbstractModuleTestSupport {
+         value =
+             currentXdocPath
+                 .getParent()
+-                .resolve(Paths.get(value))
++                .resolve(Path.of(value))
+                 .normalize()
+                 .toString()
+                 .replaceAll("src[\\\\/]xdocs[\\\\/]", "")
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/XdocsMobileWrapperTest.java
 @@ -21,6 +21,7 @@ package com.puppycrawl.tools.checkstyle.internal;
@@ -53563,7 +54232,12 @@
  
  import com.puppycrawl.tools.checkstyle.Checker;
  import com.puppycrawl.tools.checkstyle.ConfigurationLoader;
-@@ -55,7 +59,6 @@ import java.util.ArrayList;
+@@ -50,12 +54,10 @@ import java.lang.reflect.ParameterizedType;
+ import java.net.URI;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.ArrayList;
  import java.util.Arrays;
  import java.util.BitSet;
  import java.util.Collection;
@@ -53571,7 +54245,7 @@
  import java.util.HashMap;
  import java.util.HashSet;
  import java.util.Iterator;
-@@ -69,7 +72,6 @@ import java.util.Set;
+@@ -69,7 +71,6 @@ import java.util.Set;
  import java.util.TreeSet;
  import java.util.regex.Matcher;
  import java.util.regex.Pattern;
@@ -53579,16 +54253,21 @@
  import java.util.stream.IntStream;
  import java.util.stream.Stream;
  import org.apache.commons.beanutils.PropertyUtils;
-@@ -85,7 +87,7 @@ import org.xml.sax.InputSource;
+@@ -85,10 +86,10 @@ import org.xml.sax.InputSource;
   * following commands have to be executed: - mvn clean compile - Required for next command - mvn
   * plexus-component-metadata:generate-metadata - Required to find custom macros and parser
   */
 -public class XdocsPagesTest {
+-  private static final Path SITE_PATH = Paths.get("src/site/site.xml");
 +final class XdocsPagesTest {
-   private static final Path SITE_PATH = Paths.get("src/site/site.xml");
++  private static final Path SITE_PATH = Path.of("src/site/site.xml");
  
-   private static final Path AVAILABLE_CHECKS_PATH = Paths.get("src/xdocs/checks.xml");
-@@ -151,7 +153,7 @@ public class XdocsPagesTest {
+-  private static final Path AVAILABLE_CHECKS_PATH = Paths.get("src/xdocs/checks.xml");
++  private static final Path AVAILABLE_CHECKS_PATH = Path.of("src/xdocs/checks.xml");
+   private static final String LINK_TEMPLATE =
+       "(?s).*<a href=\"[^\"]+#%1$s\">([\\r\\n\\s])*%1$s([\\r\\n\\s])*</a>.*";
+ 
+@@ -151,7 +152,7 @@ public class XdocsPagesTest {
            "CustomImportOrder.customImportOrderRules");
  
    private static final Set<String> SUN_MODULES =
@@ -53597,7 +54276,7 @@
    // ignore the not yet properly covered modules while testing newly added ones
    // add proper sections to the coverage report and integration tests
    // and then remove this list eventually
-@@ -221,7 +223,7 @@ public class XdocsPagesTest {
+@@ -221,7 +222,7 @@ public class XdocsPagesTest {
            "WhitespaceAround");
  
    private static final Set<String> GOOGLE_MODULES =
@@ -53606,7 +54285,7 @@
  
    /**
     * Generate xdoc content from templates before validation. This method will be removed once <a
-@@ -230,12 +232,12 @@ public class XdocsPagesTest {
+@@ -230,12 +231,12 @@ public class XdocsPagesTest {
     * @throws Exception if something goes wrong
     */
    @BeforeAll
@@ -53621,7 +54300,7 @@
      final String availableChecks = Files.readString(AVAILABLE_CHECKS_PATH);
  
      CheckUtil.getSimpleNames(CheckUtil.getCheckstyleChecks()).stream()
-@@ -263,7 +265,7 @@ public class XdocsPagesTest {
+@@ -263,7 +264,7 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53630,7 +54309,7 @@
      final String siteContent = Files.readString(SITE_PATH);
  
      for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
-@@ -280,8 +282,8 @@ public class XdocsPagesTest {
+@@ -280,8 +281,8 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53641,7 +54320,7 @@
      final Map<String, String> summaries = readSummaries();
  
      for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
-@@ -331,7 +333,7 @@ public class XdocsPagesTest {
+@@ -331,7 +332,7 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53650,7 +54329,7 @@
      final Map<String, String> summaries = readSummaries();
      for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
        final String fileName = path.getFileName().toString();
-@@ -384,7 +386,7 @@ public class XdocsPagesTest {
+@@ -384,7 +385,7 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53659,7 +54338,7 @@
      for (Path path : XdocUtil.getXdocsFilePaths()) {
        final String input = Files.readString(path);
        final String fileName = path.getFileName().toString();
-@@ -441,7 +443,7 @@ public class XdocsPagesTest {
+@@ -441,7 +442,7 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53668,7 +54347,7 @@
      for (Path path : XdocUtil.getXdocsFilePaths()) {
        final String input = Files.readString(path);
        final String fileName = path.getFileName().toString();
-@@ -564,7 +566,7 @@ public class XdocsPagesTest {
+@@ -564,7 +565,7 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53677,7 +54356,7 @@
      final ModuleFactory moduleFactory = TestUtil.getPackageObjectFactory();
  
      for (Path path : XdocUtil.getXdocsConfigFilePaths(XdocUtil.getXdocsFilePaths())) {
-@@ -624,7 +626,7 @@ public class XdocsPagesTest {
+@@ -624,10 +625,10 @@ public class XdocsPagesTest {
     *     method
     */
    @Test
@@ -53685,8 +54364,12 @@
 +  void allCheckSectionsEx() throws Exception {
      final ModuleFactory moduleFactory = TestUtil.getPackageObjectFactory();
  
-     final Path path = Paths.get(XdocUtil.DIRECTORY_PATH + "/config.xml");
-@@ -1081,7 +1083,7 @@ public class XdocsPagesTest {
+-    final Path path = Paths.get(XdocUtil.DIRECTORY_PATH + "/config.xml");
++    final Path path = Path.of(XdocUtil.DIRECTORY_PATH + "/config.xml");
+     final String fileName = path.getFileName().toString();
+ 
+     final String input = Files.readString(path);
+@@ -1081,7 +1082,7 @@ public class XdocsPagesTest {
          Optional.ofNullable(field)
              .map(nonNullField -> nonNullField.getAnnotation(XdocsPropertyType.class))
              .map(propertyType -> propertyType.value().getDescription())
@@ -53695,7 +54378,7 @@
      final String expectedValue =
          getModulePropertyExpectedValue(sectionName, propertyName, field, fieldClass, instance);
  
-@@ -1364,7 +1366,7 @@ public class XdocsPagesTest {
+@@ -1364,7 +1365,7 @@ public class XdocsPagesTest {
          final Object[] array = (Object[]) value;
          valuesStream = Arrays.stream(array);
        }
@@ -53704,7 +54387,7 @@
      }
  
      if (result.isEmpty()) {
-@@ -1393,8 +1395,7 @@ public class XdocsPagesTest {
+@@ -1393,8 +1394,7 @@ public class XdocsPagesTest {
      } else {
        stream = Arrays.stream((int[]) value);
      }
@@ -53714,7 +54397,7 @@
      if (result.isEmpty()) {
        result = "{}";
      }
-@@ -1470,7 +1471,7 @@ public class XdocsPagesTest {
+@@ -1470,7 +1470,7 @@ public class XdocsPagesTest {
        result =
            XmlUtil.getChildrenElements(node).stream()
                .map(Node::getTextContent)
@@ -53723,7 +54406,7 @@
      }
      return result;
    }
-@@ -1684,7 +1685,7 @@ public class XdocsPagesTest {
+@@ -1684,7 +1684,7 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53732,7 +54415,7 @@
      for (Path path : XdocUtil.getXdocsStyleFilePaths(XdocUtil.getXdocsFilePaths())) {
        final String fileName = path.getFileName().toString();
        final String styleName = fileName.substring(0, fileName.lastIndexOf('_'));
-@@ -1989,7 +1990,7 @@ public class XdocsPagesTest {
+@@ -1989,7 +1989,7 @@ public class XdocsPagesTest {
    }
  
    @Test
@@ -53751,7 +54434,14 @@
  
  import com.puppycrawl.tools.checkstyle.api.AbstractCheck;
  import com.puppycrawl.tools.checkstyle.api.AbstractFileSetCheck;
-@@ -35,14 +36,13 @@ import java.util.List;
+@@ -28,21 +29,19 @@ import java.io.IOException;
+ import java.io.InputStream;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.ArrayList;
+ import java.util.HashMap;
+ import java.util.List;
  import java.util.Locale;
  import java.util.Map;
  import java.util.Set;
@@ -53767,7 +54457,16 @@
  
    private static final String PACKAGE_NAME = "src/main/java/com/puppycrawl/tools/checkstyle/checks";
  
-@@ -74,7 +74,7 @@ public class XdocsUrlTest {
+@@ -62,7 +61,7 @@ public class XdocsUrlTest {
+ 
+   private static final String SUPPRESS_WARNINGS_HOLDER = "SuppressWarningsHolder";
+ 
+-  private static final Path AVAILABLE_CHECKS_PATH = Paths.get("src/xdocs/checks.xml");
++  private static final Path AVAILABLE_CHECKS_PATH = Path.of("src/xdocs/checks.xml");
+ 
+   private static Map<String, List<String>> getXdocsMap() throws IOException {
+     final Map<String, List<String>> checksNamesMap = new HashMap<>();
+@@ -74,7 +73,7 @@ public class XdocsUrlTest {
                    return AbstractCheck.class.isAssignableFrom(clazz)
                        || AbstractFileSetCheck.class.isAssignableFrom(clazz);
                  })
@@ -53776,7 +54475,7 @@
      for (Class<?> check : treeWalkerOrFileSetCheckSet) {
        final String checkName = check.getSimpleName();
        if (!TREE_WORKER.equals(checkName)) {
-@@ -96,7 +96,7 @@ public class XdocsUrlTest {
+@@ -96,7 +95,7 @@ public class XdocsUrlTest {
    }
  
    @Test
@@ -53800,7 +54499,12 @@
  import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
  import com.puppycrawl.tools.checkstyle.Definitions;
  import com.puppycrawl.tools.checkstyle.checks.javadoc.AbstractJavadocCheck;
-@@ -38,18 +43,16 @@ import java.util.HashSet;
+@@ -33,23 +38,20 @@ import java.io.IOException;
+ import java.nio.file.DirectoryStream;
+ import java.nio.file.Files;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.HashSet;
  import java.util.Locale;
  import java.util.Map;
  import java.util.Set;
@@ -53821,7 +54525,7 @@
            "NoCodeInFile (reason is that AST is not generated for a file not containing code)",
            "Regexp (reason is at  #7759)",
            "RegexpSinglelineJava (reason is at  #7759)");
-@@ -79,7 +82,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+@@ -79,7 +81,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
    // Older regex-based checks that are under INCOMPATIBLE_JAVADOC_CHECK_NAMES
    // but not subclasses of AbstractJavadocCheck.
    private static final Set<Class<?>> REGEXP_JAVADOC_CHECKS =
@@ -53830,7 +54534,7 @@
            JavadocStyleCheck.class,
            JavadocMethodCheck.class,
            JavadocTypeCheck.class,
-@@ -110,7 +113,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+@@ -110,7 +112,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
            "VisibilityModifier");
  
    // Modules that will never have xpath support ever because they not report violations
@@ -53839,7 +54543,7 @@
  
    private static final Set<String> SIMPLE_CHECK_NAMES = getSimpleCheckNames();
    private static final Map<String, String> ALLOWED_DIRECTORY_AND_CHECKS =
-@@ -131,9 +134,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+@@ -131,9 +133,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
  
    private static Map<String, String> getAllowedDirectoryAndChecks() {
      return SIMPLE_CHECK_NAMES.stream()
@@ -53850,7 +54554,7 @@
    }
  
    private static Set<String> getInternalModules() {
-@@ -143,11 +144,11 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+@@ -143,13 +143,13 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
                final String[] packageTokens = moduleName.split("\\.");
                return packageTokens[packageTokens.length - 1];
              })
@@ -53860,11 +54564,15 @@
  
    @BeforeEach
 -  public void setUp() throws Exception {
+-    javaDir = Paths.get("src/it/java/" + getPackageLocation());
+-    inputDir = Paths.get(getPath(""));
 +  void setUp() throws Exception {
-     javaDir = Paths.get("src/it/java/" + getPackageLocation());
-     inputDir = Paths.get(getPath(""));
++    javaDir = Path.of("src/it/java/" + getPackageLocation());
++    inputDir = Path.of(getPath(""));
    }
-@@ -163,12 +164,12 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+ 
+   @Override
+@@ -163,12 +163,12 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -53879,7 +54587,7 @@
      // add the extra checks
      abstractJavadocCheckNames.addAll(REGEXP_JAVADOC_CHECKS);
      final Set<String> abstractJavadocCheckSimpleNames =
-@@ -182,7 +183,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+@@ -182,7 +182,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -53888,7 +54596,7 @@
      final Set<String> compatibleChecks = new HashSet<>();
      final Pattern pattern = Pattern.compile("^XpathRegression(.+)Test\\.java$");
      try (DirectoryStream<Path> javaPaths = Files.newDirectoryStream(javaDir)) {
-@@ -226,7 +227,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+@@ -226,7 +226,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
      final Set<String> allChecks = new HashSet<>(SIMPLE_CHECK_NAMES);
      allChecks.removeAll(INCOMPATIBLE_JAVADOC_CHECK_NAMES);
      allChecks.removeAll(INCOMPATIBLE_CHECK_NAMES);
@@ -53897,7 +54605,7 @@
      allChecks.removeAll(MISSING_CHECK_NAMES);
      allChecks.removeAll(NO_VIOLATION_MODULES);
      allChecks.removeAll(compatibleChecks);
-@@ -241,7 +242,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
+@@ -241,7 +241,7 @@ public class XpathRegressionTest extends AbstractModuleTestSupport {
    }
  
    @Test
@@ -54039,7 +54747,14 @@
  import java.nio.file.Files;
  import java.nio.file.Path;
  import java.nio.file.StandardCopyOption;
-@@ -57,11 +58,10 @@ public final class XdocGenerator {
+@@ -52,17 +53,16 @@ public final class XdocGenerator {
+       final String pathToFile = path.toString();
+       final File inputFile = new File(pathToFile);
+       final File outputFile = new File(pathToFile.replace(".template", ""));
+-      final File tempFile = File.createTempFile(outputFile.getName(), "");
++      final File tempFile = Files.createTempFile(outputFile.getName(), "").toFile();
+       tempFile.deleteOnExit();
+       final XdocsTemplateSinkFactory sinkFactory =
            (XdocsTemplateSinkFactory) plexus.lookup(SinkFactory.ROLE, XDOCS_TEMPLATE_HINT);
        final Sink sink =
            sinkFactory.createSink(
@@ -54055,7 +54770,7 @@
          sink.close();
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocUtil.java
-@@ -19,13 +19,14 @@
+@@ -19,13 +19,13 @@
  
  package com.puppycrawl.tools.checkstyle.internal.utils;
  
@@ -54064,14 +54779,23 @@
  import java.io.IOException;
  import java.nio.file.Files;
  import java.nio.file.Path;
- import java.nio.file.Paths;
+-import java.nio.file.Paths;
  import java.util.HashSet;
  import java.util.Set;
 -import java.util.stream.Collectors;
  import java.util.stream.Stream;
  import javax.xml.parsers.DocumentBuilder;
  import javax.xml.parsers.DocumentBuilderFactory;
-@@ -64,7 +65,7 @@ public final class XdocUtil {
+@@ -55,7 +55,7 @@ public final class XdocUtil {
+    * @throws IOException if an I/O error occurs.
+    */
+   public static Set<Path> getXdocsFilePaths() throws IOException {
+-    final Path directory = Paths.get(DIRECTORY_PATH);
++    final Path directory = Path.of(DIRECTORY_PATH);
+     try (Stream<Path> stream =
+         Files.find(
+             directory,
+@@ -64,7 +64,7 @@ public final class XdocUtil {
                return attr.isRegularFile()
                    && (path.toString().endsWith(".xml") || path.toString().endsWith(".xml.vm"));
              })) {
@@ -54080,7 +54804,16 @@
      }
    }
  
-@@ -85,7 +86,7 @@ public final class XdocUtil {
+@@ -77,7 +77,7 @@ public final class XdocUtil {
+    * @throws IOException if an I/O error occurs.
+    */
+   public static Set<Path> getXdocsTemplatesFilePaths() throws IOException {
+-    final Path directory = Paths.get(DIRECTORY_PATH);
++    final Path directory = Path.of(DIRECTORY_PATH);
+     try (Stream<Path> stream =
+         Files.find(
+             directory,
+@@ -85,7 +85,7 @@ public final class XdocUtil {
              (path, attr) -> {
                return attr.isRegularFile() && path.toString().endsWith(".xml.template");
              })) {
@@ -54228,7 +54961,7 @@
      final String[] expected = {
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/MetadataGeneratorUtilTest.java
-@@ -21,7 +21,9 @@ package com.puppycrawl.tools.checkstyle.meta;
+@@ -21,18 +21,18 @@ package com.puppycrawl.tools.checkstyle.meta;
  
  import static com.google.common.truth.Truth.assertWithMessage;
  import static com.puppycrawl.tools.checkstyle.meta.JavadocMetadataScraper.MSG_DESC_MISSING;
@@ -54238,7 +54971,10 @@
  import com.puppycrawl.tools.checkstyle.AbstractModuleTestSupport;
  import com.puppycrawl.tools.checkstyle.internal.utils.CheckUtil;
  import java.nio.file.Files;
-@@ -32,7 +34,6 @@ import java.util.LinkedHashSet;
+ import java.nio.file.Path;
+-import java.nio.file.Paths;
+ import java.util.Arrays;
+ import java.util.LinkedHashSet;
  import java.util.Set;
  import java.util.regex.Matcher;
  import java.util.regex.Pattern;
@@ -54246,7 +54982,7 @@
  import java.util.stream.Stream;
  import org.itsallcode.io.Capturable;
  import org.itsallcode.junit.sysextensions.SystemOutGuard;
-@@ -40,10 +41,10 @@ import org.junit.jupiter.api.Test;
+@@ -40,10 +40,10 @@ import org.junit.jupiter.api.Test;
  import org.junit.jupiter.api.extension.ExtendWith;
  
  @ExtendWith(SystemOutGuard.class)
@@ -54259,7 +54995,7 @@
            "Checker",
            "TreeWalker",
            "JavadocMetadataScraper",
-@@ -67,7 +68,7 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
+@@ -67,7 +67,7 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
     *     System.out} for error messages
     */
    @Test
@@ -54268,7 +55004,16 @@
        throws Exception {
      systemOut.captureMuted();
  
-@@ -117,12 +118,12 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
+@@ -107,7 +107,7 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
+     final Set<String> metaFiles;
+     try (Stream<Path> fileStream =
+         Files.walk(
+-            Paths.get(
++            Path.of(
+                 System.getProperty("user.dir")
+                     + "/src/main/resources/com/puppycrawl"
+                     + "/tools/checkstyle/meta"))) {
+@@ -117,12 +117,12 @@ public final class MetadataGeneratorUtilTest extends AbstractModuleTestSupport {
                .filter(path -> !path.toString().endsWith(".properties"))
                .map(MetadataGeneratorUtilTest::getMetaFileName)
                .sorted()
@@ -54285,7 +55030,13 @@
              "Number of generated metadata files dont match with " + "number of checkstyle module")
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/meta/XmlMetaReaderTest.java
-@@ -29,7 +29,7 @@ import java.util.List;
+@@ -24,12 +24,12 @@ import static com.google.common.truth.Truth.assertThat;
+ import com.puppycrawl.tools.checkstyle.AbstractPathTestSupport;
+ import java.io.InputStream;
+ import java.nio.file.Files;
+-import java.nio.file.Paths;
++import java.nio.file.Path;
+ import java.util.List;
  import org.apache.commons.io.IOUtils;
  import org.junit.jupiter.api.Test;
  
@@ -54309,7 +55060,7 @@
      assertThat(
              XmlMetaReader.readAllModulesIncludingThirdPartyIfAny(
                  "com.puppycrawl.tools.checkstyle.meta"))
-@@ -50,12 +50,12 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
+@@ -50,14 +50,14 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
    }
  
    @Test
@@ -54322,35 +55073,47 @@
 -  public void testReadXmlMetaCheckWithProperties() throws Exception {
 +  void readXmlMetaCheckWithProperties() throws Exception {
      final String path = getPath("InputXmlMetaReaderCheckWithProps.xml");
-     try (InputStream is = Files.newInputStream(Paths.get(path))) {
+-    try (InputStream is = Files.newInputStream(Paths.get(path))) {
++    try (InputStream is = Files.newInputStream(Path.of(path))) {
        final ModuleDetails result = XmlMetaReader.read(is, ModuleType.CHECK);
-@@ -87,7 +87,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
+       checkModuleProps(
+           result,
+@@ -87,9 +87,9 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testReadXmlMetaCheckNoProperties() throws Exception {
 +  void readXmlMetaCheckNoProperties() throws Exception {
      final String path = getPath("InputXmlMetaReaderCheckNoProps.xml");
-     try (InputStream is = Files.newInputStream(Paths.get(path))) {
+-    try (InputStream is = Files.newInputStream(Paths.get(path))) {
++    try (InputStream is = Files.newInputStream(Path.of(path))) {
        final ModuleDetails result = XmlMetaReader.read(is, ModuleType.CHECK);
-@@ -107,7 +107,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
+       checkModuleProps(
+           result,
+@@ -107,9 +107,9 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testReadXmlMetaFilter() throws Exception {
 +  void readXmlMetaFilter() throws Exception {
      final String path = getPath("InputXmlMetaReaderFilter.xml");
-     try (InputStream is = Files.newInputStream(Paths.get(path))) {
+-    try (InputStream is = Files.newInputStream(Paths.get(path))) {
++    try (InputStream is = Files.newInputStream(Path.of(path))) {
        final ModuleDetails result = XmlMetaReader.read(is, ModuleType.FILTER);
-@@ -133,7 +133,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
+       checkModuleProps(
+           result,
+@@ -133,9 +133,9 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
    }
  
    @Test
 -  public void testReadXmlMetaFileFilter() throws Exception {
 +  void readXmlMetaFileFilter() throws Exception {
      final String path = getPath("InputXmlMetaReaderFileFilter.xml");
-     try (InputStream is = Files.newInputStream(Paths.get(path))) {
+-    try (InputStream is = Files.newInputStream(Paths.get(path))) {
++    try (InputStream is = Files.newInputStream(Path.of(path))) {
        final ModuleDetails result = XmlMetaReader.read(is, ModuleType.FILEFILTER);
+       checkModuleProps(
+           result,
 @@ -158,7 +158,7 @@ public class XmlMetaReaderTest extends AbstractPathTestSupport {
    }
  
@@ -55335,7 +56098,11 @@
      try (MockedStatic<CommonUtil> utilities = mockStatic(CommonUtil.class, CALLS_REAL_METHODS)) {
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/FilterUtilTest.java
-@@ -26,19 +26,19 @@ import java.io.File;
+@@ -23,30 +23,31 @@ import static com.google.common.truth.Truth.assertWithMessage;
+ import static com.puppycrawl.tools.checkstyle.internal.utils.TestUtil.isUtilsClassHasPrivateConstructor;
+ 
+ import java.io.File;
++import java.nio.file.Files;
  import org.junit.jupiter.api.Test;
  import org.junit.jupiter.api.io.TempDir;
  
@@ -55354,11 +56121,12 @@
  
    @Test
 -  public void testExistingFile() throws Exception {
+-    final File file = File.createTempFile("junit", null, temporaryFolder);
 +  void existingFile() throws Exception {
-     final File file = File.createTempFile("junit", null, temporaryFolder);
++    final File file = Files.createTempFile(temporaryFolder.toPath(), "junit", null).toFile();
      assertWithMessage("Suppression file exists")
          .that(FilterUtil.isFileExists(file.getPath()))
-@@ -46,7 +46,7 @@ public class FilterUtilTest {
+         .isTrue();
    }
  
    @Test
@@ -56182,8 +56950,9 @@
 -  public void testPrintXpathNotComment() throws Exception {
 +  void printXpathNotComment() throws Exception {
      final String fileContent = "class Test { public void method() {int a = 5;}}";
-     final File file = File.createTempFile("junit", null, tempFolder);
+-    final File file = File.createTempFile("junit", null, tempFolder);
 -    Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(tempFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), fileContent.getBytes(UTF_8));
      final String expected =
          addEndOfLine(
@@ -56195,8 +56964,9 @@
 -  public void testPrintXpathComment() throws Exception {
 +  void printXpathComment() throws Exception {
      final String fileContent = "class Test { /* comment */ }";
-     final File file = File.createTempFile("junit", null, tempFolder);
+-    final File file = File.createTempFile("junit", null, tempFolder);
 -    Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(tempFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), fileContent.getBytes(UTF_8));
      final String expected =
          addEndOfLine(
@@ -56208,8 +56978,9 @@
 -  public void testPrintXpathTwo() throws Exception {
 +  void printXpathTwo() throws Exception {
      final String fileContent = "class Test { public void method() {int a = 5; int b = 5;}}";
-     final File file = File.createTempFile("junit", null, tempFolder);
+-    final File file = File.createTempFile("junit", null, tempFolder);
 -    Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(tempFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), fileContent.getBytes(UTF_8));
      final String expected =
          addEndOfLine(
@@ -56221,8 +56992,9 @@
 -  public void testInvalidXpath() throws IOException {
 +  void invalidXpath() throws IOException {
      final String fileContent = "class Test { public void method() {int a = 5; int b = 5;}}";
-     final File file = File.createTempFile("junit", null, tempFolder);
+-    final File file = File.createTempFile("junit", null, tempFolder);
 -    Files.write(file.toPath(), fileContent.getBytes(StandardCharsets.UTF_8));
++    final File file = Files.createTempFile(tempFolder.toPath(), "junit", null).toFile();
 +    Files.write(file.toPath(), fileContent.getBytes(UTF_8));
      final String invalidXpath = "\\//CLASS_DEF" + "//METHOD_DEF//VARIABLE_DEF//IDENT";
      try {

--- a/integration-tests/checkstyle-init.patch
+++ b/integration-tests/checkstyle-init.patch
@@ -134,6 +134,26 @@
  public class TreeWalkerTest extends AbstractModuleTestSupport {
  
      @TempDir
+--- a/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocGenerator.java
++++ b/src/test/java/com/puppycrawl/tools/checkstyle/internal/utils/XdocGenerator.java
+@@ -55,7 +55,8 @@ public final class XdocGenerator {
+         for (Path path : templatesFilePaths) {
+             final String pathToFile = path.toString();
+             final File inputFile = new File(pathToFile);
+-            final File tempFile = File.createTempFile(pathToFile.replace(".template", ""), "");
++            final File outputFile = new File(pathToFile.replace(".template", ""));
++            final File tempFile = File.createTempFile(outputFile.getName(), "");
+             tempFile.deleteOnExit();
+             final XdocsTemplateSinkFactory sinkFactory = (XdocsTemplateSinkFactory)
+                     plexus.lookup(SinkFactory.ROLE, XDOCS_TEMPLATE_HINT);
+@@ -70,7 +71,6 @@ public final class XdocGenerator {
+             finally {
+                 sink.close();
+             }
+-            final File outputFile = new File(pathToFile.replace(".template", ""));
+             final StandardCopyOption copyOption = StandardCopyOption.REPLACE_EXISTING;
+             Files.copy(tempFile.toPath(), outputFile.toPath(), copyOption);
+         }
 --- a/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
 +++ b/src/test/java/com/puppycrawl/tools/checkstyle/utils/CheckUtilTest.java
 @@ -47,6 +47,8 @@ import com.puppycrawl.tools.checkstyle.checks.coding.NestedIfDepthCheck;

--- a/integration-tests/checkstyle.sh
+++ b/integration-tests/checkstyle.sh
@@ -7,7 +7,7 @@ project='checkstyle'
 repository='https://github.com/checkstyle/checkstyle.git'
 revision='checkstyle-10.14.0'
 # XXX: Configure Renovate to manage the AssertJ version declared here.
-additional_build_flags='-Dassertj.version=3.24.2'
+additional_build_flags='-Perror-prone-compile,error-prone-test-compile -Dassertj.version=3.24.2 -Dmaven.compiler.failOnError=true'
 additional_source_directories='${project.basedir}${file.separator}src${file.separator}it${file.separator}java,${project.basedir}${file.separator}src${file.separator}xdocs-examples${file.separator}java'
 patch_error_prone_flags=''
 validation_error_prone_flags=''

--- a/integration-tests/run-integration-test.sh
+++ b/integration-tests/run-integration-test.sh
@@ -52,7 +52,6 @@ case "$(uname -s)" in
 esac
 
 shared_build_flags="
-  -Perror-prone-compile,error-prone-test-compile
   -Derror-prone.version=$(
     mvn -f "${error_prone_support_root}" help:evaluate -Dexpression=version.error-prone -q -DforceStdout
   )
@@ -141,10 +140,13 @@ diff_base="$(git rev-parse HEAD)"
 function apply_patch() {
   local extra_build_args="${1}"
 
-  mvn ${shared_build_flags} ${extra_build_args} \
-    package "${format_goal}" \
-    -Derror-prone.configuration-args="${error_prone_patch_flags}" \
-    -DskipTests
+  (
+    set -x \
+      && mvn ${shared_build_flags} ${extra_build_args} \
+           package "${format_goal}" \
+           -Derror-prone.configuration-args="${error_prone_patch_flags}" \
+           -DskipTests
+  )
 
   if ! git diff --exit-code; then
     git commit -m 'minor: Apply patches' .
@@ -168,12 +170,13 @@ apply_patch ''
 # By also running the tests, we validate that the (majority of) applied changes
 # are behavior preserving.
 validation_build_log="${report_directory}/${test_name}-validation-build-log.txt"
-mvn ${shared_build_flags} \
-      clean package \
-      -Derror-prone.configuration-args="${error_prone_validation_flags}" \
-      ${validation_build_flags} \
-    | tee "${validation_build_log}" \
-  || failure=1
+(
+  set -x \
+    && mvn ${shared_build_flags} \
+         clean package \
+         -Derror-prone.configuration-args="${error_prone_validation_flags}" \
+         ${validation_build_flags}
+) | tee "${validation_build_log}" || failure=1
 
 # Collect the applied changes.
 expected_changes="${integration_test_root}/${test_name}-expected-changes.patch"


### PR DESCRIPTION
Suggested commit message:
```
Update Checkstyle integration test (#1424)

Summary of changes:
- Move Checkstyle-specific build parameters out of
  `run-integration-test.sh`.
- Build with `-Dmaven.compiler.failOnError=true` to compensate for
  `<failOnError>false</failOnError>` configured by the enabled Maven
  profiles.
- Tweak `XdocGenerator.java` logic prior to integration test execution,
  to work around a subtle semantic difference introduced by the
  `FilesCreateTempFileToFile` Refaster rule.
- Document this difference on the relevant Refaster rules.
- To aid debugging, run Maven commands with `set -x`, such that the
  exact command executed is logged.
- Update the patch file containing the expected changes.
```