### PR TITLE
Declare an `Automatic-Module-Name` for all modules

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1214,7 +1214,7 @@
                                 <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             </manifest>
                             <manifestEntries>
-                                <Automatic-Module-Name>tech.picnic.errorprone.${jpms.module-name}</Automatic-Module-Name>
+                                <Automatic-Module-Name>${jpms.module-name}</Automatic-Module-Name>
                                 <Implementation-Title>${project.name}</Implementation-Title>
                                 <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                                 <Implementation-Version>${project.version}.${build.number}.${git.commit.id}</Implementation-Version>
@@ -1271,13 +1271,13 @@
                     <version>3.12.0</version>
                     <configuration>
                         <additionalJOptions>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</additionalJOption>
-                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.api=${jpms.module-name}</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.code=${jpms.module-name}</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.main=${jpms.module-name}</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.model=${jpms.module-name}</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.parser=${jpms.module-name}</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.tree=${jpms.module-name}</additionalJOption>
+                            <additionalJOption>--add-exports=jdk.compiler/com.sun.tools.javac.util=${jpms.module-name}</additionalJOption>
                         </additionalJOptions>
                         <!-- All relevant doclint checks are performed during
                         the compilation phase; no need to recheck during
@@ -1399,8 +1399,8 @@
                             <configuration>
                                 <failIfNoMatch>false</failIfNoMatch>
                                 <name>jpms.module-name.base</name>
-                                <regex>^error-prone-|-support$</regex>
-                                <replacement />
+                                <regex>^(?:error-prone-)?(.*?)(?:-support)?$</regex>
+                                <replacement>tech.picnic.errorprone.$1</replacement>
                                 <value>${project.artifactId}</value>
                             </configuration>
                         </execution>

--- a/pom.xml
+++ b/pom.xml
@@ -1214,6 +1214,7 @@
                                 <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
                             </manifest>
                             <manifestEntries>
+                                <Automatic-Module-Name>tech.picnic.errorprone.${jpms.module-name}</Automatic-Module-Name>
                                 <Implementation-Title>${project.name}</Implementation-Title>
                                 <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
                                 <Implementation-Version>${project.version}.${build.number}.${git.commit.id}</Implementation-Version>
@@ -1384,6 +1385,39 @@
                             <java.security.egd>file:/dev/./urandom</java.security.egd>
                         </systemPropertyVariables>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.codehaus.mojo</groupId>
+                    <artifactId>build-helper-maven-plugin</artifactId>
+                    <version>3.6.1</version>
+                    <executions>
+                        <execution>
+                            <id>derive-jpms-module-name-base</id>
+                            <goals>
+                                <goal>regex-property</goal>
+                            </goals>
+                            <configuration>
+                                <failIfNoMatch>false</failIfNoMatch>
+                                <name>jpms.module-name.base</name>
+                                <regex>^error-prone-|-support$</regex>
+                                <replacement />
+                                <value>${project.artifactId}</value>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>derive-jpms-module-name</id>
+                            <goals>
+                                <goal>regex-property</goal>
+                            </goals>
+                            <configuration>
+                                <failIfNoMatch>false</failIfNoMatch>
+                                <name>jpms.module-name</name>
+                                <regex>-</regex>
+                                <replacement>.</replacement>
+                                <value>${jpms.module-name.base}</value>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.codehaus.mojo</groupId>
@@ -1677,6 +1711,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.codehaus.mojo</groupId>
+                <artifactId>build-helper-maven-plugin</artifactId>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
Suggested commit message:
```
Declare an `Automatic-Module-Name` for all modules (#2220)

Without an explicit `Automatic-Module-Name` manifest entry, the JVM 
derives an automatic module name from the JAR filename when placed on
the module path. Such derived names are not guaranteed to be stable.

See https://dev.java/learn/modules/automatic-module/
```

Impact of this change:
```sh
$ find . -name "*SNAPSHOT*.jar" -not -name "*-sources.jar" | while read J; do echo "${J}:"; unzip -c "${J}" META-INF/MANIFEST.MF | grep Automatic-Module-Name; done
./refaster-support/target/refaster-support-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.refaster
./refaster-support/target/refaster-support-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.refaster
./error-prone-experimental/target/error-prone-experimental-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.experimental
./error-prone-experimental/target/error-prone-experimental-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.experimental
./error-prone-guidelines/target/error-prone-guidelines-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.guidelines
./error-prone-guidelines/target/error-prone-guidelines-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.guidelines
./documentation-support/target/documentation-support-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.documentation
./documentation-support/target/documentation-support-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.documentation
./refaster-compiler/target/refaster-compiler-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.refaster.compiler
./refaster-runner/target/refaster-runner-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.refaster.runner
./refaster-runner/target/refaster-runner-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.refaster.runner
./error-prone-contrib/target/error-prone-contrib-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.contrib
./error-prone-contrib/target/error-prone-contrib-0.29.1-SNAPSHOT-recipes.jar:
Automatic-Module-Name: tech.picnic.errorprone.contrib
./error-prone-contrib/target/error-prone-contrib-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.contrib
./error-prone-utils/target/error-prone-utils-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.utils
./error-prone-utils/target/error-prone-utils-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.utils
./refaster-test-support/target/refaster-test-support-0.29.1-SNAPSHOT-tests.jar:
Automatic-Module-Name: tech.picnic.errorprone.refaster.test
./refaster-test-support/target/refaster-test-support-0.29.1-SNAPSHOT.jar:
Automatic-Module-Name: tech.picnic.errorprone.refaster.test
```