### PR TITLE
Introduce two `FileRules` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -156,4 +156,18 @@ final class FileRules {
       return path.toFile().mkdirs() || Files.exists(path);
     }
   }
+
+  /** Prefer {@link File#mkdirs} before {@link File#exists} to avoid concurrency issues. */
+  static final class FileMkDirsFileExists {
+    @BeforeTemplate
+    boolean before(File file) {
+      return file.exists() || file.mkdirs();
+    }
+
+    @AfterTemplate
+    @AlsoNegation
+    boolean after(File file) {
+      return file.mkdirs() || file.exists();
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -143,9 +143,7 @@ final class FileRules {
     }
   }
 
-  /**
-   * Prefer `File#mkdirs` before `Files#exists` to avoid concurrency issues.
-   */
+  /** Prefer `File#mkdirs` before `Files#exists` to avoid concurrency issues. */
   static final class MkdirsBeforeFilesExists {
     @BeforeTemplate
     boolean before(Path path) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -143,8 +143,8 @@ final class FileRules {
     }
   }
 
-  /** Prefer `File#mkdirs` before `Files#exists` to avoid concurrency issues. */
-  static final class MkdirsBeforeFilesExists {
+  /** Prefer {@link File#mkdirs} before {@link Files#exists} to avoid concurrency issues. */
+  static final class PathToFileMkDirsFilesExists {
     @BeforeTemplate
     boolean before(Path path) {
       return Files.exists(path) || path.toFile().mkdirs();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -12,6 +12,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.LinkOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
@@ -143,7 +144,10 @@ final class FileRules {
     }
   }
 
-  /** Prefer {@link File#mkdirs} before {@link Files#exists} to avoid concurrency issues. */
+  /**
+   * Invoke {@link File#mkdirs()} before {@link Files#exists(Path, LinkOption...)} to avoid
+   * concurrency issues.
+   */
   static final class PathToFileMkDirsFilesExists {
     @BeforeTemplate
     boolean before(Path path) {
@@ -157,7 +161,7 @@ final class FileRules {
     }
   }
 
-  /** Prefer {@link File#mkdirs} before {@link File#exists} to avoid concurrency issues. */
+  /** Invoke {@link File#mkdirs()} before {@link File#exists()} to avoid concurrency issues. */
   static final class FileMkDirsFileExists {
     @BeforeTemplate
     boolean before(File file) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -4,6 +4,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Repeated;
 import java.io.File;
@@ -139,6 +140,22 @@ final class FileRules {
     @AfterTemplate
     File after(File directory, String prefix, String suffix) throws IOException {
       return Files.createTempFile(directory.toPath(), prefix, suffix).toFile();
+    }
+  }
+
+  /**
+   * Prefer `File#mkdirs` before `Files#exists` to avoid concurrency issues.
+   */
+  static final class MkdirsBeforeFilesExists {
+    @BeforeTemplate
+    boolean before(Path path) {
+      return Files.exists(path) || path.toFile().mkdirs();
+    }
+
+    @AfterTemplate
+    @AlsoNegation
+    boolean after(Path path) {
+      return path.toFile().mkdirs() || Files.exists(path);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
@@ -39,4 +39,9 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
   File testFilesCreateTempFileInCustomDirectoryToFile() throws IOException {
     return File.createTempFile("foo", "bar", new File("baz"));
   }
+
+  boolean testMkdirsBeforeFilesExists() {
+    Path foo = Path.of("foo");
+    return !Files.exists(foo) && !foo.toFile().mkdirs();
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
@@ -45,4 +45,10 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
         Files.exists(Path.of("foo")) || Path.of("foo").toFile().mkdirs(),
         !Files.exists(Path.of("bar")) && !Path.of("bar").toFile().mkdirs());
   }
+
+  ImmutableSet<Boolean> testFileMkDirsFileExists() {
+    return ImmutableSet.of(
+        new File("foo").exists() || new File("foo").mkdirs(),
+        !new File("bar").exists() && !new File("bar").mkdirs());
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
@@ -40,8 +40,9 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return File.createTempFile("foo", "bar", new File("baz"));
   }
 
-  boolean testMkdirsBeforeFilesExists() {
-    Path foo = Path.of("foo");
-    return !Files.exists(foo) && !foo.toFile().mkdirs();
+  ImmutableSet<Boolean> testPathToFileMkDirsFilesExists() {
+    return ImmutableSet.of(
+        Files.exists(Path.of("foo")) || Path.of("foo").toFile().mkdirs(),
+        !Files.exists(Path.of("bar")) && !Path.of("bar").toFile().mkdirs());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
@@ -39,4 +39,9 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
   File testFilesCreateTempFileInCustomDirectoryToFile() throws IOException {
     return Files.createTempFile(new File("baz").toPath(), "foo", "bar").toFile();
   }
+
+  boolean testMkdirsBeforeFilesExists() {
+    Path foo = Path.of("foo");
+    return !foo.toFile().mkdirs() && !Files.exists(foo);
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
@@ -40,8 +40,9 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return Files.createTempFile(new File("baz").toPath(), "foo", "bar").toFile();
   }
 
-  boolean testMkdirsBeforeFilesExists() {
-    Path foo = Path.of("foo");
-    return !foo.toFile().mkdirs() && !Files.exists(foo);
+  ImmutableSet<Boolean> testPathToFileMkDirsFilesExists() {
+    return ImmutableSet.of(
+        Path.of("foo").toFile().mkdirs() || Files.exists(Path.of("foo")),
+        !Path.of("bar").toFile().mkdirs() && !Files.exists(Path.of("bar")));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
@@ -45,4 +45,10 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
         Path.of("foo").toFile().mkdirs() || Files.exists(Path.of("foo")),
         !Path.of("bar").toFile().mkdirs() && !Files.exists(Path.of("bar")));
   }
+
+  ImmutableSet<Boolean> testFileMkDirsFileExists() {
+    return ImmutableSet.of(
+        new File("foo").mkdirs() || new File("foo").exists(),
+        !new File("bar").mkdirs() && !new File("bar").exists());
+  }
 }


### PR DESCRIPTION
Proposing a quick rule for something that's come up repeatedly on our end. Figured it'd be a good match for a Refaster rule.

The goal here is to avoid concurreny issues when two processes are simultaneously checking if a directory exists, before attempting to create that directory, as part of a single check. By flipping around these two commands you avoid conflicts.

I didn't spot any existing tests for any `FileRule`; let me know if I missed any. If so I'd propose to also verify the negation of `!Files.exists(path) && !path.toFile().mkdirs()`.

- As discovered on https://github.com/openrewrite/rewrite/pull/5189