### PR TITLE
Introduce `ASTHelpersGetStartPosition` Refaster rule

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
@@ -7,8 +7,11 @@ import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.Tree;
 import com.sun.tools.javac.util.Constants;
 import com.sun.tools.javac.util.Convert;
+import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import javax.lang.model.element.Name;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.utils.SourceCode;
@@ -95,6 +98,20 @@ final class BugCheckerRules {
     @AfterTemplate
     boolean after(Name name, CharSequence string) {
       return name.contentEquals(string);
+    }
+  }
+
+  /** Prefer {@link ASTHelpers#getStartPosition(Tree)} over alternatives that require casting. */
+  static final class ASTHelpersGetStartPosition<T extends DiagnosticPosition> {
+    @BeforeTemplate
+    @SuppressWarnings("unchecked" /* We also want to replace unchecked casts. */)
+    int before(Tree tree) {
+      return ((T) tree).getStartPosition();
+    }
+
+    @AfterTemplate
+    int after(Tree tree) {
+      return ASTHelpers.getStartPosition(tree);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestInput.java
@@ -4,6 +4,7 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.Constants;
 import com.sun.tools.javac.util.Convert;
 import javax.lang.model.element.Name;
@@ -12,7 +13,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Constants.class, Convert.class, FixChoosers.class);
+    return ImmutableSet.of(Constants.class, Convert.class, FixChoosers.class, JCTree.class);
   }
 
   ImmutableSet<BugCheckerRefactoringTestHelper> testBugCheckerRefactoringTestHelperIdentity() {
@@ -38,5 +39,9 @@ final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         ((Name) null).toString().equals("foo".subSequence(0, 1).toString()),
         ((com.sun.tools.javac.util.Name) null).toString().equals("bar"));
+  }
+
+  int testASTHelpersGetStartPosition() {
+    return ((JCTree) null).getStartPosition();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestOutput.java
@@ -4,6 +4,8 @@ import com.google.common.collect.ImmutableSet;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.bugpatterns.BugChecker;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.tools.javac.tree.JCTree;
 import com.sun.tools.javac.util.Constants;
 import com.sun.tools.javac.util.Convert;
 import javax.lang.model.element.Name;
@@ -13,7 +15,7 @@ import tech.picnic.errorprone.utils.SourceCode;
 final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(Constants.class, Convert.class, FixChoosers.class);
+    return ImmutableSet.of(Constants.class, Convert.class, FixChoosers.class, JCTree.class);
   }
 
   ImmutableSet<BugCheckerRefactoringTestHelper> testBugCheckerRefactoringTestHelperIdentity() {
@@ -39,5 +41,9 @@ final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         ((Name) null).contentEquals("foo".subSequence(0, 1)),
         ((com.sun.tools.javac.util.Name) null).contentEquals("bar"));
+  }
+
+  int testASTHelpersGetStartPosition() {
+    return ASTHelpers.getStartPosition(null);
   }
 }

--- a/error-prone-utils/src/main/java/tech/picnic/errorprone/utils/SourceCode.java
+++ b/error-prone-utils/src/main/java/tech/picnic/errorprone/utils/SourceCode.java
@@ -10,11 +10,11 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Streams;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.fixes.SuggestedFix;
+import com.google.errorprone.util.ASTHelpers;
 import com.google.errorprone.util.ErrorProneToken;
 import com.google.errorprone.util.ErrorProneTokens;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
-import com.sun.tools.javac.util.JCDiagnostic.DiagnosticPosition;
 import com.sun.tools.javac.util.Position;
 import java.util.Optional;
 import javax.lang.model.SourceVersion;
@@ -98,7 +98,7 @@ public final class SourceCode {
 
     int whitespaceEndPos = NON_WHITESPACE_MATCHER.indexIn(sourceCode, endPos);
     return SuggestedFix.replace(
-        ((DiagnosticPosition) tree).getStartPosition(),
+        ASTHelpers.getStartPosition(tree),
         whitespaceEndPos == -1 ? sourceCode.length() : whitespaceEndPos,
         "");
   }

--- a/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
+++ b/refaster-test-support/src/main/java/tech/picnic/errorprone/refaster/test/RefasterRuleCollection.java
@@ -134,6 +134,7 @@ public final class RefasterRuleCollection extends BugChecker implements Compilat
 
     BugCheckerRefactoringTestHelper.newInstance(RefasterRuleCollection.class, clazz)
         .setArgs(
+            "--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED",
             "--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED",
             "-XepOpt:" + RULE_COLLECTION_FLAG + '=' + className)
         .addInputLines(inputResource, loadResource(clazz, inputResource))


### PR DESCRIPTION
This rule is inspired by google/error-prone@80729a81f507b81ca09c1327b609a352e745f6e2.

Suggested commit message:
```
Introduce `ASTHelpersGetStartPosition` Refaster rule (#1954)
```