### PR TITLE
Extend `AssertThatIsPositive` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
@@ -112,11 +112,14 @@ final class AssertJDurationRules {
     }
   }
 
-  // XXX: Once we build against JDK 18+, update this rule to also rewrite
-  // `assertThat(duration.isPositive()).isTrue()`
   static final class AssertThatIsPositive {
     @BeforeTemplate
-    AbstractDurationAssert<?> before(Duration duration) {
+    AbstractBooleanAssert<?> before(Duration duration) {
+      return assertThat(duration.isPositive()).isTrue();
+    }
+
+    @BeforeTemplate
+    AbstractDurationAssert<?> before2(Duration duration) {
       return assertThat(duration).isGreaterThan(Duration.ZERO);
     }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestInput.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractDurationAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
@@ -39,8 +38,10 @@ final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Duration.ofMillis(1)).isEqualTo(Duration.ZERO));
   }
 
-  AbstractDurationAssert<?> testAssertThatIsPositive() {
-    return assertThat(Duration.ofMillis(0)).isGreaterThan(Duration.ZERO);
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsPositive() {
+    return ImmutableSet.of(
+        assertThat(Duration.ofMillis(0).isPositive()).isTrue(),
+        assertThat(Duration.ofMillis(1)).isGreaterThan(Duration.ZERO));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNegative() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDurationRulesTestOutput.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.google.common.collect.ImmutableSet;
 import java.time.Duration;
 import org.assertj.core.api.AbstractAssert;
-import org.assertj.core.api.AbstractDurationAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
@@ -38,8 +37,10 @@ final class AssertJDurationRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Duration.ofMillis(0)).isZero(), assertThat(Duration.ofMillis(1)).isZero());
   }
 
-  AbstractDurationAssert<?> testAssertThatIsPositive() {
-    return assertThat(Duration.ofMillis(0)).isPositive();
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsPositive() {
+    return ImmutableSet.of(
+        assertThat(Duration.ofMillis(0)).isPositive(),
+        assertThat(Duration.ofMillis(1)).isPositive());
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNegative() {


### PR DESCRIPTION
~:exclamation: This PR is on top of #1927. :exclamation:~

Suggested commit message:
```
Extend `AssertThatIsPositive` Refaster rule (#1943)

By simplifying expressions referencing `Duration#isPositive()`,
introduced with Java 18.
```