### PR TITLE
Introduce `CharSequenceRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
@@ -15,16 +15,19 @@ final class CharSequenceRules {
    * Prefer {@link CharSequence#isEmpty()} over alternatives that consult the char sequence's
    * length.
    */
+  // XXX: Drop this rule once we (and OpenRewrite) no longer support projects targeting Java 14 or
+  // below.
   static final class CharSequenceIsEmpty {
     @BeforeTemplate
-    boolean before(CharSequence ch) {
-      return Refaster.anyOf(ch.length() == 0, ch.length() <= 0, ch.length() < 1);
+    boolean before(CharSequence charSequence) {
+      return Refaster.anyOf(
+          charSequence.length() == 0, charSequence.length() <= 0, charSequence.length() < 1);
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(CharSequence ch) {
-      return ch.isEmpty();
+    boolean after(CharSequence charSequence) {
+      return charSequence.isEmpty();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
@@ -1,0 +1,30 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.AlsoNegation;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
+
+/** Refaster rules related to expressions dealing with {@link CharSequence}s. */
+@OnlineDocumentation
+final class CharSequenceRules {
+  private CharSequenceRules() {}
+
+  /**
+   * Prefer {@link CharSequence#isEmpty()} over alternatives that consult the char sequence's
+   * length.
+   */
+  static final class CharSequenceIsEmpty {
+    @BeforeTemplate
+    boolean before(CharSequence ch) {
+      return Refaster.anyOf(ch.length() == 0, ch.length() <= 0, ch.length() < 1);
+    }
+
+    @AfterTemplate
+    @AlsoNegation
+    boolean after(CharSequence ch) {
+      return ch.isEmpty();
+    }
+  }
+}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -29,12 +29,14 @@ final class StringRules {
   private StringRules() {}
 
   /** Prefer {@link String#isEmpty()} over alternatives that consult the string's length. */
-  // XXX: Now that we build with JDK 15+, this rule can be generalized to cover all `CharSequence`
-  // subtypes. This does require a mechanism (perhaps an annotation, or a separate Maven module) to
-  // make sure that non-String expressions are rewritten only if client code also targets JDK 15+.
-  @SuppressWarnings("CharSequenceIsEmpty" /* This is a more specific template. */)
+  // XXX: Drop this rule once we (and OpenRewrite) no longer support projects targeting Java 14 or
+  // below. The `CharSequenceIsEmpty` rule then suffices. (This rule exists so that e.g. projects
+  // that target JDK 11 can disable `CharSequenceIsEmpty` without losing a valuable rule.)
+  // XXX: Look into a more general approach to supporting different Java language levels, such as
+  // rule selection based on some annotation, or a separate Maven module.
   static final class StringIsEmpty {
     @BeforeTemplate
+    @SuppressWarnings("CharSequenceIsEmpty" /* This is a more specific template. */)
     boolean before(String str) {
       return Refaster.anyOf(str.length() == 0, str.length() <= 0, str.length() < 1);
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -32,6 +32,7 @@ final class StringRules {
   // XXX: Now that we build with JDK 15+, this rule can be generalized to cover all `CharSequence`
   // subtypes. This does require a mechanism (perhaps an annotation, or a separate Maven module) to
   // make sure that non-String expressions are rewritten only if client code also targets JDK 15+.
+  @SuppressWarnings("CharSequenceIsEmpty" /* This is a more specific template. */)
   static final class StringIsEmpty {
     @BeforeTemplate
     boolean before(String str) {

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -36,6 +36,7 @@ final class RefasterRulesTest {
           AssortedRules.class,
           BigDecimalRules.class,
           BugCheckerRules.class,
+          CharSequenceRules.class,
           ClassRules.class,
           CollectionRules.class,
           ComparatorRules.class,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestInput.java
@@ -6,11 +6,11 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class CharSequenceRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Boolean> testCharSequenceIsEmpty() {
     return ImmutableSet.of(
-        ((CharSequence) "foo").length() == 0,
-        ((CharSequence) "bar").length() <= 0,
-        ((CharSequence) "baz").length() < 1,
-        ((CharSequence) "foo").length() != 0,
-        ((CharSequence) "bar").length() > 0,
-        ((CharSequence) "baz").length() >= 1);
+        new StringBuilder("foo").length() == 0,
+        new StringBuilder("bar").length() <= 0,
+        new StringBuilder("baz").length() < 1,
+        new StringBuilder("qux").length() != 0,
+        new StringBuilder("quux").length() > 0,
+        new StringBuilder("corge").length() >= 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestInput.java
@@ -1,0 +1,16 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.common.collect.ImmutableSet;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class CharSequenceRulesTest implements RefasterRuleCollectionTestCase {
+  ImmutableSet<Boolean> testCharSequenceIsEmpty() {
+    return ImmutableSet.of(
+        ((CharSequence) "foo").length() == 0,
+        ((CharSequence) "bar").length() <= 0,
+        ((CharSequence) "baz").length() < 1,
+        ((CharSequence) "foo").length() != 0,
+        ((CharSequence) "bar").length() > 0,
+        ((CharSequence) "baz").length() >= 1);
+  }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestOutput.java
@@ -1,0 +1,16 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.common.collect.ImmutableSet;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class CharSequenceRulesTest implements RefasterRuleCollectionTestCase {
+  ImmutableSet<Boolean> testCharSequenceIsEmpty() {
+    return ImmutableSet.of(
+        ((CharSequence) "foo").isEmpty(),
+        ((CharSequence) "bar").isEmpty(),
+        ((CharSequence) "baz").isEmpty(),
+        !((CharSequence) "foo").isEmpty(),
+        !((CharSequence) "bar").isEmpty(),
+        !((CharSequence) "baz").isEmpty());
+  }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestOutput.java
@@ -6,11 +6,11 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class CharSequenceRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Boolean> testCharSequenceIsEmpty() {
     return ImmutableSet.of(
-        ((CharSequence) "foo").isEmpty(),
-        ((CharSequence) "bar").isEmpty(),
-        ((CharSequence) "baz").isEmpty(),
-        !((CharSequence) "foo").isEmpty(),
-        !((CharSequence) "bar").isEmpty(),
-        !((CharSequence) "baz").isEmpty());
+        new StringBuilder("foo").isEmpty(),
+        new StringBuilder("bar").isEmpty(),
+        new StringBuilder("baz").isEmpty(),
+        !new StringBuilder("qux").isEmpty(),
+        !new StringBuilder("quux").isEmpty(),
+        !new StringBuilder("corge").isEmpty());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -28,9 +28,9 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         "foo".length() == 0,
         "bar".length() <= 0,
         "baz".length() < 1,
-        "foo".length() != 0,
-        "bar".length() > 0,
-        "baz".length() >= 1);
+        "qux".length() != 0,
+        "quux".length() > 0,
+        "corge".length() >= 1);
   }
 
   boolean testStringIsEmptyPredicate() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -31,9 +31,9 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         "foo".isEmpty(),
         "bar".isEmpty(),
         "baz".isEmpty(),
-        !"foo".isEmpty(),
-        !"bar".isEmpty(),
-        !"baz".isEmpty());
+        !"qux".isEmpty(),
+        !"quux".isEmpty(),
+        !"corge".isEmpty());
   }
 
   boolean testStringIsEmptyPredicate() {


### PR DESCRIPTION
This aims to solve the following issue: https://github.com/PicnicSupermarket/error-prone-support/issues/1394. 

@timtebeek mentioned that OpenRewrite has some checks that ensure that only the correct recipes are loaded for the Java version it's running on. For us I also don't see any problems for running on our code. The only advantage is that we will be matching more now :).