### PR TITLE
Generate OpenRewrite recipes with `JavaParser.Builder#classpathFromResources`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -498,10 +498,6 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
-                <groupId>org.openrewrite</groupId>
-                <artifactId>rewrite-templating</artifactId>
-            </dependency>
-            <dependency>
                 <groupId>org.openrewrite.recipe</groupId>
                 <artifactId>rewrite-recipe-bom</artifactId>
                 <version>3.17.0</version>


### PR DESCRIPTION
Add a annotation processor argument to switch to classpath from resource for the generated OpenRewrite recipes:
https://github.com/openrewrite/rewrite-templating/?tab=readme-ov-file#use-javaparserbuilder-classpathfromresourcesctx-guava-31

> By default, the annotation processor will use `JavaParser.runtimeClasspath()` to resolve the classpath for newly generated Java code snippets. If you want to use `TypeTables` from `src/main/resources/META-INF/rewrite/classpath.tsv.gz` instead, pass in: `-Arewrite.javaParserClasspathFrom=resources`.

Right now we're having to [replicate](https://github.com/openrewrite/rewrite-third-party/blob/8e9b37d5fdad852f549e9f371086a4ac7004be36/build.gradle.kts#L40-L52) the provided dependencies in EPS in rewrite-third-party to get the recipes to work at all, and even then they do not work well in all environments. By switching to type tables we only need to capture the public APIs of the dependencies, for a much smaller and safer runtime.

Follows
- https://github.com/PicnicSupermarket/error-prone-support/pull/1853
- https://github.com/openrewrite/rewrite-templating/pull/139
- https://github.com/openrewrite/rewrite-templating/pull/160