### PR TITLE
Extend `MonoThen` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -939,7 +939,11 @@ final class ReactorRules {
   static final class MonoThen<T> {
     @BeforeTemplate
     Mono<@Nullable Void> before(Mono<T> mono) {
-      return Refaster.anyOf(mono.ignoreElement().then(), mono.flux().then(), Mono.when(mono));
+      return Refaster.anyOf(
+          mono.ignoreElement().then(),
+          mono.flux().then(),
+          Mono.when(mono),
+          Mono.whenDelayError(mono));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -939,7 +939,7 @@ final class ReactorRules {
   static final class MonoThen<T> {
     @BeforeTemplate
     Mono<@Nullable Void> before(Mono<T> mono) {
-      return Refaster.anyOf(mono.ignoreElement().then(), mono.flux().then());
+      return Refaster.anyOf(mono.ignoreElement().then(), mono.flux().then(), Mono.when(mono));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -346,7 +346,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").ignoreElement().then(),
         Mono.just("bar").flux().then(),
         Mono.when(Mono.just("baz")),
-        Mono.when(Mono.just("qux")));
+        Mono.whenDelayError(Mono.just("qux")));
   }
 
   ImmutableSet<Mono<Void>> testFluxThen() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -345,7 +345,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Mono.just("foo").ignoreElement().then(),
         Mono.just("bar").flux().then(),
-        Mono.when(Mono.just("baz")));
+        Mono.when(Mono.just("baz")),
+        Mono.when(Mono.just("qux")));
   }
 
   ImmutableSet<Mono<Void>> testFluxThen() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -342,7 +342,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<Void>> testMonoThen() {
-    return ImmutableSet.of(Mono.just("foo").ignoreElement().then(), Mono.just("bar").flux().then());
+    return ImmutableSet.of(
+        Mono.just("foo").ignoreElement().then(),
+        Mono.just("bar").flux().then(),
+        Mono.when(Mono.just("baz")));
   }
 
   ImmutableSet<Mono<Void>> testFluxThen() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -340,7 +340,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Mono<Void>> testMonoThen() {
-    return ImmutableSet.of(Mono.just("foo").then(), Mono.just("bar").then());
+    return ImmutableSet.of(
+        Mono.just("foo").then(), Mono.just("bar").then(), Mono.just("baz").then());
   }
 
   ImmutableSet<Mono<Void>> testFluxThen() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -341,7 +341,10 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Mono<Void>> testMonoThen() {
     return ImmutableSet.of(
-        Mono.just("foo").then(), Mono.just("bar").then(), Mono.just("baz").then());
+        Mono.just("foo").then(),
+        Mono.just("bar").then(),
+        Mono.just("baz").then(),
+        Mono.just("qux").then());
   }
 
   ImmutableSet<Mono<Void>> testFluxThen() {


### PR DESCRIPTION
* `Mono#when` aggregates multiple publishers into one `Mono<Void>`, passing only one publisher to the argument is redundant and can be re-fastered into a `Mono#then`. 

Suggested commit message
```
Extend `MonoThen` Refaster rule (#1556)
```