### PR TITLE
Introduce `AssertThatThrownBy*ExceptionRootCauseHasMessage` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
@@ -61,6 +61,27 @@ final class AssertJThrowingCallableRules {
     }
   }
 
+  static final class AssertThatThrownByIllegalArgumentExceptionRootCauseHasMessage {
+    @BeforeTemplate
+    @SuppressWarnings(
+        "AssertThatThrownByIllegalArgumentException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatIllegalArgumentException()
+          .isThrownBy(throwingCallable)
+          .havingRootCause()
+          .withMessage(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(IllegalArgumentException.class)
+          .rootCause()
+          .hasMessage(message);
+    }
+  }
+
   static final class AssertThatThrownByIllegalArgumentExceptionHasMessageParameters {
     @BeforeTemplate
     @SuppressWarnings(
@@ -167,6 +188,27 @@ final class AssertJThrowingCallableRules {
     AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
       return assertThatThrownBy(throwingCallable)
           .isInstanceOf(IllegalStateException.class)
+          .hasMessage(message);
+    }
+  }
+
+  static final class AssertThatThrownByIllegalStateExceptionRootCauseHasMessage {
+    @BeforeTemplate
+    @SuppressWarnings(
+        "AssertThatThrownByIllegalStateException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatIllegalStateException()
+          .isThrownBy(throwingCallable)
+          .havingRootCause()
+          .withMessage(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(IllegalStateException.class)
+          .rootCause()
           .hasMessage(message);
     }
   }
@@ -279,6 +321,27 @@ final class AssertJThrowingCallableRules {
     }
   }
 
+  static final class AssertThatThrownByNullPointerExceptionRootCauseHasMessage {
+    @BeforeTemplate
+    @SuppressWarnings(
+        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatNullPointerException()
+          .isThrownBy(throwingCallable)
+          .havingRootCause()
+          .withMessage(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(NullPointerException.class)
+          .rootCause()
+          .hasMessage(message);
+    }
+  }
+
   static final class AssertThatThrownByNullPointerExceptionHasMessageParameters {
     @BeforeTemplate
     @SuppressWarnings(
@@ -386,6 +449,26 @@ final class AssertJThrowingCallableRules {
     }
   }
 
+  static final class AssertThatThrownByIOExceptionRootCauseHasMessage {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+      return assertThatIOException()
+          .isThrownBy(throwingCallable)
+          .havingRootCause()
+          .withMessage(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(IOException.class)
+          .rootCause()
+          .hasMessage(message);
+    }
+  }
+
   static final class AssertThatThrownByIOExceptionHasMessageParameters {
     @BeforeTemplate
     @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
@@ -486,6 +569,32 @@ final class AssertJThrowingCallableRules {
         Class<? extends Throwable> exceptionType,
         String message) {
       return assertThatThrownBy(throwingCallable).isInstanceOf(exceptionType).hasMessage(message);
+    }
+  }
+
+  static final class AssertThatThrownByRootCauseHasMessage {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatThrownBy" /* This is a more specific template. */)
+    AbstractObjectAssert<?, ?> before(
+        ThrowingCallable throwingCallable,
+        Class<? extends Throwable> exceptionType,
+        String message) {
+      return assertThatExceptionOfType(exceptionType)
+          .isThrownBy(throwingCallable)
+          .havingRootCause()
+          .withMessage(message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractObjectAssert<?, ?> after(
+        ThrowingCallable throwingCallable,
+        Class<? extends Throwable> exceptionType,
+        String message) {
+      return assertThatThrownBy(throwingCallable)
+          .isInstanceOf(exceptionType)
+          .rootCause()
+          .hasMessage(message);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -31,6 +31,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatIllegalArgumentException().isThrownBy(() -> {}).withMessage("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionRootCauseHasMessage() {
+    return assertThatIllegalArgumentException()
+        .isThrownBy(() -> {})
+        .havingRootCause()
+        .withMessage("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessageParameters() {
     return assertThatIllegalArgumentException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
   }
@@ -59,6 +66,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatIllegalStateException().isThrownBy(() -> {}).withMessage("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionRootCauseHasMessage() {
+    return assertThatIllegalStateException()
+        .isThrownBy(() -> {})
+        .havingRootCause()
+        .withMessage("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageParameters() {
     return assertThatIllegalStateException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
   }
@@ -81,6 +95,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
 
   AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessage() {
     return assertThatNullPointerException().isThrownBy(() -> {}).withMessage("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionRootCauseHasMessage() {
+    return assertThatNullPointerException()
+        .isThrownBy(() -> {})
+        .havingRootCause()
+        .withMessage("foo");
   }
 
   AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageParameters() {
@@ -107,6 +128,10 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatIOException().isThrownBy(() -> {}).withMessage("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionRootCauseHasMessage() {
+    return assertThatIOException().isThrownBy(() -> {}).havingRootCause().withMessage("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageParameters() {
     return assertThatIOException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
   }
@@ -130,6 +155,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
   AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessage() {
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
+        .withMessage("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByRootCauseHasMessage() {
+    return assertThatExceptionOfType(IllegalArgumentException.class)
+        .isThrownBy(() -> {})
+        .havingRootCause()
         .withMessage("foo");
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -34,6 +34,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
         .hasMessage("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionRootCauseHasMessage() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IllegalArgumentException.class)
+        .rootCause()
+        .hasMessage("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessageParameters() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
@@ -68,6 +75,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class).hasMessage("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionRootCauseHasMessage() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IllegalStateException.class)
+        .rootCause()
+        .hasMessage("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageParameters() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalStateException.class)
@@ -98,6 +112,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
 
   AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessage() {
     return assertThatThrownBy(() -> {}).isInstanceOf(NullPointerException.class).hasMessage("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionRootCauseHasMessage() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(NullPointerException.class)
+        .rootCause()
+        .hasMessage("foo");
   }
 
   AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageParameters() {
@@ -132,6 +153,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class).hasMessage("foo");
   }
 
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionRootCauseHasMessage() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IOException.class)
+        .rootCause()
+        .hasMessage("foo");
+  }
+
   AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageParameters() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class).hasMessage("foo %s", "bar");
   }
@@ -159,6 +187,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
   AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage("foo");
+  }
+
+  AbstractObjectAssert<?, ?> testAssertThatThrownByRootCauseHasMessage() {
+    return assertThatThrownBy(() -> {})
+        .isInstanceOf(IllegalArgumentException.class)
+        .rootCause()
         .hasMessage("foo");
   }
 


### PR DESCRIPTION
This PR aims to get rid of the following part of the `init-patch` of the new IT: https://github.com/PicnicSupermarket/error-prone-support/pull/1468/files#diff-6b99a1fb957cc4c8081a8a95423c965335a67c526f4b5b634aafa0d6912dc4dcR61. 

Not sure about the * part in the title, let me know what options are :D.