### PR TITLE
Fix integration tests

### DIFF
--- a/integration-tests/run-integration-test.sh
+++ b/integration-tests/run-integration-test.sh
@@ -8,10 +8,6 @@
 
 set -e -u -o pipefail
 
-# Make sure that callers with a customized `MAVEN_ARGS` environment variable do
-# not influence the test result.
-export MAVEN_ARGS=
-
 integration_test_root="$(cd "$(dirname -- "${0}")" && pwd)"
 error_prone_support_root="${integration_test_root}/.."
 repos_root="${integration_test_root}/.repos"

--- a/integration-tests/run-integration-test.sh
+++ b/integration-tests/run-integration-test.sh
@@ -8,6 +8,10 @@
 
 set -e -u -o pipefail
 
+# Make sure that callers with a customized `MAVEN_ARGS` environment variable do
+# not influence the test result.
+export MAVEN_ARGS=
+
 integration_test_root="$(cd "$(dirname -- "${0}")" && pwd)"
 error_prone_support_root="${integration_test_root}/.."
 repos_root="${integration_test_root}/.repos"


### PR DESCRIPTION
Suggested commit message:
```
Fix integration tests (#1821)

By explicitly controlling the `MAVEN_ARGS` environment variable, the 
integration test scripts become compatible with the GitHub Actions
changes introduced in c70e0e76f6ef2602714dd0943a73bfce000c5927.
```