### PR TITLE
Introduce `AssertThatString{Contains,DoesNotContain}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
@@ -264,6 +264,7 @@ final class AssertJRules {
       Refaster.anyOf(
           assertThat(iterable).hasSize(0),
           assertThat(iterable.iterator().hasNext()).isFalse(),
+          assertThat(iterable.iterator()).isExhausted(),
           assertThat(Iterables.size(iterable)).isEqualTo(0L),
           assertThat(Iterables.size(iterable)).isNotPositive());
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
@@ -12,6 +12,7 @@ import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
@@ -66,6 +67,32 @@ final class AssertJStringRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     AbstractAssert<?, ?> after(String string) {
       return assertThat(string).isNotEmpty();
+    }
+  }
+
+  static final class AssertThatStringContains {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(String string, String substring) {
+      return assertThat(string.contains(substring)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(String string, String substring) {
+      return assertThat(string).contains(substring);
+    }
+  }
+
+  static final class AssertThatStringDoesNotContain {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(String string, String substring) {
+      return assertThat(string.contains(substring)).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(String string, String substring) {
+      return assertThat(string).doesNotContain(substring);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
@@ -33,6 +33,14 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat("foo".isEmpty()).isFalse();
   }
 
+  AbstractAssert<?, ?> testAssertThatStringContains() {
+    return assertThat("foo".contains("bar")).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringDoesNotContain() {
+    return assertThat("foo".contains("bar")).isFalse();
+  }
+
   AbstractAssert<?, ?> testAssertThatMatches() {
     return assertThat("foo".matches(".*")).isTrue();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
@@ -34,6 +34,14 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat("foo").isNotEmpty();
   }
 
+  AbstractAssert<?, ?> testAssertThatStringContains() {
+    return assertThat("foo").contains("bar");
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringDoesNotContain() {
+    return assertThat("foo").doesNotContain("bar");
+  }
+
   AbstractAssert<?, ?> testAssertThatMatches() {
     return assertThat("foo").matches(".*");
   }


### PR DESCRIPTION
Suggested commit message:
```
Introduce `AssertThatString{Contains,DoesNotContain}` Refaster rules (#1479)

While there, extend `AssertThatIterableIsEmpty`.
```