### PR TITLE
Deploy SNAPSHOTs to the Maven Central snapshot repository

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,10 @@
+# XXX: Once we've merged the remaining work on the `website` branch into
+# `master`, merge the `deploy-website.yml` workflow into this file and deploy
+# the website only if all builds pass. When doing this, also review which other
+# workflow files can be combined. Also use that opportunity to revisit file
+# names and workflow names.
+# XXX: Let website deployment also depend on successful SNAPSHOT deployment.
+# Then update the website to describe how users can use SNAPSHOTs.
 name: Build and verify
 on:
   pull_request:
@@ -57,3 +64,33 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       - name: Remove installed project artifacts
         run: mvn dependency:purge-local-repository -DmanualInclude='${project.groupId}' -DresolutionFuzziness=groupId
+  deploy:
+    if: github.ref == 'refs/heads/master'
+    needs: build
+    runs-on: ubuntu-24.04
+    environment: maven-deploy
+    steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@ec9f2d5744a09debf3a187a3f4f675c53b671911 # v2.13.0
+        with:
+          disable-sudo-and-containers: true
+          egress-policy: block
+          allowed-endpoints: >
+            api.adoptium.net:443
+            central.sonatype.com:443
+            github.com:443
+            release-assets.githubusercontent.com:443
+            repo.maven.apache.org:443
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
+        with:
+          java-version: 21.0.7
+          java-distribution: temurin
+          maven-version: 3.9.11
+      - name: Build and deploy
+        run: mvn deploy -s settings.xml -DskipTests -Dverification.skip
+        env:
+          MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
+          MAVEN_CENTRAL_PASS: ${{ secrets.MAVEN_CENTRAL_PASS }}
+          MAVEN_GPG_KEY: ${{ secrets.RELEASES_GPG_PRIVATE_KEY }}
+          MAVEN_GPG_PASSPHRASE: ${{ secrets.RELEASES_GPG_PASSPHRASE }}

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -10,7 +10,7 @@
 # subset of integration tests to run.
 # See this example of a dynamic build matrix:
 # https://docs.github.com/en/actions/learn-github-actions/expressions#example-returning-a-json-object
-name: "Integration tests"
+name: Integration tests
 on:
   issue_comment:
     types: [ created ]

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -2,7 +2,7 @@
 # uploads the results. The associated PR is subsequently updated by the
 # `pitest-update-pr.yml` workflow. See https://blog.pitest.org/oss-pitest-pr/
 # for details.
-name: "Mutation testing"
+name: Mutation testing
 on:
   pull_request:
 permissions:

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -1,7 +1,7 @@
 # Updates a pull request based on the corresponding mutation testing analysis
 # performed by the `pitest-analyze-pr.yml` workflow. See
 # https://blog.pitest.org/oss-pitest-pr/ for details.
-name: "Mutation testing: post results"
+name: Mutation testing - post results
 on:
   workflow_run:
     workflows: ["Mutation testing"]

--- a/pom.xml
+++ b/pom.xml
@@ -1053,6 +1053,7 @@
                     <artifactId>maven-deploy-plugin</artifactId>
                     <version>3.1.4</version>
                     <configuration>
+                        <deployAtEnd>true</deployAtEnd>
                         <retryFailedDeploymentCount>3</retryFailedDeploymentCount>
                     </configuration>
                 </plugin>
@@ -1156,6 +1157,9 @@
                             <goals>
                                 <goal>sign</goal>
                             </goals>
+                            <configuration>
+                                <signer>bc</signer>
+                            </configuration>
                         </execution>
                     </executions>
                 </plugin>
@@ -1882,9 +1886,9 @@
                                     <!-- XXX: Enable once there are fewer
                                     false-positives.
                                     -XepOpt:CheckReturnValue:CheckAllMethods=true -->
+                                    -XepOpt:ConstantExpressions:ConsiderAllMethodsPure=true
                                     <!-- XXX: Consider renaming flagged types
                                     instead. -->
-                                    -XepOpt:ConstantExpressions:ConsiderAllMethodsPure=true
                                     -XepOpt:IdentifierName:AllowInitialismsInTypeName=true
                                     -XepOpt:InlineMe:SkipInliningsWithComments=false
                                     -XepOpt:NullAway:AnnotatedPackages=tech.picnic
@@ -2077,7 +2081,7 @@
             </build>
         </profile>
         <profile>
-            <!-- This profile is auto-activated when performing a release. -->
+            <!-- This profile is activated when performing a release. -->
             <id>release</id>
             <build>
                 <plugins>
@@ -2085,16 +2089,6 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                     </plugin>
-                    <!-- Lexicographically this plugin is listed out-of-order
-                    because it must be executed after the
-                    `maven-javadoc-plugin`; otherwise not all artifacts will be
-                    signed. -->
-                    <?SORTPOM IGNORE?>
-                    <plugin>
-                        <groupId>org.apache.maven.plugins</groupId>
-                        <artifactId>maven-gpg-plugin</artifactId>
-                    </plugin>
-                    <?SORTPOM RESUME?>
                     <plugin>
                         <groupId>org.kordamp.maven</groupId>
                         <artifactId>pomchecker-maven-plugin</artifactId>
@@ -2130,6 +2124,24 @@
                         </plugin>
                     </plugins>
                 </pluginManagement>
+            </build>
+        </profile>
+        <profile>
+            <!-- Signs build artifacts if a GPG key is configured. This is
+            required when deploying a release, and optional otherwise. -->
+            <id>sign</id>
+            <activation>
+                <property>
+                    <name>env.MAVEN_GPG_KEY</name>
+                </property>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                    </plugin>
+                </plugins>
             </build>
         </profile>
     </profiles>

--- a/settings.xml
+++ b/settings.xml
@@ -19,6 +19,11 @@
 
     <servers>
         <server>
+            <id>central</id>
+            <username>${env.MAVEN_CENTRAL_USER}</username>
+            <password>${env.MAVEN_CENTRAL_PASS}</password>
+        </server>
+        <server>
             <id>error-prone-fork</id>
             <username>${env.GITHUB_ACTOR}</username>
             <password>${env.GITHUB_TOKEN}</password>


### PR DESCRIPTION
Suggested commit message:
```
Deploy SNAPSHOTs to the Maven Central snapshot repository (#1784)

Successful builds on the default branch are now followed by a `mvn
deploy` step that signs and uploads the produced SNAPSHOT artifacts. 

While there:
- Remove some unnecessary quotes from GitHub Actions workflow files.
- Move a comment about an Error Prone flag to its proper location.
```