### PR TITLE
Comprehensively apply `error-prone-contrib` during self-check

### DIFF
--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/refasterrules/RefasterRulesTest.java
@@ -7,8 +7,7 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollection;
 final class RefasterRulesTest {
   // XXX: Create a JUnit extension to automatically discover the rule collections in a given context
   // to make sure the list is exhaustive.
-  // XXX: When the entries here aren't lexicographically sorted, somehow
-  // `LexicographicalAnnotationAttributeListing` doesn't flag that; investigate why.
+  @ParameterizedTest
   @ValueSource(
       classes = {
         AssertJArrayRules.class,
@@ -90,7 +89,6 @@ final class RefasterRulesTest {
         TimeRules.class,
         WebClientRules.class
       })
-  @ParameterizedTest
   void validateRuleCollection(Class<?> clazz) {
     RefasterRuleCollection.validate(clazz);
   }

--- a/pom.xml
+++ b/pom.xml
@@ -1026,11 +1026,11 @@
                             <goals>
                                 <goal>compile</goal>
                             </goals>
-                            <!-- XXX: This goal runs *after* the `test-compile`
+                            <!-- This goal runs *after* the `test-compile`
                             phase, so that its custom output directory doesn't
                             replace the default output directory on the
                             annotation processor classpath when the self-check
-                            profile is active. Cause that woud prevent
+                            profile is active. Because that would prevent
                             `error-prone-contrib` from flagging issues with its
                             own test source code. -->
                             <phase>process-test-classes</phase>

--- a/pom.xml
+++ b/pom.xml
@@ -1026,6 +1026,14 @@
                             <goals>
                                 <goal>compile</goal>
                             </goals>
+                            <!-- XXX: This goal runs *after* the `test-compile`
+                            phase, so that its custom output directory doesn't
+                            replace the default output directory on the
+                            annotation processor classpath when the self-check
+                            profile is active. Cause that woud prevent
+                            `error-prone-contrib` from flagging issues with its
+                            own test source code. -->
+                            <phase>process-test-classes</phase>
                             <configuration>
                                 <compilerArgs combine.self="override">
                                     <!-- This step only recompiles code, so


### PR DESCRIPTION
Suggested commit message:
```
Comprehensively apply `error-prone-contrib` during self-check (#2204)

Prior to this change, bug checkers defined in `error-prone-contrib`
were not on the classpath during compilation of the
`error-prone-contrib` test source code.
```

To see the difference, run:
```
mvn -X clean package -Pself-check -pl error-prone-contrib 2>/dev/null | grep -oP '\-processorpath \S+' | grep -oP '[^:]+error-prone-contrib[^:]+'
```

Output before:
```
/home/user/.m2/repository/tech/picnic/error-prone-support/error-prone-contrib/0.28.1-SNAPSHOT/error-prone-contrib-0.28.1-SNAPSHOT.jar
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/classes
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/openrewrite-recipes
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/openrewrite-recipes
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/openrewrite-recipes
```

Output after:
```
/home/user/.m2/repository/tech/picnic/error-prone-support/error-prone-contrib/0.28.1-SNAPSHOT/error-prone-contrib-0.28.1-SNAPSHOT.jar
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/classes
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/classes
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/classes
/home/user/workspace/picnic/error-prone-support/error-prone-contrib/target/classes
```