### PR TITLE
Introduce `AssertJFileRules` Refaster rule collection

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJFileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJFileRules.java
@@ -1,0 +1,198 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.errorprone.refaster.Refaster;
+import com.google.errorprone.refaster.annotation.AfterTemplate;
+import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.io.File;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.assertj.core.api.AbstractFileAssert;
+import org.assertj.core.api.AbstractStringAssert;
+import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
+
+/**
+ * Refaster rules related to AssertJ assertions over {@link File}s.
+ *
+ * <p>These rules simplify and improve the readability of tests by using {@link File}-specific
+ * AssertJ assertion methods instead of generic assertions.
+ */
+@OnlineDocumentation
+final class AssertJFileRules {
+  private AssertJFileRules() {}
+
+  static final class AssertThatExists {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.exists()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).exists();
+    }
+  }
+
+  static final class AssertThatDoesNotExist {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.exists()).isFalse();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).doesNotExist();
+    }
+  }
+
+  static final class AssertThatIsFile {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.isFile()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).isFile();
+    }
+  }
+
+  static final class AssertThatIsDirectory {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.isDirectory()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).isDirectory();
+    }
+  }
+
+  static final class AssertThatIsAbsolute {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.isAbsolute()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).isAbsolute();
+    }
+  }
+
+  static final class AssertThatIsRelative {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.isAbsolute()).isFalse();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).isRelative();
+    }
+  }
+
+  static final class AssertThatIsReadable {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.canRead()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).isReadable();
+    }
+  }
+
+  static final class AssertThatIsWritable {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.canWrite()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).isWritable();
+    }
+  }
+
+  static final class AssertThatIsExecutable {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(File actual) {
+      return assertThat(actual.canExecute()).isTrue();
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual) {
+      return assertThat(actual).isExecutable();
+    }
+  }
+
+  static final class AssertThatHasFileName {
+    @BeforeTemplate
+    AbstractStringAssert<?> before(File actual, String fileName) {
+      return assertThat(actual.getName()).isEqualTo(fileName);
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual, String fileName) {
+      return assertThat(actual).hasFileName(fileName);
+    }
+  }
+
+  // XXX: This rule changes the `File` against which subsequent assertions are made.
+  static final class AssertThatHasParentFile {
+    @BeforeTemplate
+    AbstractFileAssert<?> before(File actual, File expected) {
+      return assertThat(actual.getParentFile()).isEqualTo(expected);
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual, File expected) {
+      return assertThat(actual).hasParent(expected);
+    }
+  }
+
+  // XXX: This rule changes the `File` against which subsequent assertions are made.
+  static final class AssertThatHasParentString {
+    @BeforeTemplate
+    AbstractFileAssert<?> before(File actual, String expected) {
+      return assertThat(actual.getParentFile()).hasFileName(expected);
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual, String expected) {
+      return assertThat(actual).hasParent(expected);
+    }
+  }
+
+  static final class AssertThatHasNoParent {
+    @BeforeTemplate
+    void before(File actual) {
+      assertThat(actual.getParent()).isNull();
+    }
+
+    @AfterTemplate
+    void after(File actual) {
+      assertThat(actual).hasNoParent();
+    }
+  }
+
+  /**
+   * Prefer using {@link AbstractFileAssert#hasExtension(String)} over more verbose and less
+   * accurate alternatives.
+   */
+  static final class AssertThatHasExtension {
+    @BeforeTemplate
+    AbstractStringAssert<?> before(File actual, String expectedExtension) {
+      return assertThat(Refaster.anyOf(actual.getName(), actual.toString()))
+          .endsWith(Refaster.anyOf('.' + expectedExtension, "." + expectedExtension));
+    }
+
+    @AfterTemplate
+    AbstractFileAssert<?> after(File actual, String expectedExtension) {
+      return assertThat(actual).hasExtension(expectedExtension);
+    }
+  }
+}

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPathRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPathRules.java
@@ -155,6 +155,7 @@ final class AssertJPathRules {
     }
   }
 
+  // XXX: This rule changes the `Path` against which subsequent assertions are made.
   static final class AssertThatHasParentRaw {
     @BeforeTemplate
     AbstractPathAssert<?> before(Path actual, Path expected) {

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -24,6 +24,7 @@ final class RefasterRulesTest {
           AssertJDurationRules.class,
           AssertJEnumerableRules.class,
           AssertJInstantRules.class,
+          AssertJFileRules.class,
           AssertJFloatRules.class,
           AssertJIntegerRules.class,
           AssertJIterableRules.class,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFileRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFileRulesTestInput.java
@@ -1,0 +1,71 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractFileAssert;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class AssertJFileRulesTest implements RefasterRuleCollectionTestCase {
+  AbstractAssert<?, ?> testAssertThatExists() {
+    return assertThat(new File("foo").exists()).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatDoesNotExist() {
+    return assertThat(new File("foo").exists()).isFalse();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsFile() {
+    return assertThat(new File("foo").isFile()).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsDirectory() {
+    return assertThat(new File("foo").isDirectory()).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsAbsolute() {
+    return assertThat(new File("foo").isAbsolute()).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsRelative() {
+    return assertThat(new File("foo").isAbsolute()).isFalse();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsReadable() {
+    return assertThat(new File("foo").canRead()).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsWritable() {
+    return assertThat(new File("foo").canWrite()).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsExecutable() {
+    return assertThat(new File("foo").canExecute()).isTrue();
+  }
+
+  AbstractAssert<?, ?> testAssertThatHasFileName() {
+    return assertThat(new File("foo").getName()).isEqualTo("bar");
+  }
+
+  AbstractFileAssert<?> testAssertThatHasParentFile() {
+    return assertThat(new File("foo").getParentFile()).isEqualTo(new File("bar"));
+  }
+
+  AbstractFileAssert<?> testAssertThatHasParentString() {
+    return assertThat(new File("foo").getParentFile()).hasFileName("bar");
+  }
+
+  void testAssertThatHasNoParent() {
+    assertThat(new File("foo").getParent()).isNull();
+  }
+
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasExtension() {
+    return ImmutableSet.of(
+        assertThat(new File("foo").getName()).endsWith('.' + "bar"),
+        assertThat(new File("baz").toString()).endsWith('.' + "qux"),
+        assertThat(new File("quux").getName()).endsWith("." + toString()),
+        assertThat(new File("corge").toString()).endsWith("." + getClass().toString()));
+  }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFileRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFileRulesTestOutput.java
@@ -1,0 +1,71 @@
+package tech.picnic.errorprone.refasterrules;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.common.collect.ImmutableSet;
+import java.io.File;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractFileAssert;
+import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+
+final class AssertJFileRulesTest implements RefasterRuleCollectionTestCase {
+  AbstractAssert<?, ?> testAssertThatExists() {
+    return assertThat(new File("foo")).exists();
+  }
+
+  AbstractAssert<?, ?> testAssertThatDoesNotExist() {
+    return assertThat(new File("foo")).doesNotExist();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsFile() {
+    return assertThat(new File("foo")).isFile();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsDirectory() {
+    return assertThat(new File("foo")).isDirectory();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsAbsolute() {
+    return assertThat(new File("foo")).isAbsolute();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsRelative() {
+    return assertThat(new File("foo")).isRelative();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsReadable() {
+    return assertThat(new File("foo")).isReadable();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsWritable() {
+    return assertThat(new File("foo")).isWritable();
+  }
+
+  AbstractAssert<?, ?> testAssertThatIsExecutable() {
+    return assertThat(new File("foo")).isExecutable();
+  }
+
+  AbstractAssert<?, ?> testAssertThatHasFileName() {
+    return assertThat(new File("foo")).hasFileName("bar");
+  }
+
+  AbstractFileAssert<?> testAssertThatHasParentFile() {
+    return assertThat(new File("foo")).hasParent(new File("bar"));
+  }
+
+  AbstractFileAssert<?> testAssertThatHasParentString() {
+    return assertThat(new File("foo")).hasParent("bar");
+  }
+
+  void testAssertThatHasNoParent() {
+    assertThat(new File("foo")).hasNoParent();
+  }
+
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasExtension() {
+    return ImmutableSet.of(
+        assertThat(new File("foo")).hasExtension("bar"),
+        assertThat(new File("baz")).hasExtension("qux"),
+        assertThat(new File("quux")).hasExtension(toString()),
+        assertThat(new File("corge")).hasExtension(getClass().toString()));
+  }
+}

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPathRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPathRulesTestInput.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractPathAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJPathRulesTest implements RefasterRuleCollectionTestCase {
@@ -54,11 +55,11 @@ final class AssertJPathRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(Files.isExecutable(Path.of("foo"))).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatHasFileName() {
+  AbstractPathAssert<?> testAssertThatHasFileName() {
     return assertThat(Path.of("foo").getFileName()).hasToString("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatHasParentRaw() {
+  AbstractPathAssert<?> testAssertThatHasParentRaw() {
     return assertThat(Path.of("foo").getParent()).isEqualTo(Path.of("bar"));
   }
 
@@ -76,10 +77,9 @@ final class AssertJPathRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasExtension() {
     return ImmutableSet.of(
-        assertThat(Path.of("foo").toString()).endsWith('.' + "bar"),
-        assertThat(Path.of("baz").getFileName().toString()).endsWith('.' + "qux"),
-        assertThat(Path.of("quux").toString()).endsWith("." + toString()),
-        assertThat(Path.of("corge").getFileName().toString())
-            .endsWith("." + getClass().toString()));
+        assertThat(Path.of("foo").getFileName().toString()).endsWith('.' + "bar"),
+        assertThat(Path.of("baz").toString()).endsWith('.' + "qux"),
+        assertThat(Path.of("quux").getFileName().toString()).endsWith("." + toString()),
+        assertThat(Path.of("corge").toString()).endsWith("." + getClass().toString()));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPathRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPathRulesTestOutput.java
@@ -6,6 +6,7 @@ import com.google.common.collect.ImmutableSet;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractPathAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJPathRulesTest implements RefasterRuleCollectionTestCase {
@@ -54,11 +55,11 @@ final class AssertJPathRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(Path.of("foo")).isExecutable();
   }
 
-  AbstractAssert<?, ?> testAssertThatHasFileName() {
+  AbstractPathAssert<?> testAssertThatHasFileName() {
     return assertThat(Path.of("foo")).hasFileName("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatHasParentRaw() {
+  AbstractPathAssert<?> testAssertThatHasParentRaw() {
     return assertThat(Path.of("foo")).hasParentRaw(Path.of("bar"));
   }
 


### PR DESCRIPTION
While usage of `java.io.File` is discouraged in favour of `java.nio.file.Path`, it's still a ubiquitous API. This PR is motivated by openrewrite/rewrite-testing-frameworks#815. CC @timtebeek.

Suggested commit message:
```
Introduce `AssertJFileRules` Refaster rule collection

This new rule collection is modelled after `AssertJPathRules`.
```