### PR TITLE
Disallow static import of `values`

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -144,7 +144,8 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
           "newInstance",
           "of",
           "parse",
-          "valueOf");
+          "valueOf",
+          "values");
 
   /** Instantiates a new {@link NonStaticImport} instance. */
   public NonStaticImport() {}


### PR DESCRIPTION
Suggested commit message:
```
Disallow static import of `values` (#1998)

This matches changes in Error Prone's `BadImport` check.

See https://github.com/google/error-prone/commit/7e6e113bad29f9e53cc0bc3b6613dcf778831cde
```