### PR TITLE
Extend `TestNGToAssertJRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
@@ -53,65 +53,13 @@ import tech.picnic.errorprone.refaster.annotation.TypeMigration;
 // XXX: As-is these rules do not result in a complete migration:
 // - Expressions containing comments are skipped due to a limitation of Refaster.
 // - Assertions inside lambda expressions are also skipped. Unclear why.
-// XXX: The `assertEquals` tests for this class generally use the same expression for `expected` and
+// XXX: Many of the test expressions for these rules use the same expression for `expected` and
 // `actual`, which makes the validation weaker than necessary; fix this. (And investigate whether we
 // can introduce validation for this.)
 @OnlineDocumentation
 @TypeMigration(
     of = Assert.class,
     unmigratedMethods = {
-      // XXX: Add migrations for the methods below.
-      "assertEquals(Boolean, Boolean)",
-      "assertEquals(Boolean, boolean)",
-      "assertEquals(boolean, Boolean)",
-      "assertEquals(Boolean, Boolean, String)",
-      "assertEquals(Boolean, boolean, String)",
-      "assertEquals(boolean, Boolean, String)",
-      "assertEquals(Byte, Byte)",
-      "assertEquals(Byte, byte)",
-      "assertEquals(byte, Byte)",
-      "assertEquals(Byte, Byte, String)",
-      "assertEquals(Byte, byte, String)",
-      "assertEquals(byte, Byte, String)",
-      "assertEquals(char, Character)",
-      "assertEquals(char, Character, String)",
-      "assertEquals(Character, char)",
-      "assertEquals(Character, char, String)",
-      "assertEquals(Character, Character)",
-      "assertEquals(Character, Character, String)",
-      "assertEquals(Double, Double)",
-      "assertEquals(Double, double)",
-      "assertEquals(double, Double)",
-      "assertEquals(Double, Double, String)",
-      "assertEquals(Double, double, String)",
-      "assertEquals(double, Double, String)",
-      "assertEquals(double[], double[], double)",
-      "assertEquals(double[], double[], double, String)",
-      "assertEquals(Float, Float)",
-      "assertEquals(Float, float)",
-      "assertEquals(float, Float)",
-      "assertEquals(Float, Float, String)",
-      "assertEquals(Float, float, String)",
-      "assertEquals(float, Float, String)",
-      "assertEquals(float[], float[], float)",
-      "assertEquals(float[], float[], float, String)",
-      "assertEquals(int, Integer)",
-      "assertEquals(int, Integer, String)",
-      "assertEquals(Integer, int)",
-      "assertEquals(Integer, int, String)",
-      "assertEquals(Integer, Integer)",
-      "assertEquals(Integer, Integer, String)",
-      "assertEquals(Long, Long)",
-      "assertEquals(Long, long)",
-      "assertEquals(long, Long)",
-      "assertEquals(Long, Long, String)",
-      "assertEquals(Long, long, String)",
-      "assertEquals(Short, Short)",
-      "assertEquals(Short, short)",
-      "assertEquals(short, Short)",
-      "assertEquals(Short, Short, String)",
-      "assertEquals(Short, short, String)",
-      "assertEquals(short, Short, String)",
       /*
        * These `assertEqualsDeep` methods cannot (easily) be expressed using AssertJ because they
        * mix regular equality and array equality:
@@ -358,7 +306,37 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(boolean actual, Boolean expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Boolean actual, boolean expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Boolean actual, Boolean expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
     void before(byte actual, byte expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(byte actual, Byte expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Byte actual, byte expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Byte actual, Byte expected) {
       assertEquals(actual, expected);
     }
 
@@ -368,7 +346,37 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(char actual, Character expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Character actual, char expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Character actual, Character expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
     void before(short actual, short expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(short actual, Short expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Short actual, short expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Short actual, Short expected) {
       assertEquals(actual, expected);
     }
 
@@ -378,7 +386,37 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(int actual, Integer expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Integer actual, int expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Integer actual, Integer expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
     void before(long actual, long expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(long actual, Long expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Long actual, long expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Long actual, Long expected) {
       assertEquals(actual, expected);
     }
 
@@ -388,7 +426,37 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(float actual, Float expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Float actual, float expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Float actual, Float expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
     void before(double actual, double expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(double actual, Double expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Double actual, double expected) {
+      assertEquals(actual, expected);
+    }
+
+    @BeforeTemplate
+    void before(Double actual, Double expected) {
       assertEquals(actual, expected);
     }
 
@@ -421,7 +489,37 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(boolean actual, String message, Boolean expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Boolean actual, String message, boolean expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Boolean actual, String message, Boolean expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
     void before(byte actual, String message, byte expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(byte actual, String message, Byte expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Byte actual, String message, byte expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Byte actual, String message, Byte expected) {
       assertEquals(actual, expected, message);
     }
 
@@ -431,7 +529,37 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(char actual, String message, Character expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Character actual, String message, char expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Character actual, String message, Character expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
     void before(short actual, String message, short expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(short actual, String message, Short expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Short actual, String message, short expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Short actual, String message, Short expected) {
       assertEquals(actual, expected, message);
     }
 
@@ -441,7 +569,32 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(int actual, String message, Integer expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Integer actual, String message, int expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Integer actual, String message, Integer expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
     void before(long actual, String message, long expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Long actual, String message, long expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Long actual, String message, Long expected) {
       assertEquals(actual, expected, message);
     }
 
@@ -451,7 +604,37 @@ final class TestNGToAssertJRules {
     }
 
     @BeforeTemplate
+    void before(float actual, String message, Float expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Float actual, String message, float expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Float actual, String message, Float expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
     void before(double actual, String message, double expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(double actual, String message, Double expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Double actual, String message, double expected) {
+      assertEquals(actual, expected, message);
+    }
+
+    @BeforeTemplate
+    void before(Double actual, String message, Double expected) {
       assertEquals(actual, expected, message);
     }
 
@@ -485,7 +668,7 @@ final class TestNGToAssertJRules {
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float actual, float expected, float delta) {
+    void after(Float actual, float expected, float delta) {
       assertThat(actual).isCloseTo(expected, offset(delta));
     }
   }
@@ -632,6 +815,58 @@ final class TestNGToAssertJRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(Object[] actual, String message, Object[] expected) {
       assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertEqualFloatArraysWithDelta {
+    @BeforeTemplate
+    void before(float[] actual, float[] expected, float delta) {
+      assertEquals(actual, expected, delta);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, float[] expected, float delta) {
+      assertThat(actual).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertEqualFloatArraysWithDeltaWithMessage {
+    @BeforeTemplate
+    void before(float[] actual, String message, float[] expected, float delta) {
+      assertEquals(actual, expected, delta, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, String message, float[] expected, float delta) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertEqualDoubleArraysWithDelta {
+    @BeforeTemplate
+    void before(double[] actual, double[] expected, double delta) {
+      assertEquals(actual, expected, delta);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, double[] expected, double delta) {
+      assertThat(actual).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertEqualDoubleArraysWithDeltaWithMessage {
+    @BeforeTemplate
+    void before(double[] actual, String message, double[] expected, double delta) {
+      assertEquals(actual, expected, delta, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, String message, double[] expected, double delta) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
@@ -96,31 +96,80 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAssertEqual() {
-    assertEquals(true, true);
-    assertEquals((byte) 0, (byte) 0);
-    assertEquals((char) 0, (char) 0);
-    assertEquals((short) 0, (short) 0);
-    assertEquals(0, 0);
-    assertEquals(0L, 0L);
-    assertEquals(0.0F, 0.0F);
-    assertEquals(0.0, 0.0);
-    assertEquals(new Object(), new Object());
+    assertEquals(true, false);
+    assertEquals(true, Boolean.FALSE);
+    assertEquals(Boolean.TRUE, false);
+    assertEquals(Boolean.TRUE, Boolean.FALSE);
+    assertEquals((byte) 0, (byte) 1);
+    assertEquals((byte) 0, Byte.decode("1"));
+    assertEquals(Byte.decode("0"), (byte) 1);
+    assertEquals(Byte.decode("0"), Byte.decode("1"));
+    assertEquals('a', 'b');
+    assertEquals('a', Character.valueOf('b'));
+    assertEquals(Character.valueOf('a'), 'b');
+    assertEquals(Character.valueOf('a'), Character.valueOf('b'));
+    assertEquals((short) 0, (short) 1);
+    assertEquals((short) 0, Short.decode("1"));
+    assertEquals(Short.decode("0"), (short) 1);
+    assertEquals(Short.decode("0"), Short.decode("1"));
+    assertEquals(0, 1);
+    assertEquals(0, Integer.valueOf(1));
+    assertEquals(Integer.valueOf(0), 1);
+    assertEquals(Integer.valueOf(0), Integer.valueOf(1));
+    assertEquals(0L, 1L);
+    assertEquals(0L, Long.valueOf(1));
+    assertEquals(Long.valueOf(0), 1L);
+    assertEquals(Long.valueOf(0), Long.valueOf(1));
+    assertEquals(0.0F, 1.0F);
+    assertEquals(0.0F, Float.valueOf(1.0F));
+    assertEquals(Float.valueOf(0.0F), 1.0F);
+    assertEquals(Float.valueOf(0.0F), Float.valueOf(1.0F));
+    assertEquals(0.0, 1.0);
+    assertEquals(0.0, Double.valueOf(1.0));
+    assertEquals(Double.valueOf(0.0), 1.0);
+    assertEquals(Double.valueOf(0.0), Double.valueOf(1.0));
+    assertEquals(new Object(), new StringBuilder());
     assertEquals("actual", "expected");
-    assertEquals(ImmutableMap.of(), ImmutableMap.of());
+    assertEquals(ImmutableMap.of(), ImmutableMap.of(1, 2));
   }
 
   void testAssertEqualWithMessage() {
-    assertEquals(true, true, "foo");
-    assertEquals((byte) 0, (byte) 0, "bar");
-    assertEquals((char) 0, (char) 0, "baz");
-    assertEquals((short) 0, (short) 0, "qux");
-    assertEquals(0, 0, "quux");
-    assertEquals(0L, 0L, "quuz");
-    assertEquals(0.0F, 0.0F, "corge");
-    assertEquals(0.0, 0.0, "grault");
-    assertEquals(new Object(), new Object(), "garply");
-    assertEquals("actual", "expected", "waldo");
-    assertEquals(ImmutableMap.of(), ImmutableMap.of(), "plugh");
+    assertEquals(true, false, "foo");
+    assertEquals(true, Boolean.FALSE, "bar");
+    assertEquals(Boolean.TRUE, false, "baz");
+    assertEquals(Boolean.TRUE, Boolean.FALSE, "qux");
+    assertEquals((byte) 0, (byte) 1, "quux");
+    assertEquals((byte) 0, Byte.decode("1"), "corge");
+    assertEquals(Byte.decode("0"), (byte) 1, "grault");
+    assertEquals(Byte.decode("0"), Byte.decode("1"), "garply");
+    assertEquals('a', 'b', "waldo");
+    assertEquals('a', Character.valueOf('b'), "fred");
+    assertEquals(Character.valueOf('a'), 'b', "plugh");
+    assertEquals(Character.valueOf('a'), Character.valueOf('b'), "xyzzy");
+    assertEquals((short) 0, (short) 1, "thud");
+    assertEquals((short) 0, Short.decode("1"), "foo");
+    assertEquals(Short.decode("0"), (short) 1, "bar");
+    assertEquals(Short.decode("0"), Short.decode("1"), "baz");
+    assertEquals(0, 1, "qux");
+    assertEquals(0, Integer.valueOf(1), "quux");
+    assertEquals(Integer.valueOf(0), 1, "corge");
+    assertEquals(Integer.valueOf(0), Integer.valueOf(1), "grault");
+    assertEquals(0L, 1L, "garply");
+    // XXX: Ambiguous method call, as the relevant overload is missing. See testng-team/testng#3199.
+    // assertEquals(0L, Long.valueOf(1), "waldo");
+    assertEquals(Long.valueOf(0), 1L, "fred");
+    assertEquals(Long.valueOf(0), Long.valueOf(1), "plugh");
+    assertEquals(0.0F, 1.0F, "xyzzy");
+    assertEquals(0.0F, Float.valueOf(1.0F), "thud");
+    assertEquals(Float.valueOf(0.0F), 1.0F, "foo");
+    assertEquals(Float.valueOf(0.0F), Float.valueOf(1.0F), "bar");
+    assertEquals(0.0, 1.0, "baz");
+    assertEquals(0.0, Double.valueOf(1.0), "qux");
+    assertEquals(Double.valueOf(0.0), 1.0, "quux");
+    assertEquals(Double.valueOf(0.0), Double.valueOf(1.0), "corge");
+    assertEquals(new Object(), new StringBuilder(), "grault");
+    assertEquals("actual", "expected", "garply");
+    assertEquals(ImmutableMap.of(), ImmutableMap.of(1, 2), "waldo");
   }
 
   void testAssertEqualFloatsWithDelta() {
@@ -161,6 +210,22 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(new float[0], new float[0], "corge");
     assertEquals(new double[0], new double[0], "grault");
     assertEquals(new Object[0], new Object[0], "garply");
+  }
+
+  void testAssertEqualFloatArraysWithDelta() {
+    assertEquals(new float[0], new float[0], 0.0F);
+  }
+
+  void testAssertEqualFloatArraysWithDeltaWithMessage() {
+    assertEquals(new float[0], new float[0], 0.0F, "foo");
+  }
+
+  void testAssertEqualDoubleArraysWithDelta() {
+    assertEquals(new double[0], new double[0], 0.0);
+  }
+
+  void testAssertEqualDoubleArraysWithDeltaWithMessage() {
+    assertEquals(new double[0], new double[0], 0.0, "foo");
   }
 
   void testAssertEqualArraysIrrespectiveOfOrder() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
@@ -101,31 +101,80 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAssertEqual() {
-    assertThat(true).isEqualTo(true);
-    assertThat((byte) 0).isEqualTo((byte) 0);
-    assertThat((char) 0).isEqualTo((char) 0);
-    assertThat((short) 0).isEqualTo((short) 0);
-    assertThat(0).isEqualTo(0);
-    assertThat(0L).isEqualTo(0L);
-    assertThat(0.0F).isEqualTo(0.0F);
-    assertThat(0.0).isEqualTo(0.0);
-    assertThat(new Object()).isEqualTo(new Object());
+    assertThat(true).isEqualTo(false);
+    assertThat(true).isEqualTo(Boolean.FALSE);
+    assertThat(Boolean.TRUE).isEqualTo(false);
+    assertThat(Boolean.TRUE).isEqualTo(Boolean.FALSE);
+    assertThat((byte) 0).isEqualTo((byte) 1);
+    assertThat((byte) 0).isEqualTo(Byte.decode("1"));
+    assertThat(Byte.decode("0")).isEqualTo((byte) 1);
+    assertThat(Byte.decode("0")).isEqualTo(Byte.decode("1"));
+    assertThat('a').isEqualTo('b');
+    assertThat('a').isEqualTo(Character.valueOf('b'));
+    assertThat(Character.valueOf('a')).isEqualTo('b');
+    assertThat(Character.valueOf('a')).isEqualTo(Character.valueOf('b'));
+    assertThat((short) 0).isEqualTo((short) 1);
+    assertThat((short) 0).isEqualTo(Short.decode("1"));
+    assertThat(Short.decode("0")).isEqualTo((short) 1);
+    assertThat(Short.decode("0")).isEqualTo(Short.decode("1"));
+    assertThat(0).isEqualTo(1);
+    assertThat(0).isEqualTo(Integer.valueOf(1));
+    assertThat(Integer.valueOf(0)).isEqualTo(1);
+    assertThat(Integer.valueOf(0)).isEqualTo(Integer.valueOf(1));
+    assertThat(0L).isEqualTo(1L);
+    assertThat(0L).isEqualTo(Long.valueOf(1));
+    assertThat(Long.valueOf(0)).isEqualTo(1L);
+    assertThat(Long.valueOf(0)).isEqualTo(Long.valueOf(1));
+    assertThat(0.0F).isEqualTo(1.0F);
+    assertThat(0.0F).isEqualTo(Float.valueOf(1.0F));
+    assertThat(Float.valueOf(0.0F)).isEqualTo(1.0F);
+    assertThat(Float.valueOf(0.0F)).isEqualTo(Float.valueOf(1.0F));
+    assertThat(0.0).isEqualTo(1.0);
+    assertThat(0.0).isEqualTo(Double.valueOf(1.0));
+    assertThat(Double.valueOf(0.0)).isEqualTo(1.0);
+    assertThat(Double.valueOf(0.0)).isEqualTo(Double.valueOf(1.0));
+    assertThat(new Object()).isEqualTo(new StringBuilder());
     assertThat("actual").isEqualTo("expected");
-    assertThat(ImmutableMap.of()).isEqualTo(ImmutableMap.of());
+    assertThat(ImmutableMap.of()).isEqualTo(ImmutableMap.of(1, 2));
   }
 
   void testAssertEqualWithMessage() {
-    assertThat(true).withFailMessage("foo").isEqualTo(true);
-    assertThat((byte) 0).withFailMessage("bar").isEqualTo((byte) 0);
-    assertThat((char) 0).withFailMessage("baz").isEqualTo((char) 0);
-    assertThat((short) 0).withFailMessage("qux").isEqualTo((short) 0);
-    assertThat(0).withFailMessage("quux").isEqualTo(0);
-    assertThat(0L).withFailMessage("quuz").isEqualTo(0L);
-    assertThat(0.0F).withFailMessage("corge").isEqualTo(0.0F);
-    assertThat(0.0).withFailMessage("grault").isEqualTo(0.0);
-    assertThat(new Object()).withFailMessage("garply").isEqualTo(new Object());
-    assertThat("actual").withFailMessage("waldo").isEqualTo("expected");
-    assertThat(ImmutableMap.of()).withFailMessage("plugh").isEqualTo(ImmutableMap.of());
+    assertThat(true).withFailMessage("foo").isEqualTo(false);
+    assertThat(true).withFailMessage("bar").isEqualTo(Boolean.FALSE);
+    assertThat(Boolean.TRUE).withFailMessage("baz").isEqualTo(false);
+    assertThat(Boolean.TRUE).withFailMessage("qux").isEqualTo(Boolean.FALSE);
+    assertThat((byte) 0).withFailMessage("quux").isEqualTo((byte) 1);
+    assertThat((byte) 0).withFailMessage("corge").isEqualTo(Byte.decode("1"));
+    assertThat(Byte.decode("0")).withFailMessage("grault").isEqualTo((byte) 1);
+    assertThat(Byte.decode("0")).withFailMessage("garply").isEqualTo(Byte.decode("1"));
+    assertThat('a').withFailMessage("waldo").isEqualTo('b');
+    assertThat('a').withFailMessage("fred").isEqualTo(Character.valueOf('b'));
+    assertThat(Character.valueOf('a')).withFailMessage("plugh").isEqualTo('b');
+    assertThat(Character.valueOf('a')).withFailMessage("xyzzy").isEqualTo(Character.valueOf('b'));
+    assertThat((short) 0).withFailMessage("thud").isEqualTo((short) 1);
+    assertThat((short) 0).withFailMessage("foo").isEqualTo(Short.decode("1"));
+    assertThat(Short.decode("0")).withFailMessage("bar").isEqualTo((short) 1);
+    assertThat(Short.decode("0")).withFailMessage("baz").isEqualTo(Short.decode("1"));
+    assertThat(0).withFailMessage("qux").isEqualTo(1);
+    assertThat(0).withFailMessage("quux").isEqualTo(Integer.valueOf(1));
+    assertThat(Integer.valueOf(0)).withFailMessage("corge").isEqualTo(1);
+    assertThat(Integer.valueOf(0)).withFailMessage("grault").isEqualTo(Integer.valueOf(1));
+    assertThat(0L).withFailMessage("garply").isEqualTo(1L);
+    // XXX: Ambiguous method call, as the relevant overload is missing. See testng-team/testng#3199.
+    // assertEquals(0L, Long.valueOf(1), "waldo");
+    assertThat(Long.valueOf(0)).withFailMessage("fred").isEqualTo(1L);
+    assertThat(Long.valueOf(0)).withFailMessage("plugh").isEqualTo(Long.valueOf(1));
+    assertThat(0.0F).withFailMessage("xyzzy").isEqualTo(1.0F);
+    assertThat(0.0F).withFailMessage("thud").isEqualTo(Float.valueOf(1.0F));
+    assertThat(Float.valueOf(0.0F)).withFailMessage("foo").isEqualTo(1.0F);
+    assertThat(Float.valueOf(0.0F)).withFailMessage("bar").isEqualTo(Float.valueOf(1.0F));
+    assertThat(0.0).withFailMessage("baz").isEqualTo(1.0);
+    assertThat(0.0).withFailMessage("qux").isEqualTo(Double.valueOf(1.0));
+    assertThat(Double.valueOf(0.0)).withFailMessage("quux").isEqualTo(1.0);
+    assertThat(Double.valueOf(0.0)).withFailMessage("corge").isEqualTo(Double.valueOf(1.0));
+    assertThat(new Object()).withFailMessage("grault").isEqualTo(new StringBuilder());
+    assertThat("actual").withFailMessage("garply").isEqualTo("expected");
+    assertThat(ImmutableMap.of()).withFailMessage("waldo").isEqualTo(ImmutableMap.of(1, 2));
   }
 
   void testAssertEqualFloatsWithDelta() {
@@ -166,6 +215,22 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(new float[0]).withFailMessage("corge").containsExactly(new float[0]);
     assertThat(new double[0]).withFailMessage("grault").containsExactly(new double[0]);
     assertThat(new Object[0]).withFailMessage("garply").containsExactly(new Object[0]);
+  }
+
+  void testAssertEqualFloatArraysWithDelta() {
+    assertThat(new float[0]).containsExactly(new float[0], offset(0.0F));
+  }
+
+  void testAssertEqualFloatArraysWithDeltaWithMessage() {
+    assertThat(new float[0]).withFailMessage("foo").containsExactly(new float[0], offset(0.0F));
+  }
+
+  void testAssertEqualDoubleArraysWithDelta() {
+    assertThat(new double[0]).containsExactly(new double[0], offset(0.0));
+  }
+
+  void testAssertEqualDoubleArraysWithDeltaWithMessage() {
+    assertThat(new double[0]).withFailMessage("foo").containsExactly(new double[0], offset(0.0));
   }
 
   void testAssertEqualArraysIrrespectiveOfOrder() {


### PR DESCRIPTION
Suggested commit message:
```
Extend `TestNGToAssertJRules` Refaster rule collection (#1483)

By migrating all remaining `assertEquals` methods.
```

While working on this I found an issue; filed testng-team/testng#3199.

(Perhaps it's time to move this to an Error Prone check, but given that we don't use TestNG internally anymore, that's likely not worth the trouble. I opened this PR primarily because I had a branch with some of these changes, and decided it was time to "flush" that work.)