### PR TITLE
Extend `{Is,Non}NullFunction` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
@@ -3,6 +3,7 @@ package tech.picnic.errorprone.refasterrules;
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
+import static java.util.function.Predicate.not;
 
 import com.google.common.base.MoreObjects;
 import com.google.errorprone.refaster.Refaster;
@@ -98,7 +99,7 @@ final class NullRules {
   static final class IsNullFunction<T> {
     @BeforeTemplate
     Predicate<T> before() {
-      return o -> o == null;
+      return Refaster.anyOf(o -> o == null, not(Objects::nonNull));
     }
 
     @AfterTemplate
@@ -111,7 +112,7 @@ final class NullRules {
   static final class NonNullFunction<T> {
     @BeforeTemplate
     Predicate<T> before() {
-      return o -> o != null;
+      return Refaster.anyOf(o -> o != null, not(Objects::isNull));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
@@ -95,7 +95,10 @@ final class NullRules {
     }
   }
 
-  /** Prefer {@link Objects#isNull(Object)} over the equivalent lambda function. */
+  /**
+   * Prefer {@link Objects#isNull(Object)} over the equivalent lambda function or more contrived
+   * alternatives.
+   */
   static final class IsNullFunction<T> {
     @BeforeTemplate
     Predicate<T> before() {
@@ -108,7 +111,10 @@ final class NullRules {
     }
   }
 
-  /** Prefer {@link Objects#nonNull(Object)} over the equivalent lambda function. */
+  /**
+   * Prefer {@link Objects#nonNull(Object)} over the equivalent lambda function or more contrived
+   * alternatives.
+   */
   static final class NonNullFunction<T> {
     @BeforeTemplate
     Predicate<T> before() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
@@ -7,13 +7,12 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class NullRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(MoreObjects.class, Optional.class, Predicate.class, not(null));
+    return ImmutableSet.of(MoreObjects.class, Optional.class, not(null));
   }
 
   ImmutableSet<Boolean> testIsNull() {
@@ -33,15 +32,11 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return Optional.ofNullable("foo").orElseGet(() -> "bar");
   }
 
-  ImmutableSet<Long> testIsNullFunction() {
-    return ImmutableSet.of(
-        Stream.of("foo").filter(s -> s == null).count(),
-        Stream.of("bar").filter(not(Objects::nonNull)).count());
+  ImmutableSet<Predicate<String>> testIsNullFunction() {
+    return ImmutableSet.of(s -> s == null, not(Objects::nonNull));
   }
 
-  ImmutableSet<Long> testNonNullFunction() {
-    return ImmutableSet.of(
-        Stream.of("foo").filter(s -> s != null).count(),
-        Stream.of("bar").filter(not(Objects::isNull)).count());
+  ImmutableSet<Predicate<String>> testNonNullFunction() {
+    return ImmutableSet.of(s -> s != null, not(Objects::isNull));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
@@ -1,16 +1,19 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static java.util.function.Predicate.not;
+
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class NullRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(MoreObjects.class, Optional.class);
+    return ImmutableSet.of(MoreObjects.class, Optional.class, Predicate.class, not(null));
   }
 
   ImmutableSet<Boolean> testIsNull() {
@@ -30,11 +33,15 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return Optional.ofNullable("foo").orElseGet(() -> "bar");
   }
 
-  long testIsNullFunction() {
-    return Stream.of("foo").filter(s -> s == null).count();
+  ImmutableSet<Long> testIsNullFunction() {
+    return ImmutableSet.of(
+        Stream.of("foo").filter(s -> s == null).count(),
+        Stream.of("bar").filter(not(Objects::nonNull)).count());
   }
 
-  long testNonNullFunction() {
-    return Stream.of("foo").filter(s -> s != null).count();
+  ImmutableSet<Long> testNonNullFunction() {
+    return ImmutableSet.of(
+        Stream.of("foo").filter(s -> s != null).count(),
+        Stream.of("bar").filter(not(Objects::isNull)).count());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
@@ -2,18 +2,20 @@ package tech.picnic.errorprone.refasterrules;
 
 import static java.util.Objects.requireNonNullElse;
 import static java.util.Objects.requireNonNullElseGet;
+import static java.util.function.Predicate.not;
 
 import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Predicate;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class NullRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(MoreObjects.class, Optional.class);
+    return ImmutableSet.of(MoreObjects.class, Optional.class, Predicate.class, not(null));
   }
 
   ImmutableSet<Boolean> testIsNull() {
@@ -32,11 +34,15 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return requireNonNullElseGet("foo", () -> "bar");
   }
 
-  long testIsNullFunction() {
-    return Stream.of("foo").filter(Objects::isNull).count();
+  ImmutableSet<Long> testIsNullFunction() {
+    return ImmutableSet.of(
+        Stream.of("foo").filter(Objects::isNull).count(),
+        Stream.of("bar").filter(Objects::isNull).count());
   }
 
-  long testNonNullFunction() {
-    return Stream.of("foo").filter(Objects::nonNull).count();
+  ImmutableSet<Long> testNonNullFunction() {
+    return ImmutableSet.of(
+        Stream.of("foo").filter(Objects::nonNull).count(),
+        Stream.of("bar").filter(Objects::nonNull).count());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
@@ -9,13 +9,12 @@ import com.google.common.collect.ImmutableSet;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.function.Predicate;
-import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class NullRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(MoreObjects.class, Optional.class, Predicate.class, not(null));
+    return ImmutableSet.of(MoreObjects.class, Optional.class, not(null));
   }
 
   ImmutableSet<Boolean> testIsNull() {
@@ -34,15 +33,11 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return requireNonNullElseGet("foo", () -> "bar");
   }
 
-  ImmutableSet<Long> testIsNullFunction() {
-    return ImmutableSet.of(
-        Stream.of("foo").filter(Objects::isNull).count(),
-        Stream.of("bar").filter(Objects::isNull).count());
+  ImmutableSet<Predicate<String>> testIsNullFunction() {
+    return ImmutableSet.of(Objects::isNull, Objects::isNull);
   }
 
-  ImmutableSet<Long> testNonNullFunction() {
-    return ImmutableSet.of(
-        Stream.of("foo").filter(Objects::nonNull).count(),
-        Stream.of("bar").filter(Objects::nonNull).count());
+  ImmutableSet<Predicate<String>> testNonNullFunction() {
+    return ImmutableSet.of(Objects::nonNull, Objects::nonNull);
   }
 }


### PR DESCRIPTION
Pretty trivial extension after I saw this construct in the wild.

---
Suggested commit message:
```
Extend `{Is,Non}NullFunction` Refaster rules (#1494)
```

