### PR TITLE
Introduce `AssertJDurationRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
@@ -13,15 +13,14 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 /**
  * Refaster rules related to AssertJ assertions over {@link Duration}s.
  *
- * <p>These rules simplify and improve the readability of Duration assertions by using the more
- * specific AssertJ Duration assertion methods instead of generic assertions on the Duration's
- * numeric values.
+ * <p>These rules simplify and improve the readability of tests by using {@link Duration}-specific
+ * AssertJ assertion methods instead of generic assertions.
  */
 @OnlineDocumentation
 final class AssertJDurationRules {
   private AssertJDurationRules() {}
 
-  static final class AbstractDurationAssertHasNanos {
+  static final class AssertThatHasNanos {
     @BeforeTemplate
     AbstractLongAssert<?> before(Duration duration, long nanos) {
       return assertThat(duration.toNanos()).isEqualTo(nanos);
@@ -33,7 +32,7 @@ final class AssertJDurationRules {
     }
   }
 
-  static final class AbstractDurationAssertHasMillis {
+  static final class AssertThatHasMillis {
     @BeforeTemplate
     AbstractLongAssert<?> before(Duration duration, long millis) {
       return assertThat(duration.toMillis()).isEqualTo(millis);
@@ -45,7 +44,7 @@ final class AssertJDurationRules {
     }
   }
 
-  static final class AbstractDurationAssertHasSeconds {
+  static final class AssertThatHasSeconds {
     @BeforeTemplate
     AbstractLongAssert<?> before(Duration duration, long seconds) {
       return assertThat(duration.toSeconds()).isEqualTo(seconds);
@@ -57,7 +56,7 @@ final class AssertJDurationRules {
     }
   }
 
-  static final class AbstractDurationAssertHasMinutes {
+  static final class AssertThatHasMinutes {
     @BeforeTemplate
     AbstractLongAssert<?> before(Duration duration, long minutes) {
       return assertThat(duration.toMinutes()).isEqualTo(minutes);
@@ -69,7 +68,7 @@ final class AssertJDurationRules {
     }
   }
 
-  static final class AbstractDurationAssertHasHours {
+  static final class AssertThatHasHours {
     @BeforeTemplate
     AbstractLongAssert<?> before(Duration duration, long hours) {
       return assertThat(duration.toHours()).isEqualTo(hours);
@@ -81,7 +80,7 @@ final class AssertJDurationRules {
     }
   }
 
-  static final class AbstractDurationAssertHasDays {
+  static final class AssertThatHasDays {
     @BeforeTemplate
     AbstractLongAssert<?> before(Duration duration, long days) {
       return assertThat(duration.toDays()).isEqualTo(days);
@@ -93,10 +92,18 @@ final class AssertJDurationRules {
     }
   }
 
-  static final class AbstractDurationAssertIsZero {
+  static final class AssertThatIsZero {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Duration duration) {
       return assertThat(duration.isZero()).isTrue();
+    }
+
+    // XXX: This method can be folded into the preceding method using `Refaster#anyOf`, but by
+    // keeping it separate, we show that this rule, contrary to the other one, retains the correct
+    // return type.
+    @BeforeTemplate
+    AbstractDurationAssert<?> before2(Duration duration) {
+      return assertThat(duration).isEqualTo(Duration.ZERO);
     }
 
     @AfterTemplate
@@ -105,10 +112,32 @@ final class AssertJDurationRules {
     }
   }
 
-  static final class AbstractDurationAssertIsNegative {
+  // XXX: Once we build against JDK 18+, update this rule to also rewrite
+  // `assertThat(duration.isPositive()).isTrue()`
+  static final class AssertThatIsPositive {
+    @BeforeTemplate
+    AbstractDurationAssert<?> before(Duration duration) {
+      return assertThat(duration).isGreaterThan(Duration.ZERO);
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration) {
+      return assertThat(duration).isPositive();
+    }
+  }
+
+  static final class AssertThatIsNegative {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Duration duration) {
       return assertThat(duration.isNegative()).isTrue();
+    }
+
+    // XXX: This method can be folded into the preceding method using `Refaster#anyOf`, but by
+    // keeping it separate, we show that this rule, contrary to the other one, retains the correct
+    // return type.
+    @BeforeTemplate
+    AbstractDurationAssert<?> before2(Duration duration) {
+      return assertThat(duration).isLessThan(Duration.ZERO);
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
@@ -1,0 +1,119 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.time.Duration;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.assertj.core.api.AbstractDurationAssert;
+import org.assertj.core.api.AbstractLongAssert;
+import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
+
+/**
+ * Refaster rules related to AssertJ assertions over {@link Duration}s.
+ *
+ * <p>These rules simplify and improve the readability of Duration assertions by using the more
+ * specific AssertJ Duration assertion methods instead of generic assertions on the Duration's
+ * numeric values.
+ */
+@OnlineDocumentation
+final class AssertJDurationRules {
+  private AssertJDurationRules() {}
+
+  static final class AbstractDurationAssertHasNanos {
+    @BeforeTemplate
+    AbstractLongAssert<?> before(Duration duration, long nanos) {
+      return assertThat(duration.toNanos()).isEqualTo(nanos);
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration, long nanos) {
+      return assertThat(duration).hasNanos(nanos);
+    }
+  }
+
+  static final class AbstractDurationAssertHasMillis {
+    @BeforeTemplate
+    AbstractLongAssert<?> before(Duration duration, long millis) {
+      return assertThat(duration.toMillis()).isEqualTo(millis);
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration, long millis) {
+      return assertThat(duration).hasMillis(millis);
+    }
+  }
+
+  static final class AbstractDurationAssertHasSeconds {
+    @BeforeTemplate
+    AbstractLongAssert<?> before(Duration duration, long seconds) {
+      return assertThat(duration.toSeconds()).isEqualTo(seconds);
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration, long seconds) {
+      return assertThat(duration).hasSeconds(seconds);
+    }
+  }
+
+  static final class AbstractDurationAssertHasMinutes {
+    @BeforeTemplate
+    AbstractLongAssert<?> before(Duration duration, long minutes) {
+      return assertThat(duration.toMinutes()).isEqualTo(minutes);
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration, long minutes) {
+      return assertThat(duration).hasMinutes(minutes);
+    }
+  }
+
+  static final class AbstractDurationAssertHasHours {
+    @BeforeTemplate
+    AbstractLongAssert<?> before(Duration duration, long hours) {
+      return assertThat(duration.toHours()).isEqualTo(hours);
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration, long hours) {
+      return assertThat(duration).hasHours(hours);
+    }
+  }
+
+  static final class AbstractDurationAssertHasDays {
+    @BeforeTemplate
+    AbstractLongAssert<?> before(Duration duration, long days) {
+      return assertThat(duration.toDays()).isEqualTo(days);
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration, long days) {
+      return assertThat(duration).hasDays(days);
+    }
+  }
+
+  static final class AbstractDurationAssertIsZero {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(Duration duration) {
+      return assertThat(duration.isZero()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration) {
+      return assertThat(duration).isZero();
+    }
+  }
+
+  static final class AbstractDurationAssertIsNegative {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(Duration duration) {
+      return assertThat(duration.isNegative()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractDurationAssert<?> after(Duration duration) {
+      return assertThat(duration).isNegative();
+    }
+  }
+}

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -20,6 +20,7 @@ final class RefasterRulesTest {
           AssertJCharSequenceRules.class,
           AssertJComparableRules.class,
           AssertJDoubleRules.class,
+          AssertJDurationRules.class,
           AssertJEnumerableRules.class,
           AssertJFloatRules.class,
           AssertJIntegerRules.class,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
@@ -1,0 +1,49 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.common.collect.ImmutableSet;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractComparableAssert;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
+    @Override
+    public ImmutableSet<Object> elidedTypesAndStaticImports() {
+        return ImmutableSet.of(Duration.class);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
+        return assertThat(Duration.ofNanos(1000).toNanos()).isEqualTo(1000L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
+        return assertThat(Duration.ofMillis(1000).toMillis()).isEqualTo(1000L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
+        return assertThat(Duration.ofSeconds(60).toSeconds()).isEqualTo(60L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
+        return assertThat(Duration.ofMinutes(5).toMinutes()).isEqualTo(5L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
+        return assertThat(Duration.ofHours(2).toHours()).isEqualTo(2L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
+        return assertThat(Duration.ofDays(7).toDays()).isEqualTo(7L);
+    }
+
+    AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
+        return assertThat(Duration.ZERO.isZero()).isTrue();
+    }
+
+    AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
+        return assertThat(Duration.ofSeconds(-1).isNegative()).isTrue();
+    }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
@@ -1,49 +1,48 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableSet;
+import java.time.Duration;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractComparableAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
-    @Override
-    public ImmutableSet<Object> elidedTypesAndStaticImports() {
-        return ImmutableSet.of(Duration.class);
-    }
+  @Override
+  public ImmutableSet<Object> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Duration.class);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
-        return assertThat(Duration.ofNanos(1000).toNanos()).isEqualTo(1000L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
+    return assertThat(Duration.ofNanos(1000).toNanos()).isEqualTo(1000L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
-        return assertThat(Duration.ofMillis(1000).toMillis()).isEqualTo(1000L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
+    return assertThat(Duration.ofMillis(1000).toMillis()).isEqualTo(1000L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
-        return assertThat(Duration.ofSeconds(60).toSeconds()).isEqualTo(60L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
+    return assertThat(Duration.ofSeconds(60).toSeconds()).isEqualTo(60L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
-        return assertThat(Duration.ofMinutes(5).toMinutes()).isEqualTo(5L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
+    return assertThat(Duration.ofMinutes(5).toMinutes()).isEqualTo(5L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
-        return assertThat(Duration.ofHours(2).toHours()).isEqualTo(2L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
+    return assertThat(Duration.ofHours(2).toHours()).isEqualTo(2L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
-        return assertThat(Duration.ofDays(7).toDays()).isEqualTo(7L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
+    return assertThat(Duration.ofDays(7).toDays()).isEqualTo(7L);
+  }
 
-    AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
-        return assertThat(Duration.ZERO.isZero()).isTrue();
-    }
+  AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
+    return assertThat(Duration.ZERO.isZero()).isTrue();
+  }
 
-    AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
-        return assertThat(Duration.ofSeconds(-1).isNegative()).isTrue();
-    }
+  AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
+    return assertThat(Duration.ofSeconds(-1).isNegative()).isTrue();
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
@@ -5,44 +5,47 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractComparableAssert;
+import org.assertj.core.api.AbstractDurationAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
-  @Override
-  public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Duration.class);
+  AbstractAssert<?, ?> testAssertThatHasNanos() {
+    return assertThat(Duration.ZERO.toNanos()).isEqualTo(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
-    return assertThat(Duration.ofNanos(1000).toNanos()).isEqualTo(1000L);
+  AbstractAssert<?, ?> testAssertThatHasMillis() {
+    return assertThat(Duration.ZERO.toMillis()).isEqualTo(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
-    return assertThat(Duration.ofMillis(1000).toMillis()).isEqualTo(1000L);
+  AbstractAssert<?, ?> testAssertThatHasSeconds() {
+    return assertThat(Duration.ZERO.toSeconds()).isEqualTo(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
-    return assertThat(Duration.ofSeconds(60).toSeconds()).isEqualTo(60L);
+  AbstractAssert<?, ?> testAssertThatHasMinutes() {
+    return assertThat(Duration.ZERO.toMinutes()).isEqualTo(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
-    return assertThat(Duration.ofMinutes(5).toMinutes()).isEqualTo(5L);
+  AbstractAssert<?, ?> testAssertThatHasHours() {
+    return assertThat(Duration.ZERO.toHours()).isEqualTo(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
-    return assertThat(Duration.ofHours(2).toHours()).isEqualTo(2L);
+  AbstractAssert<?, ?> testAssertThatHasDays() {
+    return assertThat(Duration.ZERO.toDays()).isEqualTo(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
-    return assertThat(Duration.ofDays(7).toDays()).isEqualTo(7L);
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsZero() {
+    return ImmutableSet.of(
+        assertThat(Duration.ofMillis(0).isZero()).isTrue(),
+        assertThat(Duration.ofMillis(1)).isEqualTo(Duration.ZERO));
   }
 
-  AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
-    return assertThat(Duration.ZERO.isZero()).isTrue();
+  AbstractDurationAssert<?> testAssertThatIsPositive() {
+    return assertThat(Duration.ofMillis(0)).isGreaterThan(Duration.ZERO);
   }
 
-  AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
-    return assertThat(Duration.ofSeconds(-1).isNegative()).isTrue();
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNegative() {
+    return ImmutableSet.of(
+        assertThat(Duration.ofMillis(0).isNegative()).isTrue(),
+        assertThat(Duration.ofMillis(1)).isLessThan(Duration.ZERO));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
@@ -1,0 +1,49 @@
+package tech.picnic.errorprone.refasterrules;
+
+import com.google.common.collect.ImmutableSet;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractComparableAssert;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
+    @Override
+    public ImmutableSet<Object> elidedTypesAndStaticImports() {
+        return ImmutableSet.of(Duration.class);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
+        return assertThat(Duration.ofNanos(1000)).hasNanos(1000L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
+        return assertThat(Duration.ofMillis(1000)).hasMillis(1000L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
+        return assertThat(Duration.ofSeconds(60)).hasSeconds(60L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
+        return assertThat(Duration.ofMinutes(5)).hasMinutes(5L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
+        return assertThat(Duration.ofHours(2)).hasHours(2L);
+    }
+
+    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
+        return assertThat(Duration.ofDays(7)).hasDays(7L);
+    }
+
+    AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
+        return assertThat(Duration.ZERO).isZero();
+    }
+
+    AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
+        return assertThat(Duration.ofSeconds(-1)).isNegative();
+    }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
@@ -1,49 +1,48 @@
 package tech.picnic.errorprone.refasterrules;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import com.google.common.collect.ImmutableSet;
+import java.time.Duration;
 import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractComparableAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
-import java.time.Duration;
-
-import static org.assertj.core.api.Assertions.assertThat;
-
 final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
-    @Override
-    public ImmutableSet<Object> elidedTypesAndStaticImports() {
-        return ImmutableSet.of(Duration.class);
-    }
+  @Override
+  public ImmutableSet<Object> elidedTypesAndStaticImports() {
+    return ImmutableSet.of(Duration.class);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
-        return assertThat(Duration.ofNanos(1000)).hasNanos(1000L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
+    return assertThat(Duration.ofNanos(1000)).hasNanos(1000L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
-        return assertThat(Duration.ofMillis(1000)).hasMillis(1000L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
+    return assertThat(Duration.ofMillis(1000)).hasMillis(1000L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
-        return assertThat(Duration.ofSeconds(60)).hasSeconds(60L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
+    return assertThat(Duration.ofSeconds(60)).hasSeconds(60L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
-        return assertThat(Duration.ofMinutes(5)).hasMinutes(5L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
+    return assertThat(Duration.ofMinutes(5)).hasMinutes(5L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
-        return assertThat(Duration.ofHours(2)).hasHours(2L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
+    return assertThat(Duration.ofHours(2)).hasHours(2L);
+  }
 
-    AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
-        return assertThat(Duration.ofDays(7)).hasDays(7L);
-    }
+  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
+    return assertThat(Duration.ofDays(7)).hasDays(7L);
+  }
 
-    AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
-        return assertThat(Duration.ZERO).isZero();
-    }
+  AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
+    return assertThat(Duration.ZERO).isZero();
+  }
 
-    AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
-        return assertThat(Duration.ofSeconds(-1)).isNegative();
-    }
+  AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
+    return assertThat(Duration.ofSeconds(-1)).isNegative();
+  }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
@@ -5,44 +5,46 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractComparableAssert;
+import org.assertj.core.api.AbstractDurationAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
-  @Override
-  public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Duration.class);
+  AbstractAssert<?, ?> testAssertThatHasNanos() {
+    return assertThat(Duration.ZERO).hasNanos(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasNanos() {
-    return assertThat(Duration.ofNanos(1000)).hasNanos(1000L);
+  AbstractAssert<?, ?> testAssertThatHasMillis() {
+    return assertThat(Duration.ZERO).hasMillis(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMillis() {
-    return assertThat(Duration.ofMillis(1000)).hasMillis(1000L);
+  AbstractAssert<?, ?> testAssertThatHasSeconds() {
+    return assertThat(Duration.ZERO).hasSeconds(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasSeconds() {
-    return assertThat(Duration.ofSeconds(60)).hasSeconds(60L);
+  AbstractAssert<?, ?> testAssertThatHasMinutes() {
+    return assertThat(Duration.ZERO).hasMinutes(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasMinutes() {
-    return assertThat(Duration.ofMinutes(5)).hasMinutes(5L);
+  AbstractAssert<?, ?> testAssertThatHasHours() {
+    return assertThat(Duration.ZERO).hasHours(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasHours() {
-    return assertThat(Duration.ofHours(2)).hasHours(2L);
+  AbstractAssert<?, ?> testAssertThatHasDays() {
+    return assertThat(Duration.ZERO).hasDays(0L);
   }
 
-  AbstractComparableAssert<?, ?> testAbstractDurationAssertHasDays() {
-    return assertThat(Duration.ofDays(7)).hasDays(7L);
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsZero() {
+    return ImmutableSet.of(
+        assertThat(Duration.ofMillis(0)).isZero(), assertThat(Duration.ofMillis(1)).isZero());
   }
 
-  AbstractAssert<?, ?> testAbstractDurationAssertIsZero() {
-    return assertThat(Duration.ZERO).isZero();
+  AbstractDurationAssert<?> testAssertThatIsPositive() {
+    return assertThat(Duration.ofMillis(0)).isPositive();
   }
 
-  AbstractAssert<?, ?> testAbstractDurationAssertIsNegative() {
-    return assertThat(Duration.ofSeconds(-1)).isNegative();
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNegative() {
+    return ImmutableSet.of(
+        assertThat(Duration.ofMillis(0)).isNegative(),
+        assertThat(Duration.ofMillis(1)).isNegative());
   }
 }


### PR DESCRIPTION
Figured this would fit in nicely with the other AssertJ rules for more expressive assertions.