### PR TITLE
Introduce assorted `{Flux,Mono}#timeout` fallback Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -103,7 +103,7 @@ final class ReactorRules {
    * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
    * alternatives.
    */
-  static final class MonoTimeoutMonoEmpty<T> {
+  static final class MonoTimeoutDurationMonoEmpty<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono, Duration duration) {
       return mono.timeout(duration).onErrorComplete(TimeoutException.class);
@@ -112,6 +112,38 @@ final class ReactorRules {
     @AfterTemplate
     Mono<T> after(Mono<T> mono, Duration duration) {
       return mono.timeout(duration, Mono.empty());
+    }
+  }
+
+  /**
+   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
+   * alternatives.
+   */
+  static final class MonoTimeoutDurationMonoJust<T> {
+    @BeforeTemplate
+    Mono<T> before(Mono<T> mono, Duration duration, T fallbackValue) {
+      return mono.timeout(duration).onErrorReturn(TimeoutException.class, fallbackValue);
+    }
+
+    @AfterTemplate
+    Mono<T> after(Mono<T> mono, Duration duration, T fallbackValue) {
+      return mono.timeout(duration, Mono.just(fallbackValue));
+    }
+  }
+
+  /**
+   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
+   * alternatives.
+   */
+  static final class MonoTimeoutDuration<T> {
+    @BeforeTemplate
+    Mono<T> before(Mono<T> mono, Duration duration, Mono<T> fallback) {
+      return mono.timeout(duration).onErrorResume(TimeoutException.class, e -> fallback);
+    }
+
+    @AfterTemplate
+    Mono<T> after(Mono<T> mono, Duration duration, Mono<T> fallback) {
+      return mono.timeout(duration, fallback);
     }
   }
 
@@ -128,38 +160,6 @@ final class ReactorRules {
     @AfterTemplate
     Mono<T> after(Mono<T> mono, Publisher<S> other) {
       return mono.timeout(other, Mono.empty());
-    }
-  }
-
-  /**
-   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
-   * alternatives.
-   */
-  static final class MonoTimeoutMonoJust<T> {
-    @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Duration duration, T fallbackValue) {
-      return mono.timeout(duration).onErrorReturn(TimeoutException.class, fallbackValue);
-    }
-
-    @AfterTemplate
-    Mono<T> after(Mono<T> mono, Duration duration, T fallbackValue) {
-      return mono.timeout(duration, Mono.just(fallbackValue));
-    }
-  }
-
-  /**
-   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
-   * alternatives.
-   */
-  static final class MonoTimeoutMonoFallback<T> {
-    @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Duration duration, Mono<T> fallback) {
-      return mono.timeout(duration).onErrorResume(TimeoutException.class, e -> fallback);
-    }
-
-    @AfterTemplate
-    Mono<T> after(Mono<T> mono, Duration duration, Mono<T> fallback) {
-      return mono.timeout(duration, fallback);
     }
   }
 
@@ -183,7 +183,7 @@ final class ReactorRules {
    * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less performant
    * alternatives.
    */
-  static final class MonoTimeoutPublisherMonoFallback<T, S> {
+  static final class MonoTimeoutPublisher<T, S> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono, Publisher<S> other, Mono<T> fallback) {
       return mono.timeout(other).onErrorResume(TimeoutException.class, e -> fallback);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -74,38 +74,40 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Mono.justOrEmpty(null), Mono.justOrEmpty(Optional.empty()));
   }
 
-  Mono<Integer> testMonoTimeoutMonoEmpty() {
+  Mono<Integer> testMonoTimeoutDurationMonoEmpty() {
     return Mono.just(1).timeout(Duration.ofSeconds(2)).onErrorComplete(TimeoutException.class);
+  }
+
+  Mono<Integer> testMonoTimeoutDurationMonoJust() {
+    return Mono.just(1).timeout(Duration.ofSeconds(2)).onErrorReturn(TimeoutException.class, 3);
+  }
+
+  ImmutableSet<Mono<Integer>> testMonoTimeoutDuration() {
+    return ImmutableSet.of(
+        Mono.just(1)
+            .timeout(Duration.ofSeconds(2))
+            .onErrorResume(TimeoutException.class, e -> Mono.just(toString().hashCode())),
+        Mono.just(3)
+            .timeout(Duration.ofSeconds(4))
+            .onErrorResume(TimeoutException.class, e -> Mono.just(e.toString().hashCode())));
   }
 
   Mono<Integer> testMonoTimeoutPublisherMonoEmpty() {
     return Mono.just(1).timeout(Mono.just(2)).onErrorComplete(TimeoutException.class);
   }
 
-  Mono<Integer> testMonoTimeoutMonoJust() {
-    return Mono.just(1).timeout(Duration.ofSeconds(2)).onErrorReturn(TimeoutException.class, 3);
-  }
-
-  ImmutableSet<Mono<Integer>> testMonoTimeoutMonoFallback() {
-    return ImmutableSet.of(
-        Mono.just(1)
-            .timeout(Duration.ofSeconds(2))
-            .onErrorResume(TimeoutException.class, e -> Mono.empty()),
-        Mono.just(3)
-            .timeout(Duration.ofSeconds(4))
-            .onErrorResume(TimeoutException.class, e -> Mono.just(5)));
-  }
-
   Mono<Integer> testMonoTimeoutPublisherMonoJust() {
     return Mono.just(1).timeout(Mono.just(2)).onErrorReturn(TimeoutException.class, 3);
   }
 
-  ImmutableSet<Mono<Integer>> testMonoTimeoutPublisherMonoFallback() {
+  ImmutableSet<Mono<Integer>> testMonoTimeoutPublisher() {
     return ImmutableSet.of(
-        Mono.just(1).timeout(Mono.just(2)).onErrorResume(TimeoutException.class, e -> Mono.empty()),
+        Mono.just(1)
+            .timeout(Mono.just(2))
+            .onErrorResume(TimeoutException.class, e -> Mono.just(toString().hashCode())),
         Mono.just(3)
             .timeout(Mono.just(4))
-            .onErrorResume(TimeoutException.class, e -> Mono.just(5)));
+            .onErrorResume(TimeoutException.class, e -> Mono.just(e.toString().hashCode())));
   }
 
   ImmutableSet<Mono<Integer>> testMonoJust() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -77,32 +77,36 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Mono.empty(), Mono.empty());
   }
 
-  Mono<Integer> testMonoTimeoutMonoEmpty() {
+  Mono<Integer> testMonoTimeoutDurationMonoEmpty() {
     return Mono.just(1).timeout(Duration.ofSeconds(2), Mono.empty());
+  }
+
+  Mono<Integer> testMonoTimeoutDurationMonoJust() {
+    return Mono.just(1).timeout(Duration.ofSeconds(2), Mono.just(3));
+  }
+
+  ImmutableSet<Mono<Integer>> testMonoTimeoutDuration() {
+    return ImmutableSet.of(
+        Mono.just(1).timeout(Duration.ofSeconds(2), Mono.just(toString().hashCode())),
+        Mono.just(3)
+            .timeout(Duration.ofSeconds(4))
+            .onErrorResume(TimeoutException.class, e -> Mono.just(e.toString().hashCode())));
   }
 
   Mono<Integer> testMonoTimeoutPublisherMonoEmpty() {
     return Mono.just(1).timeout(Mono.just(2), Mono.empty());
   }
 
-  Mono<Integer> testMonoTimeoutMonoJust() {
-    return Mono.just(1).timeout(Duration.ofSeconds(2), Mono.just(3));
-  }
-
-  ImmutableSet<Mono<Integer>> testMonoTimeoutMonoFallback() {
-    return ImmutableSet.of(
-        Mono.just(1).timeout(Duration.ofSeconds(2), Mono.empty()),
-        Mono.just(3).timeout(Duration.ofSeconds(4), Mono.just(5)));
-  }
-
   Mono<Integer> testMonoTimeoutPublisherMonoJust() {
     return Mono.just(1).timeout(Mono.just(2), Mono.just(3));
   }
 
-  ImmutableSet<Mono<Integer>> testMonoTimeoutPublisherMonoFallback() {
+  ImmutableSet<Mono<Integer>> testMonoTimeoutPublisher() {
     return ImmutableSet.of(
-        Mono.just(1).timeout(Mono.just(2), Mono.empty()),
-        Mono.just(3).timeout(Mono.just(4), Mono.just(5)));
+        Mono.just(1).timeout(Mono.just(2), Mono.just(toString().hashCode())),
+        Mono.just(3)
+            .timeout(Mono.just(4))
+            .onErrorResume(TimeoutException.class, e -> Mono.just(e.toString().hashCode())));
   }
 
   ImmutableSet<Mono<Integer>> testMonoJust() {


### PR DESCRIPTION
 I feel like the 2nd option is less contrived, as it eliminates the need to know that `timeout` throws a `TimeoutException`.

### Suggested commit message 🎉 
```
Introduce `MonoTimeout(Empty|Fallback)` refaster rules
```