### PR TITLE
Run GitHub Actions workflows on `macos-15` and `windows-2025`

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
         distribution: [ temurin ]
         experimental: [ false ]
         include:
-          - os: macos-15-large
+          - os: macos-15
             jdk: 17.0.13
             distribution: temurin
             experimental: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,11 +14,11 @@ jobs:
         distribution: [ temurin ]
         experimental: [ false ]
         include:
-          - os: macos-14
+          - os: macos-15-large
             jdk: 17.0.13
             distribution: temurin
             experimental: false
-          - os: windows-2022
+          - os: windows-2025
             jdk: 17.0.13
             distribution: temurin
             experimental: false


### PR DESCRIPTION
Suggested commit message:
```
Run GitHub Actions workflows on `macos-15` and `windows-2025` (#1490)

See:
- https://github.com/actions/runner-images/blob/main/README.md#available-images
- https://github.com/actions/runner-images/blob/main/images/macos/macos-15-Readme.md
- https://github.com/actions/runner-images/blob/main/images/windows/Windows2025-Readme.md
```

These new images are still in beta. Let's see whether they work for us :eyes: