### PR TITLE
Run Reviewdog CI build with JDK 21

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@4f7fb9d9675e899ca81c6161dadbba0189a4ebb1 # v1.18.0
         with:
-          java-version: 17.0.16
+          java-version: 21.0.8
           java-distribution: temurin
           maven-version: 3.9.11
       - name: Set up Reviewdog


### PR DESCRIPTION
Suggested commit message:
```
Run Reviewdog CI build with JDK 21 (#1915)

This matches other builds, and improves NullAway analysis.
```

This change likely resolves one of the causes of the CI failure in #1911.