### PR TITLE
Run SonarCloud analysis in custom GitHub Actions environment

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -17,6 +17,7 @@ jobs:
     # do not have access to the requisite secrets.
     if: ${{ github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository }}
     runs-on: ubuntu-24.04
+    environment: sonar
     steps:
       - name: Install Harden-Runner
         uses: step-security/harden-runner@f808768d1510423e83855289c910610ca9b43176 # v2.17.0


### PR DESCRIPTION
Suggested commit message:
```
Run SonarCloud analysis in custom GitHub Actions environment (#2202)

This allows us to define `SONAR_TOKEN` as an environment secret scoped
to just that workflow.
```