### PR TITLE
Extend `AssertJMapRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJMapRules.java
@@ -12,7 +12,6 @@ import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Collection;
 import java.util.Map;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractCollectionAssert;
 import org.assertj.core.api.AbstractMapAssert;
 import org.assertj.core.api.MapAssert;
@@ -154,13 +153,9 @@ final class AssertJMapRules {
 
   static final class AssertThatMapContainsKey<K, V> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Map<K, V> map, K key) {
-      return assertThat(map.containsKey(key)).isTrue();
-    }
-
-    @BeforeTemplate
-    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before2(Map<K, V> map, K key) {
-      return assertThat(map.keySet()).contains(key);
+    AbstractAssert<?, ?> before(Map<K, V> map, K key) {
+      return Refaster.anyOf(
+          assertThat(map.containsKey(key)).isTrue(), assertThat(map.keySet()).contains(key));
     }
 
     @AfterTemplate
@@ -172,13 +167,9 @@ final class AssertJMapRules {
 
   static final class AssertThatMapDoesNotContainKey<K, V> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Map<K, V> map, K key) {
-      return assertThat(map.containsKey(key)).isFalse();
-    }
-
-    @BeforeTemplate
-    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before2(Map<K, V> map, K key) {
-      return assertThat(map.keySet()).doesNotContain(key);
+    AbstractAssert<?, ?> before(Map<K, V> map, K key) {
+      return Refaster.anyOf(
+          assertThat(map.containsKey(key)).isFalse(), assertThat(map.keySet()).doesNotContain(key));
     }
 
     @AfterTemplate
@@ -188,10 +179,13 @@ final class AssertJMapRules {
     }
   }
 
+  // XXX: Strictly speaking this rule could be merged into `AssertThatMapContainsOnlyKeys` below,
+  // but that rule targets another `containsOnlyKeys` overload. Review how cases like this should
+  // impact the preferred naming scheme.
   static final class AssertThatMapContainsOnlyKey<K, V> {
     @BeforeTemplate
-    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before2(Map<K, V> map, K key) {
-      return assertThat(map.keySet()).containsOnly(key);
+    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before(Map<K, V> map, K key) {
+      return assertThat(map.keySet()).containsExactly(key);
     }
 
     @AfterTemplate
@@ -217,13 +211,10 @@ final class AssertJMapRules {
 
   static final class AssertThatMapContainsValue<K, V> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Map<K, V> map, V value) {
-      return assertThat(map.containsValue(value)).isTrue();
-    }
-
-    @BeforeTemplate
-    AbstractCollectionAssert<?, Collection<? extends V>, V, ?> before2(Map<K, V> map, V value) {
-      return assertThat(map.values()).contains(value);
+    AbstractAssert<? extends AbstractAssert<?, ?>, ? extends Object> before(
+        Map<K, V> map, V value) {
+      return Refaster.anyOf(
+          assertThat(map.containsValue(value)).isTrue(), assertThat(map.values()).contains(value));
     }
 
     @AfterTemplate
@@ -235,13 +226,10 @@ final class AssertJMapRules {
 
   static final class AssertThatMapDoesNotContainValue<K, V> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Map<K, V> map, V value) {
-      return assertThat(map.containsValue(value)).isFalse();
-    }
-
-    @BeforeTemplate
-    AbstractCollectionAssert<?, Collection<? extends V>, V, ?> before2(Map<K, V> map, V value) {
-      return assertThat(map.values()).doesNotContain(value);
+    AbstractAssert<?, ?> before(Map<K, V> map, V value) {
+      return Refaster.anyOf(
+          assertThat(map.containsValue(value)).isFalse(),
+          assertThat(map.values()).doesNotContain(value));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJMapRules.java
@@ -158,6 +158,11 @@ final class AssertJMapRules {
       return assertThat(map.containsKey(key)).isTrue();
     }
 
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before2(Map<K, V> map, K key) {
+      return assertThat(map.keySet()).contains(key);
+    }
+
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     MapAssert<K, V> after(Map<K, V> map, K key) {
@@ -171,10 +176,28 @@ final class AssertJMapRules {
       return assertThat(map.containsKey(key)).isFalse();
     }
 
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before2(Map<K, V> map, K key) {
+      return assertThat(map.keySet()).doesNotContain(key);
+    }
+
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     MapAssert<K, V> after(Map<K, V> map, K key) {
       return assertThat(map).doesNotContainKey(key);
+    }
+  }
+
+  static final class AssertThatMapContainsOnlyKey<K, V> {
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before2(Map<K, V> map, K key) {
+      return assertThat(map.keySet()).containsOnly(key);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    MapAssert<K, V> after(Map<K, V> map, K key) {
+      return assertThat(map).containsOnlyKeys(key);
     }
   }
 
@@ -198,6 +221,11 @@ final class AssertJMapRules {
       return assertThat(map.containsValue(value)).isTrue();
     }
 
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends V>, V, ?> before2(Map<K, V> map, V value) {
+      return assertThat(map.values()).contains(value);
+    }
+
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     MapAssert<K, V> after(Map<K, V> map, V value) {
@@ -209,6 +237,11 @@ final class AssertJMapRules {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Map<K, V> map, V value) {
       return assertThat(map.containsValue(value)).isFalse();
+    }
+
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends V>, V, ?> before2(Map<K, V> map, V value) {
+      return assertThat(map.values()).doesNotContain(value);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
@@ -311,7 +311,7 @@ final class AssertJRules {
   // `assertThat` overload. Consider defining a `BugChecker` instead.
   static final class AssertThatMapContainsEntry<K, V> {
     @BeforeTemplate
-    ObjectAssert<?> before(Map<K, V> map, K key, V value) {
+    ObjectAssert<V> before(Map<K, V> map, K key, V value) {
       return assertThat(map.get(key)).isEqualTo(value);
     }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestInput.java
@@ -111,6 +111,10 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2).containsKey(3)).isFalse();
   }
 
+  AbstractAssert<?, ?> testAssertThatMapContainsOnlyKey() {
+    return assertThat(ImmutableMap.of(1, 2).keySet()).containsOnly(3);
+  }
+
   AbstractAssert<?, ?> testAssertThatMapContainsOnlyKeys() {
     return assertThat(ImmutableMap.of(1, 2).keySet()).hasSameElementsAs(ImmutableSet.of(3));
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestInput.java
@@ -103,28 +103,36 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2)).hasSize(ImmutableMap.of(3, 4).size());
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsKey() {
-    return assertThat(ImmutableMap.of(1, 2).containsKey(3)).isTrue();
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsKey() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2).containsKey(3)).isTrue(),
+        assertThat(ImmutableMap.of(4, 5).keySet()).contains(6));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapDoesNotContainKey() {
-    return assertThat(ImmutableMap.of(1, 2).containsKey(3)).isFalse();
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainKey() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2).containsKey(3)).isFalse(),
+        assertThat(ImmutableMap.of(4, 5).keySet()).doesNotContain(6));
   }
 
   AbstractAssert<?, ?> testAssertThatMapContainsOnlyKey() {
-    return assertThat(ImmutableMap.of(1, 2).keySet()).containsOnly(3);
+    return assertThat(ImmutableMap.of(1, 2).keySet()).containsExactly(3);
   }
 
   AbstractAssert<?, ?> testAssertThatMapContainsOnlyKeys() {
     return assertThat(ImmutableMap.of(1, 2).keySet()).hasSameElementsAs(ImmutableSet.of(3));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsValue() {
-    return assertThat(ImmutableMap.of(1, 2).containsValue(3)).isTrue();
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsValue() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2).containsValue(3)).isTrue(),
+        assertThat(ImmutableMap.of(4, 5).values()).contains(6));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapDoesNotContainValue() {
-    return assertThat(ImmutableMap.of(1, 2).containsValue(3)).isFalse();
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainValue() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2).containsValue(3)).isFalse(),
+        assertThat(ImmutableMap.of(4, 5).values()).doesNotContain(6));
   }
 
   AbstractObjectAssert<?, ?> testAssertThatMapContainsEntry() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestOutput.java
@@ -103,12 +103,16 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2)).hasSameSizeAs(ImmutableMap.of(3, 4));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsKey() {
-    return assertThat(ImmutableMap.of(1, 2)).containsKey(3);
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsKey() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2)).containsKey(3),
+        assertThat(ImmutableMap.of(4, 5)).containsKey(6));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapDoesNotContainKey() {
-    return assertThat(ImmutableMap.of(1, 2)).doesNotContainKey(3);
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainKey() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2)).doesNotContainKey(3),
+        assertThat(ImmutableMap.of(4, 5)).doesNotContainKey(6));
   }
 
   AbstractAssert<?, ?> testAssertThatMapContainsOnlyKey() {
@@ -119,12 +123,16 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2)).containsOnlyKeys(ImmutableSet.of(3));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsValue() {
-    return assertThat(ImmutableMap.of(1, 2)).containsValue(3);
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsValue() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2)).containsValue(3),
+        assertThat(ImmutableMap.of(4, 5)).containsValue(6));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapDoesNotContainValue() {
-    return assertThat(ImmutableMap.of(1, 2)).doesNotContainValue(3);
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainValue() {
+    return ImmutableSet.of(
+        assertThat(ImmutableMap.of(1, 2)).doesNotContainValue(3),
+        assertThat(ImmutableMap.of(4, 5)).doesNotContainValue(6));
   }
 
   AbstractObjectAssert<?, ?> testAssertThatMapContainsEntry() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestOutput.java
@@ -111,6 +111,10 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2)).doesNotContainKey(3);
   }
 
+  AbstractAssert<?, ?> testAssertThatMapContainsOnlyKey() {
+    return assertThat(ImmutableMap.of(1, 2)).containsOnlyKeys(3);
+  }
+
   AbstractAssert<?, ?> testAssertThatMapContainsOnlyKeys() {
     return assertThat(ImmutableMap.of(1, 2)).containsOnlyKeys(ImmutableSet.of(3));
   }


### PR DESCRIPTION
While working on https://github.com/openrewrite/rewrite-testing-frameworks/pull/713 I discovered some patterns that weren't included as rules here, and figured you all would appreciate having these as well.