### PR TITLE
Validate build against JDK 25 rather than JDK 24

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ jobs:
         target-jdk: [ 17.0.16 ]
         include:
           - os: ubuntu-24.04
-            build-jdk: 24.0.2
+            build-jdk: 25
             target-jdk: 17.0.16
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
~:exclamation: This PR also contains the changes of #1853 and #1915. Those should be merged first. :exclamation:~

Suggested commit message:
```
Validate build against JDK 25 rather than JDK 24 (#1916)
```