### PR TITLE
Drop explicit `rewrite-templating` version declaration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -494,11 +494,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.openrewrite</groupId>
-                <artifactId>rewrite-templating</artifactId>
-                <version>1.27.0</version>
-            </dependency>
-            <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
                 <version>3.8.1</version>


### PR DESCRIPTION
Suggested commit message:
```
Drop explicit `rewrite-templating` version declaration

And depend on the version specified by `rewrite-recipe-bom` instead.
```

This explicit dependency version declaration was introduced in #925 as a workaround for mojohaus/versions-maven-plugin#244, but #515 was merged first, so [9c57f7d](https://github.com/PicnicSupermarket/error-prone-support/pull/925/commits/9c57f7db921c269a637fb823ed09e8aa6ab1e5e5) should have dropped it. Thanks to @timtebeek for the [suggestion](https://github.com/PicnicSupermarket/error-prone-support/pull/1703#discussion_r2133775637).