### PR TITLE
Make integration tests Error Prone 2.36.0-compatible

### DIFF
--- a/integration-tests/checkstyle-init.patch
+++ b/integration-tests/checkstyle-init.patch
@@ -13,7 +13,12 @@
      <dependency>
        <groupId>nl.jqno.equalsverifier</groupId>
        <artifactId>equalsverifier</artifactId>
-@@ -2420,6 +2426,8 @@
+@@ -2417,9 +2423,13 @@
+                   <compilerArgs>
+                     <arg>-Xpkginfo:always</arg>
+                     <arg>-XDcompilePolicy=simple</arg>
++                    <!-- XXX: Drop this flag once the project uses Error Prone 2.36.0+ by default. -->
++                    <arg>--should-stop=ifError=FLOW</arg>
                      <arg>
                        -Xplugin:ErrorProne ${error-prone.configuration-args}
                      </arg>
@@ -22,7 +27,7 @@
                    </compilerArgs>
                    <annotationProcessorPaths>
                      <path>
-@@ -2432,6 +2440,11 @@
+@@ -2432,6 +2442,11 @@
                        <artifactId>error-prone-contrib</artifactId>
                        <version>${error-prone-support.version}</version>
                      </path>
@@ -34,8 +39,12 @@
                    </annotationProcessorPaths>
                  </configuration>
                </execution>
-@@ -2474,9 +2487,10 @@
+@@ -2472,11 +2487,14 @@
+                   <compilerArgs>
+                     <arg>-Xpkginfo:always</arg>
                      <arg>-XDcompilePolicy=simple</arg>
++                    <!-- XXX: Drop this flag once the project uses Error Prone 2.36.0+ by default. -->
++                    <arg>--should-stop=ifError=FLOW</arg>
                      <arg>
                        -Xplugin:ErrorProne \
 -                      -XepExcludedPaths:.*[\\/]resources[\\/].* \
@@ -46,7 +55,7 @@
                    </compilerArgs>
                    <annotationProcessorPaths>
                      <path>
-@@ -2489,6 +2503,11 @@
+@@ -2489,6 +2507,11 @@
                        <artifactId>error-prone-contrib</artifactId>
                        <version>${error-prone-support.version}</version>
                      </path>

--- a/integration-tests/metrics-init.patch
+++ b/integration-tests/metrics-init.patch
@@ -52,16 +52,18 @@
      <profiles>
          <profile>
              <id>jdk8</id>
-@@ -218,7 +239,7 @@
+@@ -218,7 +239,9 @@
                              <compilerArgs>
                                  <arg>-Xlint:all</arg>
                                  <arg>-XDcompilePolicy=simple</arg>
 -                                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.*</arg>
++                                <!-- XXX: Drop this flag once the project uses Error Prone 2.36.0+ by default. -->
++                                <arg>--should-stop=ifError=FLOW</arg>
 +                                <arg>-Xplugin:ErrorProne ${error-prone.configuration-args}</arg>
                                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
                                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
                                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-@@ -229,12 +250,24 @@
+@@ -229,12 +252,24 @@
                                  <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
                                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
                                  <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
@@ -87,7 +89,7 @@
                                  </path>
                              </annotationProcessorPaths>
                          </configuration>
-@@ -364,7 +397,7 @@
+@@ -364,7 +399,7 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <configuration>


### PR DESCRIPTION
Fixes [this](https://github.com/PicnicSupermarket/error-prone-support/pull/985#issuecomment-2536960426) issue.

Suggested commit message:
```
Make integration tests Error Prone 2.36.0-compatible (#1455)
```