### PR TITLE
Introduce `ImmutableTableRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitArgumentEnumeration.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/ExplicitArgumentEnumeration.java
@@ -113,7 +113,7 @@ public final class ExplicitArgumentEnumeration extends BugChecker
           .put(OBJECT_ENUMERABLE_ASSERT, "doesNotContainAnyElementsOf", "doesNotContain")
           .put(OBJECT_ENUMERABLE_ASSERT, "hasSameElementsAs", "containsOnly")
           .put(STEP_VERIFIER_STEP, "expectNextSequence", "expectNext")
-          .build();
+          .buildOrThrow();
 
   /** Instantiates a new {@link ExplicitArgumentEnumeration} instance. */
   public ExplicitArgumentEnumeration() {}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -182,7 +182,7 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
       }
     }
 
-    return imports.build();
+    return imports.buildOrThrow();
   }
 
   private static boolean shouldNotBeStaticallyImported(String type, String member) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableTableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableTableRules.java
@@ -1,0 +1,114 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static com.google.common.collect.ImmutableTable.toImmutableTable;
+import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.MayOptionallyUse;
+import com.google.errorprone.refaster.annotation.Placeholder;
+import com.google.errorprone.refaster.annotation.UseImportPolicy;
+import java.util.stream.Stream;
+import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
+
+/** Refaster rules related to expressions dealing with {@link ImmutableTable}s. */
+@OnlineDocumentation
+final class ImmutableTableRules {
+  private ImmutableTableRules() {}
+
+  /** Prefer {@link ImmutableTable#builder()} over the associated constructor. */
+  // XXX: This rule may drop generic type information, leading to non-compilable code.
+  static final class ImmutableTableBuilder<R, C, V> {
+    @BeforeTemplate
+    ImmutableTable.Builder<R, C, V> before() {
+      return new ImmutableTable.Builder<>();
+    }
+
+    @AfterTemplate
+    ImmutableTable.Builder<R, C, V> after() {
+      return ImmutableTable.builder();
+    }
+  }
+
+  /**
+   * Prefer {@link ImmutableTable.Builder#buildOrThrow()} over the less explicit {@link
+   * ImmutableTable.Builder#build()}.
+   */
+  static final class ImmutableTableBuilderBuildOrThrow<R, C, V> {
+    @BeforeTemplate
+    ImmutableTable<R, C, V> before(ImmutableTable.Builder<R, C, V> builder) {
+      return builder.build();
+    }
+
+    @AfterTemplate
+    ImmutableTable<R, C, V> after(ImmutableTable.Builder<R, C, V> builder) {
+      return builder.buildOrThrow();
+    }
+  }
+
+  /** Prefer {@link ImmutableTable#of(Object, Object, Object)} over more contrived alternatives. */
+  static final class CellToImmutableTable<R, C, V> {
+    @BeforeTemplate
+    ImmutableTable<R, C, V> before(Table.Cell<? extends R, ? extends C, ? extends V> cell) {
+      return Refaster.anyOf(
+          ImmutableTable.<R, C, V>builder().put(cell).buildOrThrow(),
+          Stream.of(cell)
+              .collect(
+                  toImmutableTable(
+                      Table.Cell::getRowKey, Table.Cell::getColumnKey, Table.Cell::getValue)));
+    }
+
+    @AfterTemplate
+    ImmutableTable<R, C, V> after(Table.Cell<? extends R, ? extends C, ? extends V> cell) {
+      return ImmutableTable.of(cell.getRowKey(), cell.getColumnKey(), cell.getValue());
+    }
+  }
+
+  /**
+   * Don't map a stream's elements to table cells, only to subsequently collect them into an {@link
+   * ImmutableTable}. The collection can be performed directly.
+   */
+  abstract static class StreamOfCellsToImmutableTable<E, R, C, V> {
+    @Placeholder(allowsIdentity = true)
+    abstract R rowFunction(@MayOptionallyUse E element);
+
+    @Placeholder(allowsIdentity = true)
+    abstract C columnFunction(@MayOptionallyUse E element);
+
+    @Placeholder(allowsIdentity = true)
+    abstract V valueFunction(@MayOptionallyUse E element);
+
+    @BeforeTemplate
+    ImmutableTable<R, C, V> before(Stream<E> stream) {
+      return stream
+          .map(e -> Tables.immutableCell(rowFunction(e), columnFunction(e), valueFunction(e)))
+          .collect(
+              toImmutableTable(
+                  Table.Cell::getRowKey, Table.Cell::getColumnKey, Table.Cell::getValue));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ImmutableTable<R, C, V> after(Stream<E> stream) {
+      return stream.collect(
+          toImmutableTable(e -> rowFunction(e), e -> columnFunction(e), e -> valueFunction(e)));
+    }
+  }
+
+  /** Prefer {@link ImmutableTable#of()} over more contrived alternatives . */
+  static final class ImmutableTableOf<R, C, V> {
+    @BeforeTemplate
+    ImmutableTable<R, C, V> before() {
+      return ImmutableTable.<R, C, V>builder().buildOrThrow();
+    }
+
+    @AfterTemplate
+    ImmutableTable<R, C, V> after() {
+      return ImmutableTable.of();
+    }
+  }
+}

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -54,6 +54,7 @@ final class RefasterRulesTest {
           ImmutableSortedMapRules.class,
           ImmutableSortedMultisetRules.class,
           ImmutableSortedSetRules.class,
+          ImmutableTableRules.class,
           IntStreamRules.class,
           JUnitRules.class,
           JUnitToAssertJRules.class,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestInput.java
@@ -1,0 +1,48 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static com.google.common.collect.ImmutableTable.toImmutableTable;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
+import java.util.stream.Stream;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<Object> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Table.class);
+  }
+
+  ImmutableTable.Builder<String, Integer, String> testImmutableTableBuilder() {
+    return new ImmutableTable.Builder<>();
+  }
+
+  ImmutableTable<Object, Object, Object> testImmutableTableBuilderBuildOrThrow() {
+    return ImmutableTable.builder().build();
+  }
+
+  ImmutableSet<ImmutableTable<String, Integer, String>> testCellToImmutableTable() {
+    return ImmutableSet.of(
+        ImmutableTable.<String, Integer, String>builder()
+            .put(Tables.immutableCell("foo", 1, "bar"))
+            .buildOrThrow(),
+        Stream.of(Tables.immutableCell("baz", 2, "qux"))
+            .collect(
+                toImmutableTable(
+                    Table.Cell::getRowKey, Table.Cell::getColumnKey, Table.Cell::getValue)));
+  }
+
+  ImmutableTable<Integer, String, Integer> testStreamOfCellsToImmutableTable() {
+    return Stream.of(1, 2, 3)
+        .map(n -> Tables.immutableCell(n, n.toString(), n * 2))
+        .collect(
+            toImmutableTable(
+                Table.Cell::getRowKey, Table.Cell::getColumnKey, Table.Cell::getValue));
+  }
+
+  ImmutableTable<String, String, String> testImmutableTableOf() {
+    return ImmutableTable.<String, String, String>builder().buildOrThrow();
+  }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestOutput.java
@@ -1,0 +1,45 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static com.google.common.collect.ImmutableTable.toImmutableTable;
+
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.Table;
+import com.google.common.collect.Tables;
+import java.util.stream.Stream;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
+  public ImmutableSet<Object> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Table.class);
+  }
+
+  ImmutableTable.Builder<String, Integer, String> testImmutableTableBuilder() {
+    return ImmutableTable.builder();
+  }
+
+  ImmutableTable<Object, Object, Object> testImmutableTableBuilderBuildOrThrow() {
+    return ImmutableTable.builder().buildOrThrow();
+  }
+
+  ImmutableSet<ImmutableTable<String, Integer, String>> testCellToImmutableTable() {
+    return ImmutableSet.of(
+        ImmutableTable.of(
+            Tables.immutableCell("foo", 1, "bar").getRowKey(),
+            Tables.immutableCell("foo", 1, "bar").getColumnKey(),
+            Tables.immutableCell("foo", 1, "bar").getValue()),
+        ImmutableTable.of(
+            Tables.immutableCell("baz", 2, "qux").getRowKey(),
+            Tables.immutableCell("baz", 2, "qux").getColumnKey(),
+            Tables.immutableCell("baz", 2, "qux").getValue()));
+  }
+
+  ImmutableTable<Integer, String, Integer> testStreamOfCellsToImmutableTable() {
+    return Stream.of(1, 2, 3).collect(toImmutableTable(n -> n, n -> n.toString(), n -> n * 2));
+  }
+
+  ImmutableTable<String, String, String> testImmutableTableOf() {
+    return ImmutableTable.of();
+  }
+}


### PR DESCRIPTION
Suggested commit message:
```
Introduce `ImmutableTableRules` Refaster rule collection (#1489)
```

This work results from #1223 and [this comment](https://github.com/PicnicSupermarket/error-prone-support/pull/1488#discussion_r1899183057), with the observation that `ImmutableTable` has a distinct builder type. The rules introduced here are a subset of those defined by `ImmutableMapRules`.