### PR TITLE
Introduce `AssertThatString{DoesNotEnd,DoesNotStart,Ends,Starts}With` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
@@ -44,6 +44,58 @@ final class AssertJStringRules {
     }
   }
 
+  static final class AssertThatStringStartsWith {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(String string, String prefix) {
+      return assertThat(string.startsWith(prefix)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(String string, String prefix) {
+      return assertThat(string).startsWith(prefix);
+    }
+  }
+
+  static final class AssertThatStringDoesNotStartWith {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(String string, String prefix) {
+      return assertThat(string.startsWith(prefix)).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(String string, String prefix) {
+      return assertThat(string).doesNotStartWith(prefix);
+    }
+  }
+
+  static final class AssertThatStringEndsWith {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(String string, String prefix) {
+      return assertThat(string.endsWith(prefix)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(String string, String prefix) {
+      return assertThat(string).endsWith(prefix);
+    }
+  }
+
+  static final class AssertThatStringDoesNotEndWith {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(String string, String prefix) {
+      return assertThat(string.endsWith(prefix)).isFalse();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractStringAssert<?> after(String string, String prefix) {
+      return assertThat(string).doesNotEndWith(prefix);
+    }
+  }
+
   static final class AssertThatStringContains {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(String string, CharSequence substring) {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
@@ -25,6 +25,22 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat("foo").isNotEqualTo("");
   }
 
+  AbstractAssert<?, ?> testAssertThatStringStartsWith() {
+    return assertThat("foo".startsWith("bar")).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringDoesNotStartWith() {
+    return assertThat("foo".startsWith("bar")).isFalse();
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringEndsWith() {
+    return assertThat("foo".endsWith("bar")).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringDoesNotEndWith() {
+    return assertThat("foo".endsWith("bar")).isFalse();
+  }
+
   AbstractAssert<?, ?> testAssertThatStringContains() {
     return assertThat("foo".contains("bar")).isTrue();
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
@@ -26,6 +26,22 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat("foo").isNotEmpty();
   }
 
+  AbstractAssert<?, ?> testAssertThatStringStartsWith() {
+    return assertThat("foo").startsWith("bar");
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringDoesNotStartWith() {
+    return assertThat("foo").doesNotStartWith("bar");
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringEndsWith() {
+    return assertThat("foo").endsWith("bar");
+  }
+
+  AbstractAssert<?, ?> testAssertThatStringDoesNotEndWith() {
+    return assertThat("foo").doesNotEndWith("bar");
+  }
+
   AbstractAssert<?, ?> testAssertThatStringContains() {
     return assertThat("foo").contains("bar");
   }


### PR DESCRIPTION
Inspired by one of the rules in #1775.

Suggested commit message:
```
Introduce `AssertThatString{DoesNotEnd,DoesNotStart,Ends,Starts}With` Refaster rules (#1777)
```