### PR TITLE
Suppress various SonarCloud violations

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
@@ -19,6 +19,7 @@ final class CharSequenceRules {
   // below.
   static final class CharSequenceIsEmpty {
     @BeforeTemplate
+    @SuppressWarnings("java:S7158" /* This violation will be rewritten. */)
     boolean before(CharSequence charSequence) {
       return Refaster.anyOf(
           charSequence.length() == 0, charSequence.length() <= 0, charSequence.length() < 1);

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -13,6 +13,7 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Objects;
+import org.jspecify.annotations.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster templates related to statements dealing with {@link Preconditions}. */
@@ -89,7 +90,7 @@ final class PreconditionsRules {
   }
 
   /** Prefer {@link Objects#requireNonNull(Object)} over more verbose alternatives. */
-  static final class RequireNonNullStatement<T> {
+  static final class RequireNonNullStatement<T extends @Nullable Object> {
     @BeforeTemplate
     @SuppressWarnings("java:S1695" /* This violation will be rewritten. */)
     void before(T object) {
@@ -120,7 +121,7 @@ final class PreconditionsRules {
   }
 
   /** Prefer {@link Objects#requireNonNull(Object, String)} over more verbose alternatives. */
-  static final class RequireNonNullWithMessageStatement<T> {
+  static final class RequireNonNullWithMessageStatement<T extends @Nullable Object> {
     @BeforeTemplate
     @SuppressWarnings("java:S1695" /* This violation will be rewritten. */)
     void before(T object, String message) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -34,6 +34,7 @@ final class StringRules {
    */
   static final class EmptyString {
     @BeforeTemplate
+    @SuppressWarnings("java:S2129" /* This violation will be rewritten. */)
     String before() {
       return Refaster.anyOf(
           new String(),
@@ -54,6 +55,7 @@ final class StringRules {
   // instead of this Refaster rule.
   static final class StringIdentity {
     @BeforeTemplate
+    @SuppressWarnings("java:S2129" /* This violation will be rewritten. */)
     String before(String str) {
       return new String(str);
     }
@@ -72,7 +74,11 @@ final class StringRules {
   // rule selection based on some annotation, or a separate Maven module.
   static final class StringIsEmpty {
     @BeforeTemplate
-    @SuppressWarnings("CharSequenceIsEmpty" /* This is a more specific template. */)
+    @SuppressWarnings({
+      "CharSequenceIsEmpty" /* This is a more specific template. */,
+      "java:S7158" /* This violation will be rewritten. */,
+      "key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
+    })
     boolean before(String str) {
       return Refaster.anyOf(str.length() == 0, str.length() <= 0, str.length() < 1);
     }


### PR DESCRIPTION
This resolves two new issues flagged after #1755, plus some other things. (The SonarCloud analysis currently [doesn't run](https://github.com/PicnicSupermarket/error-prone-support/blob/0331cd00945742f30907e86061932dc9e9effb02/.github/workflows/sonarcloud.yml#L14-L16) for PRs based off forks.)

Suggested commit message:
```
Suppress various SonarCloud violations (#1764)
```