### PR TITLE
Introduce `StreamMapFilter` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -298,18 +298,17 @@ final class StreamRules {
   }
 
   /**
-   * When using {@link Map#get(Object)} in a {@link Stream#map(Function)} operation, prefer
-   * filtering null values after the map operation with {@link Objects#nonNull(Object)} over
-   * filtering beforehand with {@link Map#containsKey(Object)} to avoid a double lookup.
+   * Prefer an unconditional {@link Map#get(Object)} call followed by a {@code null} check over a
+   * call to {@link Map#containsKey(Object)}, as the former avoids a second lookup operation.
    */
-  static final class StreamMapFilter<K, V> {
+  static final class StreamMapFilter<T, K, V> {
     @BeforeTemplate
-    Stream<V> before(Stream<K> stream, Map<K, V> map) {
+    Stream<V> before(Stream<T> stream, Map<K, V> map) {
       return stream.filter(map::containsKey).map(map::get);
     }
 
     @AfterTemplate
-    Stream<V> after(Stream<K> stream, Map<K, V> map) {
+    Stream<V> after(Stream<T> stream, Map<K, V> map) {
       return stream.map(map::get).filter(Objects::nonNull);
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -297,7 +297,12 @@ final class StreamRules {
     }
   }
 
-  static final class StreamMapToValuesFromMap<K, V> {
+  /**
+   * When using {@link Map#get(Object)} in a {@link Stream#map(Function)} operation, prefer
+   * filtering null values after the map operation with {@link Objects#nonNull(Object)} over
+   * filtering beforehand with {@link Map#containsKey(Object)} to avoid a double lookup.
+   */
+  static final class StreamMapFilter<K, V> {
     @BeforeTemplate
     Stream<V> before(Stream<K> stream, Map<K, V> map) {
       return stream.filter(map::containsKey).map(map::get);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -297,6 +297,18 @@ final class StreamRules {
     }
   }
 
+  static final class StreamMapToValuesFromMap<K, V> {
+    @BeforeTemplate
+    Stream<V> before(Stream<K> stream, Map<K, V> map) {
+      return stream.filter(map::containsKey).map(map::get);
+    }
+
+    @AfterTemplate
+    Stream<V> after(Stream<K> stream, Map<K, V> map) {
+      return stream.map(map::get).filter(Objects::nonNull);
+    }
+  }
+
   static final class StreamMin<T> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -141,6 +141,11 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).findFirst().isPresent();
   }
 
+  Stream<String> testStreamMapToValuesFromMap() {
+    ImmutableMap<String, String> map = ImmutableMap.of("foo", "bar");
+    return Stream.of("foo").filter(map::containsKey).map(map::get);
+  }
+
   ImmutableSet<Optional<String>> testStreamMin() {
     return ImmutableSet.of(
         Stream.of("foo").max(comparingInt(String::length).reversed()),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -141,9 +141,10 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).findFirst().isPresent();
   }
 
-  Stream<String> testStreamMapFilter() {
-    ImmutableMap<String, String> map = ImmutableMap.of("foo", "bar");
-    return Stream.of("foo").filter(map::containsKey).map(map::get);
+  Stream<Integer> testStreamMapFilter() {
+    return Stream.of("foo")
+        .filter(ImmutableMap.of(1, 2)::containsKey)
+        .map(ImmutableMap.of(1, 2)::get);
   }
 
   ImmutableSet<Optional<String>> testStreamMin() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -141,7 +141,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).findFirst().isPresent();
   }
 
-  Stream<String> testStreamMapToValuesFromMap() {
+  Stream<String> testStreamMapFilter() {
     ImmutableMap<String, String> map = ImmutableMap.of("foo", "bar");
     return Stream.of("foo").filter(map::containsKey).map(map::get);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -141,9 +141,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).findAny().isPresent();
   }
 
-  Stream<String> testStreamMapFilter() {
-    ImmutableMap<String, String> map = ImmutableMap.of("foo", "bar");
-    return Stream.of("foo").map(map::get).filter(Objects::nonNull);
+  Stream<Integer> testStreamMapFilter() {
+    return Stream.of("foo").map(ImmutableMap.of(1, 2)::get).filter(Objects::nonNull);
   }
 
   ImmutableSet<Optional<String>> testStreamMin() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -141,7 +141,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).findAny().isPresent();
   }
 
-  Stream<String> testStreamMapToValuesFromMap() {
+  Stream<String> testStreamMapFilter() {
     ImmutableMap<String, String> map = ImmutableMap.of("foo", "bar");
     return Stream.of("foo").map(map::get).filter(Objects::nonNull);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -141,6 +141,11 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).findAny().isPresent();
   }
 
+  Stream<String> testStreamMapToValuesFromMap() {
+    ImmutableMap<String, String> map = ImmutableMap.of("foo", "bar");
+    return Stream.of("foo").map(map::get).filter(Objects::nonNull);
+  }
+
   ImmutableSet<Optional<String>> testStreamMin() {
     return ImmutableSet.of(
         Stream.of("foo").min(comparingInt(String::length)),


### PR DESCRIPTION
Prefer
```java
stream.map(map::get).filter(Objects::nonNull)
``` 
over
```java
stream.filter(map::containsKey).map(map::get)
```

### Suggested commit message
```
Introduce `StreamMapFilter` Refaster rule (#1467)
```