### PR TITLE
Validate compatibility with latest Error Prone release

### DIFF
--- a/.github/workflows/error-prone-compat.yml
+++ b/.github/workflows/error-prone-compat.yml
@@ -1,0 +1,36 @@
+# Validates compatibility with the latest Error Prone release.
+#
+# XXX: This workflow compiles the code against the `LATEST` Error Prone release
+# as determined by Maven, and subsequently runs the unit tests. No other checks
+# are performed. This guards against false positives, but is not quite as
+# thorough as the validation performed by
+# `website/generate-version-compatibility-overview.sh`. Consider unifying these
+# approaches.
+name: Error Prone compatibility check
+on:
+  # XXX: Drop `pull_request` trigger.
+  pull_request:
+  push:
+    branches: [ master ]
+  schedule:
+    - cron: '0 4 * * *'
+permissions:
+  contents: read
+jobs:
+  validate:
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
+        with:
+          disable-sudo: true
+          # XXX: Replace with `block` policy.
+          egress-policy: audit
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
+        with:
+          java-version: 17.0.13
+          java-distribution: temurin
+          maven-version: 3.9.9
+      - name: Build project against the latest Error Prone release
+        run: mvn -T1C clean install -Dverification.skip -Dversion.error-prone=LATEST

--- a/.github/workflows/error-prone-compat.yml
+++ b/.github/workflows/error-prone-compat.yml
@@ -12,8 +12,6 @@
 # incompatibilities.
 name: Error Prone compatibility check
 on:
-  # XXX: Drop `pull_request` trigger.
-  pull_request:
   push:
     branches: [ master ]
   schedule:

--- a/.github/workflows/error-prone-compat.yml
+++ b/.github/workflows/error-prone-compat.yml
@@ -24,8 +24,12 @@ jobs:
         uses: step-security/harden-runner@c6295a65d1254861815972266d5933fd6e532bdf # v2.11.1
         with:
           disable-sudo: true
-          # XXX: Replace with `block` policy.
-          egress-policy: audit
+          egress-policy: block
+          allowed-endpoints: >
+            api.adoptium.net:443
+            github.com:443
+            objects.githubusercontent.com:443
+            repo.maven.apache.org:443
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:

--- a/.github/workflows/error-prone-compat.yml
+++ b/.github/workflows/error-prone-compat.yml
@@ -6,6 +6,10 @@
 # thorough as the validation performed by
 # `website/generate-version-compatibility-overview.sh`. Consider unifying these
 # approaches.
+# XXX: Instead of the `LATEST` release, this workflow could also attempt to
+# build against the `1.0-HEAD-SNAPSHOT` version published to the Sonatype
+# snapshot repository. This would enable advance notification of upcoming
+# incompatibilities.
 name: Error Prone compatibility check
 on:
   # XXX: Drop `pull_request` trigger.

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -14,8 +14,6 @@ jobs:
     # Analysis of code in forked repositories is skipped, as such workflow runs
     # do not have access to the requisite secrets.
     if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
-    permissions:
-      contents: read
     runs-on: ubuntu-24.04
     steps:
       - name: Install Harden-Runner

--- a/run-full-build.sh
+++ b/run-full-build.sh
@@ -11,9 +11,11 @@ set -e -u -o pipefail
 settings="$(dirname "${0}")/settings.xml"
 
 mvn clean install \
+  -T1C \
   -s "${settings}" \
   $@
 mvn clean install \
+  -T1C \
   -s "${settings}" \
   -Perror-prone-fork \
   -Pself-check \


### PR DESCRIPTION
See discussion in #1646. I opted not to bother with testing against a "locally" built HEAD release of Error Prone, as that would at most speed up incompatibility identification by 24 hours, while potentially causing weeks/months of build failures between the time an incompatibility is introduced and a subsequent release.

Suggested commit message:
```
Validate compatibility with latest Error Prone release (#1651)

Every day and after each merged change we now run a GitHub Actions
workflow that builds the project against the latest Error Prone release,
as determined by Maven. This should pro-actively inform us of
incompatibilities that demand a new release.

While there:
- Drop a redundant permission declaration from the SonarCloud workflow.
- Update `run-full-build.sh` to parallelize the build.
```