### PR TITLE
Share same generic parameters with the templates

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
@@ -904,30 +904,30 @@ final class TestNGToAssertJRules {
     }
   }
 
-  static final class AssertEqualIteratorIterationOrder {
+  static final class AssertEqualIteratorIterationOrder<S, T extends S> {
     @BeforeTemplate
-    void before(Iterator<?> actual, Iterator<?> expected) {
+    void before(Iterator<S> actual, Iterator<T> expected) {
       assertEquals(actual, expected);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    <S, T extends S> void after(Iterator<S> actual, Iterator<T> expected) {
+    void after(Iterator<S> actual, Iterator<T> expected) {
       // XXX: This is not `null`-safe.
       // XXX: The `ImmutableList.copyOf` should actually *not* be imported statically.
       assertThat(actual).toIterable().containsExactlyElementsOf(ImmutableList.copyOf(expected));
     }
   }
 
-  static final class AssertEqualIteratorIterationOrderWithMessage {
+  static final class AssertEqualIteratorIterationOrderWithMessage<S, T extends S> {
     @BeforeTemplate
-    void before(Iterator<?> actual, String message, Iterator<?> expected) {
+    void before(Iterator<S> actual, String message, Iterator<T> expected) {
       assertEquals(actual, expected, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    <S, T extends S> void after(Iterator<S> actual, String message, Iterator<T> expected) {
+    void after(Iterator<S> actual, String message, Iterator<T> expected) {
       // XXX: This is not `null`-safe.
       // XXX: The `ImmutableList.copyOf` should actually *not* be imported statically.
       assertThat(actual)
@@ -939,64 +939,64 @@ final class TestNGToAssertJRules {
 
   // XXX This rule fails for `java.nio.file.Path` as it is `Iterable`, but AssertJ's
   // `assertThat(Path)` does not support `.containsExactlyElementsOf`.
-  static final class AssertEqualIterableIterationOrder {
+  static final class AssertEqualIterableIterationOrder<S, T extends S> {
     @BeforeTemplate
-    void before(Iterable<?> actual, Iterable<?> expected) {
+    void before(Iterable<S> actual, Iterable<T> expected) {
       assertEquals(actual, expected);
     }
 
     @BeforeTemplate
-    void before(Collection<?> actual, Collection<?> expected) {
+    void before(Collection<S> actual, Collection<T> expected) {
       assertEquals(actual, expected);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    <S, T extends S> void after(Iterable<S> actual, Iterable<T> expected) {
+    void after(Iterable<S> actual, Iterable<T> expected) {
       assertThat(actual).containsExactlyElementsOf(expected);
     }
   }
 
-  static final class AssertEqualIterableIterationOrderWithMessage {
+  static final class AssertEqualIterableIterationOrderWithMessage<S, T extends S> {
     @BeforeTemplate
-    void before(Iterable<?> actual, String message, Iterable<?> expected) {
+    void before(Iterable<S> actual, String message, Iterable<T> expected) {
       assertEquals(actual, expected, message);
     }
 
     @BeforeTemplate
-    void before(Collection<?> actual, String message, Collection<?> expected) {
+    void before(Collection<S> actual, String message, Collection<T> expected) {
       assertEquals(actual, expected, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    <S, T extends S> void after(Iterable<S> actual, String message, Iterable<T> expected) {
+    void after(Iterable<S> actual, String message, Iterable<T> expected) {
       assertThat(actual).withFailMessage(message).containsExactlyElementsOf(expected);
     }
   }
 
-  static final class AssertEqualSets {
+  static final class AssertEqualSets<S, T extends S> {
     @BeforeTemplate
-    void before(Set<?> actual, Set<?> expected) {
+    void before(Set<S> actual, Set<T> expected) {
       assertEquals(actual, expected);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    <S, T extends S> void after(Set<S> actual, Set<T> expected) {
+    void after(Set<S> actual, Set<T> expected) {
       assertThat(actual).hasSameElementsAs(expected);
     }
   }
 
-  static final class AssertEqualSetsWithMessage {
+  static final class AssertEqualSetsWithMessage<S, T extends S> {
     @BeforeTemplate
-    void before(Set<?> actual, String message, Set<?> expected) {
+    void before(Set<S> actual, String message, Set<T> expected) {
       assertEquals(actual, expected, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    <S, T extends S> void after(Set<S> actual, String message, Set<T> expected) {
+    void after(Set<S> actual, String message, Set<T> expected) {
       assertThat(actual).withFailMessage(message).hasSameElementsAs(expected);
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
@@ -904,6 +904,8 @@ final class TestNGToAssertJRules {
     }
   }
 
+  // XXX: TestNG's `assertEquals` accepts arbitrary `Iterator<?>` arguments. As such some
+  // expressions will not be rewritten.
   static final class AssertEqualIteratorIterationOrder<S, T extends S> {
     @BeforeTemplate
     void before(Iterator<S> actual, Iterator<T> expected) {
@@ -919,6 +921,8 @@ final class TestNGToAssertJRules {
     }
   }
 
+  // XXX: TestNG's `assertEquals` accepts arbitrary `Iterator<?>` arguments. As such some
+  // expressions will not be rewritten.
   static final class AssertEqualIteratorIterationOrderWithMessage<S, T extends S> {
     @BeforeTemplate
     void before(Iterator<S> actual, String message, Iterator<T> expected) {
@@ -939,6 +943,8 @@ final class TestNGToAssertJRules {
 
   // XXX This rule fails for `java.nio.file.Path` as it is `Iterable`, but AssertJ's
   // `assertThat(Path)` does not support `.containsExactlyElementsOf`.
+  // XXX: TestNG's `assertEquals` accepts arbitrary `Iterable<?>` and `Collection<?>` arguments. As
+  // such some expressions will not be rewritten.
   static final class AssertEqualIterableIterationOrder<S, T extends S> {
     @BeforeTemplate
     void before(Iterable<S> actual, Iterable<T> expected) {
@@ -957,6 +963,10 @@ final class TestNGToAssertJRules {
     }
   }
 
+  // XXX This rule fails for `java.nio.file.Path` as it is `Iterable`, but AssertJ's
+  // `assertThat(Path)` does not support `.containsExactlyElementsOf`.
+  // XXX: TestNG's `assertEquals` accepts arbitrary `Iterable<?>` and `Collection<?>` arguments. As
+  // such some expressions will not be rewritten.
   static final class AssertEqualIterableIterationOrderWithMessage<S, T extends S> {
     @BeforeTemplate
     void before(Iterable<S> actual, String message, Iterable<T> expected) {
@@ -975,6 +985,8 @@ final class TestNGToAssertJRules {
     }
   }
 
+  // XXX: TestNG's `assertEquals` accepts arbitrary `Set<?>` arguments. As such some expressions
+  // will not be rewritten.
   static final class AssertEqualSets<S, T extends S> {
     @BeforeTemplate
     void before(Set<S> actual, Set<T> expected) {
@@ -988,6 +1000,8 @@ final class TestNGToAssertJRules {
     }
   }
 
+  // XXX: TestNG's `assertEquals` accepts arbitrary `Set<?>` arguments. As such some expressions
+  // will not be rewritten.
   static final class AssertEqualSetsWithMessage<S, T extends S> {
     @BeforeTemplate
     void before(Set<S> actual, String message, Set<T> expected) {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
@@ -239,6 +239,9 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(
         Iterators.unmodifiableIterator(new ArrayList<>().iterator()),
         Iterators.unmodifiableIterator(new ArrayList<>().iterator()));
+    assertEquals(
+        Iterators.unmodifiableIterator(new ArrayList<String>().iterator()),
+        Iterators.unmodifiableIterator(new ArrayList<Number>().iterator()));
   }
 
   void testAssertEqualIteratorIterationOrderWithMessage() {
@@ -255,6 +258,9 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(
         Collections.synchronizedCollection(new ArrayList<>()),
         Collections.synchronizedCollection(new ArrayList<>()));
+    assertEquals(
+        Collections.synchronizedCollection(new ArrayList<String>()),
+        Collections.synchronizedCollection(new ArrayList<Number>()));
   }
 
   void testAssertEqualIterableIterationOrderWithMessage() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
@@ -256,8 +256,8 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         Iterables.unmodifiableIterable(new ArrayList<>()),
         Iterables.unmodifiableIterable(new ArrayList<>()));
     assertEquals(
-        Collections.synchronizedCollection(new ArrayList<>()),
-        Collections.synchronizedCollection(new ArrayList<>()));
+        Collections.synchronizedCollection(new ArrayList<Number>()),
+        Collections.synchronizedCollection(new ArrayList<Integer>()));
     assertEquals(
         Collections.synchronizedCollection(new ArrayList<String>()),
         Collections.synchronizedCollection(new ArrayList<Number>()));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
@@ -14,9 +14,7 @@ import static org.testng.Assert.assertTrue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import java.util.ArrayList;
-import java.util.Collections;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
@@ -236,50 +234,47 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAssertEqualIteratorIterationOrder() {
-    assertEquals(
-        Iterators.unmodifiableIterator(new ArrayList<>().iterator()),
-        Iterators.unmodifiableIterator(new ArrayList<>().iterator()));
-    assertEquals(
-        Iterators.unmodifiableIterator(new ArrayList<String>().iterator()),
-        Iterators.unmodifiableIterator(new ArrayList<Number>().iterator()));
+    assertEquals(new ArrayList<Number>().iterator(), new ArrayList<Integer>().iterator());
+    assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator());
   }
 
   void testAssertEqualIteratorIterationOrderWithMessage() {
-    assertEquals(
-        Iterators.unmodifiableIterator(new ArrayList<>().iterator()),
-        Iterators.unmodifiableIterator(new ArrayList<>().iterator()),
-        "foo");
+    assertEquals(new ArrayList<Number>().iterator(), new ArrayList<Integer>().iterator(), "foo");
+    assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator(), "bar");
   }
 
   void testAssertEqualIterableIterationOrder() {
     assertEquals(
-        Iterables.unmodifiableIterable(new ArrayList<>()),
-        Iterables.unmodifiableIterable(new ArrayList<>()));
+        Iterables.unmodifiableIterable(new ArrayList<Number>()),
+        Iterables.unmodifiableIterable(new ArrayList<Integer>()));
     assertEquals(
-        Collections.synchronizedCollection(new ArrayList<Number>()),
-        Collections.synchronizedCollection(new ArrayList<Integer>()));
-    assertEquals(
-        Collections.synchronizedCollection(new ArrayList<String>()),
-        Collections.synchronizedCollection(new ArrayList<Number>()));
+        Iterables.unmodifiableIterable(new ArrayList<Number>()),
+        Iterables.unmodifiableIterable(new ArrayList<String>()));
+    assertEquals(new ArrayList<Number>(), new ArrayList<Integer>());
+    assertEquals(new ArrayList<Number>(), new ArrayList<String>());
   }
 
   void testAssertEqualIterableIterationOrderWithMessage() {
     assertEquals(
-        Iterables.unmodifiableIterable(new ArrayList<>()),
-        Iterables.unmodifiableIterable(new ArrayList<>()),
+        Iterables.unmodifiableIterable(new ArrayList<Number>()),
+        Iterables.unmodifiableIterable(new ArrayList<Integer>()),
         "foo");
     assertEquals(
-        Collections.synchronizedCollection(new ArrayList<>()),
-        Collections.synchronizedCollection(new ArrayList<>()),
+        Iterables.unmodifiableIterable(new ArrayList<Number>()),
+        Iterables.unmodifiableIterable(new ArrayList<String>()),
         "bar");
+    assertEquals(new ArrayList<Number>(), new ArrayList<Integer>(), "baz");
+    assertEquals(new ArrayList<Number>(), new ArrayList<String>(), "qux");
   }
 
   void testAssertEqualSets() {
-    assertEquals(ImmutableSet.of(), ImmutableSet.of());
+    assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<Integer>of());
+    assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of());
   }
 
   void testAssertEqualSetsWithMessage() {
-    assertEquals(ImmutableSet.of(), ImmutableSet.of(), "foo");
+    assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<Integer>of(), "foo");
+    assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of(), "bar");
   }
 
   void testAssertUnequal() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
@@ -261,8 +261,8 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   void testAssertEqualIterableIterationOrder() {
     assertThat(Iterables.unmodifiableIterable(new ArrayList<>()))
         .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<>()));
-    assertThat(Collections.synchronizedCollection(new ArrayList<>()))
-        .containsExactlyElementsOf(Collections.synchronizedCollection(new ArrayList<>()));
+    assertThat(Collections.synchronizedCollection(new ArrayList<Number>()))
+        .containsExactlyElementsOf(Collections.synchronizedCollection(new ArrayList<Integer>()));
     assertEquals(
         Collections.synchronizedCollection(new ArrayList<String>()),
         Collections.synchronizedCollection(new ArrayList<Number>()));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
@@ -245,6 +245,9 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         .toIterable()
         .containsExactlyElementsOf(
             copyOf(Iterators.unmodifiableIterator(new ArrayList<>().iterator())));
+    assertEquals(
+        Iterators.unmodifiableIterator(new ArrayList<String>().iterator()),
+        Iterators.unmodifiableIterator(new ArrayList<Number>().iterator()));
   }
 
   void testAssertEqualIteratorIterationOrderWithMessage() {
@@ -260,6 +263,9 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<>()));
     assertThat(Collections.synchronizedCollection(new ArrayList<>()))
         .containsExactlyElementsOf(Collections.synchronizedCollection(new ArrayList<>()));
+    assertEquals(
+        Collections.synchronizedCollection(new ArrayList<String>()),
+        Collections.synchronizedCollection(new ArrayList<Number>()));
   }
 
   void testAssertEqualIterableIterationOrderWithMessage() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
@@ -19,9 +19,7 @@ import static org.testng.Assert.assertTrue;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
-import com.google.common.collect.Iterators;
 import java.util.ArrayList;
-import java.util.Collections;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
@@ -241,48 +239,54 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAssertEqualIteratorIterationOrder() {
-    assertThat(Iterators.unmodifiableIterator(new ArrayList<>().iterator()))
+    assertThat(new ArrayList<Number>().iterator())
         .toIterable()
-        .containsExactlyElementsOf(
-            copyOf(Iterators.unmodifiableIterator(new ArrayList<>().iterator())));
-    assertEquals(
-        Iterators.unmodifiableIterator(new ArrayList<String>().iterator()),
-        Iterators.unmodifiableIterator(new ArrayList<Number>().iterator()));
+        .containsExactlyElementsOf(copyOf(new ArrayList<Integer>().iterator()));
+    assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator());
   }
 
   void testAssertEqualIteratorIterationOrderWithMessage() {
-    assertThat(Iterators.unmodifiableIterator(new ArrayList<>().iterator()))
+    assertThat(new ArrayList<Number>().iterator())
         .toIterable()
         .withFailMessage("foo")
-        .containsExactlyElementsOf(
-            copyOf(Iterators.unmodifiableIterator(new ArrayList<>().iterator())));
+        .containsExactlyElementsOf(copyOf(new ArrayList<Integer>().iterator()));
+    assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator(), "bar");
   }
 
   void testAssertEqualIterableIterationOrder() {
-    assertThat(Iterables.unmodifiableIterable(new ArrayList<>()))
-        .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<>()));
-    assertThat(Collections.synchronizedCollection(new ArrayList<Number>()))
-        .containsExactlyElementsOf(Collections.synchronizedCollection(new ArrayList<Integer>()));
+    assertThat(Iterables.unmodifiableIterable(new ArrayList<Number>()))
+        .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<Integer>()));
     assertEquals(
-        Collections.synchronizedCollection(new ArrayList<String>()),
-        Collections.synchronizedCollection(new ArrayList<Number>()));
+        Iterables.unmodifiableIterable(new ArrayList<Number>()),
+        Iterables.unmodifiableIterable(new ArrayList<String>()));
+    assertThat(new ArrayList<Number>()).containsExactlyElementsOf(new ArrayList<Integer>());
+    assertEquals(new ArrayList<Number>(), new ArrayList<String>());
   }
 
   void testAssertEqualIterableIterationOrderWithMessage() {
-    assertThat(Iterables.unmodifiableIterable(new ArrayList<>()))
+    assertThat(Iterables.unmodifiableIterable(new ArrayList<Number>()))
         .withFailMessage("foo")
-        .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<>()));
-    assertThat(Collections.synchronizedCollection(new ArrayList<>()))
-        .withFailMessage("bar")
-        .containsExactlyElementsOf(Collections.synchronizedCollection(new ArrayList<>()));
+        .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<Integer>()));
+    assertEquals(
+        Iterables.unmodifiableIterable(new ArrayList<Number>()),
+        Iterables.unmodifiableIterable(new ArrayList<String>()),
+        "bar");
+    assertThat(new ArrayList<Number>())
+        .withFailMessage("baz")
+        .containsExactlyElementsOf(new ArrayList<Integer>());
+    assertEquals(new ArrayList<Number>(), new ArrayList<String>(), "qux");
   }
 
   void testAssertEqualSets() {
-    assertThat(ImmutableSet.of()).hasSameElementsAs(ImmutableSet.of());
+    assertThat(ImmutableSet.<Number>of()).hasSameElementsAs(ImmutableSet.<Integer>of());
+    assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of());
   }
 
   void testAssertEqualSetsWithMessage() {
-    assertThat(ImmutableSet.of()).withFailMessage("foo").hasSameElementsAs(ImmutableSet.of());
+    assertThat(ImmutableSet.<Number>of())
+        .withFailMessage("foo")
+        .hasSameElementsAs(ImmutableSet.<Integer>of());
+    assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of(), "bar");
   }
 
   void testAssertUnequal() {


### PR DESCRIPTION
**Summary**
Refactor a few Refaster recipes by moving type variable declarations from the method level to the class level. This ensures consistency between before() and after() templates.

**Motivation**
OpenRewrite doesn’t support method-level generic type variables, which can result in incorrect or uncompilable replacements.