### PR TITLE
Skip documentation generation on compilation error

### DIFF
--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListener.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListener.java
@@ -54,18 +54,18 @@ final class DocumentationGeneratorTaskListener implements TaskListener {
       return;
     }
 
-    JavaFileObject sourceFile = requireNonNull(taskEvent.getSourceFile(), "No source file");
-    CompilationUnitTree compilationUnit =
-        requireNonNull(taskEvent.getCompilationUnit(), "No compilation unit");
     ClassTree classTree = JavacTrees.instance(context).getTree(taskEvent.getTypeElement());
     if (classTree == null) {
       return;
     }
 
+    CompilationUnitTree compilationUnit =
+        requireNonNull(taskEvent.getCompilationUnit(), "No compilation unit");
     VisitorState state =
         VisitorState.createForUtilityPurposes(context)
             .withPath(new TreePath(new TreePath(compilationUnit), classTree));
 
+    JavaFileObject sourceFile = requireNonNull(taskEvent.getSourceFile(), "No source file");
     for (Extractor<?> extractor : EXTRACTORS) {
       extractor
           .tryExtract(classTree, state)

--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListener.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListener.java
@@ -9,6 +9,7 @@ import com.sun.source.util.TaskEvent.Kind;
 import com.sun.source.util.TaskListener;
 import com.sun.source.util.TreePath;
 import com.sun.tools.javac.api.JavacTrees;
+import com.sun.tools.javac.main.JavaCompiler;
 import com.sun.tools.javac.util.Context;
 import java.io.IOException;
 import java.net.URI;
@@ -47,7 +48,7 @@ final class DocumentationGeneratorTaskListener implements TaskListener {
 
   @Override
   public void finished(TaskEvent taskEvent) {
-    if (taskEvent.getKind() != Kind.ANALYZE) {
+    if (taskEvent.getKind() != Kind.ANALYZE || JavaCompiler.instance(context).errorCount() > 0) {
       return;
     }
 

--- a/documentation-support/src/main/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListener.java
+++ b/documentation-support/src/main/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListener.java
@@ -1,5 +1,7 @@
 package tech.picnic.errorprone.documentation;
 
+import static java.util.Objects.requireNonNull;
+
 import com.google.common.collect.ImmutableList;
 import com.google.errorprone.VisitorState;
 import com.sun.source.tree.ClassTree;
@@ -52,10 +54,11 @@ final class DocumentationGeneratorTaskListener implements TaskListener {
       return;
     }
 
-    JavaFileObject sourceFile = taskEvent.getSourceFile();
-    CompilationUnitTree compilationUnit = taskEvent.getCompilationUnit();
+    JavaFileObject sourceFile = requireNonNull(taskEvent.getSourceFile(), "No source file");
+    CompilationUnitTree compilationUnit =
+        requireNonNull(taskEvent.getCompilationUnit(), "No compilation unit");
     ClassTree classTree = JavacTrees.instance(context).getTree(taskEvent.getTypeElement());
-    if (sourceFile == null || compilationUnit == null || classTree == null) {
+    if (classTree == null) {
       return;
     }
 

--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/Compilation.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/Compilation.java
@@ -48,7 +48,8 @@ public final class Compilation {
             "-Xlint:all,-serial",
             "-Xplugin:DocumentationGenerator -XoutputDirectory=" + outputDirectory,
             "-XDdev",
-            "-XDcompilePolicy=simple"),
+            "-XDcompilePolicy=simple",
+            "--should-stop=ifError=FLOW"),
         FileObjects.forSourceLines(path, lines));
   }
 

--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListenerTest.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListenerTest.java
@@ -87,6 +87,24 @@ final class DocumentationGeneratorTaskListenerTest {
   }
 
   @Test
+  void skipOnError(@TempDir Path outputDirectory) {
+    assertThatThrownBy(
+            () ->
+                Compilation.compileWithDocumentationGenerator(
+                    outputDirectory,
+                    "A.java",
+                    "class A {",
+                    "  void m() {",
+                    "    nonExistentMethod();",
+                    "  }",
+                    "}"))
+        .isInstanceOf(AssertionError.class)
+        .hasMessageContainingAll("error: cannot find symbol", "nonExistentMethod()");
+
+    assertThat(outputDirectory).isEmptyDirectory();
+  }
+
+  @Test
   void extraction(@TempDir Path outputDirectory) {
     Compilation.compileWithDocumentationGenerator(
         outputDirectory,

--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListenerTest.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListenerTest.java
@@ -105,6 +105,14 @@ final class DocumentationGeneratorTaskListenerTest {
   }
 
   @Test
+  void skipPackageInfo(@TempDir Path outputDirectory) {
+    Compilation.compileWithDocumentationGenerator(
+        outputDirectory, "package-info.java", "package pkg;");
+
+    assertThat(outputDirectory).isEmptyDirectory();
+  }
+
+  @Test
   void extraction(@TempDir Path outputDirectory) {
     Compilation.compileWithDocumentationGenerator(
         outputDirectory,


### PR DESCRIPTION
This is quite an important quality of life improvement. It avoids confusing users and AI coding agents when e.g. a non-existent method is referenced.

Suggested commit message:
```
Skip documentation generation on compilation error (#1826)

This change prevents `DocumentationGeneratorTaskListener` from analyzing
invalid code, as that may trigger an exception that prevents the 
original compilation error from properly being reported.

While there, improve `null` handing and test coverage.
```