### PR TITLE
Introduce Devcontainers-based Claude Code sandbox

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,87 @@
+# A sandboxed development environment for running Claude Code with
+# `--dangerously-skip-permissions`.
+
+FROM library/node:25.9.0-trixie@sha256:6caf08ae7d5c8b8c3455161bee6ab84e658458cb0855f47172ccbe22c8be54ba
+
+# Install additional Debian packages. Recent releases of `gh` are available
+# only from the GitHub CLI marketing site.
+# XXX: Extend this list if Claude Code is observed trying to use missing
+# commands.
+# XXX: Drop `pandoc` installation if `./generate-review-checklist.sh` is
+# migrated to Java.
+RUN curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+    -o /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+  && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+    > /etc/apt/sources.list.d/github-cli.list \
+  && apt-get update \
+  && apt-get install -y --no-install-recommends \
+    fzf \
+    gh \
+    jq \
+    less \
+    man-db \
+    pandoc \
+    python3 \
+    vim \
+    xxd \
+    zip \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
+
+ARG USERNAME=node
+# Rename the `node` user/group to `${USERNAME}` (keeping UID/GID 1000) so that
+# the container identity matches the host user. This is a workaround for
+# https://github.com/anthropics/claude-code/issues/15717.
+RUN if [ "${USERNAME}" != "node" ]; then \
+    groupmod -n "${USERNAME}" node \
+      && usermod -l "${USERNAME}" -d "/home/${USERNAME}" -m node; \
+    fi
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+
+# Pre-create directories that will receive bind mounts or be written to by
+# tools at runtime. This ensures correct ownership and prevents Docker from
+# creating parent directories as `root`.
+RUN mkdir -p \
+  .config \
+  .m2/repository \
+  .ssh
+
+# Install Claude Code using the native installer.
+RUN curl -fsSL https://claude.ai/install.sh | bash
+
+# Install SDKMAN! and the tools declared in `.sdkmanrc`. Also configure Maven
+# Toolchains support for JDK 21, as required by `./run-full-build.sh`.
+# Note: the `echo >> .sdkmanrc` intentionally creates a duplicate `java=` entry,
+# so that `sdk env install` installs both the default JDK (listed first) and
+# `${TARGET_JDK}`.
+ARG TARGET_JDK=21.0.10-tem
+COPY --chown="${USERNAME}:${USERNAME}" .sdkmanrc .sdkmanrc
+SHELL ["/bin/bash", "-c"]
+RUN curl -fsSL https://get.sdkman.io | bash \
+  && source "${HOME}/.sdkman/bin/sdkman-init.sh" \
+  && echo "java=${TARGET_JDK}" >> .sdkmanrc \
+  && sdk env install \
+  && rm .sdkmanrc \
+  && printf '%s\n' \
+    '<toolchains xmlns="https://maven.apache.org/TOOLCHAINS/1.1.0"' \
+    '    xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance"' \
+    '    xsi:schemaLocation="http://maven.apache.org/TOOLCHAINS/1.1.0 https://maven.apache.org/xsd/toolchains-1.1.0.xsd">' \
+    '  <toolchain>' \
+    '    <type>jdk</type>' \
+    '    <provides>' \
+    '      <version>21</version>' \
+    '    </provides>' \
+    '    <configuration>' \
+    "      <jdkHome>$(sdk home java "${TARGET_JDK}")</jdkHome>" \
+    '    </configuration>' \
+    '  </toolchain>' \
+    '</toolchains>' \
+    > "${HOME}/.m2/toolchains.xml"
+
+# Ensure that SDKMAN!-managed tools are on the `${PATH}` for both interactive
+# and non-interactive shells. The former load `.bashrc`, while the latter use
+# `${BASH_ENV}`.
+RUN echo 'source "${HOME}/.sdkman/bin/sdkman-init.sh"' \
+  | tee "${HOME}/.bashrc" "${HOME}/.bash-env"
+ENV BASH_ENV=/home/${USERNAME}/.bash-env

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+{
+  "name": "Claude Code Sandbox",
+  "build": {
+    "dockerfile": "Dockerfile",
+    "context": "..",
+    "args": {
+      "USERNAME": "${localEnv:USER}"
+    }
+  },
+  "mounts": [
+    "source=${localEnv:HOME}/.claude.json,target=/home/${localEnv:USER}/.claude.json,type=bind",
+    "source=${localEnv:HOME}/.claude,target=/home/${localEnv:USER}/.claude,type=bind",
+    "source=${localEnv:HOME}/.config/ccstatusline,target=/home/${localEnv:USER}/.config/ccstatusline,type=bind,readonly",
+    "source=${localEnv:HOME}/.config/gh,target=/home/${localEnv:USER}/.config/gh,type=bind,readonly",
+    "source=${localEnv:HOME}/.gitconfig,target=/home/${localEnv:USER}/.gitconfig,type=bind,readonly",
+    "source=${localEnv:HOME}/.m2/repository,target=/home/${localEnv:USER}/.m2/repository,type=bind",
+    "source=${localEnv:HOME}/.ssh/known_hosts,target=/home/${localEnv:USER}/.ssh/known_hosts,type=bind,readonly",
+    "source=${localEnv:SSH_AUTH_SOCK},target=/ssh-agent,type=bind"
+  ],
+  "containerEnv": {
+    "COLORTERM": "truecolor",
+    "SSH_AUTH_SOCK": "/ssh-agent"
+  },
+  "remoteEnv": {
+    "GITHUB_ACTOR": "${localEnv:GITHUB_ACTOR}",
+    "GITHUB_TOKEN": "${localEnv:GITHUB_TOKEN}",
+    "MAVEN_OPTS": "-Daether.enhancedLocalRepository.split=true -Daether.enhancedLocalRepository.splitRemoteRepository=true -Daether.enhancedLocalRepository.localPrefix=${localEnv:WORKSPACE_ID}"
+  },
+  "workspaceMount": "source=${localWorkspaceFolder},target=${localWorkspaceFolder},type=bind",
+  "workspaceFolder": "${localWorkspaceFolder}"
+}

--- a/claude-sandbox.sh
+++ b/claude-sandbox.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Launches a Claude Code session with `--dangerously-skip-permissions` inside a
+# Development Container. Each session runs in its own Git worktree, isolated
+# from the host filesystem.
+#
+# Usage:
+#   ./claude-sandbox.sh <branch-or-worktree-path> [claude-args...]
+#
+# The first argument is interpreted as follows:
+# - Existing directory: used as the worktree path.
+# - Branch with an existing worktree: that worktree's path is used.
+# - Otherwise: a worktree is created at `${WORKTREE_BASE}/<name>` (default base:
+#   ~/workspace/worktrees/error-prone-support/), where slashes in the name are
+#   replaced with dashes.
+
+set -e -u -o pipefail
+
+if [ "${#}" -lt 1 ]; then
+  echo "Usage: ${0} <branch-or-worktree-path> [claude-args...]" >&2
+  exit 1
+fi
+
+for cmd in devcontainer docker flock git shasum; do
+  if ! command -v "${cmd}" >/dev/null 2>&1; then
+    echo "This script requires \`${cmd}\`; please install it." >&2
+    exit 1
+  fi
+done
+
+REPO_ROOT="$(git -C "$(dirname "${0}")" rev-parse --show-toplevel)"
+REPO_NAME="$(basename "${REPO_ROOT}")"
+WORKTREE_BASE="${WORKTREE_BASE:-${REPO_ROOT}/../${REPO_NAME}-worktrees}"
+GIT_DIR="$(git -C "${REPO_ROOT}" rev-parse --absolute-git-dir)"
+DEVCONTAINER_CONFIG="${REPO_ROOT}/.devcontainer/devcontainer.json"
+
+TARGET="${1}"
+shift
+
+# Determine the workspace folder:
+# 1. Existing directory: use as-is.
+# 2. Branch with an attached worktree: use that worktree's path.
+# 3. Otherwise: derive the path as ${WORKTREE_BASE}/${TARGET} with slashes
+#    replaced by dashes, and create the worktree if it does not yet exist.
+if [ -d "${TARGET}" ]; then
+  WORKSPACE_FOLDER="$(cd "${TARGET}" && pwd)"
+else
+  WORKSPACE_FOLDER="$(git -C "${REPO_ROOT}" worktree list --porcelain \
+    | awk -v branch="refs/heads/${TARGET}" '
+        /^worktree / { wt = substr($0, 10) }
+        $0 == "branch " branch { print wt; exit }
+      ')"
+
+  if [ -z "${WORKSPACE_FOLDER}" ]; then
+    WORKSPACE_FOLDER="${WORKTREE_BASE}/${TARGET//\//-}"
+    if [ ! -d "${WORKSPACE_FOLDER}" ]; then
+      echo "Creating worktree at ${WORKSPACE_FOLDER}"
+      if git -C "${REPO_ROOT}" rev-parse --verify --quiet "refs/heads/${TARGET}" \
+          >/dev/null 2>&1; then
+        git -C "${REPO_ROOT}" worktree add "${WORKSPACE_FOLDER}" "${TARGET}"
+      else
+        git -C "${REPO_ROOT}" worktree add -b "${TARGET}" "${WORKSPACE_FOLDER}"
+      fi
+    fi
+  fi
+fi
+
+# We want to keep locally-installed Maven artifacts (SNAPSHOTs) separate from
+# remotely-cached ones, so that `mvn install` invocations in different
+# environments (host, container) don't overwrite each other's builds. The
+# Devcontainer configures `MAVEN_OPTS` to achieve this, but it does require an
+# installation prefix that is unique to the workspace; here we generate that
+# prefix.
+export WORKSPACE_ID="$(echo "${WORKSPACE_FOLDER}" | shasum -a 256 | cut -d ' ' -f 1)"
+
+# Use a lock file to track concurrent sessions for this workspace. A shared
+# lock is held while the session is active; on exit, an exclusive lock is
+# attempted: if it succeeds, this was the last session and the container is
+# shut down.
+exec {SESSION_LOCK}>"/tmp/claude-sandbox-${WORKSPACE_ID}.session.lock"
+flock -s "${SESSION_LOCK}"
+
+function tear_down() {
+  if flock -x -n "${SESSION_LOCK}" 2>/dev/null; then
+    # XXX: Use `devcontainer down` once available; see
+    # https://github.com/devcontainers/cli/issues/386.
+    docker ps -q -f "label=devcontainer.local_folder=${WORKSPACE_FOLDER}" \
+        | xargs docker rm -f
+  fi
+}
+trap tear_down INT TERM HUP EXIT
+
+# Start the devcontainer based on the configuration in the main repo.
+#
+# This operation is performed under an exclusive lock, so that per workspace
+# only a single container is created.
+#
+# Worktrees have a `.git` file specifying the absolute path to the main repo's
+# `.git/worktrees/<name>` directory. For this to resolve inside the container,
+# we mount the main `.git` directory at its real host path.
+flock -x "/tmp/claude-sandbox-${WORKSPACE_ID}.startup.lock" \
+  devcontainer up \
+    --workspace-folder "${WORKSPACE_FOLDER}" \
+    --config "${DEVCONTAINER_CONFIG}" \
+    --mount "type=bind,source=${GIT_DIR},target=${GIT_DIR}"
+
+# Start Claude Code inside the container.
+devcontainer exec \
+  --workspace-folder "${WORKSPACE_FOLDER}" \
+  --config "${DEVCONTAINER_CONFIG}" \
+  claude --dangerously-skip-permissions "${@}"


### PR DESCRIPTION
Suggested commit message:
```
Introduce Devcontainers-based Claude Code sandbox (#2194)

The new `claude-sandbox.sh` script executes Claude Code with
`--dangerously-skip-permissions` in a Devcontainers-managed Docker container,
with limited access to the host filesystem. The container's working directory
is either an explicitly specified directory, or a Git worktree (which will be
created if it does not yet exist).

Maven SNAPSHOTs installed by the container have a custom prefix, so that these
artifacts are ignored by other containers and processes on the host system.
This enables concurrent work on multiple branches.

This setup is not fully secure: the host system access provides plenty of
opportunity to wreak havoc, and network access is not restricted. The primary
aim here is to reduce friction and facilitate concurrent development.
```