### PR TITLE
Extend `JUnitToAssertJRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -5,6 +5,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.offset;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -34,7 +36,8 @@ import tech.picnic.errorprone.refaster.annotation.TypeMigration;
  * <p>Note that, while both libraries throw an {@link AssertionError} in case of an assertion
  * failure, the exact subtype used generally differs.
  */
-// XXX: Not all JUnit `Assertions` methods have an associated Refaster rule yet; expand this class.
+// XXX: The `AssertThat*Array*ContainsExactly*` rules assume that `expected` and `actual` are not
+// both `null`.
 // XXX: Introduce a `@Matcher` on `Executable` and `ThrowingSupplier` expressions, such that they
 // are only matched if they are also compatible with the `ThrowingCallable` functional interface.
 // When implementing such a matcher, note that expressions with a non-void return type such as
@@ -50,39 +53,6 @@ import tech.picnic.errorprone.refaster.annotation.TypeMigration;
       "assertAll(String, Collection<Executable>)",
       "assertAll(String, Executable[])",
       "assertAll(String, Stream<Executable>)",
-      "assertArrayEquals(boolean[], boolean[])",
-      "assertArrayEquals(boolean[], boolean[], String)",
-      "assertArrayEquals(boolean[], boolean[], Supplier<String>)",
-      "assertArrayEquals(byte[], byte[])",
-      "assertArrayEquals(byte[], byte[], String)",
-      "assertArrayEquals(byte[], byte[], Supplier<String>)",
-      "assertArrayEquals(char[], char[])",
-      "assertArrayEquals(char[], char[], String)",
-      "assertArrayEquals(char[], char[], Supplier<String>)",
-      "assertArrayEquals(double[], double[])",
-      "assertArrayEquals(double[], double[], double)",
-      "assertArrayEquals(double[], double[], double, String)",
-      "assertArrayEquals(double[], double[], double, Supplier<String>)",
-      "assertArrayEquals(double[], double[], String)",
-      "assertArrayEquals(double[], double[], Supplier<String>)",
-      "assertArrayEquals(float[], float[])",
-      "assertArrayEquals(float[], float[], float)",
-      "assertArrayEquals(float[], float[], float, String)",
-      "assertArrayEquals(float[], float[], float, Supplier<String>)",
-      "assertArrayEquals(float[], float[], String)",
-      "assertArrayEquals(float[], float[], Supplier<String>)",
-      "assertArrayEquals(int[], int[])",
-      "assertArrayEquals(int[], int[], String)",
-      "assertArrayEquals(int[], int[], Supplier<String>)",
-      "assertArrayEquals(long[], long[])",
-      "assertArrayEquals(long[], long[], String)",
-      "assertArrayEquals(long[], long[], Supplier<String>)",
-      "assertArrayEquals(Object[], Object[])",
-      "assertArrayEquals(Object[], Object[], String)",
-      "assertArrayEquals(Object[], Object[], Supplier<String>)",
-      "assertArrayEquals(short[], short[])",
-      "assertArrayEquals(short[], short[], String)",
-      "assertArrayEquals(short[], short[], Supplier<String>)",
       "assertEquals(Byte, Byte)",
       "assertEquals(Byte, byte)",
       "assertEquals(byte, Byte)",
@@ -301,6 +271,436 @@ import tech.picnic.errorprone.refaster.annotation.TypeMigration;
     })
 final class JUnitToAssertJRules {
   private JUnitToAssertJRules() {}
+
+  static final class AssertThatBooleanArrayContainsExactly {
+    @BeforeTemplate
+    void before(boolean[] actual, boolean[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean[] actual, boolean[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatBooleanArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(boolean[] actual, String message, boolean[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean[] actual, String message, boolean[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatBooleanArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(boolean[] actual, Supplier<String> message, boolean[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(boolean[] actual, Supplier<String> message, boolean[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatByteArrayContainsExactly {
+    @BeforeTemplate
+    void before(byte[] actual, byte[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(byte[] actual, byte[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatByteArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(byte[] actual, String message, byte[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(byte[] actual, String message, byte[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatByteArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(byte[] actual, Supplier<String> message, byte[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(byte[] actual, Supplier<String> message, byte[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatCharArrayContainsExactly {
+    @BeforeTemplate
+    void before(char[] actual, char[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(char[] actual, char[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatCharArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(char[] actual, String message, char[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(char[] actual, String message, char[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatCharArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(char[] actual, Supplier<String> message, char[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(char[] actual, Supplier<String> message, char[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatShortArrayContainsExactly {
+    @BeforeTemplate
+    void before(short[] actual, short[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(short[] actual, short[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatShortArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(short[] actual, String message, short[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(short[] actual, String message, short[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatShortArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(short[] actual, Supplier<String> message, short[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(short[] actual, Supplier<String> message, short[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatIntArrayContainsExactly {
+    @BeforeTemplate
+    void before(int[] actual, int[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(int[] actual, int[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatIntArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(int[] actual, String message, int[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(int[] actual, String message, int[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatIntArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(int[] actual, Supplier<String> message, int[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(int[] actual, Supplier<String> message, int[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatLongArrayContainsExactly {
+    @BeforeTemplate
+    void before(long[] actual, long[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(long[] actual, long[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatLongArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(long[] actual, String message, long[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(long[] actual, String message, long[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatLongArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(long[] actual, Supplier<String> message, long[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(long[] actual, Supplier<String> message, long[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatFloatArrayContainsExactly {
+    @BeforeTemplate
+    void before(float[] actual, float[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, float[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatFloatArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(float[] actual, String message, float[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, String message, float[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatFloatArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(float[] actual, Supplier<String> message, float[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, Supplier<String> message, float[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatFloatArrayContainsExactlyWithOffset {
+    @BeforeTemplate
+    void before(float[] actual, float[] expected, float delta) {
+      assertArrayEquals(expected, actual, delta);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, float[] expected, float delta) {
+      assertThat(actual).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertThatFloatArrayWithFailMessageContainsExactlyWithOffset {
+    @BeforeTemplate
+    void before(float[] actual, String message, float[] expected, float delta) {
+      assertArrayEquals(expected, actual, delta, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, String message, float[] expected, float delta) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffset {
+    @BeforeTemplate
+    void before(float[] actual, Supplier<String> message, float[] expected, float delta) {
+      assertArrayEquals(expected, actual, delta, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, Supplier<String> message, float[] expected, float delta) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertThatDoubleArrayContainsExactly {
+    @BeforeTemplate
+    void before(double[] actual, double[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, double[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatDoubleArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(double[] actual, String message, double[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, String message, double[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatDoubleArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(double[] actual, Supplier<String> message, double[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, Supplier<String> message, double[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatDoubleArrayContainsExactlyWithOffset {
+    @BeforeTemplate
+    void before(double[] actual, double[] expected, double delta) {
+      assertArrayEquals(expected, actual, delta);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, double[] expected, double delta) {
+      assertThat(actual).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertThatDoubleArrayWithFailMessageContainsExactlyWithOffset {
+    @BeforeTemplate
+    void before(double[] actual, String message, double[] expected, double delta) {
+      assertArrayEquals(expected, actual, delta, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, String message, double[] expected, double delta) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffset {
+    @BeforeTemplate
+    void before(
+        double[] actual, Supplier<String> messageSupplier, double[] expected, double delta) {
+      assertArrayEquals(expected, actual, delta, messageSupplier);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(double[] actual, Supplier<String> messageSupplier, double[] expected, double delta) {
+      assertThat(actual).withFailMessage(messageSupplier).containsExactly(expected, offset(delta));
+    }
+  }
+
+  static final class AssertThatObjectArrayContainsExactly {
+    @BeforeTemplate
+    void before(Object[] actual, Object[] expected) {
+      assertArrayEquals(expected, actual);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object[] actual, Object[] expected) {
+      assertThat(actual).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatObjectArrayWithFailMessageContainsExactly {
+    @BeforeTemplate
+    void before(Object[] actual, String message, Object[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object[] actual, String message, Object[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
+
+  static final class AssertThatObjectArrayWithFailMessageSupplierContainsExactly {
+    @BeforeTemplate
+    void before(Object[] actual, Supplier<String> message, Object[] expected) {
+      assertArrayEquals(expected, actual, message);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(Object[] actual, Supplier<String> message, Object[] expected) {
+      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    }
+  }
 
   static final class Fail<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -1,5 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static org.assertj.core.api.Assertions.offset;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -24,12 +26,146 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         assertInstanceOf(null, null),
         assertThrows(null, null),
         assertThrowsExactly(null, null),
+        offset(0.0),
+        (Runnable) () -> assertArrayEquals((int[]) null, null),
         (Runnable) () -> assertFalse(true),
         (Runnable) () -> assertNotNull(null),
         (Runnable) () -> assertNotSame(null, null),
         (Runnable) () -> assertNull(null),
         (Runnable) () -> assertSame(null, null),
         (Runnable) () -> assertTrue(true));
+  }
+
+  void testAssertThatBooleanArrayContainsExactly() {
+    assertArrayEquals(new boolean[] {true}, new boolean[] {false});
+  }
+
+  void testAssertThatBooleanArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new boolean[] {true}, new boolean[] {false}, "foo");
+  }
+
+  void testAssertThatBooleanArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new boolean[] {true}, new boolean[] {false}, () -> "foo");
+  }
+
+  void testAssertThatByteArrayContainsExactly() {
+    assertArrayEquals(new byte[] {1}, new byte[] {2});
+  }
+
+  void testAssertThatByteArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new byte[] {1}, new byte[] {2}, "foo");
+  }
+
+  void testAssertThatByteArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new byte[] {1}, new byte[] {2}, () -> "foo");
+  }
+
+  void testAssertThatCharArrayContainsExactly() {
+    assertArrayEquals(new char[] {'a'}, new char[] {'b'});
+  }
+
+  void testAssertThatCharArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new char[] {'a'}, new char[] {'b'}, "foo");
+  }
+
+  void testAssertThatCharArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new char[] {'a'}, new char[] {'b'}, () -> "foo");
+  }
+
+  void testAssertThatShortArrayContainsExactly() {
+    assertArrayEquals(new short[] {1}, new short[] {2});
+  }
+
+  void testAssertThatShortArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new short[] {1}, new short[] {2}, "foo");
+  }
+
+  void testAssertThatShortArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new short[] {1}, new short[] {2}, () -> "foo");
+  }
+
+  void testAssertThatIntArrayContainsExactly() {
+    assertArrayEquals(new int[] {1}, new int[] {2});
+  }
+
+  void testAssertThatIntArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new int[] {1}, new int[] {2}, "foo");
+  }
+
+  void testAssertThatIntArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new int[] {1}, new int[] {2}, () -> "foo");
+  }
+
+  void testAssertThatLongArrayContainsExactly() {
+    assertArrayEquals(new long[] {1L}, new long[] {2L});
+  }
+
+  void testAssertThatLongArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new long[] {1L}, new long[] {2L}, "foo");
+  }
+
+  void testAssertThatLongArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new long[] {1L}, new long[] {2L}, () -> "foo");
+  }
+
+  void testAssertThatFloatArrayContainsExactly() {
+    assertArrayEquals(new float[] {1.0F}, new float[] {2.0F});
+  }
+
+  void testAssertThatFloatArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new float[] {1.0F}, new float[] {2.0F}, "foo");
+  }
+
+  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new float[] {1.0F}, new float[] {2.0F}, () -> "foo");
+  }
+
+  void testAssertThatFloatArrayContainsExactlyWithOffset() {
+    assertArrayEquals(new float[] {1.0F}, new float[] {2.0F}, 0.1f);
+  }
+
+  void testAssertThatFloatArrayWithFailMessageContainsExactlyWithOffset() {
+    assertArrayEquals(new float[] {1.0F}, new float[] {2.0F}, 0.1f, "foo");
+  }
+
+  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+    assertArrayEquals(new float[] {1.0F}, new float[] {2.0F}, 0.1f, () -> "foo");
+  }
+
+  void testAssertThatDoubleArrayContainsExactly() {
+    assertArrayEquals(new double[] {1.0}, new double[] {2.0});
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new double[] {1.0}, new double[] {2.0}, "foo");
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new double[] {1.0}, new double[] {2.0}, () -> "foo");
+  }
+
+  void testAssertThatDoubleArrayContainsExactlyWithOffset() {
+    assertArrayEquals(new double[] {1.0}, new double[] {2.0}, 0.1);
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageContainsExactlyWithOffset() {
+    assertArrayEquals(new double[] {1.0}, new double[] {2.0}, 0.1, "foo");
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+    assertArrayEquals(new double[] {1.0}, new double[] {2.0}, 0.1, () -> "foo");
+  }
+
+  void testAssertThatObjectArrayContainsExactly() {
+    assertArrayEquals(new Object[] {"foo"}, new Object[] {"bar"});
+  }
+
+  void testAssertThatObjectArrayWithFailMessageContainsExactly() {
+    assertArrayEquals(new Object[] {"foo"}, new Object[] {"bar"}, "foo");
+  }
+
+  void testAssertThatObjectArrayWithFailMessageSupplierContainsExactly() {
+    assertArrayEquals(new Object[] {"foo"}, new Object[] {"bar"}, () -> "foo");
   }
 
   Object testFail() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -3,6 +3,8 @@ package tech.picnic.errorprone.refasterrules;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.offset;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -27,12 +29,158 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         assertInstanceOf(null, null),
         assertThrows(null, null),
         assertThrowsExactly(null, null),
+        offset(0.0),
+        (Runnable) () -> assertArrayEquals((int[]) null, null),
         (Runnable) () -> assertFalse(true),
         (Runnable) () -> assertNotNull(null),
         (Runnable) () -> assertNotSame(null, null),
         (Runnable) () -> assertNull(null),
         (Runnable) () -> assertSame(null, null),
         (Runnable) () -> assertTrue(true));
+  }
+
+  void testAssertThatBooleanArrayContainsExactly() {
+    assertThat(new boolean[] {false}).containsExactly(new boolean[] {true});
+  }
+
+  void testAssertThatBooleanArrayWithFailMessageContainsExactly() {
+    assertThat(new boolean[] {false}).withFailMessage("foo").containsExactly(new boolean[] {true});
+  }
+
+  void testAssertThatBooleanArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new boolean[] {false})
+        .withFailMessage(() -> "foo")
+        .containsExactly(new boolean[] {true});
+  }
+
+  void testAssertThatByteArrayContainsExactly() {
+    assertThat(new byte[] {2}).containsExactly(new byte[] {1});
+  }
+
+  void testAssertThatByteArrayWithFailMessageContainsExactly() {
+    assertThat(new byte[] {2}).withFailMessage("foo").containsExactly(new byte[] {1});
+  }
+
+  void testAssertThatByteArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new byte[] {2}).withFailMessage(() -> "foo").containsExactly(new byte[] {1});
+  }
+
+  void testAssertThatCharArrayContainsExactly() {
+    assertThat(new char[] {'b'}).containsExactly(new char[] {'a'});
+  }
+
+  void testAssertThatCharArrayWithFailMessageContainsExactly() {
+    assertThat(new char[] {'b'}).withFailMessage("foo").containsExactly(new char[] {'a'});
+  }
+
+  void testAssertThatCharArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new char[] {'b'}).withFailMessage(() -> "foo").containsExactly(new char[] {'a'});
+  }
+
+  void testAssertThatShortArrayContainsExactly() {
+    assertThat(new short[] {2}).containsExactly(new short[] {1});
+  }
+
+  void testAssertThatShortArrayWithFailMessageContainsExactly() {
+    assertThat(new short[] {2}).withFailMessage("foo").containsExactly(new short[] {1});
+  }
+
+  void testAssertThatShortArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new short[] {2}).withFailMessage(() -> "foo").containsExactly(new short[] {1});
+  }
+
+  void testAssertThatIntArrayContainsExactly() {
+    assertThat(new int[] {2}).containsExactly(new int[] {1});
+  }
+
+  void testAssertThatIntArrayWithFailMessageContainsExactly() {
+    assertThat(new int[] {2}).withFailMessage("foo").containsExactly(new int[] {1});
+  }
+
+  void testAssertThatIntArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new int[] {2}).withFailMessage(() -> "foo").containsExactly(new int[] {1});
+  }
+
+  void testAssertThatLongArrayContainsExactly() {
+    assertThat(new long[] {2L}).containsExactly(new long[] {1L});
+  }
+
+  void testAssertThatLongArrayWithFailMessageContainsExactly() {
+    assertThat(new long[] {2L}).withFailMessage("foo").containsExactly(new long[] {1L});
+  }
+
+  void testAssertThatLongArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new long[] {2L}).withFailMessage(() -> "foo").containsExactly(new long[] {1L});
+  }
+
+  void testAssertThatFloatArrayContainsExactly() {
+    assertThat(new float[] {2.0F}).containsExactly(new float[] {1.0F});
+  }
+
+  void testAssertThatFloatArrayWithFailMessageContainsExactly() {
+    assertThat(new float[] {2.0F}).withFailMessage("foo").containsExactly(new float[] {1.0F});
+  }
+
+  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new float[] {2.0F}).withFailMessage(() -> "foo").containsExactly(new float[] {1.0F});
+  }
+
+  void testAssertThatFloatArrayContainsExactlyWithOffset() {
+    assertThat(new float[] {2.0F}).containsExactly(new float[] {1.0F}, offset(0.1f));
+  }
+
+  void testAssertThatFloatArrayWithFailMessageContainsExactlyWithOffset() {
+    assertThat(new float[] {2.0F})
+        .withFailMessage("foo")
+        .containsExactly(new float[] {1.0F}, offset(0.1f));
+  }
+
+  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+    assertThat(new float[] {2.0F})
+        .withFailMessage(() -> "foo")
+        .containsExactly(new float[] {1.0F}, offset(0.1f));
+  }
+
+  void testAssertThatDoubleArrayContainsExactly() {
+    assertThat(new double[] {2.0}).containsExactly(new double[] {1.0});
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageContainsExactly() {
+    assertThat(new double[] {2.0}).withFailMessage("foo").containsExactly(new double[] {1.0});
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new double[] {2.0}).withFailMessage(() -> "foo").containsExactly(new double[] {1.0});
+  }
+
+  void testAssertThatDoubleArrayContainsExactlyWithOffset() {
+    assertThat(new double[] {2.0}).containsExactly(new double[] {1.0}, offset(0.1));
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageContainsExactlyWithOffset() {
+    assertThat(new double[] {2.0})
+        .withFailMessage("foo")
+        .containsExactly(new double[] {1.0}, offset(0.1));
+  }
+
+  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+    assertThat(new double[] {2.0})
+        .withFailMessage(() -> "foo")
+        .containsExactly(new double[] {1.0}, offset(0.1));
+  }
+
+  void testAssertThatObjectArrayContainsExactly() {
+    assertThat(new Object[] {"bar"}).containsExactly(new Object[] {"foo"});
+  }
+
+  void testAssertThatObjectArrayWithFailMessageContainsExactly() {
+    assertThat(new Object[] {"bar"}).withFailMessage("foo").containsExactly(new Object[] {"foo"});
+  }
+
+  void testAssertThatObjectArrayWithFailMessageSupplierContainsExactly() {
+    assertThat(new Object[] {"bar"})
+        .withFailMessage(() -> "foo")
+        .containsExactly(new Object[] {"foo"});
   }
 
   Object testFail() {


### PR DESCRIPTION
Suggested commit message:
```
Extend `JUnitToAssertJRules` Refaster rule collection (#1484)

By migrating all remaining `assertArrayEquals` methods.
```

Analogous to #1483, this is me putting up a PR for a existing branch, this time after extending the work with the help of GitHub Copilot. (Also here, perhaps an Error Prone check is in order, but not today.)