### PR TITLE
Extend `AssertJEnumerableRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
@@ -7,7 +7,6 @@ import com.google.common.collect.Multiset;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
-import com.google.errorprone.refaster.annotation.Matches;
 import com.google.errorprone.refaster.annotation.NotMatches;
 import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
@@ -34,7 +33,6 @@ import org.assertj.core.api.OptionalIntAssert;
 import org.assertj.core.api.OptionalLongAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.matchers.IsArray;
-import tech.picnic.errorprone.refaster.matchers.IsEmpty;
 
 /** Refaster rules related to AssertJ expressions and statements. */
 // XXX: Most `AbstractIntegerAssert` rules can also be applied for other primitive types. Generate
@@ -65,8 +63,7 @@ import tech.picnic.errorprone.refaster.matchers.IsEmpty;
 // XXX: `assertThat(optional.map(fun)).hasValue(v)` ->
 // `assertThat(optional).get().extracting(fun).isEqualTo(v)` (if the get fails the map was useless)
 // XXX: `someAssert.extracting(pred).isEqualTo(true)` -> `someAssert.matches(pred)`
-// XXX: `assertThat(someString.contains(s)).isTrue()` -> assertThat(someString).contains(s)` -> Also
-// for collections
+// XXX: `assertThat(someCollection.contains(s)).isTrue()` -> assertThat(someCollection).contains(s)`
 // XXX: `assertThat(someString.matches(s)).isTrue()` -> assertThat(someString).matches(s)`
 // XXX: `assertThat(n > k).isTrue()` -> assertThat(n).isGreaterThan(k)` (etc. Also `==`!)
 // XXX: `assertThat(n > k && n < m).isTrue()` -> assertThat(n).isStrictlyBetween(k, m)` (etc.)
@@ -159,35 +156,6 @@ final class AssertJRules {
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     OptionalLongAssert after(OptionalLong optional, long expected) {
       return assertThat(optional).hasValue(expected);
-    }
-  }
-
-  //
-  // ObjectEnumerable
-  //
-
-  static final class AssertThatObjectEnumerableIsEmpty<E> {
-    @BeforeTemplate
-    @SuppressWarnings("unchecked")
-    void before(
-        ObjectEnumerableAssert<?, E> enumAssert,
-        @Matches(IsEmpty.class) Iterable<? extends E> wellTypedIterable,
-        @Matches(IsEmpty.class) Iterable<?> arbitrarilyTypedIterable) {
-      Refaster.anyOf(
-          enumAssert.containsExactlyElementsOf(wellTypedIterable),
-          enumAssert.containsExactlyInAnyOrderElementsOf(wellTypedIterable),
-          enumAssert.hasSameElementsAs(wellTypedIterable),
-          enumAssert.hasSameSizeAs(arbitrarilyTypedIterable),
-          enumAssert.isSubsetOf(wellTypedIterable),
-          enumAssert.containsExactly(),
-          enumAssert.containsExactlyInAnyOrder(),
-          enumAssert.containsOnly(),
-          enumAssert.isSubsetOf());
-    }
-
-    @AfterTemplate
-    void after(ObjectEnumerableAssert<?, E> enumAssert) {
-      enumAssert.isEmpty();
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
@@ -18,7 +18,26 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(1)).hasSize(0);
     assertThat(ImmutableSet.of(2)).hasSizeLessThanOrEqualTo(0);
     assertThat(ImmutableSet.of(3)).hasSizeLessThan(1);
-    assertThat(ImmutableSet.of(4)).size().isNotPositive();
+    assertThat(ImmutableSet.of(4)).hasSameSizeAs(ImmutableSet.of());
+    assertThat(ImmutableSet.of(5)).hasSameSizeAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(6)).containsExactlyElementsOf(ImmutableSet.of());
+    assertThat(ImmutableSet.of(7)).containsExactlyElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(8)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of());
+    assertThat(ImmutableSet.of(9)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(10)).hasSameElementsAs(ImmutableSet.of());
+    assertThat(ImmutableSet.of(11)).hasSameElementsAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(12)).isSubsetOf(ImmutableSet.of());
+    assertThat(ImmutableSet.of(13)).isSubsetOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(14)).containsExactly();
+    assertThat(ImmutableSet.of(15)).containsExactlyInAnyOrder();
+    assertThat(ImmutableSet.of(16)).containsOnly();
+    assertThat(ImmutableSet.of(17)).isSubsetOf();
+    assertThat(ImmutableSet.of(18)).size().isNotPositive();
+  }
+
+  void testAssertAndEnumerableAssertIsEmpty() {
+    assertThat(ImmutableSet.of(1)).isEqualTo(ImmutableSet.of());
+    assertThat(ImmutableSet.of(2)).isEqualTo(ImmutableSet.of(0));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
@@ -19,6 +19,25 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(2)).isEmpty();
     assertThat(ImmutableSet.of(3)).isEmpty();
     assertThat(ImmutableSet.of(4)).isEmpty();
+    assertThat(ImmutableSet.of(5)).hasSameSizeAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(6)).isEmpty();
+    assertThat(ImmutableSet.of(7)).containsExactlyElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(8)).isEmpty();
+    assertThat(ImmutableSet.of(9)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(10)).isEmpty();
+    assertThat(ImmutableSet.of(11)).hasSameElementsAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(12)).isEmpty();
+    assertThat(ImmutableSet.of(13)).isSubsetOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(14)).isEmpty();
+    assertThat(ImmutableSet.of(15)).isEmpty();
+    assertThat(ImmutableSet.of(16)).isEmpty();
+    assertThat(ImmutableSet.of(17)).isEmpty();
+    assertThat(ImmutableSet.of(18)).isEmpty();
+  }
+
+  void testAssertAndEnumerableAssertIsEmpty() {
+    assertThat(ImmutableSet.of(1)).isEmpty();
+    assertThat(ImmutableSet.of(2)).isEqualTo(ImmutableSet.of(0));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {


### PR DESCRIPTION
Suggested commit message:
```
Extend `AssertJEnumerableRules` Refaster rule collection

By porting and generalizing the `AssertThatObjectEnumerableIsEmpty` rule
from the `AssertJRules` rule collection.

While there, update a partially-outdated comment in `AssertJRules`.
```