### PR TITLE
Reference `--should-stop=ifError=FLOW` flag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ that your build is executed using JDK 21 or above, but supports builds that
                                https://errorprone.info/docs/flags. -->
                            </arg>
                            <arg>-XDcompilePolicy=simple</arg>
+                           <arg>--should-stop=ifError=FLOW</arg>
                        </compilerArgs>
                        <!-- Enable this if you'd like to fail your build upon warnings. -->
                        <!-- <failOnWarning>true</failOnWarning> -->


### PR DESCRIPTION
Suggested commit message:
```
Reference `--should-stop=ifError=FLOW` flag in README (#1966)

Error Prone requires this flag to be specified, after all.
```