### PR TITLE
Update `step-security/harden-runner` configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,10 +34,7 @@ jobs:
             api.adoptium.net:443
             github.com:443
             github-registry-files.githubusercontent.com:443
-            hosted-compute-watchdog-prod-eus-01.githubapp.com:443
-            hosted-compute-watchdog-prod-eus-02.githubapp.com:443
-            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
-            hosted-compute-watchdog-prod-iad-02.githubapp.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             maven.pkg.github.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
             api.adoptium.net:443
             github.com:443
             github-registry-files.githubusercontent.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             maven.pkg.github.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,10 @@ jobs:
             api.adoptium.net:443
             github.com:443
             github-registry-files.githubusercontent.com:443
-            hosted-compute-watchdog-prod-*.githubapp.com:443
+            hosted-compute-watchdog-prod-eus-01.githubapp.com:443
+            hosted-compute-watchdog-prod-eus-02.githubapp.com:443
+            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
+            hosted-compute-watchdog-prod-iad-02.githubapp.com:443
             maven.pkg.github.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,7 +34,6 @@ jobs:
             api.adoptium.net:443
             github.com:443
             github-registry-files.githubusercontent.com:443
-            hosted-compute-watchdog-prod-*.githubapp.com:443
             maven.pkg.github.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,10 @@ jobs:
             api.adoptium.net:443
             api.github.com:443
             github.com:443
+            hosted-compute-watchdog-prod-eus-01.githubapp.com:443
+            hosted-compute-watchdog-prod-eus-02.githubapp.com:443
+            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
+            hosted-compute-watchdog-prod-iad-02.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
             uploads.github.com:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
             api.adoptium.net:443
             api.github.com:443
             github.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
             uploads.github.com:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,7 +30,6 @@ jobs:
             api.adoptium.net:443
             api.github.com:443
             github.com:443
-            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
             uploads.github.com:443

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,10 +30,7 @@ jobs:
             api.adoptium.net:443
             api.github.com:443
             github.com:443
-            hosted-compute-watchdog-prod-eus-01.githubapp.com:443
-            hosted-compute-watchdog-prod-eus-02.githubapp.com:443
-            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
-            hosted-compute-watchdog-prod-iad-02.githubapp.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
             uploads.github.com:443

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -19,6 +19,10 @@ jobs:
           allowed-endpoints: >
             api.adoptium.net:443
             github.com:443
+            hosted-compute-watchdog-prod-eus-01.githubapp.com:443
+            hosted-compute-watchdog-prod-eus-02.githubapp.com:443
+            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
+            hosted-compute-watchdog-prod-iad-02.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
       - name: Check out code and set up JDK and Maven

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -19,10 +19,7 @@ jobs:
           allowed-endpoints: >
             api.adoptium.net:443
             github.com:443
-            hosted-compute-watchdog-prod-eus-01.githubapp.com:443
-            hosted-compute-watchdog-prod-eus-02.githubapp.com:443
-            hosted-compute-watchdog-prod-iad-01.githubapp.com:443
-            hosted-compute-watchdog-prod-iad-02.githubapp.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
       - name: Check out code and set up JDK and Maven

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -19,7 +19,6 @@ jobs:
           allowed-endpoints: >
             api.adoptium.net:443
             github.com:443
-            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
       - name: Check out code and set up JDK and Maven

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -19,6 +19,7 @@ jobs:
           allowed-endpoints: >
             api.adoptium.net:443
             github.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             repo.maven.apache.org:443
       - name: Check out code and set up JDK and Maven


### PR DESCRIPTION
Suggested commit message:
```
Update `step-security/harden-runner` configuration (#1683)

By allowing access to
`hosted-compute-watchdog-prod-*.githubapp.com:443`, as required by the
GitHub-internal [1] `provjobd` process.

[1] https://www.stepsecurity.io/blog/harden-runner-detects-anomalous-traffic-to-api-ipify-org-across-multiple-customers
```