### PR TITLE
Introduce `PublisherProbeAssertThatWas{Subscribed,Cancelled,Requested}` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -43,6 +43,7 @@ import java.util.function.Predicate;
 import java.util.function.Supplier;
 import java.util.stream.Collector;
 import java.util.stream.Stream;
+import org.assertj.core.api.Assertions;
 import org.jspecify.annotations.Nullable;
 import org.reactivestreams.Publisher;
 import reactor.core.publisher.Flux;
@@ -1891,6 +1892,93 @@ final class ReactorRules {
     @AfterTemplate
     void after(PublisherProbe<T> probe) {
       probe.assertWasNotRequested();
+    }
+  }
+
+  /**
+   * Prefer {@link Assertions#assertThat(boolean)} to check whether a {@link
+   * PublisherProbe#wasSubscribed()} to over more verbose alternatives.
+   */
+  static final class PublisherProbeAssertThatWasSubscribed<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe, boolean wasSubscribed) {
+      if (wasSubscribed) {
+        probe.assertWasSubscribed();
+      } else {
+        probe.assertWasNotSubscribed();
+      }
+    }
+
+    @BeforeTemplate
+    void before2(PublisherProbe<T> probe, boolean wasSubscribed) {
+      if (!wasSubscribed) {
+        probe.assertWasNotSubscribed();
+      } else {
+        probe.assertWasSubscribed();
+      }
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe, boolean wasSubscribed) {
+      assertThat(probe.wasSubscribed()).isEqualTo(wasSubscribed);
+    }
+  }
+
+  /**
+   * Prefer {@link Assertions#assertThat(boolean)} to check whether a {@link
+   * PublisherProbe#wasCancelled()} to over more verbose alternatives.
+   */
+  static final class PublisherProbeAssertThatWasCancelled<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe, boolean wasCancelled) {
+      if (wasCancelled) {
+        probe.assertWasCancelled();
+      } else {
+        probe.assertWasNotCancelled();
+      }
+    }
+
+    @BeforeTemplate
+    void before2(PublisherProbe<T> probe, boolean wasCancelled) {
+      if (!wasCancelled) {
+        probe.assertWasNotCancelled();
+      } else {
+        probe.assertWasCancelled();
+      }
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe, boolean wasCancelled) {
+      assertThat(probe.wasCancelled()).isEqualTo(wasCancelled);
+    }
+  }
+
+  /**
+   * Prefer {@link Assertions#assertThat(boolean)} to check whether a {@link
+   * PublisherProbe#wasRequested()} to over more verbose alternatives.
+   */
+  static final class PublisherProbeAssertThatWasRequested<T> {
+    @BeforeTemplate
+    void before(PublisherProbe<T> probe, boolean wasRequested) {
+      if (wasRequested) {
+        probe.assertWasRequested();
+      } else {
+        probe.assertWasNotRequested();
+      }
+    }
+
+    @BeforeTemplate
+    void before2(PublisherProbe<T> probe, boolean wasRequested) {
+      if (!wasRequested) {
+        probe.assertWasNotRequested();
+      } else {
+        probe.assertWasRequested();
+      }
+    }
+
+    @AfterTemplate
+    void after(PublisherProbe<T> probe, boolean wasRequested) {
+      assertThat(probe.wasRequested()).isEqualTo(wasRequested);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -639,6 +639,36 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(PublisherProbe.empty().wasRequested()).isFalse();
   }
 
+  void testPublisherProbeAssertThatWasSubscribed() {
+    PublisherProbe<Integer> probe = PublisherProbe.of(Mono.just(1));
+    boolean wasSubscribed = true;
+    if (wasSubscribed) {
+      probe.assertWasSubscribed();
+    } else {
+      probe.assertWasNotSubscribed();
+    }
+  }
+
+  void testPublisherProbeAssertThatWasCancelled() {
+    PublisherProbe<Integer> probe = PublisherProbe.of(Mono.just(1));
+    boolean wasCancelled = true;
+    if (wasCancelled) {
+      probe.assertWasCancelled();
+    } else {
+      probe.assertWasNotCancelled();
+    }
+  }
+
+  void testPublisherProbeAssertThatWasRequested() {
+    PublisherProbe<Integer> probe = PublisherProbe.of(Mono.just(1));
+    boolean wasRequested = true;
+    if (wasRequested) {
+      probe.assertWasRequested();
+    } else {
+      probe.assertWasNotRequested();
+    }
+  }
+
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.just(1)), Mono.just(2).flux().as(StepVerifier::create));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -622,6 +622,24 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     PublisherProbe.empty().assertWasNotRequested();
   }
 
+  void testPublisherProbeAssertThatWasSubscribed() {
+    PublisherProbe<Integer> probe = PublisherProbe.of(Mono.just(1));
+    boolean wasSubscribed = true;
+    assertThat(probe.wasSubscribed()).isEqualTo(wasSubscribed);
+  }
+
+  void testPublisherProbeAssertThatWasCancelled() {
+    PublisherProbe<Integer> probe = PublisherProbe.of(Mono.just(1));
+    boolean wasCancelled = true;
+    assertThat(probe.wasCancelled()).isEqualTo(wasCancelled);
+  }
+
+  void testPublisherProbeAssertThatWasRequested() {
+    PublisherProbe<Integer> probe = PublisherProbe.of(Mono.just(1));
+    boolean wasRequested = true;
+    assertThat(probe.wasRequested()).isEqualTo(wasRequested);
+  }
+
   ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create), Mono.just(2).as(StepVerifier::create));


### PR DESCRIPTION
Conceptually similar to #1423, but taking it one step further since I found this setup now multiple times.