### PR TITLE
Introduce `AbstractThrowableAssertHasCauseReference` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
@@ -759,4 +759,18 @@ final class AssertJThrowingCallableRules {
       return abstractThrowableAssert.withFailMessage(message, args);
     }
   }
+
+  static final class AbstractThrowableAssertHasCauseReference {
+    @BeforeTemplate
+    AbstractThrowableAssert<?, ? extends Throwable> before(
+        AbstractThrowableAssert<?, ? extends Throwable> throwableAssert, Throwable expected) {
+      return throwableAssert.hasCauseReference(expected);
+    }
+
+    @AfterTemplate
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        AbstractThrowableAssert<?, ? extends Throwable> throwableAssert, Throwable expected) {
+      return throwableAssert.cause().isSameAs(expected);
+    }
+  }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
@@ -760,9 +760,10 @@ final class AssertJThrowingCallableRules {
     }
   }
 
+  // XXX: This rule changes the `Throwable` against which subsequent assertions are made.
   static final class AbstractThrowableAssertCauseIsSameAs {
     @BeforeTemplate
-    @SuppressWarnings("deprecation" /* Migrates away from deprecated API. */)
+    @SuppressWarnings("deprecation" /* This deprecated API will be rewritten. */)
     AbstractThrowableAssert<?, ? extends Throwable> before(
         AbstractThrowableAssert<?, ? extends Throwable> throwableAssert, Throwable expected) {
       return throwableAssert.hasCauseReference(expected);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
@@ -762,6 +762,7 @@ final class AssertJThrowingCallableRules {
 
   static final class AbstractThrowableAssertHasCauseReference {
     @BeforeTemplate
+    @SuppressWarnings("deprecation" /* Support migration away from deprecated API */)
     AbstractThrowableAssert<?, ? extends Throwable> before(
         AbstractThrowableAssert<?, ? extends Throwable> throwableAssert, Throwable expected) {
       return throwableAssert.hasCauseReference(expected);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
@@ -760,9 +760,9 @@ final class AssertJThrowingCallableRules {
     }
   }
 
-  static final class AbstractThrowableAssertHasCauseReference {
+  static final class AbstractThrowableAssertCauseIsSameAs {
     @BeforeTemplate
-    @SuppressWarnings("deprecation" /* Support migration away from deprecated API */)
+    @SuppressWarnings("deprecation" /* Migrates away from deprecated API. */)
     AbstractThrowableAssert<?, ? extends Throwable> before(
         AbstractThrowableAssert<?, ? extends Throwable> throwableAssert, Throwable expected) {
       return throwableAssert.hasCauseReference(expected);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -220,8 +220,7 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage(String.format("foo %s %s", "bar", 1)));
   }
 
-  ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
-      testAbstractThrowableAssertHasCauseReference() {
+  AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertHasCauseReference() {
     IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
     IllegalStateException illegalStateException =
         new IllegalStateException(illegalArgumentException);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -220,6 +220,7 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage(String.format("foo %s %s", "bar", 1)));
   }
 
+  @SuppressWarnings("deprecation" /* Support migration away from deprecated API */)
   AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertHasCauseReference() {
     IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
     IllegalStateException illegalStateException =

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -220,8 +220,8 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage(String.format("foo %s %s", "bar", 1)));
   }
 
-  @SuppressWarnings("deprecation" /* Support migration away from deprecated API */)
-  AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertHasCauseReference() {
+  @SuppressWarnings("deprecation" /* Migrates away from deprecated API. */)
+  AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertCauseIsSameAs() {
     IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
     IllegalStateException illegalStateException =
         new IllegalStateException(illegalArgumentException);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -1,5 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -217,5 +218,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
             .withFailMessage(String.format("foo %s %s", "bar", 1)));
+  }
+
+  ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
+      testAbstractThrowableAssertHasCauseReference() {
+    IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
+    IllegalStateException illegalStateException =
+        new IllegalStateException(illegalArgumentException);
+    return assertThat(illegalStateException).hasCauseReference(illegalArgumentException);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -220,11 +220,9 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage(String.format("foo %s %s", "bar", 1)));
   }
 
-  @SuppressWarnings("deprecation" /* Migrates away from deprecated API. */)
+  @SuppressWarnings("deprecation" /* Rule targets deprecated API. */)
   AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertCauseIsSameAs() {
-    IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
-    IllegalStateException illegalStateException =
-        new IllegalStateException(illegalArgumentException);
-    return assertThat(illegalStateException).hasCauseReference(illegalArgumentException);
+    return assertThat(new IllegalStateException())
+        .hasCauseReference(new IllegalArgumentException());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -1,5 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.Assertions.assertThatIOException;
 import static org.assertj.core.api.Assertions.assertThatIllegalArgumentException;
@@ -249,5 +250,13 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
         assertThatThrownBy(() -> {})
             .isInstanceOf(IllegalArgumentException.class)
             .withFailMessage("foo %s %s", "bar", 1));
+  }
+
+  ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
+      testAbstractThrowableAssertHasCauseReference() {
+    IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
+    IllegalStateException illegalStateException =
+        new IllegalStateException(illegalArgumentException);
+    return assertThat(illegalStateException).cause().isSameAs(illegalArgumentException);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -252,8 +252,8 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage("foo %s %s", "bar", 1));
   }
 
-  @SuppressWarnings("deprecation" /* Support migration away from deprecated API */)
-  AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertHasCauseReference() {
+  @SuppressWarnings("deprecation" /* Migrates away from deprecated API. */)
+  AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertCauseIsSameAs() {
     IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
     IllegalStateException illegalStateException =
         new IllegalStateException(illegalArgumentException);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -252,11 +252,8 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage("foo %s %s", "bar", 1));
   }
 
-  @SuppressWarnings("deprecation" /* Migrates away from deprecated API. */)
+  @SuppressWarnings("deprecation" /* Rule targets deprecated API. */)
   AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertCauseIsSameAs() {
-    IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
-    IllegalStateException illegalStateException =
-        new IllegalStateException(illegalArgumentException);
-    return assertThat(illegalStateException).cause().isSameAs(illegalArgumentException);
+    return assertThat(new IllegalStateException()).cause().isSameAs(new IllegalArgumentException());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -252,8 +252,7 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage("foo %s %s", "bar", 1));
   }
 
-  ImmutableSet<AbstractThrowableAssert<?, ? extends Throwable>>
-      testAbstractThrowableAssertHasCauseReference() {
+  AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertHasCauseReference() {
     IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
     IllegalStateException illegalStateException =
         new IllegalStateException(illegalArgumentException);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -252,6 +252,7 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
             .withFailMessage("foo %s %s", "bar", 1));
   }
 
+  @SuppressWarnings("deprecation" /* Support migration away from deprecated API */)
   AbstractThrowableAssert<?, ? extends Throwable> testAbstractThrowableAssertHasCauseReference() {
     IllegalArgumentException illegalArgumentException = new IllegalArgumentException();
     IllegalStateException illegalStateException =


### PR DESCRIPTION
- Following https://github.com/assertj/assertj/issues/3715

@rickie would this be an accepted contribution if tests are added?