### PR TITLE
Fix the Error Prone compatibility check

### DIFF
--- a/.github/workflows/error-prone-compat.yml
+++ b/.github/workflows/error-prone-compat.yml
@@ -13,7 +13,7 @@
 name: Error Prone compatibility check
 on:
   push:
-    branches: [ master, sschroevers/fix-error-prone-compat ]
+    branches: [ master ]
   schedule:
     - cron: '0 4 * * *'
 permissions:


### PR DESCRIPTION
Suggested commit message:
```
Fix the Error Prone compatibility check (#1886)

By preventing `dependency:analyze-dep-mgt` from complaining about
`LATEST` usage.
```

See commit history and associated builds for test results.