### PR TITLE
Extend size-related `AssertJEnumerableRules` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
@@ -26,8 +26,7 @@ final class AssertJEnumerableRules {
 
     @BeforeTemplate
     void before(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
-      Refaster.anyOf(
-          enumAssert.size().isNotPositive(), enumAssert.size().isNotPositive().returnToIterable());
+      enumAssert.size().isNotPositive();
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
@@ -26,7 +26,8 @@ final class AssertJEnumerableRules {
 
     @BeforeTemplate
     void before(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
-      enumAssert.size().isNotPositive();
+      Refaster.anyOf(
+          enumAssert.size().isNotPositive(), enumAssert.size().isNotPositive().returnToIterable());
     }
 
     @AfterTemplate
@@ -47,6 +48,13 @@ final class AssertJEnumerableRules {
       return Refaster.anyOf(enumAssert.size().isNotEqualTo(0), enumAssert.size().isPositive());
     }
 
+    @BeforeTemplate
+    AbstractIterableAssert<?, ?, E, ?> before2(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
+      return Refaster.anyOf(
+          enumAssert.size().isNotEqualTo(0).returnToIterable(),
+          enumAssert.size().isPositive().returnToIterable());
+    }
+
     @AfterTemplate
     EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert) {
       return enumAssert.isNotEmpty();
@@ -58,6 +66,12 @@ final class AssertJEnumerableRules {
     AbstractIterableSizeAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
       return enumAssert.size().isEqualTo(size);
+    }
+
+    @BeforeTemplate
+    AbstractIterableAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isEqualTo(size).returnToIterable();
     }
 
     @AfterTemplate
@@ -73,6 +87,12 @@ final class AssertJEnumerableRules {
       return enumAssert.size().isLessThan(size);
     }
 
+    @BeforeTemplate
+    AbstractIterableAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isLessThan(size).returnToIterable();
+    }
+
     @AfterTemplate
     EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
       return enumAssert.hasSizeLessThan(size);
@@ -84,6 +104,12 @@ final class AssertJEnumerableRules {
     AbstractIterableSizeAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
       return enumAssert.size().isLessThanOrEqualTo(size);
+    }
+
+    @BeforeTemplate
+    AbstractIterableAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isLessThanOrEqualTo(size).returnToIterable();
     }
 
     @AfterTemplate
@@ -99,6 +125,12 @@ final class AssertJEnumerableRules {
       return enumAssert.size().isGreaterThan(size);
     }
 
+    @BeforeTemplate
+    AbstractIterableAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isGreaterThan(size).returnToIterable();
+    }
+
     @AfterTemplate
     EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
       return enumAssert.hasSizeGreaterThan(size);
@@ -112,6 +144,12 @@ final class AssertJEnumerableRules {
       return enumAssert.size().isGreaterThanOrEqualTo(size);
     }
 
+    @BeforeTemplate
+    AbstractIterableAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isGreaterThanOrEqualTo(size).returnToIterable();
+    }
+
     @AfterTemplate
     EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
       return enumAssert.hasSizeGreaterThanOrEqualTo(size);
@@ -123,6 +161,12 @@ final class AssertJEnumerableRules {
     AbstractIterableSizeAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int lower, int upper) {
       return enumAssert.size().isBetween(lower, upper);
+    }
+
+    @BeforeTemplate
+    AbstractIterableAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int lower, int upper) {
+      return enumAssert.size().isBetween(lower, upper).returnToIterable();
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
@@ -43,15 +43,17 @@ final class AssertJEnumerableRules {
     }
 
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
-      return Refaster.anyOf(enumAssert.size().isNotEqualTo(0), enumAssert.size().isPositive());
-    }
-
-    @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before2(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
+    AbstractIterableAssert<?, ?, E, ?> before(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
       return Refaster.anyOf(
           enumAssert.size().isNotEqualTo(0).returnToIterable(),
           enumAssert.size().isPositive().returnToIterable());
+    }
+
+    // XXX: If this template matches, then the expression's return type changes incompatibly.
+    // Consider moving this template to a separate block (statement) rule.
+    @BeforeTemplate
+    AbstractIntegerAssert<?> before2(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
+      return Refaster.anyOf(enumAssert.size().isNotEqualTo(0), enumAssert.size().isPositive());
     }
 
     @AfterTemplate
@@ -62,15 +64,17 @@ final class AssertJEnumerableRules {
 
   static final class EnumerableAssertHasSize<E> {
     @BeforeTemplate
-    AbstractIterableSizeAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isEqualTo(size);
-    }
-
-    @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before2(
+    AbstractIterableAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
       return enumAssert.size().isEqualTo(size).returnToIterable();
+    }
+
+    // XXX: If this template matches, then the expression's return type changes incompatibly.
+    // Consider moving this template to a separate block (statement) rule.
+    @BeforeTemplate
+    AbstractIterableSizeAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isEqualTo(size);
     }
 
     @AfterTemplate
@@ -81,15 +85,17 @@ final class AssertJEnumerableRules {
 
   static final class EnumerableAssertHasSizeLessThan<E> {
     @BeforeTemplate
-    AbstractIterableSizeAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isLessThan(size);
-    }
-
-    @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before2(
+    AbstractIterableAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
       return enumAssert.size().isLessThan(size).returnToIterable();
+    }
+
+    // XXX: If this template matches, then the expression's return type changes incompatibly.
+    // Consider moving this template to a separate block (statement) rule.
+    @BeforeTemplate
+    AbstractIterableSizeAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isLessThan(size);
     }
 
     @AfterTemplate
@@ -100,15 +106,17 @@ final class AssertJEnumerableRules {
 
   static final class EnumerableAssertHasSizeLessThanOrEqualTo<E> {
     @BeforeTemplate
-    AbstractIterableSizeAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isLessThanOrEqualTo(size);
-    }
-
-    @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before2(
+    AbstractIterableAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
       return enumAssert.size().isLessThanOrEqualTo(size).returnToIterable();
+    }
+
+    // XXX: If this template matches, then the expression's return type changes incompatibly.
+    // Consider moving this template to a separate block (statement) rule.
+    @BeforeTemplate
+    AbstractIterableSizeAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isLessThanOrEqualTo(size);
     }
 
     @AfterTemplate
@@ -119,15 +127,17 @@ final class AssertJEnumerableRules {
 
   static final class EnumerableAssertHasSizeGreaterThan<E> {
     @BeforeTemplate
-    AbstractIterableSizeAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isGreaterThan(size);
-    }
-
-    @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before2(
+    AbstractIterableAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
       return enumAssert.size().isGreaterThan(size).returnToIterable();
+    }
+
+    // XXX: If this template matches, then the expression's return type changes incompatibly.
+    // Consider moving this template to a separate block (statement) rule.
+    @BeforeTemplate
+    AbstractIterableSizeAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isGreaterThan(size);
     }
 
     @AfterTemplate
@@ -138,15 +148,17 @@ final class AssertJEnumerableRules {
 
   static final class EnumerableAssertHasSizeGreaterThanOrEqualTo<E> {
     @BeforeTemplate
-    AbstractIterableSizeAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isGreaterThanOrEqualTo(size);
-    }
-
-    @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before2(
+    AbstractIterableAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
       return enumAssert.size().isGreaterThanOrEqualTo(size).returnToIterable();
+    }
+
+    // XXX: If this template matches, then the expression's return type changes incompatibly.
+    // Consider moving this template to a separate block (statement) rule.
+    @BeforeTemplate
+    AbstractIterableSizeAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
+      return enumAssert.size().isGreaterThanOrEqualTo(size);
     }
 
     @AfterTemplate
@@ -157,15 +169,17 @@ final class AssertJEnumerableRules {
 
   static final class EnumerableAssertHasSizeBetween<E> {
     @BeforeTemplate
-    AbstractIterableSizeAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int lower, int upper) {
-      return enumAssert.size().isBetween(lower, upper);
-    }
-
-    @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before2(
+    AbstractIterableAssert<?, ?, E, ?> before(
         AbstractIterableAssert<?, ?, E, ?> enumAssert, int lower, int upper) {
       return enumAssert.size().isBetween(lower, upper).returnToIterable();
+    }
+
+    // XXX: If this template matches, then the expression's return type changes incompatibly.
+    // Consider moving this template to a separate block (statement) rule.
+    @BeforeTemplate
+    AbstractIterableSizeAssert<?, ?, E, ?> before2(
+        AbstractIterableAssert<?, ?, E, ?> enumAssert, int lower, int upper) {
+      return enumAssert.size().isBetween(lower, upper);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
@@ -25,46 +25,46 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     return ImmutableSet.of(
         assertThat(ImmutableSet.of(1)).hasSizeGreaterThan(0),
         assertThat(ImmutableSet.of(2)).hasSizeGreaterThanOrEqualTo(1),
-        assertThat(ImmutableSet.of(3)).size().isNotEqualTo(0),
-        assertThat(ImmutableSet.of(4)).size().isPositive(),
-        assertThat(ImmutableSet.of(5)).size().isNotEqualTo(0).returnToIterable(),
-        assertThat(ImmutableSet.of(6)).size().isPositive().returnToIterable());
+        assertThat(ImmutableSet.of(3)).size().isNotEqualTo(0).returnToIterable(),
+        assertThat(ImmutableSet.of(4)).size().isPositive().returnToIterable(),
+        assertThat(ImmutableSet.of(5)).size().isNotEqualTo(0),
+        assertThat(ImmutableSet.of(6)).size().isPositive());
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSize() {
     return ImmutableSet.of(
-        assertThat(ImmutableSet.of(1)).size().isEqualTo(2),
-        assertThat(ImmutableSet.of(3)).size().isEqualTo(4).returnToIterable());
+        assertThat(ImmutableSet.of(1)).size().isEqualTo(2).returnToIterable(),
+        assertThat(ImmutableSet.of(3)).size().isEqualTo(4));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeLessThan() {
     return ImmutableSet.of(
-        assertThat(ImmutableSet.of(1)).size().isLessThan(2),
-        assertThat(ImmutableSet.of(3)).size().isLessThan(4).returnToIterable());
+        assertThat(ImmutableSet.of(1)).size().isLessThan(2).returnToIterable(),
+        assertThat(ImmutableSet.of(3)).size().isLessThan(4));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeLessThanOrEqualTo() {
     return ImmutableSet.of(
-        assertThat(ImmutableSet.of(1)).size().isLessThanOrEqualTo(2),
-        assertThat(ImmutableSet.of(3)).size().isLessThanOrEqualTo(4).returnToIterable());
+        assertThat(ImmutableSet.of(1)).size().isLessThanOrEqualTo(2).returnToIterable(),
+        assertThat(ImmutableSet.of(3)).size().isLessThanOrEqualTo(4));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeGreaterThan() {
     return ImmutableSet.of(
-        assertThat(ImmutableSet.of(1)).size().isGreaterThan(2),
-        assertThat(ImmutableSet.of(3)).size().isGreaterThan(4).returnToIterable());
+        assertThat(ImmutableSet.of(1)).size().isGreaterThan(2).returnToIterable(),
+        assertThat(ImmutableSet.of(3)).size().isGreaterThan(4));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeGreaterThanOrEqualTo() {
     return ImmutableSet.of(
-        assertThat(ImmutableSet.of(1)).size().isGreaterThanOrEqualTo(2),
-        assertThat(ImmutableSet.of(3)).size().isGreaterThanOrEqualTo(4).returnToIterable());
+        assertThat(ImmutableSet.of(1)).size().isGreaterThanOrEqualTo(2).returnToIterable(),
+        assertThat(ImmutableSet.of(3)).size().isGreaterThanOrEqualTo(4));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeBetween() {
     return ImmutableSet.of(
-        assertThat(ImmutableSet.of(1)).size().isBetween(2, 3),
-        assertThat(ImmutableSet.of(4)).size().isBetween(5, 6).returnToIterable());
+        assertThat(ImmutableSet.of(1)).size().isBetween(2, 3).returnToIterable(),
+        assertThat(ImmutableSet.of(4)).size().isBetween(5, 6));
   }
 
   ImmutableSet<EnumerableAssert<?, Integer>> testEnumerableAssertHasSameSizeAs() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
@@ -19,7 +19,6 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(2)).hasSizeLessThanOrEqualTo(0);
     assertThat(ImmutableSet.of(3)).hasSizeLessThan(1);
     assertThat(ImmutableSet.of(4)).size().isNotPositive();
-    assertThat(ImmutableSet.of(5)).size().isNotPositive().returnToIterable();
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
@@ -19,6 +19,7 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(2)).hasSizeLessThanOrEqualTo(0);
     assertThat(ImmutableSet.of(3)).hasSizeLessThan(1);
     assertThat(ImmutableSet.of(4)).size().isNotPositive();
+    assertThat(ImmutableSet.of(5)).size().isNotPositive().returnToIterable();
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {
@@ -26,31 +27,45 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
         assertThat(ImmutableSet.of(1)).hasSizeGreaterThan(0),
         assertThat(ImmutableSet.of(2)).hasSizeGreaterThanOrEqualTo(1),
         assertThat(ImmutableSet.of(3)).size().isNotEqualTo(0),
-        assertThat(ImmutableSet.of(4)).size().isPositive());
+        assertThat(ImmutableSet.of(4)).size().isPositive(),
+        assertThat(ImmutableSet.of(5)).size().isNotEqualTo(0).returnToIterable(),
+        assertThat(ImmutableSet.of(6)).size().isPositive().returnToIterable());
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSize() {
-    return assertThat(ImmutableSet.of(1)).size().isEqualTo(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSize() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).size().isEqualTo(2),
+        assertThat(ImmutableSet.of(3)).size().isEqualTo(4).returnToIterable());
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeLessThan() {
-    return assertThat(ImmutableSet.of(1)).size().isLessThan(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeLessThan() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).size().isLessThan(2),
+        assertThat(ImmutableSet.of(3)).size().isLessThan(4).returnToIterable());
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeLessThanOrEqualTo() {
-    return assertThat(ImmutableSet.of(1)).size().isLessThanOrEqualTo(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeLessThanOrEqualTo() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).size().isLessThanOrEqualTo(2),
+        assertThat(ImmutableSet.of(3)).size().isLessThanOrEqualTo(4).returnToIterable());
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeGreaterThan() {
-    return assertThat(ImmutableSet.of(1)).size().isGreaterThan(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeGreaterThan() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).size().isGreaterThan(2),
+        assertThat(ImmutableSet.of(3)).size().isGreaterThan(4).returnToIterable());
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeGreaterThanOrEqualTo() {
-    return assertThat(ImmutableSet.of(1)).size().isGreaterThanOrEqualTo(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeGreaterThanOrEqualTo() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).size().isGreaterThanOrEqualTo(2),
+        assertThat(ImmutableSet.of(3)).size().isGreaterThanOrEqualTo(4).returnToIterable());
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeBetween() {
-    return assertThat(ImmutableSet.of(1)).size().isBetween(2, 3);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeBetween() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).size().isBetween(2, 3),
+        assertThat(ImmutableSet.of(4)).size().isBetween(5, 6).returnToIterable());
   }
 
   ImmutableSet<EnumerableAssert<?, Integer>> testEnumerableAssertHasSameSizeAs() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
@@ -19,7 +19,6 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(2)).isEmpty();
     assertThat(ImmutableSet.of(3)).isEmpty();
     assertThat(ImmutableSet.of(4)).isEmpty();
-    assertThat(ImmutableSet.of(5)).isEmpty();
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
@@ -19,6 +19,7 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(2)).isEmpty();
     assertThat(ImmutableSet.of(3)).isEmpty();
     assertThat(ImmutableSet.of(4)).isEmpty();
+    assertThat(ImmutableSet.of(5)).isEmpty();
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {
@@ -26,31 +27,44 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
         assertThat(ImmutableSet.of(1)).isNotEmpty(),
         assertThat(ImmutableSet.of(2)).isNotEmpty(),
         assertThat(ImmutableSet.of(3)).isNotEmpty(),
-        assertThat(ImmutableSet.of(4)).isNotEmpty());
+        assertThat(ImmutableSet.of(4)).isNotEmpty(),
+        assertThat(ImmutableSet.of(5)).isNotEmpty(),
+        assertThat(ImmutableSet.of(6)).isNotEmpty());
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSize() {
-    return assertThat(ImmutableSet.of(1)).hasSize(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSize() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).hasSize(2), assertThat(ImmutableSet.of(3)).hasSize(4));
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeLessThan() {
-    return assertThat(ImmutableSet.of(1)).hasSizeLessThan(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeLessThan() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).hasSizeLessThan(2),
+        assertThat(ImmutableSet.of(3)).hasSizeLessThan(4));
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeLessThanOrEqualTo() {
-    return assertThat(ImmutableSet.of(1)).hasSizeLessThanOrEqualTo(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeLessThanOrEqualTo() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).hasSizeLessThanOrEqualTo(2),
+        assertThat(ImmutableSet.of(3)).hasSizeLessThanOrEqualTo(4));
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeGreaterThan() {
-    return assertThat(ImmutableSet.of(1)).hasSizeGreaterThan(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeGreaterThan() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).hasSizeGreaterThan(2),
+        assertThat(ImmutableSet.of(3)).hasSizeGreaterThan(4));
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeGreaterThanOrEqualTo() {
-    return assertThat(ImmutableSet.of(1)).hasSizeGreaterThanOrEqualTo(2);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeGreaterThanOrEqualTo() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).hasSizeGreaterThanOrEqualTo(2),
+        assertThat(ImmutableSet.of(3)).hasSizeGreaterThanOrEqualTo(4));
   }
 
-  AbstractAssert<?, ?> testEnumerableAssertHasSizeBetween() {
-    return assertThat(ImmutableSet.of(1)).hasSizeBetween(2, 3);
+  ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertHasSizeBetween() {
+    return ImmutableSet.of(
+        assertThat(ImmutableSet.of(1)).hasSizeBetween(2, 3),
+        assertThat(ImmutableSet.of(4)).hasSizeBetween(5, 6));
   }
 
   ImmutableSet<EnumerableAssert<?, Integer>> testEnumerableAssertHasSameSizeAs() {


### PR DESCRIPTION
Suggested commit message:
```
Extend size-related `AssertJEnumerableRules` Refaster rules (#1512)

By also matching expressions ending in `.returnToIterable()`.
```