### PR TITLE
Upgrade Arcmutate plugins

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -214,7 +214,7 @@
         <version.mockito>5.16.1</version.mockito>
         <version.nopen-checker>1.0.1</version.nopen-checker>
         <version.nullaway>0.12.4</version.nullaway>
-        <version.pitest-git>1.1.4</version.pitest-git>
+        <version.pitest-git>2.1.0</version.pitest-git>
         <version.rewrite-templating>1.24.0</version.rewrite-templating>
         <version.surefire>3.2.3</version.surefire>
     </properties>
@@ -576,12 +576,12 @@
                     </executions>
                 </plugin>
                 <plugin>
-                    <groupId>com.groupcdg</groupId>
+                    <groupId>com.arcmutate</groupId>
                     <artifactId>pitest-git-maven-plugin</artifactId>
                     <version>${version.pitest-git}</version>
                 </plugin>
                 <plugin>
-                    <groupId>com.groupcdg</groupId>
+                    <groupId>com.arcmutate</groupId>
                     <artifactId>pitest-github-maven-plugin</artifactId>
                     <version>${version.pitest-git}</version>
                 </plugin>
@@ -1547,19 +1547,19 @@
                     </configuration>
                     <dependencies>
                         <dependency>
-                            <groupId>com.groupcdg</groupId>
+                            <groupId>com.arcmutate</groupId>
                             <artifactId>pitest-git-plugin</artifactId>
                             <version>${version.pitest-git}</version>
                         </dependency>
                         <dependency>
-                            <groupId>com.groupcdg.arcmutate</groupId>
+                            <groupId>com.arcmutate</groupId>
                             <artifactId>base</artifactId>
-                            <version>1.2.2</version>
+                            <version>1.3.2</version>
                         </dependency>
                         <dependency>
-                            <groupId>com.groupcdg.pitest</groupId>
+                            <groupId>com.arcmutate</groupId>
                             <artifactId>pitest-accelerator-junit5</artifactId>
-                            <version>1.0.6</version>
+                            <version>1.2.0</version>
                         </dependency>
                         <dependency>
                             <groupId>org.pitest</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -549,6 +549,16 @@
         <pluginManagement>
             <plugins>
                 <plugin>
+                    <groupId>com.arcmutate</groupId>
+                    <artifactId>pitest-git-maven-plugin</artifactId>
+                    <version>${version.pitest-git}</version>
+                </plugin>
+                <plugin>
+                    <groupId>com.arcmutate</groupId>
+                    <artifactId>pitest-github-maven-plugin</artifactId>
+                    <version>${version.pitest-git}</version>
+                </plugin>
+                <plugin>
                     <groupId>com.github.ekryd.sortpom</groupId>
                     <artifactId>sortpom-maven-plugin</artifactId>
                     <version>4.0.0</version>
@@ -574,16 +584,6 @@
                             <phase>verify</phase>
                         </execution>
                     </executions>
-                </plugin>
-                <plugin>
-                    <groupId>com.arcmutate</groupId>
-                    <artifactId>pitest-git-maven-plugin</artifactId>
-                    <version>${version.pitest-git}</version>
-                </plugin>
-                <plugin>
-                    <groupId>com.arcmutate</groupId>
-                    <artifactId>pitest-github-maven-plugin</artifactId>
-                    <version>${version.pitest-git}</version>
                 </plugin>
                 <plugin>
                     <groupId>com.spotify.fmt</groupId>
@@ -1548,11 +1548,6 @@
                     <dependencies>
                         <dependency>
                             <groupId>com.arcmutate</groupId>
-                            <artifactId>pitest-git-plugin</artifactId>
-                            <version>${version.pitest-git}</version>
-                        </dependency>
-                        <dependency>
-                            <groupId>com.arcmutate</groupId>
                             <artifactId>base</artifactId>
                             <version>1.3.2</version>
                         </dependency>
@@ -1560,6 +1555,11 @@
                             <groupId>com.arcmutate</groupId>
                             <artifactId>pitest-accelerator-junit5</artifactId>
                             <version>1.2.0</version>
+                        </dependency>
+                        <dependency>
+                            <groupId>com.arcmutate</groupId>
+                            <artifactId>pitest-git-plugin</artifactId>
+                            <version>${version.pitest-git}</version>
                         </dependency>
                         <dependency>
                             <groupId>org.pitest</groupId>


### PR DESCRIPTION
Suggested commit message:
```
Upgrade Arcmutate plugins (#1586)

These upgrades were not picked up automatically due to a groupId change.

Summary of changes:
- Upgrade Pitest Git plugins 1.1.4 -> 2.1.0
- Upgrade Arcmutate 1.2.2 -> 1.3.2
- Upgrade pitest-accelerator-junit5 1.0.6 -> 1.2.0
```

Hat tip to @jqno for his instructions [here](https://github.com/jqno/equalsverifier/pull/1055#issuecomment-2720240606). Based on _local_ testing I shouldn't rename the license file, but let's see what GitHub Actions thinks :eyes:

(Tested before and after results: no changes except that on [this line](https://github.com/PicnicSupermarket/error-prone-support/blob/7a051146b618a206baa0761c2fdb1878574ec77d/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/RedundantStringConversion.java#L305) there's now a surviving mutant instead of a `MEMORY_ERROR` mutant :heavy_check_mark:.)