### PR TITLE
Upgrade Error Prone 2.37.0 -> 2.38.0

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/IdentityConversion.java
@@ -33,7 +33,7 @@ import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.google.errorprone.matchers.Matchers;
 import com.google.errorprone.util.ASTHelpers;
-import com.google.errorprone.util.ASTHelpers.TargetType;
+import com.google.errorprone.util.TargetType;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
@@ -106,7 +106,7 @@ public final class IdentityConversion extends BugChecker implements MethodInvoca
     ExpressionTree sourceTree = arguments.get(0);
     Type sourceType = ASTHelpers.getType(sourceTree);
     Type resultType = ASTHelpers.getType(tree);
-    TargetType targetType = ASTHelpers.targetType(state);
+    TargetType targetType = TargetType.targetType(state);
     if (sourceType == null || resultType == null || targetType == null) {
       return Description.NO_MATCH;
     }

--- a/pom.xml
+++ b/pom.xml
@@ -206,7 +206,7 @@
         <version.auto-value>1.11.0</version.auto-value>
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
         <version.error-prone-fork>${version.error-prone-orig}-picnic-1</version.error-prone-fork>
-        <version.error-prone-orig>2.37.0</version.error-prone-orig>
+        <version.error-prone-orig>2.38.0</version.error-prone-orig>
         <version.error-prone-slf4j>0.1.28</version.error-prone-slf4j>
         <version.guava-beta-checker>1.0</version.guava-beta-checker>
         <version.jdk>17</version.jdk>
@@ -1644,11 +1644,15 @@
                                 <!-- XXX: Inline and drop the version
                                 declaration once properly supported. See
                                 https://youtrack.jetbrains.com/issue/IDEA-342187. -->
+                                <!-- XXX: This dependency is incompatible with
+                                Error Prone 2.38.0+. Re-enabled it once it is
+                                compatible again.
                                 <path>
                                     <groupId>com.github.lhotari</groupId>
                                     <artifactId>reactor-error-prone</artifactId>
                                     <version>${version.reactor-error-prone}</version>
                                 </path>
+                                -->
                             </annotationProcessorPaths>
                         </configuration>
                     </plugin>
@@ -1928,8 +1932,6 @@
                                     <!-- XXX: Enable this once we open-source
                                     this library. -->
                                     -Xep:BetaApi:OFF
-                                    <!-- We don't target JDK 7. -->
-                                    -Xep:Java7ApiChecker:OFF
                                     <!-- We don't target JDK 8. -->
                                     -Xep:Java8ApiChecker:OFF
                                     <!-- We don't target Android. -->
@@ -1945,6 +1947,7 @@
                                     -XepOpt:CheckReturnValue:CheckAllMethods=true -->
                                     <!-- XXX: Consider renaming flagged types
                                     instead. -->
+                                    -XepOpt:ConstantExpressions:ConsiderAllMethodsPure=true
                                     -XepOpt:IdentifierName:AllowInitialismsInTypeName=true
                                     -XepOpt:InlineMe:SkipInliningsWithComments=false
                                     -XepOpt:NullAway:AnnotatedPackages=tech.picnic
@@ -1952,7 +1955,6 @@
                                     -XepOpt:NullAway:CheckOptionalEmptiness=true
                                     -XepOpt:NullAway:JSpecifyMode=true
                                     -XepOpt:Nullness:Conservative=false
-                                    -XepOpt:StatementSwitchToExpressionSwitch:EnableDirectConversion=true
                                     <!-- Append additional custom arguments. -->
                                     ${error-prone.patch-args}
                                     ${error-prone.self-check-args}


### PR DESCRIPTION
Renovate didn't open a PR, so did it manually.

Suggested commit message:
```
Upgrade Error Prone 2.37.0 -> 2.38.0 (#1649)

Resolves #1646.

See:
- https://github.com/google/error-prone/releases/tag/v2.38.0
- https://github.com/google/error-prone/compare/v2.37.0...v2.38.0
- https://github.com/PicnicSupermarket/error-prone/compare/v2.37.0-picnic-1...v2.38.0-picnic-1
```