### PR TITLE
Drop IDEA-342187 workaround

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -294,23 +294,17 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <annotationProcessorPaths combine.children="append">
-                            <!-- XXX: Drop the version declarations once
-                            properly supported. See
-                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>documentation-support</artifactId>
-                                <version>${project.version}</version>
                             </path>
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>refaster-compiler</artifactId>
-                                <version>${project.version}</version>
                             </path>
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>refaster-support</artifactId>
-                                <version>${project.version}</version>
                             </path>
                         </annotationProcessorPaths>
                         <compilerArgs combine.children="append">

--- a/error-prone-guidelines/pom.xml
+++ b/error-prone-guidelines/pom.xml
@@ -109,13 +109,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <annotationProcessorPaths combine.children="append">
-                            <!-- XXX: Drop the version declarations once
-                            properly supported. See
-                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>documentation-support</artifactId>
-                                <version>${project.version}</version>
                             </path>
                         </annotationProcessorPaths>
                         <compilerArgs combine.children="append">

--- a/pom.xml
+++ b/pom.xml
@@ -207,16 +207,9 @@
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
         <version.error-prone-fork>${version.error-prone-orig}-picnic-1</version.error-prone-fork>
         <version.error-prone-orig>2.38.0</version.error-prone-orig>
-        <version.error-prone-slf4j>0.1.28</version.error-prone-slf4j>
-        <version.guava-beta-checker>1.0</version.guava-beta-checker>
         <version.jdk>17</version.jdk>
         <version.maven>3.9.9</version.maven>
-        <version.mockito>5.17.0</version.mockito>
-        <version.nopen-checker>1.0.1</version.nopen-checker>
-        <version.nullaway>0.12.6</version.nullaway>
         <version.pitest-git>2.2.1</version.pitest-git>
-        <version.rewrite-templating>1.26.1</version.rewrite-templating>
-        <version.surefire>3.2.3</version.surefire>
     </properties>
 
     <dependencyManagement>
@@ -346,7 +339,7 @@
             <dependency>
                 <groupId>com.google.guava</groupId>
                 <artifactId>guava-beta-checker</artifactId>
-                <version>${version.guava-beta-checker}</version>
+                <version>1.0</version>
             </dependency>
             <dependency>
                 <groupId>com.google.guava</groupId>
@@ -363,12 +356,12 @@
             <dependency>
                 <groupId>com.jakewharton.nopen</groupId>
                 <artifactId>nopen-checker</artifactId>
-                <version>${version.nopen-checker}</version>
+                <version>1.0.1</version>
             </dependency>
             <dependency>
                 <groupId>com.uber.nullaway</groupId>
                 <artifactId>nullaway</artifactId>
-                <version>${version.nullaway}</version>
+                <version>0.12.6</version>
             </dependency>
             <dependency>
                 <groupId>io.micrometer</groupId>
@@ -422,7 +415,7 @@
             <dependency>
                 <groupId>jp.skypencil.errorprone.slf4j</groupId>
                 <artifactId>errorprone-slf4j</artifactId>
-                <version>${version.error-prone-slf4j}</version>
+                <version>0.1.28</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
@@ -489,7 +482,7 @@
             <dependency>
                 <groupId>org.mockito</groupId>
                 <artifactId>mockito-bom</artifactId>
-                <version>${version.mockito}</version>
+                <version>5.17.0</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -503,7 +496,7 @@
             <dependency>
                 <groupId>org.openrewrite</groupId>
                 <artifactId>rewrite-templating</artifactId>
-                <version>${version.rewrite-templating}</version>
+                <version>1.26.1</version>
             </dependency>
             <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
@@ -963,23 +956,17 @@
                     <version>3.14.0</version>
                     <configuration>
                         <annotationProcessorPaths>
-                            <!-- XXX: Inline and drop the version
-                            declarations once properly supported. See
-                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>com.google.auto.value</groupId>
                                 <artifactId>auto-value</artifactId>
-                                <version>${version.auto-value}</version>
                             </path>
                             <path>
                                 <groupId>com.google.auto.service</groupId>
                                 <artifactId>auto-service</artifactId>
-                                <version>${version.auto-service}</version>
                             </path>
                             <path>
                                 <groupId>org.openrewrite</groupId>
                                 <artifactId>rewrite-templating</artifactId>
-                                <version>${version.rewrite-templating}</version>
                             </path>
                         </annotationProcessorPaths>
                         <compilerArgs>
@@ -1640,28 +1627,21 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <annotationProcessorPaths combine.children="append">
-                                <!-- XXX: Drop the version declarations once
-                                properly supported. See
-                                https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                                 <path>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>error-prone-contrib</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                                 <path>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>error-prone-experimental</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                                 <path>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>error-prone-guidelines</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                                 <path>
                                     <groupId>${project.groupId}</groupId>
                                     <artifactId>refaster-runner</artifactId>
-                                    <version>${project.version}</version>
                                 </path>
                             </annotationProcessorPaths>
                         </configuration>
@@ -1825,38 +1805,29 @@
                         <artifactId>maven-compiler-plugin</artifactId>
                         <configuration>
                             <annotationProcessorPaths combine.children="append">
-                                <!-- XXX: Inline and drop the version
-                                declarations once properly supported. See
-                                https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                                 <path>
                                     <groupId>com.google.errorprone</groupId>
                                     <artifactId>error_prone_core</artifactId>
-                                    <version>${version.error-prone}</version>
                                 </path>
                                 <path>
                                     <groupId>com.google.guava</groupId>
                                     <artifactId>guava-beta-checker</artifactId>
-                                    <version>${version.guava-beta-checker}</version>
                                 </path>
                                 <path>
                                     <groupId>com.jakewharton.nopen</groupId>
                                     <artifactId>nopen-checker</artifactId>
-                                    <version>${version.nopen-checker}</version>
                                 </path>
                                 <path>
                                     <groupId>com.uber.nullaway</groupId>
                                     <artifactId>nullaway</artifactId>
-                                    <version>${version.nullaway}</version>
                                 </path>
                                 <path>
                                     <groupId>jp.skypencil.errorprone.slf4j</groupId>
                                     <artifactId>errorprone-slf4j</artifactId>
-                                    <version>${version.error-prone-slf4j}</version>
                                 </path>
                                 <path>
                                     <groupId>org.mockito</groupId>
                                     <artifactId>mockito-errorprone</artifactId>
-                                    <version>${version.mockito}</version>
                                 </path>
                             </annotationProcessorPaths>
                             <compilerArgs combine.children="append">

--- a/refaster-runner/pom.xml
+++ b/refaster-runner/pom.xml
@@ -120,13 +120,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <annotationProcessorPaths combine.children="append">
-                            <!-- XXX: Drop the version declaration once
-                            properly supported. See
-                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>refaster-compiler</artifactId>
-                                <version>${project.version}</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>

--- a/refaster-test-support/pom.xml
+++ b/refaster-test-support/pom.xml
@@ -102,13 +102,9 @@
                     <artifactId>maven-compiler-plugin</artifactId>
                     <configuration>
                         <annotationProcessorPaths combine.children="append">
-                            <!-- XXX: Drop the version declaration once
-                            properly supported. See
-                            https://youtrack.jetbrains.com/issue/IDEA-342187. -->
                             <path>
                                 <groupId>${project.groupId}</groupId>
                                 <artifactId>refaster-compiler</artifactId>
-                                <version>${project.version}</version>
                             </path>
                         </annotationProcessorPaths>
                     </configuration>


### PR DESCRIPTION
Suggested commit message:
```
Drop IDEA-342187 workaround (#1648)

As of IntelliJ IDEA 2024.3.2.2, the IDE gracefully handles the absence
of explicitly specified annotation processor path dependency versions,
consistent with `maven-compiler-plugin`'s dependency resolution.
```