### PR TITLE
Register well-known custom Javadoc tags

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1275,6 +1275,24 @@
                         Javadoc generation. -->
                         <doclint>none</doclint>
                         <source>${version.jdk}</source>
+                        <!-- See https://bugs.openjdk.org/browse/JDK-8068562. -->
+                        <tags>
+                            <tag>
+                                <name>apiNote</name>
+                                <placement>a</placement>
+                                <head>API Note:</head>
+                            </tag>
+                            <tag>
+                                <name>implNote</name>
+                                <placement>a</placement>
+                                <head>Implementation Note:</head>
+                            </tag>
+                            <tag>
+                                <name>implSpec</name>
+                                <placement>a</placement>
+                                <head>Implementation Requirements:</head>
+                            </tag>
+                        </tags>
                     </configuration>
                     <executions>
                         <execution>


### PR DESCRIPTION
Suggested commit message:
```
Register well-known custom Javadoc tags (#1965)

This resolves `mvn javadoc:jar` warnings about `@apiNote`, `@implNote`
and `@implSpec`, following the approach taken by the JDK.

See https://bugs.openjdk.org/browse/JDK-8068562
```