### PR TITLE
Upgrade JDKs used by GitHub Actions builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,9 +42,9 @@ Please replace this sentence with log output, if applicable.
 <!-- Please complete the following information: -->
 
 - Operating system (e.g. MacOS Monterey).
-- Java version (i.e. `java --version`, e.g. `17.0.15`).
-- Error Prone version (e.g. `2.38.0`).
-- Error Prone Support version (e.g. `0.23.0`).
+- Java version (i.e. `java --version`, e.g. `17.0.16`).
+- Error Prone version (e.g. `2.41.0`).
+- Error Prone Support version (e.g. `0.24.0`).
 
 ### Additional context
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-24.04, macos-15, windows-2025 ]
-        build-jdk: [ 21.0.7 ]
-        target-jdk: [ 17.0.15 ]
+        build-jdk: [ 21.0.8 ]
+        target-jdk: [ 17.0.16 ]
         include:
           - os: ubuntu-24.04
-            build-jdk: 24.0.1
-            target-jdk: 17.0.15
+            build-jdk: 24.0.2
+            target-jdk: 17.0.16
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Harden-Runner
@@ -84,7 +84,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
-          java-version: 21.0.7
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Build and deploy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
-          java-version: 21.0.7
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Initialize CodeQL

--- a/.github/workflows/error-prone-compat.yml
+++ b/.github/workflows/error-prone-compat.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
-          java-version: 21.0.7
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Build project against the latest Error Prone release

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -63,7 +63,7 @@ jobs:
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
           checkout-ref: ${{ github.event.issue.pull_request && format('refs/pull/{0}/head', github.event.issue.number) || github.ref }}
-          java-version: 21.0.7
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Install project to local Maven repository

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -29,7 +29,7 @@ jobs:
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
           checkout-fetch-depth: 2
-          java-version: 21.0.7
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Run Pitest

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -36,7 +36,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
-          java-version: 21.0.7
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Download Pitest analysis artifact

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
-          java-version: 17.0.15
+          java-version: 17.0.16
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Set up Reviewdog

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -39,7 +39,7 @@ jobs:
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
           checkout-fetch-depth: 0
-          java-version: 21.0.7
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Create missing `test` directory

--- a/website/generate-version-compatibility-overview.sh
+++ b/website/generate-version-compatibility-overview.sh
@@ -12,7 +12,7 @@ set -e -u -o pipefail
 
 # Currently all released Error Prone Support versions are compatible with Java
 # 17.
-java_version=17.0.15-tem
+java_version=17.0.16-tem
 (set +u && echo n | sdk install java "${java_version}")
 sdk use java "${java_version}"
 


### PR DESCRIPTION
Suggested commit message:
```
Upgrade JDKs used by GitHub Actions builds (#1831)

Summary of changes:
- Use JDK 17.0.16 instead of 17.0.15.
- Use JDK 21.0.8 instead of 21.0.7.
- Use JDK 24.0.2 instead of 24.0.1.
- Have GitHub issue template reference more recent version numbers.

See:
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.16+8
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.8+9
- https://adoptium.net/temurin/release-notes/?version=jdk-24.0.2+12
```