### PR TITLE
Update `step-security/harden-runner` configuration

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -20,6 +20,7 @@ jobs:
             api.github.com:443
             github-registry-files.githubusercontent.com:443
             github.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             maven.pkg.github.com:443
             objects.githubusercontent.com:443
             raw.githubusercontent.com:443


### PR DESCRIPTION
Following [this transient build failure](https://github.com/PicnicSupermarket/error-prone-support/actions/runs/15807908625/attempts/1?pr=1737).

Suggested commit message:
```
Update `step-security/harden-runner` configuration (#1738)

By also allowing `reviewdog.yml` access to
`hosted-compute-watchdog-prod-*.githubapp.com:443`.

See https://www.stepsecurity.io/blog/harden-runner-detects-anomalous-traffic-to-api-ipify-org-across-multiple-customers
```