### PR TITLE
Introduce `CollectionsNCopiesStream` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -35,6 +35,7 @@ import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
@@ -59,6 +60,7 @@ import tech.picnic.errorprone.refaster.matchers.IsEmpty;
 import tech.picnic.errorprone.refaster.matchers.IsIdentityOperation;
 import tech.picnic.errorprone.refaster.matchers.IsLambdaExpressionOrMethodReference;
 import tech.picnic.errorprone.refaster.matchers.IsRefasterAsVarargs;
+import tech.picnic.errorprone.refaster.matchers.RequiresComputation;
 
 /** Refaster rules related to expressions dealing with {@link Stream}s. */
 @OnlineDocumentation
@@ -813,6 +815,22 @@ final class StreamRules {
     @AfterTemplate
     Stream<T> after(Collection<T> collection) {
       return collection.parallelStream();
+    }
+  }
+
+  /**
+   * Prefer streaming the result of {@link Collections#nCopies(int, Object)} if a stream of
+   * identical elements is required.
+   */
+  static final class CollectionsNCopiesStream<T> {
+    @BeforeTemplate
+    Stream<T> before(int n, @NotMatches(RequiresComputation.class) T element) {
+      return Stream.generate(() -> element).limit(n);
+    }
+
+    @AfterTemplate
+    Stream<T> after(int n, T element) {
+      return Collections.nCopies(n, element).stream();
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -36,6 +36,7 @@ import java.util.LongSummaryStatistics;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -332,5 +333,11 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
 
   Stream<String> testCollectionParallelStream() {
     return StreamSupport.stream(ImmutableList.of("foo").spliterator(), true);
+  }
+
+  ImmutableSet<Stream<String>> testCollectionsNCopiesStream() {
+    return ImmutableSet.of(
+        Stream.generate(() -> "foo").limit(1),
+        Stream.generate(() -> UUID.randomUUID().toString()).limit(2));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -30,6 +30,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Streams;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.DoubleSummaryStatistics;
 import java.util.IntSummaryStatistics;
 import java.util.List;
@@ -37,6 +38,7 @@ import java.util.LongSummaryStatistics;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Stream;
@@ -329,5 +331,11 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
 
   Stream<String> testCollectionParallelStream() {
     return ImmutableList.of("foo").parallelStream();
+  }
+
+  ImmutableSet<Stream<String>> testCollectionsNCopiesStream() {
+    return ImmutableSet.of(
+        Collections.nCopies(1, "foo").stream(),
+        Stream.generate(() -> UUID.randomUUID().toString()).limit(2));
   }
 }


### PR DESCRIPTION
Suggested commit message:
```
Introduce `CollectionsNCopiesStream` Refaster rule (#1892)
```

Combined with other rules, this will rewrite `Stream.generate(() -> constant).limit(n).collect(toImmutableList())` to `ImmutableList.copyOf(Collections.nCopies(n, constant))`. I see variants of this internally, and expect the code to be more performant. (Generating JMH benchmarks based on rules is still on the TODO list...)