### PR TITLE
Have OpenAI's Codex suggest commit messages

### DIFF
--- a/.github/workflows/suggest-commit-message.yml
+++ b/.github/workflows/suggest-commit-message.yml
@@ -117,7 +117,7 @@ jobs:
               git(['log', '--grep', '^Upgrade', '--invert-grep', '--pretty=format:%h %B%n---', '-n', '50', baseSha]) ||
               '<no non-upgrade commits found>';
             const upgradeCommits =
-              git(['log', '--grep', '^Upgrade', '--pretty=format:%h %B%n---', '-n', '50', baseSha]) ||
+              git(['log', '--grep', '^Upgrade', '--pretty=format:%h %B%n---', '-n', '150', baseSha]) ||
               '<no upgrade commits found>';
 
             const cleanedBody = (body || '').trim() || '<no pull request description>';
@@ -201,7 +201,7 @@ jobs:
             ${nonUpgradeCommits}
             \u0060\u0060\u0060
 
-            Recent upgrade commit examples (\u0060git log --grep '^Upgrade' --pretty='format:%h %B%n---' -n 50\u0060):
+            Recent upgrade commit examples (\u0060git log --grep '^Upgrade' --pretty='format:%h %B%n---' -n 150\u0060):
             \u0060\u0060\u0060
             ${upgradeCommits}
             \u0060\u0060\u0060


### PR DESCRIPTION
Suggested commit message:
```
Have OpenAI's Codex suggest commit messages (#1984)

This new GitHub Actions workflow upserts a pull request comment any time
the PR is updated, to suggest an appropriate commit message for the 
squash-and-merge workflow.

The workflow can also be triggered manually to simplify testing.
```

I tested part of this PR by temporarily changing the default branch (necessary because the new workflow doesn't exist on `master` yet) and running e.g.:
```
gh workflow run suggest-commit-message.yml --ref 'sschroevers/automate-commit-message-suggestions' -f pr_number=1963
```

Examples of generated commit messages:
- [Upgrade Google Java Format](https://github.com/PicnicSupermarket/error-prone-support/pull/1904#issuecomment-3538765839)
- [Upgrade JUnit](https://github.com/PicnicSupermarket/error-prone-support/pull/1911#issuecomment-3538789626) (this one isn't _always_ generated to my liking.)
- [Upgrade Checkstyle](https://github.com/PicnicSupermarket/error-prone-support/pull/1928#issuecomment-3538789239)
- [Upgrade NullAway](https://github.com/PicnicSupermarket/error-prone-support/pull/1957#issuecomment-3538757231)
- [Upgrade Error Prone](https://github.com/PicnicSupermarket/error-prone-support/pull/1963#issuecomment-3538735591)
- [Upgrade jOOQ](https://github.com/PicnicSupermarket/error-prone-support/pull/1976#issuecomment-3538734871)
- [Upgrade Spring](https://github.com/PicnicSupermarket/error-prone-support/pull/1978#issuecomment-3538801037) (I think we can still improve here.)
- [Upgrade maven-jar-plugin](https://github.com/PicnicSupermarket/error-prone-support/pull/1985#issuecomment-3539329541)
- [This PR](https://github.com/PicnicSupermarket/error-prone-support/pull/1984#issuecomment-3538543036)

This PR was largely created using Windsurf with the `GPT-5-Codex` model, with tweaks from my side.