### PR TITLE
Update `step-security/harden-runner` configuration

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -48,6 +48,7 @@ jobs:
             checkstyle.org:443
             example.com:80
             github.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             oss.sonatype.org:443
             production.cloudflare.docker.com:443


### PR DESCRIPTION
Suggested commit message:
```
Update `step-security/harden-runner` configuration (#1757)

By also allowing `integration-tests.yml` access to
`hosted-compute-watchdog-prod-*.githubapp.com:443`.

See https://www.stepsecurity.io/blog/harden-runner-detects-anomalous-traffic-to-api-ipify-org-across-multiple-customers
```