### PR TITLE
Introduce `ObjectMapperConvertValueWith{Class,JavaType,TypeReference}` Refaster rules

### DIFF
--- a/error-prone-contrib/pom.xml
+++ b/error-prone-contrib/pom.xml
@@ -290,6 +290,11 @@
         </dependency>
         <dependency>
             <groupId>tools.jackson.core</groupId>
+            <artifactId>jackson-core</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>tools.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
             <scope>provided</scope>
         </dependency>

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/Jackson2Rules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/Jackson2Rules.java
@@ -1,11 +1,13 @@
 package tech.picnic.errorprone.refasterrules;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JavaType;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import java.io.IOException;
 import java.util.Optional;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
@@ -54,13 +56,70 @@ final class Jackson2Rules {
    */
   static final class ObjectMapperValueToTree {
     @BeforeTemplate
-    JsonNode before(ObjectMapper objectMapper, Object object) throws JsonProcessingException {
-      return objectMapper.readTree(objectMapper.writeValueAsString(object));
+    JsonNode before(ObjectMapper objectMapper, Object object) throws IOException {
+      return Refaster.anyOf(
+          objectMapper.readTree(objectMapper.writeValueAsBytes(object)),
+          objectMapper.readTree(objectMapper.writeValueAsString(object)));
     }
 
     @AfterTemplate
     JsonNode after(ObjectMapper objectMapper, Object object) {
       return objectMapper.valueToTree(object);
+    }
+  }
+
+  /**
+   * Prefer {@link ObjectMapper#convertValue(Object, Class)} over more contrived and less efficient
+   * alternatives.
+   */
+  static final class ObjectMapperConvertValueWithClass<T> {
+    @BeforeTemplate
+    T before(ObjectMapper objectMapper, Object object, Class<T> valueType) throws IOException {
+      return Refaster.anyOf(
+          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueType),
+          objectMapper.readValue(objectMapper.writeValueAsString(object), valueType));
+    }
+
+    @AfterTemplate
+    T after(ObjectMapper objectMapper, Object object, Class<T> valueType) {
+      return objectMapper.convertValue(object, valueType);
+    }
+  }
+
+  /**
+   * Prefer {@link ObjectMapper#convertValue(Object, JavaType)} over more contrived and less
+   * efficient alternatives.
+   */
+  static final class ObjectMapperConvertValueWithJavaType<T> {
+    @BeforeTemplate
+    T before(ObjectMapper objectMapper, Object object, JavaType valueType) throws IOException {
+      return Refaster.anyOf(
+          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueType),
+          objectMapper.readValue(objectMapper.writeValueAsString(object), valueType));
+    }
+
+    @AfterTemplate
+    T after(ObjectMapper objectMapper, Object object, JavaType valueType) {
+      return objectMapper.convertValue(object, valueType);
+    }
+  }
+
+  /**
+   * Prefer {@link ObjectMapper#convertValue(Object, TypeReference)} over more contrived and less
+   * efficient alternatives.
+   */
+  static final class ObjectMapperConvertValueWithTypeReference<T> {
+    @BeforeTemplate
+    T before(ObjectMapper objectMapper, Object object, TypeReference<T> valueTypeRef)
+        throws IOException {
+      return Refaster.anyOf(
+          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueTypeRef),
+          objectMapper.readValue(objectMapper.writeValueAsString(object), valueTypeRef));
+    }
+
+    @AfterTemplate
+    T after(ObjectMapper objectMapper, Object object, TypeReference<T> valueTypeRef) {
+      return objectMapper.convertValue(object, valueTypeRef);
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson2RulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson2RulesTestOutput.java
@@ -1,10 +1,13 @@
 package tech.picnic.errorprone.refasterrules;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.NullNode;
+import com.fasterxml.jackson.databind.type.SimpleType;
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
 import java.util.Optional;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
@@ -25,7 +28,28 @@ final class Jackson2RulesTest implements RefasterRuleCollectionTestCase {
         NullNode.getInstance().optional("qux"));
   }
 
-  JsonNode testObjectMapperValueToTree() throws JsonProcessingException {
-    return new ObjectMapper().valueToTree("foo");
+  ImmutableSet<JsonNode> testObjectMapperValueToTree() throws IOException {
+    return ImmutableSet.of(
+        new ObjectMapper().valueToTree("foo"),
+        new ObjectMapper(new JsonFactory()).valueToTree("bar"));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithClass() throws IOException {
+    return ImmutableSet.of(
+        new ObjectMapper().convertValue("1", Integer.class),
+        new ObjectMapper(new JsonFactory()).convertValue("2.0", Double.class));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithJavaType() throws IOException {
+    return ImmutableSet.of(
+        new ObjectMapper().convertValue("1", SimpleType.constructUnsafe(Integer.class)),
+        new ObjectMapper(new JsonFactory())
+            .convertValue("2.0", SimpleType.constructUnsafe(Double.class)));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithTypeReference() throws IOException {
+    return ImmutableSet.of(
+        new ObjectMapper().convertValue("1", new TypeReference<Integer>() {}),
+        new ObjectMapper(new JsonFactory()).convertValue("2.0", new TypeReference<Double>() {}));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestInput.java
@@ -3,9 +3,12 @@ package tech.picnic.errorprone.refasterrules;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.type.SimpleType;
 
 final class Jackson3RulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Optional<JsonNode>> testJsonNodeOptionalInt() {
@@ -24,7 +27,36 @@ final class Jackson3RulesTest implements RefasterRuleCollectionTestCase {
         Optional.ofNullable(NullNode.getInstance().get("qux")));
   }
 
-  JsonNode testObjectMapperValueToTree() {
-    return new ObjectMapper().readTree(new ObjectMapper().writeValueAsString("foo"));
+  ImmutableSet<JsonNode> testObjectMapperValueToTree() {
+    return ImmutableSet.of(
+        new ObjectMapper().readTree(new ObjectMapper().writeValueAsBytes("foo")),
+        JsonMapper.shared().readTree(JsonMapper.shared().writeValueAsString("bar")));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithClass() {
+    return ImmutableSet.of(
+        new ObjectMapper().readValue(new ObjectMapper().writeValueAsBytes("1"), Integer.class),
+        JsonMapper.shared().readValue(JsonMapper.shared().writeValueAsString("2.0"), Double.class));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithJavaType() {
+    return ImmutableSet.of(
+        new ObjectMapper()
+            .readValue(
+                new ObjectMapper().writeValueAsBytes("1"),
+                SimpleType.constructUnsafe(Integer.class)),
+        JsonMapper.shared()
+            .readValue(
+                JsonMapper.shared().writeValueAsString("2.0"),
+                SimpleType.constructUnsafe(Double.class)));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithTypeReference() {
+    return ImmutableSet.of(
+        new ObjectMapper()
+            .readValue(new ObjectMapper().writeValueAsBytes("1"), new TypeReference<Integer>() {}),
+        JsonMapper.shared()
+            .readValue(
+                JsonMapper.shared().writeValueAsString("2.0"), new TypeReference<Double>() {}));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestOutput.java
@@ -3,9 +3,12 @@ package tech.picnic.errorprone.refasterrules;
 import com.google.common.collect.ImmutableSet;
 import java.util.Optional;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
+import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.JsonNode;
 import tools.jackson.databind.ObjectMapper;
+import tools.jackson.databind.json.JsonMapper;
 import tools.jackson.databind.node.NullNode;
+import tools.jackson.databind.type.SimpleType;
 
 final class Jackson3RulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Optional<JsonNode>> testJsonNodeOptionalInt() {
@@ -24,7 +27,26 @@ final class Jackson3RulesTest implements RefasterRuleCollectionTestCase {
         NullNode.getInstance().optional("qux"));
   }
 
-  JsonNode testObjectMapperValueToTree() {
-    return new ObjectMapper().valueToTree("foo");
+  ImmutableSet<JsonNode> testObjectMapperValueToTree() {
+    return ImmutableSet.of(
+        new ObjectMapper().valueToTree("foo"), JsonMapper.shared().valueToTree("bar"));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithClass() {
+    return ImmutableSet.of(
+        new ObjectMapper().convertValue("1", Integer.class),
+        JsonMapper.shared().convertValue("2.0", Double.class));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithJavaType() {
+    return ImmutableSet.of(
+        new ObjectMapper().convertValue("1", SimpleType.constructUnsafe(Integer.class)),
+        JsonMapper.shared().convertValue("2.0", SimpleType.constructUnsafe(Double.class)));
+  }
+
+  ImmutableSet<Number> testObjectMapperConvertValueWithTypeReference() {
+    return ImmutableSet.of(
+        new ObjectMapper().convertValue("1", new TypeReference<Integer>() {}),
+        JsonMapper.shared().convertValue("2.0", new TypeReference<Double>() {}));
   }
 }


### PR DESCRIPTION
~:exclamation: This PR is on top of #1980. :exclamation:~

Suggested commit message:
```
Introduce `ObjectMapperConvertValueWith{Class,JavaType,TypeReference}` Refaster rules (#1981)
    
While there, generalize the `ObjectMapperValueToTree` Refaster rule.
```