### PR TITLE
Introduce `StringIndexOf{Char,String}BetweenIndices` Refaster rules

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -309,7 +309,7 @@ final class StringRules {
   }
 
   /** Prefer {@link String#indexOf(int, int)} over less efficient alternatives. */
-  static final class StringIndexOfChar {
+  static final class StringIndexOfCharFromIndex {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, int ch, int fromIndex) {
@@ -322,8 +322,21 @@ final class StringRules {
     }
   }
 
+  /** Prefer {@link String#indexOf(int, int, int)} over less efficient alternatives. */
+  static final class StringIndexOfCharBetweenIndices {
+    @BeforeTemplate
+    int before(String string, int ch, int beginIndex, int endIndex) {
+      return string.substring(beginIndex, endIndex).indexOf(ch);
+    }
+
+    @AfterTemplate
+    int after(String string, int ch, int beginIndex, int endIndex) {
+      return Math.max(-1, string.indexOf(ch, beginIndex, endIndex) - beginIndex);
+    }
+  }
+
   /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
-  static final class StringIndexOfString {
+  static final class StringIndexOfStringFromIndex {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
     int before(String string, String substring, int fromIndex) {
@@ -336,8 +349,18 @@ final class StringRules {
     }
   }
 
-  // XXX: Once we compile Refaster templates with JDK 21 also suggest `String#indexOf(int, int,
-  // int)` and `String#indexOf(String, int, int)`.
+  /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
+  static final class StringIndexOfStringBetweenIndices {
+    @BeforeTemplate
+    int before(String string, String substring, int beginIndex, int endIndex) {
+      return string.substring(beginIndex, endIndex).indexOf(substring);
+    }
+
+    @AfterTemplate
+    int after(String string, String substring, int beginIndex, int endIndex) {
+      return Math.max(-1, string.indexOf(substring, beginIndex, endIndex) - beginIndex);
+    }
+  }
 
   /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
   static final class StringLastIndexOfChar {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -114,12 +114,20 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return "foo".getBytes(UTF_8).length;
   }
 
-  int testStringIndexOfChar() {
+  int testStringIndexOfCharFromIndex() {
     return "foo".substring(1).indexOf('a');
   }
 
-  int testStringIndexOfString() {
+  int testStringIndexOfCharBetweenIndices() {
+    return "foo".substring(1, 2).indexOf('a');
+  }
+
+  int testStringIndexOfStringFromIndex() {
     return "foo".substring(1).indexOf("bar");
+  }
+
+  int testStringIndexOfStringBetweenIndices() {
+    return "foo".substring(1, 2).indexOf("bar");
   }
 
   int testStringLastIndexOfChar() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -109,12 +109,20 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return Utf8.encodedLength("foo");
   }
 
-  int testStringIndexOfChar() {
+  int testStringIndexOfCharFromIndex() {
     return Math.max(-1, "foo".indexOf('a', 1) - 1);
   }
 
-  int testStringIndexOfString() {
+  int testStringIndexOfCharBetweenIndices() {
+    return Math.max(-1, "foo".indexOf('a', 1, 2) - 1);
+  }
+
+  int testStringIndexOfStringFromIndex() {
     return Math.max(-1, "foo".indexOf("bar", 1) - 1);
+  }
+
+  int testStringIndexOfStringBetweenIndices() {
+    return Math.max(-1, "foo".indexOf("bar", 1, 2) - 1);
   }
 
   int testStringLastIndexOfChar() {


### PR DESCRIPTION
~:exclamation: This PR is on top of #1927. :exclamation:~

Suggested commit message:
```
Introduce `StringIndexOf{Char,String}BetweenIndices` Refaster rules (#1947)

And rename the `StringIndexOf{Char,String}` rules to
`StringIndexOf{Char,String}FromIndex`.

```