### PR TITLE
Improve Reviewdog issue reporting

### DIFF
--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -59,9 +59,8 @@ jobs:
             | reviewdog \
                 -name=javac \
                 -efm='[WARNING] %f:[%l,%c] %m' \
-                -filter-mode=file \
-                -reporter=github-pr-review \
-                -tee
+                -filter-mode=nofilter \
+                -reporter=github-pr-review
           find -name checkstyle-result.json -exec sh -c '
             reviewdog -name=Checkstyle -f=sarif -reporter=github-pr-review < "{}"
           ' \;


### PR DESCRIPTION
Suggested commit message:
```
Improve Reviewdog issue reporting (#1970)

A change in one place (such as a dependency upgrade or the introduction
of a new Refaster rule) can trigger a build warning in some other place.
With this change, Reviewdog also reports warnings against unaltered
files.

While there, drop the redundant `-tee` flag.
```