### PR TITLE
Upgrade Error Prone fork 2.36.0-picnic-1 -> 2.36.0-picnic-2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,9 @@ jobs:
           allowed-endpoints: >
             api.adoptium.net:443
             github.com:443
+            github-registry-files.githubusercontent.com:443
             jitpack.io:443
+            maven.pkg.github.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
       # We run the build twice for each supported JDK: once against the
@@ -53,6 +55,8 @@ jobs:
         run: mvn -T1C install javadoc:jar
       - name: Build project with self-check against Error Prone fork
         run: mvn -T1C clean verify -Perror-prone-fork -Pnon-maven-central -Pself-check -s settings.xml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove installed project artifacts
         run: mvn dependency:purge-local-repository -DmanualInclude='${project.groupId}' -DresolutionFuzziness=groupId
 

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -21,6 +21,7 @@ jobs:
             api.github.com:443
             bestpractices.coreinfrastructure.org:443
             blog.picnic.nl:443
+            docs.github.com:443
             errorprone.info:443
             github.com:443
             img.shields.io:443

--- a/README.md
+++ b/README.md
@@ -205,12 +205,13 @@ Relevant Maven build parameters:
   version of Error Prone. This is useful e.g. when testing a locally built
   Error Prone SNAPSHOT.
 - `-Perror-prone-fork` runs the build using Picnic's [Error Prone
-  fork][error-prone-fork-repo], hosted on [Jitpack][error-prone-fork-jitpack].
-  This fork generally contains a few changes on top of the latest Error Prone
-  release.
+  fork][error-prone-fork-repo], hosted using [GitHub
+  Packages][error-prone-fork-packages]. This fork generally contains a few
+  changes on top of the latest Error Prone release. Using this profile
+  generally requires passing `-s settings.xml`, with [suitably
+  configured][github-packages-auth] `GITHUB_ACTOR` and `GITHUB_TOKEN`
+  environment variables.
 - `-Pself-check` runs the checks defined by this project against itself.
-  Pending a release of [google/error-prone#3301][error-prone-pull-3301], this
-  flag must currently be used in combination with `-Perror-prone-fork`.
 
 Other highly relevant commands:
 
@@ -275,14 +276,14 @@ channel; please see our [security policy][security] for details.
 [contributing]: https://github.com/PicnicSupermarket/error-prone-support/blob/master/CONTRIBUTING.md
 [contributing-pull-request]: https://github.com/PicnicSupermarket/error-prone-support/blob/master/CONTRIBUTING.md#-opening-a-pull-request
 [error-prone-bugchecker]: https://github.com/google/error-prone/blob/master/check_api/src/main/java/com/google/errorprone/bugpatterns/BugChecker.java
-[error-prone-fork-jitpack]: https://jitpack.io/#PicnicSupermarket/error-prone
+[error-prone-fork-packages]: https://github.com/PicnicSupermarket/error-prone/packages
 [error-prone-fork-repo]: https://github.com/PicnicSupermarket/error-prone
 [error-prone-gradle-installation-guide]: https://github.com/tbroyer/gradle-errorprone-plugin
 [error-prone-installation-guide]: https://errorprone.info/docs/installation#maven
 [error-prone-orig-repo]: https://github.com/google/error-prone
-[error-prone-pull-3301]: https://github.com/google/error-prone/pull/3301
 [github-actions-build-badge]: https://github.com/PicnicSupermarket/error-prone-support/actions/workflows/build.yml/badge.svg
 [github-actions-build-master]: https://github.com/PicnicSupermarket/error-prone-support/actions/workflows/build.yml?query=branch:master&event=push
+[github-packages-auth]: https://docs.github.com/en/packages/working-with-a-github-packages-registry/working-with-the-apache-maven-registry#authenticating-to-github-packages
 [google-java-format]: https://github.com/google/google-java-format
 [idea-288052]: https://youtrack.jetbrains.com/issue/IDEA-288052
 [license-badge]: https://img.shields.io/github/license/PicnicSupermarket/error-prone-support

--- a/documentation-support/pom.xml
+++ b/documentation-support/pom.xml
@@ -16,24 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_test_helpers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>error-prone-utils</artifactId>
         </dependency>
@@ -71,6 +53,24 @@
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -16,31 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotation</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_test_helpers</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>documentation-support</artifactId>
             <!-- This dependency is declared only as a hint to Maven that
@@ -85,6 +60,31 @@
         <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/error-prone-experimental/pom.xml
+++ b/error-prone-experimental/pom.xml
@@ -16,26 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotation</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_test_helpers</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>error-prone-utils</artifactId>
             <scope>provided</scope>
@@ -43,6 +23,26 @@
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/error-prone-guidelines/pom.xml
+++ b/error-prone-guidelines/pom.xml
@@ -16,31 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotation</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_test_helpers</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>documentation-support</artifactId>
             <!-- This dependency is declared only as a hint to Maven that
@@ -66,6 +41,31 @@
         <dependency>
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service-annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>

--- a/error-prone-utils/pom.xml
+++ b/error-prone-utils/pom.xml
@@ -16,22 +16,22 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
+            <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotation</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
+            <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_annotations</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
+            <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_check_api</artifactId>
             <scope>provided</scope>
         </dependency>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
+            <groupId>com.google.errorprone</groupId>
             <artifactId>error_prone_test_helpers</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -144,11 +144,6 @@
         specified. Used by the `patch` and `self-check` profiles. -->
         <error-prone.patch-args />
         <error-prone.self-check-args />
-        <!-- The Maven `groupId` under which Error Prone dependencies are
-        published. We use an official Error Prone release by default. This
-        property allows the `error-prone-fork` profile below to build the
-        project using Picnic's Error Prone fork instead. -->
-        <groupId.error-prone>com.google.errorprone</groupId.error-prone>
         <!-- The build timestamp is derived from the most recent commit
         timestamp in support of reproducible builds. -->
         <project.build.outputTimestamp>2024-11-03T15:58:19Z</project.build.outputTimestamp>
@@ -210,7 +205,7 @@
         <version.auto-service>1.1.1</version.auto-service>
         <version.auto-value>1.11.0</version.auto-value>
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
-        <version.error-prone-fork>v${version.error-prone-orig}-picnic-1</version.error-prone-fork>
+        <version.error-prone-fork>${version.error-prone-orig}-picnic-2</version.error-prone-fork>
         <version.error-prone-orig>2.36.0</version.error-prone-orig>
         <version.error-prone-slf4j>0.1.28</version.error-prone-slf4j>
         <version.guava-beta-checker>1.0</version.guava-beta-checker>
@@ -226,31 +221,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>${groupId.error-prone}</groupId>
-                <artifactId>error_prone_annotation</artifactId>
-                <version>${version.error-prone}</version>
-            </dependency>
-            <dependency>
-                <groupId>${groupId.error-prone}</groupId>
-                <artifactId>error_prone_annotations</artifactId>
-                <version>${version.error-prone}</version>
-            </dependency>
-            <dependency>
-                <groupId>${groupId.error-prone}</groupId>
-                <artifactId>error_prone_check_api</artifactId>
-                <version>${version.error-prone}</version>
-            </dependency>
-            <dependency>
-                <groupId>${groupId.error-prone}</groupId>
-                <artifactId>error_prone_core</artifactId>
-                <version>${version.error-prone}</version>
-            </dependency>
-            <dependency>
-                <groupId>${groupId.error-prone}</groupId>
-                <artifactId>error_prone_test_helpers</artifactId>
-                <version>${version.error-prone}</version>
-            </dependency>
             <dependency>
                 <groupId>${project.groupId}</groupId>
                 <artifactId>documentation-support</artifactId>
@@ -332,6 +302,31 @@
                 <groupId>com.google.auto.value</groupId>
                 <artifactId>auto-value-annotations</artifactId>
                 <version>${version.auto-value}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotation</artifactId>
+                <version>${version.error-prone}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_annotations</artifactId>
+                <version>${version.error-prone}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_check_api</artifactId>
+                <version>${version.error-prone}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_core</artifactId>
+                <version>${version.error-prone}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.google.errorprone</groupId>
+                <artifactId>error_prone_test_helpers</artifactId>
+                <version>${version.error-prone}</version>
             </dependency>
             <dependency>
                 <groupId>com.google.googlejavaformat</groupId>
@@ -1607,63 +1602,8 @@
         <profile>
             <id>error-prone-fork</id>
             <properties>
-                <groupId.error-prone>com.github.PicnicSupermarket.error-prone</groupId.error-prone>
                 <version.error-prone>${version.error-prone-fork}</version.error-prone>
             </properties>
-            <dependencyManagement>
-                <!-- Even when we directly depend on the Picnic Error Prone
-                fork, some other dependencies depend on the official (i.e.,
-                non-forked) `error_prone_annotations`. Here we fix which
-                version is pulled in. -->
-                <dependencies>
-                    <dependency>
-                        <groupId>com.google.errorprone</groupId>
-                        <artifactId>error_prone_annotations</artifactId>
-                        <version>${version.error-prone-orig}</version>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-            <build>
-                <pluginManagement>
-                    <plugins>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-enforcer-plugin</artifactId>
-                            <configuration>
-                                <rules>
-                                    <banDuplicateClasses>
-                                        <!-- The original
-                                        `error_prone_annotations` dependency
-                                        contains the same classes as those
-                                        provided by the corresponding Picnic
-                                        Error Prone fork artifact. -->
-                                        <dependencies combine.children="append">
-                                            <dependency>
-                                                <groupId>com.google.errorprone</groupId>
-                                                <artifactId>error_prone_annotations</artifactId>
-                                                <ignoreClasses>
-                                                    <ignoreClass>*</ignoreClass>
-                                                </ignoreClasses>
-                                            </dependency>
-                                        </dependencies>
-                                    </banDuplicateClasses>
-                                </rules>
-                            </configuration>
-                        </plugin>
-                        <plugin>
-                            <groupId>org.apache.maven.plugins</groupId>
-                            <artifactId>maven-surefire-plugin</artifactId>
-                            <configuration>
-                                <systemPropertyVariables>
-                                    <!-- Property used by `ErrorProneForkTest`
-                                    to verify fork identification. -->
-                                    <error-prone-fork-in-use>true</error-prone-fork-in-use>
-                                </systemPropertyVariables>
-                            </configuration>
-                        </plugin>
-                    </plugins>
-                </pluginManagement>
-            </build>
         </profile>
         <profile>
             <!-- Error Prone checks that are not available from Maven Central;
@@ -1913,7 +1853,7 @@
                                 declarations once properly supported. See
                                 https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                                 <path>
-                                    <groupId>${groupId.error-prone}</groupId>
+                                    <groupId>com.google.errorprone</groupId>
                                     <artifactId>error_prone_core</artifactId>
                                     <version>${version.error-prone}</version>
                                 </path>

--- a/refaster-compiler/pom.xml
+++ b/refaster-compiler/pom.xml
@@ -16,19 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_core</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>refaster-support</artifactId>
         </dependency>
@@ -36,6 +23,19 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/refaster-runner/pom.xml
+++ b/refaster-runner/pom.xml
@@ -16,26 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotation</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_test_helpers</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>refaster-compiler</artifactId>
             <!-- This dependency is declared only as a hint to Maven that
@@ -52,6 +32,26 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/refaster-support/pom.xml
+++ b/refaster-support/pom.xml
@@ -15,42 +15,35 @@
     <url>https://error-prone.picnic.tech</url>
 
     <dependencies>
-        <!-- This dependency is listed out-of-order so as not to confuse the
-        `maven-dependency-plugin` when the `error-prone-fork` profile is
-        enabled: the `error_prone_annotation` dependency pulls in the
-        non-forked `error_prone_annotations` artifact through a dependency on
-        Guava. -->
-        <?SORTPOM IGNORE?>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <?SORTPOM RESUME?>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotation</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_test_helpers</artifactId>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.google.auto.value</groupId>
             <artifactId>auto-value-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/refaster-test-support/pom.xml
+++ b/refaster-test-support/pom.xml
@@ -16,28 +16,6 @@
 
     <dependencies>
         <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotation</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_check_api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_core</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>${groupId.error-prone}</groupId>
-            <artifactId>error_prone_test_helpers</artifactId>
-        </dependency>
-        <dependency>
             <groupId>${project.groupId}</groupId>
             <artifactId>refaster-runner</artifactId>
         </dependency>
@@ -45,6 +23,28 @@
             <groupId>com.google.auto.service</groupId>
             <artifactId>auto-service-annotations</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotation</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_annotations</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_check_api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.google.errorprone</groupId>
+            <artifactId>error_prone_test_helpers</artifactId>
         </dependency>
         <dependency>
             <groupId>com.google.guava</groupId>

--- a/settings.xml
+++ b/settings.xml
@@ -5,13 +5,13 @@
         <profile>
             <!-- The build defines an optional `error-prone-fork` profile using
             which the code is built against a Picnic-managed fork of Error
-            Prone. This fork is hosted by Jitpack.io. See
-            https://jitpack.io/#PicnicSupermarket/error-prone. -->
+            Prone. This fork is hosted using GitHub Packages. See
+            https://github.com/PicnicSupermarket/error-prone/packages. -->
             <id>error-prone-fork</id>
             <repositories>
                 <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
+                    <id>error-prone-fork</id>
+                    <url>https://maven.pkg.github.com/PicnicSupermarket/error-prone</url>
                 </repository>
             </repositories>
         </profile>
@@ -29,4 +29,11 @@
         </profile>
     </profiles>
 
+    <servers>
+        <server>
+            <id>error-prone-fork</id>
+            <username>${env.GITHUB_ACTOR}</username>
+            <password>${env.GITHUB_TOKEN}</password>
+        </server>
+    </servers>
 </settings>

--- a/website/generate-version-compatibility-overview.sh
+++ b/website/generate-version-compatibility-overview.sh
@@ -86,7 +86,7 @@ for eps_version in ${eps_versions}; do
         -Ppatch \
         -Pself-check \
         -Dverification.skip \
-        -Dversion.error-prone-orig="${ep_version}" \
+        -Dversion.error-prone="${ep_version}" \
       && echo "SUCCESS: { \"eps_version\": \"${eps_version}\", \"ep_version\": \"${ep_version}\" }" || true
     # Undo any changes applied by the checks.
     git checkout -- '*.java'


### PR DESCRIPTION
Suggested commit message:
```
Upgrade Error Prone fork 2.36.0-picnic-1 -> 2.36.0-picnic-2 (#1499)

This new release is published using GitHub Packages rather than
JitPack. This comes with a simpler release setup and a (hopefully) more
stable package repository. A minor downside is that GitHub Packages
require authenticated access, even for read access. The documentation
has been updated accordingly.

The new release is no longer published using a custom groupId, enabling
some build simplifications.

While there, some obsolete fork-related documentation and configuration
is dropped.

See:
- https://github.com/PicnicSupermarket/error-prone/releases/tag/v2.36.0-picnic-2
- https://github.com/PicnicSupermarket/error-prone/compare/v2.36.0-picnic-1...v2.36.0-picnic-2
```

This is possible thanks to PicnicSupermarket/error-prone@a3aaf7c134838a1719192f8b0591f240ac791526. See the README update for the requisite local changes. In the context of this work I also filed s4u/setup-maven-action#112.

NB: There's still a dependency on JitPack for `com.github.lhotari:reactor-error-prone`. It appears that in the last few days JitPack is more stable again. Let's review this dependency if/when flakiness returns.