### PR TITLE
Introduce `FluxMapNotNull{,Transformation}OrElse` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -889,14 +889,17 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Flux#mapNotNull(Function)} over more contrived alternatives. */
-  abstract static class FluxMapNotNullMapOptional<T, S> {
+  /**
+   * Prefer immediately unwrapping {@link Optional} transformation results inside {@link
+   * Flux#mapNotNull(Function)} over more contrived alternatives.
+   */
+  abstract static class FluxMapNotNullTransformationOrElse<T, S> {
     @Placeholder(allowsIdentity = true)
     abstract Optional<S> transformation(@MayOptionallyUse T value);
 
     @BeforeTemplate
     Flux<S> before(Flux<T> flux) {
-      return flux.map(x -> transformation(x)).mapNotNull(x -> x.orElse(null));
+      return flux.map(v -> transformation(v)).mapNotNull(o -> o.orElse(null));
     }
 
     @AfterTemplate
@@ -906,7 +909,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Flux#mapNotNull(Function)} over more contrived alternatives. */
-  static final class FluxMapNotNullOptional<T> {
+  static final class FluxMapNotNullOrElse<T> {
     @BeforeTemplate
     Flux<T> before(Flux<Optional<T>> flux) {
       return flux.filter(Optional::isPresent).map(Optional::orElseThrow);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -889,6 +889,37 @@ final class ReactorRules {
     }
   }
 
+  /** Prefer {@link Flux#mapNotNull(Function)} over more contrived alternatives. */
+  abstract static class FluxMapNotNullMapOptional<T, S> {
+    @Placeholder(allowsIdentity = true)
+    abstract Optional<S> transformation(@MayOptionallyUse T value);
+
+    @BeforeTemplate
+    Flux<S> before(Flux<T> flux) {
+      return flux.map(x -> transformation(x))
+          .filter(Optional::isPresent)
+          .map(Optional::orElseThrow);
+    }
+
+    @AfterTemplate
+    Flux<S> after(Flux<T> flux) {
+      return flux.mapNotNull(x -> transformation(x).orElse(null));
+    }
+  }
+
+  /** Prefer {@link Flux#mapNotNull(Function)} over more contrived alternatives. */
+  static final class FluxMapNotNullOptional<T> {
+    @BeforeTemplate
+    Flux<T> before(Flux<Optional<T>> flux) {
+      return flux.filter(Optional::isPresent).map(Optional::orElseThrow);
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flux<Optional<T>> flux) {
+      return flux.mapNotNull(x -> x.orElse(null));
+    }
+  }
+
   /** Prefer {@link Mono#flux()}} over more contrived alternatives. */
   static final class MonoFlux<T> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -896,9 +896,7 @@ final class ReactorRules {
 
     @BeforeTemplate
     Flux<S> before(Flux<T> flux) {
-      return flux.map(x -> transformation(x))
-          .filter(Optional::isPresent)
-          .map(Optional::orElseThrow);
+      return flux.map(x -> transformation(x)).mapNotNull(x -> x.orElse(null));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -325,6 +325,17 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).switchMap(n -> Mono.fromSupplier(() -> n * 2)));
   }
 
+  Flux<String> testFluxMapNotNullMapOptional() {
+    return Flux.just(1)
+        .map(x -> Optional.of(x.toString()))
+        .filter(Optional::isPresent)
+        .map(Optional::orElseThrow);
+  }
+
+  Flux<Integer> testFluxMapNotNullOptional() {
+    return Flux.just(Optional.of(1)).filter(Optional::isPresent).map(Optional::orElseThrow);
+  }
+
   ImmutableSet<Flux<String>> testMonoFlux() {
     return ImmutableSet.of(
         Mono.just("foo").flatMapMany(Mono::just),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -325,11 +325,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).switchMap(n -> Mono.fromSupplier(() -> n * 2)));
   }
 
-  Flux<String> testFluxMapNotNullMapOptional() {
+  Flux<String> testFluxMapNotNullTransformationOrElse() {
     return Flux.just(1).map(x -> Optional.of(x.toString())).mapNotNull(x -> x.orElse(null));
   }
 
-  Flux<Integer> testFluxMapNotNullOptional() {
+  Flux<Integer> testFluxMapNotNullOrElse() {
     return Flux.just(Optional.of(1)).filter(Optional::isPresent).map(Optional::orElseThrow);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -326,10 +326,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   Flux<String> testFluxMapNotNullMapOptional() {
-    return Flux.just(1)
-        .map(x -> Optional.of(x.toString()))
-        .filter(Optional::isPresent)
-        .map(Optional::orElseThrow);
+    return Flux.just(1).map(x -> Optional.of(x.toString())).mapNotNull(x -> x.orElse(null));
   }
 
   Flux<Integer> testFluxMapNotNullOptional() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -325,11 +325,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).mapNotNull(n -> n * 2));
   }
 
-  Flux<String> testFluxMapNotNullMapOptional() {
+  Flux<String> testFluxMapNotNullTransformationOrElse() {
     return Flux.just(1).mapNotNull(x -> Optional.of(x.toString()).orElse(null));
   }
 
-  Flux<Integer> testFluxMapNotNullOptional() {
+  Flux<Integer> testFluxMapNotNullOrElse() {
     return Flux.just(Optional.of(1)).mapNotNull(x -> x.orElse(null));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -325,6 +325,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).mapNotNull(n -> n * 2));
   }
 
+  Flux<String> testFluxMapNotNullMapOptional() {
+    return Flux.just(1).mapNotNull(x -> Optional.of(x.toString()).orElse(null));
+  }
+
+  Flux<Integer> testFluxMapNotNullOptional() {
+    return Flux.just(Optional.of(1)).mapNotNull(x -> x.orElse(null));
+  }
+
   ImmutableSet<Flux<String>> testMonoFlux() {
     return ImmutableSet.of(
         Mono.just("foo").flux(), Mono.just("bar").flux(), Mono.just("baz").flux());


### PR DESCRIPTION
I want to advocate for using `Flux#mapNotNull` more, even if that includes defaulting to an explicit `null` value.

I'm happy to learn how to fuse those into one rule. :eyes:

Suggested commit message:
```
Introduce `FluxMapNotNull{,Transformation}OrElse` Refaster rules (#1493)
```

