### PR TITLE
Drop unmaintained `reactor-error-prone` dependency

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
             api.adoptium.net:443
             github.com:443
             github-registry-files.githubusercontent.com:443
-            jitpack.io:443
             maven.pkg.github.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build project against vanilla Error Prone, compile Javadoc
         run: mvn -T1C install javadoc:jar
       - name: Build project with self-check against Error Prone fork
-        run: mvn -T1C clean verify -Perror-prone-fork -Pnon-maven-central -Pself-check -s settings.xml
+        run: mvn -T1C clean verify -Perror-prone-fork -Pself-check -s settings.xml
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove installed project artifacts

--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -26,7 +26,6 @@ jobs:
             github.com:443
             img.shields.io:443
             index.rubygems.org:443
-            jitpack.io:443
             maven.apache.org:443
             objects.githubusercontent.com:443
             pitest.org:443

--- a/pom.xml
+++ b/pom.xml
@@ -1619,43 +1619,6 @@
             </properties>
         </profile>
         <profile>
-            <!-- Error Prone checks that are not available from Maven Central;
-            these are therefore not enabled by default. -->
-            <id>non-maven-central</id>
-            <properties>
-                <version.reactor-error-prone>0.1.4</version.reactor-error-prone>
-            </properties>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>com.github.lhotari</groupId>
-                        <artifactId>reactor-error-prone</artifactId>
-                        <version>${version.reactor-error-prone}</version>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
-            <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-compiler-plugin</artifactId>
-                        <configuration>
-                            <annotationProcessorPaths combine.children="append">
-                                <!-- XXX: Inline and drop the version
-                                declaration once properly supported. See
-                                https://youtrack.jetbrains.com/issue/IDEA-342187. -->
-                                <path>
-                                    <groupId>com.github.lhotari</groupId>
-                                    <artifactId>reactor-error-prone</artifactId>
-                                    <version>${version.reactor-error-prone}</version>
-                                </path>
-                            </annotationProcessorPaths>
-                        </configuration>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
-        <profile>
             <!-- Applies the Error Prone checks defined by this project to the
             code base itself. Assumes that a prior build has already installed
             the project in the local Maven repository. -->

--- a/run-full-build.sh
+++ b/run-full-build.sh
@@ -16,6 +16,5 @@ mvn clean install \
 mvn clean install \
   -s "${settings}" \
   -Perror-prone-fork \
-  -Pnon-maven-central \
   -Pself-check \
   $@

--- a/settings.xml
+++ b/settings.xml
@@ -15,18 +15,6 @@
                 </repository>
             </repositories>
         </profile>
-        <profile>
-            <!-- The build defines an optional `non-maven-central` profile
-            using which additional Error Prone checks not available on Maven
-            Central are enabled. -->
-            <id>non-maven-central</id>
-            <repositories>
-                <repository>
-                    <id>jitpack.io</id>
-                    <url>https://jitpack.io</url>
-                </repository>
-            </repositories>
-        </profile>
     </profiles>
 
     <servers>


### PR DESCRIPTION
Suggested commit message:
```
Drop unmaintained `reactor-error-prone` dependency (#1650)

This dependency is incompatible with Error Prone 2.38.0. By dropping it, 
the `non-maven-central` Maven profile and Jitpack mirror can also be
dropped.
```