### PR TITLE
Update `step-security/harden-runner` configuration

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -29,6 +29,7 @@ jobs:
             maven.apache.org:443
             objects.githubusercontent.com:443
             pitest.org:443
+            release-assets.githubusercontent.com:443
             repo.maven.apache.org:443
             rubygems.org:443
             search.maven.org:443


### PR DESCRIPTION
Suggested commit message:
```
Update `step-security/harden-runner` configuration (#1727)

By also allowing `deploy-website.yml` access to
`release-assets.githubusercontent.com:443`.

See https://www.stepsecurity.io/blog/harden-runner-detects-new-traffic-to-release-assets-githubusercontent-com-across-multiple-customers
```