### PR TITLE
Make Mockito setup IntelliJ IDEA-compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,8 +235,9 @@ Other highly relevant commands:
   against _all_ code in the current working directory. For more information
   check the [PIT Maven plugin][pitest-maven].
 
-When running the project's tests in IntelliJ IDEA, you might see the following
-error:
+Opening the project in IntelliJ IDEA may require running `mvn clean install`
+first. Additionally, when running the project's tests using the IDE, you might
+see the following error:
 
 ```
 java: exporting a package from system module jdk.compiler is not allowed with --release

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
             -Xmx${argLine.xmx}
             <!-- Configure the Byte Buddy Java agent used by Mockito to create
             mocks. -->
-            -javaagent:${org.mockito:mockito-core:jar}
+            -javaagent:${project.build.directory}/test-agents/mockito-core.jar
             <!-- This argument cannot be set through Surefire's
             'systemPropertyVariables' configuration setting. Setting the file
             encoding is necessary because forked unit test invocations
@@ -1045,10 +1045,16 @@
                     </configuration>
                     <executions>
                         <execution>
-                            <id>set-additional-properties</id>
+                            <id>copy-test-agents</id>
                             <goals>
-                                <goal>properties</goal>
+                                <goal>copy-dependencies</goal>
                             </goals>
+                            <configuration>
+                                <includeGroupIds>org.mockito</includeGroupIds>
+                                <includeArtifactIds>mockito-core</includeArtifactIds>
+                                <stripVersion>true</stripVersion>
+                                <outputDirectory>${project.build.directory}/test-agents</outputDirectory>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>


### PR DESCRIPTION
Suggested commit message:
```
Make Mockito setup IntelliJ IDEA-compatible (#1500)

See https://github.com/mockito/mockito/issues/3037#issuecomment-2569680756
```

Hat tip to @runeflobakk for [this clearly-written comment](https://github.com/mockito/mockito/issues/3037#issuecomment-2569680756).