### PR TITLE
Migrate to the new Maven Central Publisher Portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,13 +64,9 @@
         <url>https://github.com/PicnicSupermarket/error-prone-support/actions</url>
     </ciManagement>
     <distributionManagement>
-        <repository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/service/local/staging/deploy/maven2</url>
-        </repository>
         <snapshotRepository>
-            <id>ossrh</id>
-            <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+            <id>central</id>
+            <url>https://central.sonatype.com/repository/maven-snapshots</url>
         </snapshotRepository>
     </distributionManagement>
 
@@ -1585,6 +1581,12 @@
                     <artifactId>sonar-maven-plugin</artifactId>
                     <version>5.1.0.4751</version>
                 </plugin>
+                <plugin>
+                    <groupId>org.sonatype.central</groupId>
+                    <artifactId>central-publishing-maven-plugin</artifactId>
+                    <version>0.8.0</version>
+                    <extensions>true</extensions>
+                </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -2099,6 +2101,10 @@
                         <configuration>
                             <release>true</release>
                         </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
                     </plugin>
                 </plugins>
             </build>


### PR DESCRIPTION
This is a subset of #1784. Validated by creating a 0.23.1 release and deploying it. (And then dropping it from the portal, as well as deleting the created tags.)

Suggested commit message:
```
Migrate to the new Maven Central Publisher Portal (#1785)

As the OSSRH service reached end-of-life. This unblocks local deployment
of new releases.
```