### PR TITLE
Extend `MonoSingleOptional` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1082,11 +1082,12 @@ final class ReactorRules {
   // rule. Consider introducing an Error Prone check for this.
   static final class MonoSingleOptional<T> {
     @BeforeTemplate
-    Mono<Optional<T>> before(Mono<T> mono) {
+    Mono<Optional<T>> before(Mono<T> mono, Optional<T> optional, Mono<Optional<T>> alternate) {
       return Refaster.anyOf(
           mono.flux().collect(toOptional()),
           mono.map(Optional::of),
-          mono.singleOptional().defaultIfEmpty(Optional.empty()),
+          mono.singleOptional().defaultIfEmpty(optional),
+          mono.singleOptional().switchIfEmpty(alternate),
           mono.transform(Mono::singleOptional));
     }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -1085,7 +1085,8 @@ final class ReactorRules {
     Mono<Optional<T>> before(Mono<T> mono) {
       return Refaster.anyOf(
           mono.flux().collect(toOptional()),
-          mono.map(Optional::of).defaultIfEmpty(Optional.empty()),
+          mono.map(Optional::of),
+          mono.singleOptional().defaultIfEmpty(Optional.empty()),
           mono.transform(Mono::singleOptional));
     }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -394,7 +394,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").flux().collect(toOptional()),
         Mono.just("bar").map(Optional::of),
         Mono.just("baz").singleOptional().defaultIfEmpty(Optional.empty()),
-        Mono.just("quux").singleOptional().switchIfEmpty(Mono.empty()),
+        Mono.just("quux").singleOptional().switchIfEmpty(Mono.just(Optional.empty())),
         Mono.just("quuz").transform(Mono::singleOptional));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -394,7 +394,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").flux().collect(toOptional()),
         Mono.just("bar").map(Optional::of),
         Mono.just("baz").singleOptional().defaultIfEmpty(Optional.empty()),
-        Mono.just("quux").transform(Mono::singleOptional));
+        Mono.just("quux").singleOptional().switchIfEmpty(Mono.empty()),
+        Mono.just("quuz").transform(Mono::singleOptional));
   }
 
   Mono<Number> testMonoCast() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -392,8 +392,9 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Mono<Optional<String>>> testMonoSingleOptional() {
     return ImmutableSet.of(
         Mono.just("foo").flux().collect(toOptional()),
-        Mono.just("bar").map(Optional::of).defaultIfEmpty(Optional.empty()),
-        Mono.just("baz").transform(Mono::singleOptional));
+        Mono.just("bar").map(Optional::of),
+        Mono.just("baz").singleOptional().defaultIfEmpty(Optional.empty()),
+        Mono.just("quux").transform(Mono::singleOptional));
   }
 
   Mono<Number> testMonoCast() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -389,7 +389,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").singleOptional(),
         Mono.just("bar").singleOptional(),
         Mono.just("baz").singleOptional(),
-        Mono.just("quux").singleOptional());
+        Mono.just("quux").singleOptional(),
+        Mono.just("quuz").singleOptional());
   }
 
   Mono<Number> testMonoCast() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -388,7 +388,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Mono.just("foo").singleOptional(),
         Mono.just("bar").singleOptional(),
-        Mono.just("baz").singleOptional());
+        Mono.just("baz").singleOptional(),
+        Mono.just("quux").singleOptional());
   }
 
   Mono<Number> testMonoCast() {


### PR DESCRIPTION
Another bite-sized Refaster rule extension.

Suggested commit message:
```
Extend `MonoSingleOptional` Refaster rule (#1553)
```