### PR TITLE
Unify Refaster rule definitions

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJArrayRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJArrayRules.java
@@ -8,7 +8,7 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.NotMatches;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import org.assertj.core.api.AbstractIntegerAssert;
-import org.assertj.core.api.AbstractObjectArrayAssert;
+import org.assertj.core.api.ObjectArrayAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.matchers.IsMultidimensionalArray;
 
@@ -19,87 +19,100 @@ import tech.picnic.errorprone.refaster.matchers.IsMultidimensionalArray;
 final class AssertJArrayRules {
   private AssertJArrayRules() {}
 
+  /** Prefer {@link ObjectArrayAssert#hasSize(int)} over less explicit alternatives. */
   static final class AssertThatHasSize<T> {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(
-        @NotMatches(IsMultidimensionalArray.class) T[] array, int size) {
-      return assertThat(array.length).isEqualTo(size);
+        @NotMatches(IsMultidimensionalArray.class) T[] actual, int expected) {
+      return assertThat(actual.length).isEqualTo(expected);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectArrayAssert<?, T> after(T[] array, int size) {
-      return assertThat(array).hasSize(size);
+    ObjectArrayAssert<T> after(T[] actual, int expected) {
+      return assertThat(actual).hasSize(expected);
     }
   }
 
+  /** Prefer {@link ObjectArrayAssert#hasSizeLessThan(int)} over less explicit alternatives. */
   static final class AssertThatHasSizeLessThan<T> {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(
-        @NotMatches(IsMultidimensionalArray.class) T[] array, int size) {
-      return assertThat(array.length).isLessThan(size);
+        @NotMatches(IsMultidimensionalArray.class) T[] actual, int boundary) {
+      return assertThat(actual.length).isLessThan(boundary);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectArrayAssert<?, T> after(T[] array, int size) {
-      return assertThat(array).hasSizeLessThan(size);
+    ObjectArrayAssert<T> after(T[] actual, int boundary) {
+      return assertThat(actual).hasSizeLessThan(boundary);
     }
   }
 
+  /**
+   * Prefer {@link ObjectArrayAssert#hasSizeLessThanOrEqualTo(int)} over less explicit alternatives.
+   */
   static final class AssertThatHasSizeLessThanOrEqualTo<T> {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(
-        @NotMatches(IsMultidimensionalArray.class) T[] array, int size) {
-      return assertThat(array.length).isLessThanOrEqualTo(size);
+        @NotMatches(IsMultidimensionalArray.class) T[] actual, int boundary) {
+      return assertThat(actual.length).isLessThanOrEqualTo(boundary);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectArrayAssert<?, T> after(T[] array, int size) {
-      return assertThat(array).hasSizeLessThanOrEqualTo(size);
+    ObjectArrayAssert<T> after(T[] actual, int boundary) {
+      return assertThat(actual).hasSizeLessThanOrEqualTo(boundary);
     }
   }
 
+  /** Prefer {@link ObjectArrayAssert#hasSizeGreaterThan(int)} over less explicit alternatives. */
   static final class AssertThatHasSizeGreaterThan<T> {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(
-        @NotMatches(IsMultidimensionalArray.class) T[] array, int size) {
-      return assertThat(array.length).isGreaterThan(size);
+        @NotMatches(IsMultidimensionalArray.class) T[] actual, int boundary) {
+      return assertThat(actual.length).isGreaterThan(boundary);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectArrayAssert<?, T> after(T[] array, int size) {
-      return assertThat(array).hasSizeGreaterThan(size);
+    ObjectArrayAssert<T> after(T[] actual, int boundary) {
+      return assertThat(actual).hasSizeGreaterThan(boundary);
     }
   }
 
+  /**
+   * Prefer {@link ObjectArrayAssert#hasSizeGreaterThanOrEqualTo(int)} over less explicit
+   * alternatives.
+   */
   static final class AssertThatHasSizeGreaterThanOrEqualTo<T> {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(
-        @NotMatches(IsMultidimensionalArray.class) T[] array, int size) {
-      return assertThat(array.length).isGreaterThanOrEqualTo(size);
+        @NotMatches(IsMultidimensionalArray.class) T[] actual, int boundary) {
+      return assertThat(actual.length).isGreaterThanOrEqualTo(boundary);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectArrayAssert<?, T> after(T[] array, int size) {
-      return assertThat(array).hasSizeGreaterThanOrEqualTo(size);
+    ObjectArrayAssert<T> after(T[] actual, int boundary) {
+      return assertThat(actual).hasSizeGreaterThanOrEqualTo(boundary);
     }
   }
 
+  /** Prefer {@link ObjectArrayAssert#hasSizeBetween(int, int)} over less explicit alternatives. */
   static final class AssertThatHasSizeBetween<T> {
     @BeforeTemplate
     AbstractIntegerAssert<?> before(
-        @NotMatches(IsMultidimensionalArray.class) T[] array, int lowerBound, int upperBound) {
-      return assertThat(array.length).isBetween(lowerBound, upperBound);
+        @NotMatches(IsMultidimensionalArray.class) T[] actual,
+        int lowerBoundary,
+        int higherBoundary) {
+      return assertThat(actual.length).isBetween(lowerBoundary, higherBoundary);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectArrayAssert<?, T> after(T[] array, int lowerBound, int upperBound) {
-      return assertThat(array).hasSizeBetween(lowerBound, upperBound);
+    ObjectArrayAssert<T> after(T[] actual, int lowerBoundary, int higherBoundary) {
+      return assertThat(actual).hasSizeBetween(lowerBoundary, higherBoundary);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBigDecimalRules.java
@@ -25,31 +25,43 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJBigDecimalRules {
   private AssertJBigDecimalRules() {}
 
+  /**
+   * Prefer {@link AbstractBigDecimalAssert#isEqualByComparingTo(BigDecimal)} over more contrived
+   * alternatives.
+   */
   static final class AbstractBigDecimalAssertIsEqualByComparingTo {
     @BeforeTemplate
-    AbstractBigDecimalAssert<?> before(AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal n) {
+    AbstractBigDecimalAssert<?> before(
+        AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal other) {
       return Refaster.anyOf(
-          bigDecimalAssert.isCloseTo(n, offset(BigDecimal.ZERO)),
-          bigDecimalAssert.isCloseTo(n, withPercentage(0)));
+          bigDecimalAssert.isCloseTo(other, offset(BigDecimal.ZERO)),
+          bigDecimalAssert.isCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractBigDecimalAssert<?> after(AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal n) {
-      return bigDecimalAssert.isEqualByComparingTo(n);
+    AbstractBigDecimalAssert<?> after(
+        AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal other) {
+      return bigDecimalAssert.isEqualByComparingTo(other);
     }
   }
 
+  /**
+   * Prefer {@link AbstractBigDecimalAssert#isNotEqualByComparingTo(BigDecimal)} over more contrived
+   * alternatives.
+   */
   static final class AbstractBigDecimalAssertIsNotEqualByComparingTo {
     @BeforeTemplate
-    AbstractBigDecimalAssert<?> before(AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal n) {
+    AbstractBigDecimalAssert<?> before(
+        AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal other) {
       return Refaster.anyOf(
-          bigDecimalAssert.isNotCloseTo(n, offset(BigDecimal.ZERO)),
-          bigDecimalAssert.isNotCloseTo(n, withPercentage(0)));
+          bigDecimalAssert.isNotCloseTo(other, offset(BigDecimal.ZERO)),
+          bigDecimalAssert.isNotCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractBigDecimalAssert<?> after(AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal n) {
-      return bigDecimalAssert.isNotEqualByComparingTo(n);
+    AbstractBigDecimalAssert<?> after(
+        AbstractBigDecimalAssert<?> bigDecimalAssert, BigDecimal other) {
+      return bigDecimalAssert.isNotEqualByComparingTo(other);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRules.java
@@ -17,7 +17,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJBigIntegerRules {
   private AssertJBigIntegerRules() {}
 
-  /** Prefer {@code isEqualTo(n)} over more contrived alternatives. */
+  /** Prefer {@link AbstractBigIntegerAssert#isEqualTo(Object)} over more contrived alternatives. */
   static final class AbstractBigIntegerAssertIsEqualTo {
     @BeforeTemplate
     AbstractBigIntegerAssert<?> before(
@@ -34,7 +34,9 @@ final class AssertJBigIntegerRules {
     }
   }
 
-  /** Prefer {@code isNotEqualTo(n)} over more contrived alternatives. */
+  /**
+   * Prefer {@link AbstractBigIntegerAssert#isNotEqualTo(Object)} over more contrived alternatives.
+   */
   static final class AbstractBigIntegerAssertIsNotEqualTo {
     @BeforeTemplate
     AbstractBigIntegerAssert<?> before(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRules.java
@@ -17,35 +17,42 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJBigIntegerRules {
   private AssertJBigIntegerRules() {}
 
+  /** Prefer {@code isEqualTo(n)} over more contrived alternatives. */
   static final class AbstractBigIntegerAssertIsEqualTo {
     @BeforeTemplate
-    AbstractBigIntegerAssert<?> before(AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger n) {
+    AbstractBigIntegerAssert<?> before(
+        AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger expected) {
       return Refaster.anyOf(
-          bigIntegerAssert.isCloseTo(n, offset(BigInteger.ZERO)),
-          bigIntegerAssert.isCloseTo(n, withPercentage(0)));
+          bigIntegerAssert.isCloseTo(expected, offset(BigInteger.ZERO)),
+          bigIntegerAssert.isCloseTo(expected, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractBigIntegerAssert<?> after(AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger n) {
-      return bigIntegerAssert.isEqualTo(n);
+    AbstractBigIntegerAssert<?> after(
+        AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger expected) {
+      return bigIntegerAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@code isNotEqualTo(n)} over more contrived alternatives. */
   static final class AbstractBigIntegerAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractBigIntegerAssert<?> before(AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger n) {
+    AbstractBigIntegerAssert<?> before(
+        AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger other) {
       return Refaster.anyOf(
-          bigIntegerAssert.isNotCloseTo(n, offset(BigInteger.ZERO)),
-          bigIntegerAssert.isNotCloseTo(n, withPercentage(0)));
+          bigIntegerAssert.isNotCloseTo(other, offset(BigInteger.ZERO)),
+          bigIntegerAssert.isNotCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractBigIntegerAssert<?> after(AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger n) {
-      return bigIntegerAssert.isNotEqualTo(n);
+    AbstractBigIntegerAssert<?> after(
+        AbstractBigIntegerAssert<?> bigIntegerAssert, BigInteger other) {
+      return bigIntegerAssert.isNotEqualTo(other);
     }
   }
 
-  static final class AbstractBigIntegerAssertIsZero {
+  /** Prefer {@code isEqualTo(0)} over more contrived alternatives. */
+  static final class AbstractBigIntegerAssertIsEqualToZero {
     @BeforeTemplate
     AbstractBigIntegerAssert<?> before(AbstractBigIntegerAssert<?> bigIntegerAssert) {
       return Refaster.anyOf(
@@ -60,7 +67,8 @@ final class AssertJBigIntegerRules {
     }
   }
 
-  static final class AbstractBigIntegerAssertIsNotZero {
+  /** Prefer {@code isNotEqualTo(0)} over more contrived alternatives. */
+  static final class AbstractBigIntegerAssertIsNotEqualToZero {
     @BeforeTemplate
     AbstractBigIntegerAssert<?> before(AbstractBigIntegerAssert<?> bigIntegerAssert) {
       return Refaster.anyOf(
@@ -75,7 +83,8 @@ final class AssertJBigIntegerRules {
     }
   }
 
-  static final class AbstractBigIntegerAssertIsOne {
+  /** Prefer {@code isEqualTo(1)} over more contrived alternatives. */
+  static final class AbstractBigIntegerAssertIsEqualToOne {
     @BeforeTemplate
     AbstractBigIntegerAssert<?> before(AbstractBigIntegerAssert<?> bigIntegerAssert) {
       return Refaster.anyOf(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBooleanRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBooleanRules.java
@@ -15,77 +15,83 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJBooleanRules {
   private AssertJBooleanRules() {}
 
+  /** Prefer {@link AbstractBooleanAssert#isEqualTo(Object)} over more contrived alternatives. */
   static final class AbstractBooleanAssertIsEqualTo {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> boolAssert, boolean other) {
-      return boolAssert.isNotEqualTo(!other);
+    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> booleanAssert, boolean expected) {
+      return booleanAssert.isNotEqualTo(!expected);
     }
 
     @AfterTemplate
-    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> boolAssert, boolean other) {
-      return boolAssert.isEqualTo(other);
+    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> booleanAssert, boolean expected) {
+      return booleanAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@link AbstractBooleanAssert#isNotEqualTo(Object)} over more contrived alternatives. */
   static final class AbstractBooleanAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> boolAssert, boolean other) {
-      return boolAssert.isEqualTo(!other);
+    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> booleanAssert, boolean other) {
+      return booleanAssert.isEqualTo(!other);
     }
 
     @AfterTemplate
-    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> boolAssert, boolean other) {
-      return boolAssert.isNotEqualTo(other);
+    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> booleanAssert, boolean other) {
+      return booleanAssert.isNotEqualTo(other);
     }
   }
 
+  /** Prefer {@link AbstractBooleanAssert#isTrue()} over less explicit alternatives. */
   static final class AbstractBooleanAssertIsTrue {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> boolAssert) {
-      return Refaster.anyOf(boolAssert.isEqualTo(true), boolAssert.isNotEqualTo(false));
+    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> booleanAssert) {
+      return Refaster.anyOf(booleanAssert.isEqualTo(true), booleanAssert.isNotEqualTo(false));
     }
 
     @AfterTemplate
-    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> boolAssert) {
-      return boolAssert.isTrue();
+    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> booleanAssert) {
+      return booleanAssert.isTrue();
     }
   }
 
-  static final class AssertThatBooleanIsTrue {
+  /** Prefer {@code assertThat(b).isTrue()} over more contrived alternatives. */
+  static final class AssertThatIsTrue {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(boolean b) {
-      return assertThat(!b).isFalse();
+    AbstractBooleanAssert<?> before(boolean actual) {
+      return assertThat(!actual).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractBooleanAssert<?> after(boolean b) {
-      return assertThat(b).isTrue();
+    AbstractBooleanAssert<?> after(boolean actual) {
+      return assertThat(actual).isTrue();
     }
   }
 
+  /** Prefer {@link AbstractBooleanAssert#isFalse()} over less explicit alternatives. */
   static final class AbstractBooleanAssertIsFalse {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> boolAssert) {
-      return Refaster.anyOf(boolAssert.isEqualTo(false), boolAssert.isNotEqualTo(true));
+    AbstractBooleanAssert<?> before(AbstractBooleanAssert<?> booleanAssert) {
+      return Refaster.anyOf(booleanAssert.isEqualTo(false), booleanAssert.isNotEqualTo(true));
     }
 
     @AfterTemplate
-    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> boolAssert) {
-      return boolAssert.isFalse();
+    AbstractBooleanAssert<?> after(AbstractBooleanAssert<?> booleanAssert) {
+      return booleanAssert.isFalse();
     }
   }
 
-  static final class AssertThatBooleanIsFalse {
+  /** Prefer {@code assertThat(b).isFalse()} over more contrived alternatives. */
+  static final class AssertThatIsFalse {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(boolean b) {
-      return assertThat(!b).isTrue();
+    AbstractBooleanAssert<?> before(boolean actual) {
+      return assertThat(!actual).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractBooleanAssert<?> after(boolean b) {
-      return assertThat(b).isFalse();
+    AbstractBooleanAssert<?> after(boolean actual) {
+      return assertThat(actual).isFalse();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBooleanRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJBooleanRules.java
@@ -54,7 +54,7 @@ final class AssertJBooleanRules {
     }
   }
 
-  /** Prefer {@code assertThat(b).isTrue()} over more contrived alternatives. */
+  /** Prefer {@link AbstractBooleanAssert#isTrue()} over more contrived alternatives. */
   static final class AssertThatIsTrue {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(boolean actual) {
@@ -81,7 +81,7 @@ final class AssertJBooleanRules {
     }
   }
 
-  /** Prefer {@code assertThat(b).isFalse()} over more contrived alternatives. */
+  /** Prefer {@link AbstractBooleanAssert#isFalse()} over more contrived alternatives. */
   static final class AssertThatIsFalse {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(boolean actual) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJByteRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJByteRules.java
@@ -14,34 +14,38 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJByteRules {
   private AssertJByteRules() {}
 
+  /** Prefer {@link AbstractByteAssert#isEqualTo(byte)} over more contrived alternatives. */
   static final class AbstractByteAssertIsEqualTo {
     @BeforeTemplate
-    AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert, byte n) {
+    AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert, byte expected) {
       return Refaster.anyOf(
-          byteAssert.isCloseTo(n, offset((byte) 0)), byteAssert.isCloseTo(n, withPercentage(0)));
+          byteAssert.isCloseTo(expected, offset((byte) 0)),
+          byteAssert.isCloseTo(expected, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractByteAssert<?> after(AbstractByteAssert<?> byteAssert, byte n) {
-      return byteAssert.isEqualTo(n);
+    AbstractByteAssert<?> after(AbstractByteAssert<?> byteAssert, byte expected) {
+      return byteAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@link AbstractByteAssert#isNotEqualTo(byte)} over more contrived alternatives. */
   static final class AbstractByteAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert, byte n) {
+    AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert, byte other) {
       return Refaster.anyOf(
-          byteAssert.isNotCloseTo(n, offset((byte) 0)),
-          byteAssert.isNotCloseTo(n, withPercentage(0)));
+          byteAssert.isNotCloseTo(other, offset((byte) 0)),
+          byteAssert.isNotCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractByteAssert<?> after(AbstractByteAssert<?> byteAssert, byte n) {
-      return byteAssert.isNotEqualTo(n);
+    AbstractByteAssert<?> after(AbstractByteAssert<?> byteAssert, byte other) {
+      return byteAssert.isNotEqualTo(other);
     }
   }
 
-  static final class AbstractByteAssertIsZero {
+  /** Prefer {@link AbstractByteAssert#isEqualTo(byte)} over less explicit alternatives. */
+  static final class AbstractByteAssertIsEqualToZero {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert) {
       return byteAssert.isZero();
@@ -53,7 +57,8 @@ final class AssertJByteRules {
     }
   }
 
-  static final class AbstractByteAssertIsNotZero {
+  /** Prefer {@link AbstractByteAssert#isNotEqualTo(byte)} over less explicit alternatives. */
+  static final class AbstractByteAssertIsNotEqualToZero {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert) {
       return byteAssert.isNotZero();
@@ -65,7 +70,8 @@ final class AssertJByteRules {
     }
   }
 
-  static final class AbstractByteAssertIsOne {
+  /** Prefer {@link AbstractByteAssert#isEqualTo(byte)} over less explicit alternatives. */
+  static final class AbstractByteAssertIsEqualToOne {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> byteAssert) {
       return byteAssert.isOne();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJCharSequenceRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJCharSequenceRules.java
@@ -8,6 +8,8 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractCharSequenceAssert;
+import org.assertj.core.api.AbstractIntegerAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to AssertJ assertions over {@link CharSequence}s. */
@@ -15,48 +17,51 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJCharSequenceRules {
   private AssertJCharSequenceRules() {}
 
-  static final class AssertThatCharSequenceIsEmpty {
+  /** Prefer {@link AbstractCharSequenceAssert#isEmpty()} over more contrived alternatives. */
+  static final class AssertThatIsEmpty {
     @BeforeTemplate
-    void before(CharSequence charSequence) {
+    void before(CharSequence actual) {
       Refaster.anyOf(
-          assertThat(charSequence.isEmpty()).isTrue(),
-          assertThat(charSequence.length()).isEqualTo(0L),
-          assertThat(charSequence.length()).isNotPositive());
+          assertThat(actual.isEmpty()).isTrue(),
+          assertThat(actual.length()).isEqualTo(0L),
+          assertThat(actual.length()).isNotPositive());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(CharSequence charSequence) {
-      assertThat(charSequence).isEmpty();
+    void after(CharSequence actual) {
+      assertThat(actual).isEmpty();
     }
   }
 
-  static final class AssertThatCharSequenceIsNotEmpty {
+  /** Prefer {@link AbstractCharSequenceAssert#isNotEmpty()} over more contrived alternatives. */
+  static final class AssertThatIsNotEmpty {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(CharSequence charSequence) {
+    AbstractAssert<?, ?> before(CharSequence actual) {
       return Refaster.anyOf(
-          assertThat(charSequence.isEmpty()).isFalse(),
-          assertThat(charSequence.length()).isNotEqualTo(0),
-          assertThat(charSequence.length()).isPositive());
+          assertThat(actual.isEmpty()).isFalse(),
+          assertThat(actual.length()).isNotEqualTo(0),
+          assertThat(actual.length()).isPositive());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractAssert<?, ?> after(CharSequence charSequence) {
-      return assertThat(charSequence).isNotEmpty();
+    AbstractCharSequenceAssert<?, ? extends CharSequence> after(CharSequence actual) {
+      return assertThat(actual).isNotEmpty();
     }
   }
 
-  static final class AssertThatCharSequenceHasSize {
+  /** Prefer {@link AbstractCharSequenceAssert#hasSize(int)} over more contrived alternatives. */
+  static final class AssertThatHasSize {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(CharSequence charSequence, int length) {
-      return assertThat(charSequence.length()).isEqualTo(length);
+    AbstractIntegerAssert<?> before(CharSequence actual, int expected) {
+      return assertThat(actual.length()).isEqualTo(expected);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractAssert<?, ?> after(CharSequence charSequence, int length) {
-      return assertThat(charSequence).hasSize(length);
+    AbstractCharSequenceAssert<?, ? extends CharSequence> after(CharSequence actual, int expected) {
+      return assertThat(actual).hasSize(expected);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJComparableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJComparableRules.java
@@ -15,81 +15,105 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJComparableRules {
   private AssertJComparableRules() {}
 
+  /**
+   * Prefer {@link AbstractComparableAssert#isEqualByComparingTo(Comparable)} over more contrived
+   * alternatives.
+   */
   static final class AssertThatIsEqualByComparingTo<T extends Comparable<? super T>> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(T actual, T expected) {
-      return assertThat(actual.compareTo(expected)).isEqualTo(0);
+    AbstractIntegerAssert<?> before(T actual, T other) {
+      return assertThat(actual.compareTo(other)).isEqualTo(0);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractComparableAssert<?, ?> after(T actual, T expected) {
-      return assertThat(actual).isEqualByComparingTo(expected);
+    AbstractComparableAssert<?, T> after(T actual, T other) {
+      return assertThat(actual).isEqualByComparingTo(other);
     }
   }
 
+  /**
+   * Prefer {@link AbstractComparableAssert#isNotEqualByComparingTo(Comparable)} over more contrived
+   * alternatives.
+   */
   static final class AssertThatIsNotEqualByComparingTo<T extends Comparable<? super T>> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(T actual, T expected) {
-      return assertThat(actual.compareTo(expected)).isNotEqualTo(0);
+    AbstractIntegerAssert<?> before(T actual, T other) {
+      return assertThat(actual.compareTo(other)).isNotEqualTo(0);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractComparableAssert<?, ?> after(T actual, T expected) {
-      return assertThat(actual).isNotEqualByComparingTo(expected);
+    AbstractComparableAssert<?, T> after(T actual, T other) {
+      return assertThat(actual).isNotEqualByComparingTo(other);
     }
   }
 
+  /**
+   * Prefer {@link AbstractComparableAssert#isLessThan(Comparable)} over more contrived
+   * alternatives.
+   */
   static final class AssertThatIsLessThan<T extends Comparable<? super T>> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(T actual, T expected) {
-      return assertThat(actual.compareTo(expected)).isNegative();
+    AbstractIntegerAssert<?> before(T actual, T other) {
+      return assertThat(actual.compareTo(other)).isNegative();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractComparableAssert<?, ?> after(T actual, T expected) {
-      return assertThat(actual).isLessThan(expected);
+    AbstractComparableAssert<?, T> after(T actual, T other) {
+      return assertThat(actual).isLessThan(other);
     }
   }
 
+  /**
+   * Prefer {@link AbstractComparableAssert#isLessThanOrEqualTo(Comparable)} over more contrived
+   * alternatives.
+   */
   static final class AssertThatIsLessThanOrEqualTo<T extends Comparable<? super T>> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(T actual, T expected) {
-      return assertThat(actual.compareTo(expected)).isNotPositive();
+    AbstractIntegerAssert<?> before(T actual, T other) {
+      return assertThat(actual.compareTo(other)).isNotPositive();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractComparableAssert<?, ?> after(T actual, T expected) {
-      return assertThat(actual).isLessThanOrEqualTo(expected);
+    AbstractComparableAssert<?, T> after(T actual, T other) {
+      return assertThat(actual).isLessThanOrEqualTo(other);
     }
   }
 
+  /**
+   * Prefer {@link AbstractComparableAssert#isGreaterThan(Comparable)} over more contrived
+   * alternatives.
+   */
   static final class AssertThatIsGreaterThan<T extends Comparable<? super T>> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(T actual, T expected) {
-      return assertThat(actual.compareTo(expected)).isPositive();
+    AbstractIntegerAssert<?> before(T actual, T other) {
+      return assertThat(actual.compareTo(other)).isPositive();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractComparableAssert<?, ?> after(T actual, T expected) {
-      return assertThat(actual).isGreaterThan(expected);
+    AbstractComparableAssert<?, T> after(T actual, T other) {
+      return assertThat(actual).isGreaterThan(other);
     }
   }
 
+  /**
+   * Prefer {@link AbstractComparableAssert#isGreaterThanOrEqualTo(Comparable)} over more contrived
+   * alternatives.
+   */
   static final class AssertThatIsGreaterThanOrEqualTo<T extends Comparable<? super T>> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(T actual, T expected) {
-      return assertThat(actual.compareTo(expected)).isNotNegative();
+    AbstractIntegerAssert<?> before(T actual, T other) {
+      return assertThat(actual.compareTo(other)).isNotNegative();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractComparableAssert<?, ?> after(T actual, T expected) {
-      return assertThat(actual).isGreaterThanOrEqualTo(expected);
+    AbstractComparableAssert<?, T> after(T actual, T other) {
+      return assertThat(actual).isGreaterThanOrEqualTo(other);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDoubleRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDoubleRules.java
@@ -15,54 +15,61 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJDoubleRules {
   private AssertJDoubleRules() {}
 
-  static final class AbstractDoubleAssertIsCloseToWithOffset {
+  /**
+   * Prefer {@link AbstractDoubleAssert#isCloseTo(double, Offset)} over less explicit alternatives.
+   */
+  static final class AbstractDoubleAssertIsCloseTo {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(
-        AbstractDoubleAssert<?> doubleAssert, double n, Offset<Double> offset) {
-      return doubleAssert.isEqualTo(n, offset);
+        AbstractDoubleAssert<?> doubleAssert, double expected, Offset<Double> offset) {
+      return doubleAssert.isEqualTo(expected, offset);
     }
 
     @BeforeTemplate
     AbstractDoubleAssert<?> before(
-        AbstractDoubleAssert<?> doubleAssert, Double n, Offset<Double> offset) {
-      return doubleAssert.isEqualTo(n, offset);
+        AbstractDoubleAssert<?> doubleAssert, Double expected, Offset<Double> offset) {
+      return doubleAssert.isEqualTo(expected, offset);
     }
 
     @AfterTemplate
     AbstractDoubleAssert<?> after(
-        AbstractDoubleAssert<?> doubleAssert, double n, Offset<Double> offset) {
-      return doubleAssert.isCloseTo(n, offset);
+        AbstractDoubleAssert<?> doubleAssert, double expected, Offset<Double> offset) {
+      return doubleAssert.isCloseTo(expected, offset);
     }
   }
 
+  /** Prefer {@link AbstractDoubleAssert#isEqualTo(double)} over more contrived alternatives. */
   static final class AbstractDoubleAssertIsEqualTo {
     @BeforeTemplate
-    AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert, double n) {
+    AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert, double expected) {
       return Refaster.anyOf(
-          doubleAssert.isCloseTo(n, offset(0.0)), doubleAssert.isCloseTo(n, withPercentage(0.0)));
+          doubleAssert.isCloseTo(expected, offset(0.0)),
+          doubleAssert.isCloseTo(expected, withPercentage(0.0)));
     }
 
     @AfterTemplate
-    AbstractDoubleAssert<?> after(AbstractDoubleAssert<?> doubleAssert, double n) {
-      return doubleAssert.isEqualTo(n);
+    AbstractDoubleAssert<?> after(AbstractDoubleAssert<?> doubleAssert, double expected) {
+      return doubleAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@link AbstractDoubleAssert#isNotEqualTo(double)} over more contrived alternatives. */
   static final class AbstractDoubleAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert, double n) {
+    AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert, double other) {
       return Refaster.anyOf(
-          doubleAssert.isNotCloseTo(n, offset(0.0)),
-          doubleAssert.isNotCloseTo(n, withPercentage(0.0)));
+          doubleAssert.isNotCloseTo(other, offset(0.0)),
+          doubleAssert.isNotCloseTo(other, withPercentage(0.0)));
     }
 
     @AfterTemplate
-    AbstractDoubleAssert<?> after(AbstractDoubleAssert<?> doubleAssert, double n) {
-      return doubleAssert.isNotEqualTo(n);
+    AbstractDoubleAssert<?> after(AbstractDoubleAssert<?> doubleAssert, double other) {
+      return doubleAssert.isNotEqualTo(other);
     }
   }
 
-  static final class AbstractDoubleAssertIsZero {
+  /** Prefer {@link AbstractDoubleAssert#isEqualTo(double)} over less explicit alternatives. */
+  static final class AbstractDoubleAssertIsEqualToZero {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert) {
       return doubleAssert.isZero();
@@ -74,7 +81,8 @@ final class AssertJDoubleRules {
     }
   }
 
-  static final class AbstractDoubleAssertIsNotZero {
+  /** Prefer {@link AbstractDoubleAssert#isNotEqualTo(double)} over less explicit alternatives. */
+  static final class AbstractDoubleAssertIsNotEqualToZero {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert) {
       return doubleAssert.isNotZero();
@@ -86,7 +94,8 @@ final class AssertJDoubleRules {
     }
   }
 
-  static final class AbstractDoubleAssertIsOne {
+  /** Prefer {@link AbstractDoubleAssert#isEqualTo(double)} over less explicit alternatives. */
+  static final class AbstractDoubleAssertIsEqualToOne {
     @BeforeTemplate
     AbstractDoubleAssert<?> before(AbstractDoubleAssert<?> doubleAssert) {
       return doubleAssert.isOne();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJDurationRules.java
@@ -10,142 +10,146 @@ import org.assertj.core.api.AbstractDurationAssert;
 import org.assertj.core.api.AbstractLongAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/**
- * Refaster rules related to AssertJ assertions over {@link Duration}s.
- *
- * <p>These rules simplify and improve the readability of tests by using {@link Duration}-specific
- * AssertJ assertion methods instead of generic assertions.
- */
+/** Refaster rules related to AssertJ assertions over {@link Duration}s. */
 @OnlineDocumentation
 final class AssertJDurationRules {
   private AssertJDurationRules() {}
 
+  /** Prefer {@link AbstractDurationAssert#hasNanos(long)} over less explicit alternatives. */
   static final class AssertThatHasNanos {
     @BeforeTemplate
-    AbstractLongAssert<?> before(Duration duration, long nanos) {
-      return assertThat(duration.toNanos()).isEqualTo(nanos);
+    AbstractLongAssert<?> before(Duration actual, long otherNanos) {
+      return assertThat(actual.toNanos()).isEqualTo(otherNanos);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration, long nanos) {
-      return assertThat(duration).hasNanos(nanos);
+    AbstractDurationAssert<?> after(Duration actual, long otherNanos) {
+      return assertThat(actual).hasNanos(otherNanos);
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#hasMillis(long)} over less explicit alternatives. */
   static final class AssertThatHasMillis {
     @BeforeTemplate
-    AbstractLongAssert<?> before(Duration duration, long millis) {
-      return assertThat(duration.toMillis()).isEqualTo(millis);
+    AbstractLongAssert<?> before(Duration actual, long otherMillis) {
+      return assertThat(actual.toMillis()).isEqualTo(otherMillis);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration, long millis) {
-      return assertThat(duration).hasMillis(millis);
+    AbstractDurationAssert<?> after(Duration actual, long otherMillis) {
+      return assertThat(actual).hasMillis(otherMillis);
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#hasSeconds(long)} over less explicit alternatives. */
   static final class AssertThatHasSeconds {
     @BeforeTemplate
-    AbstractLongAssert<?> before(Duration duration, long seconds) {
-      return assertThat(duration.toSeconds()).isEqualTo(seconds);
+    AbstractLongAssert<?> before(Duration actual, long otherSeconds) {
+      return assertThat(actual.toSeconds()).isEqualTo(otherSeconds);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration, long seconds) {
-      return assertThat(duration).hasSeconds(seconds);
+    AbstractDurationAssert<?> after(Duration actual, long otherSeconds) {
+      return assertThat(actual).hasSeconds(otherSeconds);
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#hasMinutes(long)} over less explicit alternatives. */
   static final class AssertThatHasMinutes {
     @BeforeTemplate
-    AbstractLongAssert<?> before(Duration duration, long minutes) {
-      return assertThat(duration.toMinutes()).isEqualTo(minutes);
+    AbstractLongAssert<?> before(Duration actual, long otherMinutes) {
+      return assertThat(actual.toMinutes()).isEqualTo(otherMinutes);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration, long minutes) {
-      return assertThat(duration).hasMinutes(minutes);
+    AbstractDurationAssert<?> after(Duration actual, long otherMinutes) {
+      return assertThat(actual).hasMinutes(otherMinutes);
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#hasHours(long)} over less explicit alternatives. */
   static final class AssertThatHasHours {
     @BeforeTemplate
-    AbstractLongAssert<?> before(Duration duration, long hours) {
-      return assertThat(duration.toHours()).isEqualTo(hours);
+    AbstractLongAssert<?> before(Duration actual, long otherHours) {
+      return assertThat(actual.toHours()).isEqualTo(otherHours);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration, long hours) {
-      return assertThat(duration).hasHours(hours);
+    AbstractDurationAssert<?> after(Duration actual, long otherHours) {
+      return assertThat(actual).hasHours(otherHours);
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#hasDays(long)} over less explicit alternatives. */
   static final class AssertThatHasDays {
     @BeforeTemplate
-    AbstractLongAssert<?> before(Duration duration, long days) {
-      return assertThat(duration.toDays()).isEqualTo(days);
+    AbstractLongAssert<?> before(Duration actual, long otherDays) {
+      return assertThat(actual.toDays()).isEqualTo(otherDays);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration, long days) {
-      return assertThat(duration).hasDays(days);
+    AbstractDurationAssert<?> after(Duration actual, long otherDays) {
+      return assertThat(actual).hasDays(otherDays);
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#isZero()} over less explicit alternatives. */
   static final class AssertThatIsZero {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Duration duration) {
-      return assertThat(duration.isZero()).isTrue();
+    AbstractBooleanAssert<?> before(Duration actual) {
+      return assertThat(actual.isZero()).isTrue();
     }
 
     // XXX: This method can be folded into the preceding method using `Refaster#anyOf`, but by
     // keeping it separate, we show that this rule, contrary to the other one, retains the correct
     // return type.
     @BeforeTemplate
-    AbstractDurationAssert<?> before2(Duration duration) {
-      return assertThat(duration).isEqualTo(Duration.ZERO);
+    AbstractDurationAssert<?> before2(Duration actual) {
+      return assertThat(actual).isEqualTo(Duration.ZERO);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration) {
-      return assertThat(duration).isZero();
+    AbstractDurationAssert<?> after(Duration actual) {
+      return assertThat(actual).isZero();
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#isPositive()} over less explicit alternatives. */
   static final class AssertThatIsPositive {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Duration duration) {
-      return assertThat(duration.isPositive()).isTrue();
+    AbstractBooleanAssert<?> before(Duration actual) {
+      return assertThat(actual.isPositive()).isTrue();
     }
 
     @BeforeTemplate
-    AbstractDurationAssert<?> before2(Duration duration) {
-      return assertThat(duration).isGreaterThan(Duration.ZERO);
+    AbstractDurationAssert<?> before2(Duration actual) {
+      return assertThat(actual).isGreaterThan(Duration.ZERO);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration) {
-      return assertThat(duration).isPositive();
+    AbstractDurationAssert<?> after(Duration actual) {
+      return assertThat(actual).isPositive();
     }
   }
 
+  /** Prefer {@link AbstractDurationAssert#isNegative()} over less explicit alternatives. */
   static final class AssertThatIsNegative {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Duration duration) {
-      return assertThat(duration.isNegative()).isTrue();
+    AbstractBooleanAssert<?> before(Duration actual) {
+      return assertThat(actual.isNegative()).isTrue();
     }
 
     // XXX: This method can be folded into the preceding method using `Refaster#anyOf`, but by
     // keeping it separate, we show that this rule, contrary to the other one, retains the correct
     // return type.
     @BeforeTemplate
-    AbstractDurationAssert<?> before2(Duration duration) {
-      return assertThat(duration).isLessThan(Duration.ZERO);
+    AbstractDurationAssert<?> before2(Duration actual) {
+      return assertThat(actual).isLessThan(Duration.ZERO);
     }
 
     @AfterTemplate
-    AbstractDurationAssert<?> after(Duration duration) {
-      return assertThat(duration).isNegative();
+    AbstractDurationAssert<?> after(Duration actual) {
+      return assertThat(actual).isNegative();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJEnumerableRules.java
@@ -6,7 +6,7 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Matches;
 import java.util.Collection;
-import org.assertj.core.api.AbstractIntegerAssert;
+import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractIterableAssert;
 import org.assertj.core.api.AbstractIterableSizeAssert;
 import org.assertj.core.api.Assert;
@@ -20,51 +20,53 @@ import tech.picnic.errorprone.refaster.matchers.IsEmpty;
 final class AssertJEnumerableRules {
   private AssertJEnumerableRules() {}
 
+  /** Prefer {@link EnumerableAssert#isEmpty()} over more contrived alternatives. */
   static final class EnumerableAssertIsEmpty<E> {
     @BeforeTemplate
     void before(
-        EnumerableAssert<?, E> enumAssert, @Matches(IsEmpty.class) Iterable<?> emptyIterable) {
+        EnumerableAssert<?, E> enumerableAssert, @Matches(IsEmpty.class) Iterable<?> emptyOther) {
       Refaster.anyOf(
-          enumAssert.hasSize(0),
-          enumAssert.hasSizeLessThanOrEqualTo(0),
-          enumAssert.hasSizeLessThan(1),
-          enumAssert.hasSameSizeAs(emptyIterable));
+          enumerableAssert.hasSize(0),
+          enumerableAssert.hasSizeLessThanOrEqualTo(0),
+          enumerableAssert.hasSizeLessThan(1),
+          enumerableAssert.hasSameSizeAs(emptyOther));
     }
 
     @BeforeTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
     void before(
-        ObjectEnumerableAssert<?, E> enumAssert,
-        @Matches(IsEmpty.class) Iterable<? extends E> emptyIterable) {
+        ObjectEnumerableAssert<?, E> enumerableAssert,
+        @Matches(IsEmpty.class) Iterable<? extends E> emptyOther) {
       Refaster.anyOf(
-          enumAssert.containsExactlyElementsOf(emptyIterable),
-          enumAssert.containsExactlyInAnyOrderElementsOf(emptyIterable),
-          enumAssert.hasSameElementsAs(emptyIterable),
-          enumAssert.isSubsetOf(emptyIterable),
-          enumAssert.containsExactly(),
-          enumAssert.containsExactlyInAnyOrder(),
-          enumAssert.containsOnly(),
-          enumAssert.isSubsetOf());
+          enumerableAssert.containsExactlyElementsOf(emptyOther),
+          enumerableAssert.containsExactlyInAnyOrderElementsOf(emptyOther),
+          enumerableAssert.hasSameElementsAs(emptyOther),
+          enumerableAssert.isSubsetOf(emptyOther),
+          enumerableAssert.containsExactly(),
+          enumerableAssert.containsExactlyInAnyOrder(),
+          enumerableAssert.containsOnly(),
+          enumerableAssert.isSubsetOf());
     }
 
     @BeforeTemplate
-    void before(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
-      enumAssert.size().isNotPositive();
+    void before(AbstractIterableAssert<?, ?, E, ?> enumerableAssert) {
+      enumerableAssert.size().isNotPositive();
     }
 
     @AfterTemplate
-    void after(EnumerableAssert<?, E> enumAssert) {
-      enumAssert.isEmpty();
+    void after(EnumerableAssert<?, E> enumerableAssert) {
+      enumerableAssert.isEmpty();
     }
   }
 
+  /** Prefer {@link EnumerableAssert#isEmpty()} over more contrived alternatives. */
   // XXX: This rule assumes that the rewritten assertion aims to compare the contents of two
   // iterables, rather than other semantics (such as `Set` vs. `List`).
-  static final class AssertAndEnumerableAssertIsEmpty<
+  static final class AssertIsEmpty<
       E, A extends Assert<?, ? extends Iterable<? extends E>> & EnumerableAssert<?, E>> {
     @BeforeTemplate
-    void before(A enumAssert, @Matches(IsEmpty.class) Iterable<?> emptyIterable) {
-      enumAssert.isEqualTo(emptyIterable);
+    void before(A enumAssert, @Matches(IsEmpty.class) Iterable<?> emptyExpected) {
+      enumAssert.isEqualTo(emptyExpected);
     }
 
     @AfterTemplate
@@ -73,183 +75,210 @@ final class AssertJEnumerableRules {
     }
   }
 
+  /** Prefer {@link EnumerableAssert#isNotEmpty()} over more contrived alternatives. */
   static final class EnumerableAssertIsNotEmpty<E> {
     @BeforeTemplate
-    EnumerableAssert<?, E> before(EnumerableAssert<?, E> enumAssert) {
+    EnumerableAssert<?, E> before(EnumerableAssert<?, E> enumerableAssert) {
       return Refaster.anyOf(
-          enumAssert.hasSizeGreaterThan(0), enumAssert.hasSizeGreaterThanOrEqualTo(1));
+          enumerableAssert.hasSizeGreaterThan(0), enumerableAssert.hasSizeGreaterThanOrEqualTo(1));
     }
 
     @BeforeTemplate
-    AbstractIterableAssert<?, ?, E, ?> before(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
+    AbstractIterableAssert<?, ?, E, ?> before(AbstractIterableAssert<?, ?, E, ?> enumerableAssert) {
       return Refaster.anyOf(
-          enumAssert.size().isNotEqualTo(0).returnToIterable(),
-          enumAssert.size().isPositive().returnToIterable());
+          enumerableAssert.size().isNotEqualTo(0).returnToIterable(),
+          enumerableAssert.size().isPositive().returnToIterable());
     }
 
-    // XXX: If this template matches, then the expression's return type changes incompatibly.
-    // Consider moving this template to a separate block (statement) rule.
     @BeforeTemplate
-    AbstractIntegerAssert<?> before2(AbstractIterableAssert<?, ?, E, ?> enumAssert) {
-      return Refaster.anyOf(enumAssert.size().isNotEqualTo(0), enumAssert.size().isPositive());
+    AbstractIterableSizeAssert<
+            ? extends
+                AbstractIterableAssert<
+                    ? extends AbstractIterableAssert<?, ?, E, ?>,
+                    ? extends Iterable<? extends E>,
+                    E,
+                    ? extends AbstractAssert<? extends AbstractAssert<?, E>, E>>,
+            ? extends Iterable<? extends E>,
+            E,
+            ? extends AbstractAssert<? extends AbstractAssert<?, E>, E>>
+        before2(AbstractIterableAssert<?, ?, E, ?> enumerableAssert) {
+      return Refaster.anyOf(
+          enumerableAssert.size().isNotEqualTo(0), enumerableAssert.size().isPositive());
     }
 
     @AfterTemplate
-    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert) {
-      return enumAssert.isNotEmpty();
+    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumerableAssert) {
+      return enumerableAssert.isNotEmpty();
     }
   }
 
+  /** Prefer {@link EnumerableAssert#hasSize(int)} over more verbose alternatives. */
   static final class EnumerableAssertHasSize<E> {
     @BeforeTemplate
     AbstractIterableAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isEqualTo(size).returnToIterable();
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int expected) {
+      return enumerableAssert.size().isEqualTo(expected).returnToIterable();
     }
 
     // XXX: If this template matches, then the expression's return type changes incompatibly.
     // Consider moving this template to a separate block (statement) rule.
     @BeforeTemplate
     AbstractIterableSizeAssert<?, ?, E, ?> before2(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isEqualTo(size);
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int expected) {
+      return enumerableAssert.size().isEqualTo(expected);
     }
 
     @AfterTemplate
-    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
-      return enumAssert.hasSize(size);
+    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumerableAssert, int expected) {
+      return enumerableAssert.hasSize(expected);
     }
   }
 
+  /** Prefer {@link EnumerableAssert#hasSizeLessThan(int)} over more verbose alternatives. */
   static final class EnumerableAssertHasSizeLessThan<E> {
     @BeforeTemplate
     AbstractIterableAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isLessThan(size).returnToIterable();
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isLessThan(boundary).returnToIterable();
     }
 
     // XXX: If this template matches, then the expression's return type changes incompatibly.
     // Consider moving this template to a separate block (statement) rule.
     @BeforeTemplate
     AbstractIterableSizeAssert<?, ?, E, ?> before2(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isLessThan(size);
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isLessThan(boundary);
     }
 
     @AfterTemplate
-    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
-      return enumAssert.hasSizeLessThan(size);
+    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumerableAssert, int boundary) {
+      return enumerableAssert.hasSizeLessThan(boundary);
     }
   }
 
+  /**
+   * Prefer {@link EnumerableAssert#hasSizeLessThanOrEqualTo(int)} over more verbose alternatives.
+   */
   static final class EnumerableAssertHasSizeLessThanOrEqualTo<E> {
     @BeforeTemplate
     AbstractIterableAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isLessThanOrEqualTo(size).returnToIterable();
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isLessThanOrEqualTo(boundary).returnToIterable();
     }
 
     // XXX: If this template matches, then the expression's return type changes incompatibly.
     // Consider moving this template to a separate block (statement) rule.
     @BeforeTemplate
     AbstractIterableSizeAssert<?, ?, E, ?> before2(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isLessThanOrEqualTo(size);
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isLessThanOrEqualTo(boundary);
     }
 
     @AfterTemplate
-    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
-      return enumAssert.hasSizeLessThanOrEqualTo(size);
+    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumerableAssert, int boundary) {
+      return enumerableAssert.hasSizeLessThanOrEqualTo(boundary);
     }
   }
 
+  /** Prefer {@link EnumerableAssert#hasSizeGreaterThan(int)} over more verbose alternatives. */
   static final class EnumerableAssertHasSizeGreaterThan<E> {
     @BeforeTemplate
     AbstractIterableAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isGreaterThan(size).returnToIterable();
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isGreaterThan(boundary).returnToIterable();
     }
 
     // XXX: If this template matches, then the expression's return type changes incompatibly.
     // Consider moving this template to a separate block (statement) rule.
     @BeforeTemplate
     AbstractIterableSizeAssert<?, ?, E, ?> before2(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isGreaterThan(size);
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isGreaterThan(boundary);
     }
 
     @AfterTemplate
-    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
-      return enumAssert.hasSizeGreaterThan(size);
+    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumerableAssert, int boundary) {
+      return enumerableAssert.hasSizeGreaterThan(boundary);
     }
   }
 
+  /**
+   * Prefer {@link EnumerableAssert#hasSizeGreaterThanOrEqualTo(int)} over more verbose
+   * alternatives.
+   */
   static final class EnumerableAssertHasSizeGreaterThanOrEqualTo<E> {
     @BeforeTemplate
     AbstractIterableAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isGreaterThanOrEqualTo(size).returnToIterable();
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isGreaterThanOrEqualTo(boundary).returnToIterable();
     }
 
     // XXX: If this template matches, then the expression's return type changes incompatibly.
     // Consider moving this template to a separate block (statement) rule.
     @BeforeTemplate
     AbstractIterableSizeAssert<?, ?, E, ?> before2(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int size) {
-      return enumAssert.size().isGreaterThanOrEqualTo(size);
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert, int boundary) {
+      return enumerableAssert.size().isGreaterThanOrEqualTo(boundary);
     }
 
     @AfterTemplate
-    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int size) {
-      return enumAssert.hasSizeGreaterThanOrEqualTo(size);
+    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumerableAssert, int boundary) {
+      return enumerableAssert.hasSizeGreaterThanOrEqualTo(boundary);
     }
   }
 
+  /** Prefer {@link EnumerableAssert#hasSizeBetween(int, int)} over more verbose alternatives. */
   static final class EnumerableAssertHasSizeBetween<E> {
     @BeforeTemplate
     AbstractIterableAssert<?, ?, E, ?> before(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int lower, int upper) {
-      return enumAssert.size().isBetween(lower, upper).returnToIterable();
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert,
+        int lowerBoundary,
+        int higherBoundary) {
+      return enumerableAssert.size().isBetween(lowerBoundary, higherBoundary).returnToIterable();
     }
 
     // XXX: If this template matches, then the expression's return type changes incompatibly.
     // Consider moving this template to a separate block (statement) rule.
     @BeforeTemplate
     AbstractIterableSizeAssert<?, ?, E, ?> before2(
-        AbstractIterableAssert<?, ?, E, ?> enumAssert, int lower, int upper) {
-      return enumAssert.size().isBetween(lower, upper);
+        AbstractIterableAssert<?, ?, E, ?> enumerableAssert,
+        int lowerBoundary,
+        int higherBoundary) {
+      return enumerableAssert.size().isBetween(lowerBoundary, higherBoundary);
     }
 
     @AfterTemplate
-    EnumerableAssert<?, E> after(EnumerableAssert<?, E> enumAssert, int lower, int upper) {
-      return enumAssert.hasSizeBetween(lower, upper);
+    EnumerableAssert<?, E> after(
+        EnumerableAssert<?, E> enumerableAssert, int lowerBoundary, int higherBoundary) {
+      return enumerableAssert.hasSizeBetween(lowerBoundary, higherBoundary);
     }
   }
 
+  /** Prefer {@link EnumerableAssert#hasSameSizeAs(Iterable)} over more verbose alternatives. */
   static final class EnumerableAssertHasSameSizeAs<S, E> {
     @BeforeTemplate
-    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumAssert, Iterable<E> iterable) {
-      return enumAssert.hasSize(Iterables.size(iterable));
+    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumerableAssert, Iterable<E> other) {
+      return enumerableAssert.hasSize(Iterables.size(other));
     }
 
     @BeforeTemplate
-    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumAssert, Collection<E> iterable) {
-      return enumAssert.hasSize(iterable.size());
+    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumerableAssert, Collection<E> other) {
+      return enumerableAssert.hasSize(other.size());
     }
 
     @BeforeTemplate
-    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumAssert, E[] iterable) {
-      return enumAssert.hasSize(iterable.length);
+    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumerableAssert, E[] other) {
+      return enumerableAssert.hasSize(other.length);
     }
 
     @BeforeTemplate
-    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumAssert, CharSequence iterable) {
-      return enumAssert.hasSize(iterable.length());
+    EnumerableAssert<?, S> before(EnumerableAssert<?, S> enumerableAssert, CharSequence other) {
+      return enumerableAssert.hasSize(other.length());
     }
 
     @AfterTemplate
-    EnumerableAssert<?, S> after(EnumerableAssert<?, S> enumAssert, Iterable<E> iterable) {
-      return enumAssert.hasSameSizeAs(iterable);
+    EnumerableAssert<?, S> after(EnumerableAssert<?, S> enumerableAssert, Iterable<E> other) {
+      return enumerableAssert.hasSameSizeAs(other);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJFileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJFileRules.java
@@ -11,16 +11,12 @@ import org.assertj.core.api.AbstractFileAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/**
- * Refaster rules related to AssertJ assertions over {@link File}s.
- *
- * <p>These rules simplify and improve the readability of tests by using {@link File}-specific
- * AssertJ assertion methods instead of generic assertions.
- */
+/** Refaster rules related to AssertJ assertions over {@link File}s. */
 @OnlineDocumentation
 final class AssertJFileRules {
   private AssertJFileRules() {}
 
+  /** Prefer {@link AbstractFileAssert#exists()} over more verbose alternatives. */
   static final class AssertThatExists {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -33,6 +29,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#doesNotExist()} over more verbose alternatives. */
   static final class AssertThatDoesNotExist {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -45,6 +42,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#isFile()} over more verbose alternatives. */
   static final class AssertThatIsFile {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -57,6 +55,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#isDirectory()} over more verbose alternatives. */
   static final class AssertThatIsDirectory {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -69,6 +68,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#isAbsolute()} over more verbose alternatives. */
   static final class AssertThatIsAbsolute {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -81,6 +81,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#isRelative()} over more verbose alternatives. */
   static final class AssertThatIsRelative {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -93,6 +94,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#isReadable()} over more verbose alternatives. */
   static final class AssertThatIsReadable {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -105,6 +107,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#isWritable()} over more verbose alternatives. */
   static final class AssertThatIsWritable {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -117,6 +120,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#isExecutable()} over more verbose alternatives. */
   static final class AssertThatIsExecutable {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(File actual) {
@@ -129,18 +133,20 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#hasFileName(String)} over more verbose alternatives. */
   static final class AssertThatHasFileName {
     @BeforeTemplate
-    AbstractStringAssert<?> before(File actual, String fileName) {
-      return assertThat(actual.getName()).isEqualTo(fileName);
+    AbstractStringAssert<?> before(File actual, String expected) {
+      return assertThat(actual.getName()).isEqualTo(expected);
     }
 
     @AfterTemplate
-    AbstractFileAssert<?> after(File actual, String fileName) {
-      return assertThat(actual).hasFileName(fileName);
+    AbstractFileAssert<?> after(File actual, String expected) {
+      return assertThat(actual).hasFileName(expected);
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#hasParent(File)} over more verbose alternatives. */
   // XXX: This rule changes the `File` against which subsequent assertions are made.
   static final class AssertThatHasParentFile {
     @BeforeTemplate
@@ -154,6 +160,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#hasParent(String)} over more verbose alternatives. */
   // XXX: This rule changes the `File` against which subsequent assertions are made.
   static final class AssertThatHasParentString {
     @BeforeTemplate
@@ -167,6 +174,7 @@ final class AssertJFileRules {
     }
   }
 
+  /** Prefer {@link AbstractFileAssert#hasNoParent()} over more verbose alternatives. */
   static final class AssertThatHasNoParent {
     @BeforeTemplate
     void before(File actual) {
@@ -180,19 +188,19 @@ final class AssertJFileRules {
   }
 
   /**
-   * Prefer using {@link AbstractFileAssert#hasExtension(String)} over more verbose and less
-   * accurate alternatives.
+   * Prefer {@link AbstractFileAssert#hasExtension(String)} over more verbose or less explicit
+   * alternatives.
    */
   static final class AssertThatHasExtension {
     @BeforeTemplate
-    AbstractStringAssert<?> before(File actual, String expectedExtension) {
+    AbstractStringAssert<?> before(File actual, String expected) {
       return assertThat(Refaster.anyOf(actual.getName(), actual.toString()))
-          .endsWith(Refaster.anyOf('.' + expectedExtension, "." + expectedExtension));
+          .endsWith(Refaster.anyOf('.' + expected, "." + expected));
     }
 
     @AfterTemplate
-    AbstractFileAssert<?> after(File actual, String expectedExtension) {
-      return assertThat(actual).hasExtension(expectedExtension);
+    AbstractFileAssert<?> after(File actual, String expected) {
+      return assertThat(actual).hasExtension(expected);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJFloatRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJFloatRules.java
@@ -15,53 +15,61 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJFloatRules {
   private AssertJFloatRules() {}
 
-  static final class AbstractFloatAssertIsCloseToWithOffset {
+  /**
+   * Prefer {@link AbstractFloatAssert#isCloseTo(float, Offset)} over less explicit alternatives.
+   */
+  static final class AbstractFloatAssertIsCloseTo {
     @BeforeTemplate
     AbstractFloatAssert<?> before(
-        AbstractFloatAssert<?> floatAssert, float n, Offset<Float> offset) {
-      return floatAssert.isEqualTo(n, offset);
+        AbstractFloatAssert<?> floatAssert, float expected, Offset<Float> offset) {
+      return floatAssert.isEqualTo(expected, offset);
     }
 
     @BeforeTemplate
     AbstractFloatAssert<?> before(
-        AbstractFloatAssert<?> floatAssert, Float n, Offset<Float> offset) {
-      return floatAssert.isEqualTo(n, offset);
+        AbstractFloatAssert<?> floatAssert, Float expected, Offset<Float> offset) {
+      return floatAssert.isEqualTo(expected, offset);
     }
 
     @AfterTemplate
     AbstractFloatAssert<?> after(
-        AbstractFloatAssert<?> floatAssert, float n, Offset<Float> offset) {
-      return floatAssert.isCloseTo(n, offset);
+        AbstractFloatAssert<?> floatAssert, float expected, Offset<Float> offset) {
+      return floatAssert.isCloseTo(expected, offset);
     }
   }
 
+  /** Prefer {@link AbstractFloatAssert#isEqualTo(float)} over more contrived alternatives. */
   static final class AbstractFloatAssertIsEqualTo {
     @BeforeTemplate
-    AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert, float n) {
+    AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert, float expected) {
       return Refaster.anyOf(
-          floatAssert.isCloseTo(n, offset(0f)), floatAssert.isCloseTo(n, withPercentage(0)));
+          floatAssert.isCloseTo(expected, offset(0f)),
+          floatAssert.isCloseTo(expected, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractFloatAssert<?> after(AbstractFloatAssert<?> floatAssert, float n) {
-      return floatAssert.isEqualTo(n);
+    AbstractFloatAssert<?> after(AbstractFloatAssert<?> floatAssert, float expected) {
+      return floatAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@link AbstractFloatAssert#isNotEqualTo(float)} over more contrived alternatives. */
   static final class AbstractFloatAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert, float n) {
+    AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert, float other) {
       return Refaster.anyOf(
-          floatAssert.isNotCloseTo(n, offset(0f)), floatAssert.isNotCloseTo(n, withPercentage(0)));
+          floatAssert.isNotCloseTo(other, offset(0f)),
+          floatAssert.isNotCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractFloatAssert<?> after(AbstractFloatAssert<?> floatAssert, float n) {
-      return floatAssert.isNotEqualTo(n);
+    AbstractFloatAssert<?> after(AbstractFloatAssert<?> floatAssert, float other) {
+      return floatAssert.isNotEqualTo(other);
     }
   }
 
-  static final class AbstractFloatAssertIsZero {
+  /** Prefer {@code isEqualTo(0)} over more contrived alternatives. */
+  static final class AbstractFloatAssertIsEqualToZero {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
       return floatAssert.isZero();
@@ -73,7 +81,8 @@ final class AssertJFloatRules {
     }
   }
 
-  static final class AbstractFloatAssertIsNotZero {
+  /** Prefer {@code isNotEqualTo(0)} over more contrived alternatives. */
+  static final class AbstractFloatAssertIsNotEqualToZero {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
       return floatAssert.isNotZero();
@@ -85,7 +94,8 @@ final class AssertJFloatRules {
     }
   }
 
-  static final class AbstractFloatAssertIsOne {
+  /** Prefer {@code isEqualTo(1)} over more contrived alternatives. */
+  static final class AbstractFloatAssertIsEqualToOne {
     @BeforeTemplate
     AbstractFloatAssert<?> before(AbstractFloatAssert<?> floatAssert) {
       return floatAssert.isOne();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJInstantRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJInstantRules.java
@@ -10,16 +10,12 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractInstantAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/**
- * Refaster rules related to AssertJ assertions over {@link Instant}s.
- *
- * <p>These rules simplify and improve the readability of tests by using {@link Instant}-specific
- * AssertJ assertion methods instead of generic assertions.
- */
+/** Refaster rules related to AssertJ assertions over {@link Instant}s. */
 @OnlineDocumentation
 final class AssertJInstantRules {
   private AssertJInstantRules() {}
 
+  /** Prefer {@link AbstractInstantAssert#isAfter(Instant)} over less explicit alternatives. */
   static final class AssertThatIsAfter {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Instant actual, Instant other) {
@@ -32,6 +28,10 @@ final class AssertJInstantRules {
     }
   }
 
+  /**
+   * Prefer {@link AbstractInstantAssert#isBeforeOrEqualTo(Instant)} over less explicit
+   * alternatives.
+   */
   static final class AssertThatIsBeforeOrEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Instant actual, Instant other) {
@@ -44,6 +44,7 @@ final class AssertJInstantRules {
     }
   }
 
+  /** Prefer {@link AbstractInstantAssert#isBefore(Instant)} over less explicit alternatives. */
   static final class AssertThatIsBefore {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Instant actual, Instant other) {
@@ -56,6 +57,9 @@ final class AssertJInstantRules {
     }
   }
 
+  /**
+   * Prefer {@link AbstractInstantAssert#isAfterOrEqualTo(Instant)} over less explicit alternatives.
+   */
   static final class AssertThatIsAfterOrEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Instant actual, Instant other) {
@@ -68,31 +72,39 @@ final class AssertJInstantRules {
     }
   }
 
+  /**
+   * Prefer {@link AbstractInstantAssert#isBetween(Instant, Instant)} over more verbose
+   * alternatives.
+   */
   static final class AssertThatIsBetween {
     @BeforeTemplate
-    AbstractInstantAssert<?> before(Instant actual, Instant start, Instant end) {
+    AbstractInstantAssert<?> before(Instant actual, Instant startInclusive, Instant endInclusive) {
       return Refaster.anyOf(
-          assertThat(actual).isAfterOrEqualTo(start).isBeforeOrEqualTo(end),
-          assertThat(actual).isBeforeOrEqualTo(end).isAfterOrEqualTo(start));
+          assertThat(actual).isAfterOrEqualTo(startInclusive).isBeforeOrEqualTo(endInclusive),
+          assertThat(actual).isBeforeOrEqualTo(endInclusive).isAfterOrEqualTo(startInclusive));
     }
 
     @AfterTemplate
-    AbstractInstantAssert<?> after(Instant actual, Instant start, Instant end) {
-      return assertThat(actual).isBetween(start, end);
+    AbstractInstantAssert<?> after(Instant actual, Instant startInclusive, Instant endInclusive) {
+      return assertThat(actual).isBetween(startInclusive, endInclusive);
     }
   }
 
+  /**
+   * Prefer {@link AbstractInstantAssert#isStrictlyBetween(Instant, Instant)} over more verbose
+   * alternatives.
+   */
   static final class AssertThatIsStrictlyBetween {
     @BeforeTemplate
-    AbstractInstantAssert<?> before(Instant actual, Instant start, Instant end) {
+    AbstractInstantAssert<?> before(Instant actual, Instant startExclusive, Instant endExclusive) {
       return Refaster.anyOf(
-          assertThat(actual).isAfter(start).isBefore(end),
-          assertThat(actual).isBefore(end).isAfter(start));
+          assertThat(actual).isAfter(startExclusive).isBefore(endExclusive),
+          assertThat(actual).isBefore(endExclusive).isAfter(startExclusive));
     }
 
     @AfterTemplate
-    AbstractInstantAssert<?> after(Instant actual, Instant start, Instant end) {
-      return assertThat(actual).isStrictlyBetween(start, end);
+    AbstractInstantAssert<?> after(Instant actual, Instant startExclusive, Instant endExclusive) {
+      return assertThat(actual).isStrictlyBetween(startExclusive, endExclusive);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJIntegerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJIntegerRules.java
@@ -14,65 +14,72 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJIntegerRules {
   private AssertJIntegerRules() {}
 
+  /** Prefer {@link AbstractIntegerAssert#isEqualTo(int)} over more contrived alternatives. */
   static final class AbstractIntegerAssertIsEqualTo {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert, int n) {
+    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> integerAssert, int expected) {
       return Refaster.anyOf(
-          intAssert.isCloseTo(n, offset(0)), intAssert.isCloseTo(n, withPercentage(0)));
+          integerAssert.isCloseTo(expected, offset(0)),
+          integerAssert.isCloseTo(expected, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> intAssert, int n) {
-      return intAssert.isEqualTo(n);
+    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> integerAssert, int expected) {
+      return integerAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@link AbstractIntegerAssert#isNotEqualTo(int)} over more contrived alternatives. */
   static final class AbstractIntegerAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert, int n) {
+    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> integerAssert, int other) {
       return Refaster.anyOf(
-          intAssert.isNotCloseTo(n, offset(0)), intAssert.isNotCloseTo(n, withPercentage(0)));
+          integerAssert.isNotCloseTo(other, offset(0)),
+          integerAssert.isNotCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> intAssert, int n) {
-      return intAssert.isNotEqualTo(n);
+    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> integerAssert, int other) {
+      return integerAssert.isNotEqualTo(other);
     }
   }
 
-  static final class AbstractIntegerAssertIsZero {
+  /** Prefer {@link AbstractIntegerAssert#isEqualTo(int)} over less explicit alternatives. */
+  static final class AbstractIntegerAssertIsEqualToZero {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isZero();
+    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> integerAssert) {
+      return integerAssert.isZero();
     }
 
     @AfterTemplate
-    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isEqualTo(0);
+    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> integerAssert) {
+      return integerAssert.isEqualTo(0);
     }
   }
 
-  static final class AbstractIntegerAssertIsNotZero {
+  /** Prefer {@link AbstractIntegerAssert#isNotEqualTo(int)} over less explicit alternatives. */
+  static final class AbstractIntegerAssertIsNotEqualToZero {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isNotZero();
+    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> integerAssert) {
+      return integerAssert.isNotZero();
     }
 
     @AfterTemplate
-    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isNotEqualTo(0);
+    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> integerAssert) {
+      return integerAssert.isNotEqualTo(0);
     }
   }
 
-  static final class AbstractIntegerAssertIsOne {
+  /** Prefer {@link AbstractIntegerAssert#isEqualTo(int)} over less explicit alternatives. */
+  static final class AbstractIntegerAssertIsEqualToOne {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isOne();
+    AbstractIntegerAssert<?> before(AbstractIntegerAssert<?> integerAssert) {
+      return integerAssert.isOne();
     }
 
     @AfterTemplate
-    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> intAssert) {
-      return intAssert.isEqualTo(1);
+    AbstractIntegerAssert<?> after(AbstractIntegerAssert<?> integerAssert) {
+      return integerAssert.isEqualTo(1);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJIterableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJIterableRules.java
@@ -8,11 +8,12 @@ import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Collection;
-import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractIntegerAssert;
 import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.AbstractIterableSizeAssert;
 import org.assertj.core.api.IterableAssert;
+import org.assertj.core.api.IteratorAssert;
 import org.assertj.core.api.ObjectAssert;
 import org.assertj.core.api.ObjectEnumerableAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -22,71 +23,75 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJIterableRules {
   private AssertJIterableRules() {}
 
-  static final class AssertThatIterableIsEmpty<E> {
+  /** Prefer {@code assertThat(iterable).isEmpty()} over more contrived alternatives. */
+  static final class AssertThatIsEmpty<E> {
     @BeforeTemplate
-    void before(Iterable<E> iterable) {
-      assertThat(iterable.iterator()).isExhausted();
+    void before(Iterable<E> actual) {
+      assertThat(actual.iterator()).isExhausted();
     }
 
     @BeforeTemplate
-    void before(Collection<E> iterable) {
-      assertThat(iterable.isEmpty()).isTrue();
+    void before(Collection<E> actual) {
+      assertThat(actual.isEmpty()).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Iterable<E> iterable) {
-      assertThat(iterable).isEmpty();
+    void after(Iterable<E> actual) {
+      assertThat(actual).isEmpty();
     }
   }
 
-  static final class AssertThatIterableIsNotEmpty<E> {
+  /** Prefer {@code assertThat(iterable).isNotEmpty()} over more contrived alternatives. */
+  static final class AssertThatIsNotEmpty<E> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Iterable<E> iterable) {
-      return assertThat(iterable.iterator()).hasNext();
+    IteratorAssert<E> before(Iterable<E> actual) {
+      return assertThat(actual.iterator()).hasNext();
     }
 
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Collection<E> iterable) {
-      return assertThat(iterable.isEmpty()).isFalse();
+    AbstractBooleanAssert<?> before(Collection<E> actual) {
+      return assertThat(actual.isEmpty()).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    IterableAssert<E> after(Iterable<E> iterable) {
-      return assertThat(iterable).isNotEmpty();
+    IterableAssert<E> after(Iterable<E> actual) {
+      return assertThat(actual).isNotEmpty();
     }
   }
 
-  static final class AssertThatIterableSize<E> {
+  /** Prefer {@code assertThat(iterable).size()} over non-JDK or more contrived alternatives. */
+  static final class AssertThatSize<E> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(Iterable<E> iterable) {
-      return assertThat(Iterables.size(iterable));
+    AbstractIntegerAssert<?> before(Iterable<E> actual) {
+      return assertThat(Iterables.size(actual));
     }
 
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(Collection<E> iterable) {
-      return assertThat(iterable.size());
+    AbstractIntegerAssert<?> before(Collection<E> actual) {
+      return assertThat(actual.size());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractIntegerAssert<?> after(Iterable<E> iterable) {
-      return assertThat(iterable).size();
+    AbstractIterableSizeAssert<IterableAssert<E>, Iterable<? extends E>, E, ObjectAssert<E>> after(
+        Iterable<E> actual) {
+      return assertThat(actual).size();
     }
   }
 
   /** Prefer {@link ObjectEnumerableAssert#contains(Object[])} over less explicit alternatives. */
   static final class AssertThatContains<E> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Collection<E> iterable, E element) {
-      return assertThat(iterable.contains(element)).isTrue();
+    AbstractBooleanAssert<?> before(Collection<E> actual, E element) {
+      return assertThat(actual.contains(element)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    IterableAssert<E> after(Iterable<E> iterable, E element) {
-      return assertThat(iterable).contains(element);
+    IterableAssert<E> after(Iterable<E> actual, E element) {
+      return assertThat(actual).contains(element);
     }
   }
 
@@ -95,14 +100,14 @@ final class AssertJIterableRules {
    */
   static final class AssertThatDoesNotContain<E> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Collection<E> iterable, E element) {
-      return assertThat(iterable.contains(element)).isFalse();
+    AbstractBooleanAssert<?> before(Collection<E> actual, E element) {
+      return assertThat(actual.contains(element)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    IterableAssert<E> after(Iterable<E> iterable, E element) {
-      return assertThat(iterable).doesNotContain(element);
+    IterableAssert<E> after(Iterable<E> actual, E element) {
+      return assertThat(actual).doesNotContain(element);
     }
   }
 
@@ -111,30 +116,33 @@ final class AssertJIterableRules {
    */
   static final class AssertThatContainsAll<E> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Collection<E> iterable, Collection<? extends E> elements) {
-      return assertThat(iterable.containsAll(elements)).isTrue();
+    AbstractBooleanAssert<?> before(Collection<E> actual, Collection<? extends E> iterable) {
+      return assertThat(actual.containsAll(iterable)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    IterableAssert<E> after(Iterable<E> iterable, Collection<? extends E> elements) {
-      return assertThat(iterable).containsAll(elements);
+    IterableAssert<E> after(Iterable<E> actual, Collection<? extends E> iterable) {
+      return assertThat(actual).containsAll(iterable);
     }
   }
 
+  /**
+   * Prefer {@code assertThat(iterable).containsExactly(element)} over more contrived alternatives.
+   */
   // XXX: In practice this rule isn't very useful, as it only matches invocations of
   // `assertThat(E)`. In most cases a more specific overload of `assertThat` is invoked, in which
   // case this rule won't match. Look into a more robust approach.
-  static final class AssertThatIterableHasOneElementEqualTo<S, E extends S> {
+  static final class AssertThatContainsExactly<S, E extends S> {
     @BeforeTemplate
-    ObjectAssert<S> before(Iterable<S> iterable, E element) {
-      return assertThat(Iterables.getOnlyElement(iterable)).isEqualTo(element);
+    ObjectAssert<S> before(Iterable<S> actual, E expected) {
+      return assertThat(Iterables.getOnlyElement(actual)).isEqualTo(expected);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    IterableAssert<S> after(Iterable<S> iterable, E element) {
-      return assertThat(iterable).containsExactly(element);
+    IterableAssert<S> after(Iterable<S> actual, E expected) {
+      return assertThat(actual).containsExactly(expected);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJIteratorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJIteratorRules.java
@@ -16,29 +16,31 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJIteratorRules {
   private AssertJIteratorRules() {}
 
+  /** Prefer {@link IteratorAssert#hasNext()} over more contrived alternatives. */
   static final class AssertThatHasNext<T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Iterator<T> iterator) {
-      return assertThat(iterator.hasNext()).isTrue();
+    AbstractBooleanAssert<?> before(Iterator<T> actual) {
+      return assertThat(actual.hasNext()).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    IteratorAssert<T> after(Iterator<T> iterator) {
-      return assertThat(iterator).hasNext();
+    IteratorAssert<T> after(Iterator<T> actual) {
+      return assertThat(actual).hasNext();
     }
   }
 
+  /** Prefer {@link IteratorAssert#isExhausted()} over more contrived alternatives. */
   static final class AssertThatIsExhausted<T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(Iterator<T> iterator) {
-      return assertThat(iterator.hasNext()).isFalse();
+    AbstractBooleanAssert<?> before(Iterator<T> actual) {
+      return assertThat(actual.hasNext()).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    IteratorAssert<T> after(Iterator<T> iterator) {
-      return assertThat(iterator).isExhausted();
+    IteratorAssert<T> after(Iterator<T> actual) {
+      return assertThat(actual).isExhausted();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJLongRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJLongRules.java
@@ -14,33 +14,38 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJLongRules {
   private AssertJLongRules() {}
 
+  /** Prefer {@link AbstractLongAssert#isEqualTo(long)} over more contrived alternatives. */
   static final class AbstractLongAssertIsEqualTo {
     @BeforeTemplate
-    AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert, long n) {
+    AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert, long expected) {
       return Refaster.anyOf(
-          longAssert.isCloseTo(n, offset(0L)), longAssert.isCloseTo(n, withPercentage(0)));
+          longAssert.isCloseTo(expected, offset(0L)),
+          longAssert.isCloseTo(expected, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractLongAssert<?> after(AbstractLongAssert<?> longAssert, long n) {
-      return longAssert.isEqualTo(n);
+    AbstractLongAssert<?> after(AbstractLongAssert<?> longAssert, long expected) {
+      return longAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@link AbstractLongAssert#isNotEqualTo(long)} over more contrived alternatives. */
   static final class AbstractLongAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert, long n) {
+    AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert, long other) {
       return Refaster.anyOf(
-          longAssert.isNotCloseTo(n, offset(0L)), longAssert.isNotCloseTo(n, withPercentage(0)));
+          longAssert.isNotCloseTo(other, offset(0L)),
+          longAssert.isNotCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractLongAssert<?> after(AbstractLongAssert<?> longAssert, long n) {
-      return longAssert.isNotEqualTo(n);
+    AbstractLongAssert<?> after(AbstractLongAssert<?> longAssert, long other) {
+      return longAssert.isNotEqualTo(other);
     }
   }
 
-  static final class AbstractLongAssertIsZero {
+  /** Prefer {@link AbstractLongAssert#isEqualTo(long)} over less explicit alternatives. */
+  static final class AbstractLongAssertIsEqualToZero {
     @BeforeTemplate
     AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert) {
       return longAssert.isZero();
@@ -52,7 +57,8 @@ final class AssertJLongRules {
     }
   }
 
-  static final class AbstractLongAssertIsNotZero {
+  /** Prefer {@link AbstractLongAssert#isNotEqualTo(long)} over less explicit alternatives. */
+  static final class AbstractLongAssertIsNotEqualToZero {
     @BeforeTemplate
     AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert) {
       return longAssert.isNotZero();
@@ -64,7 +70,8 @@ final class AssertJLongRules {
     }
   }
 
-  static final class AbstractLongAssertIsOne {
+  /** Prefer {@link AbstractLongAssert#isEqualTo(long)} over less explicit alternatives. */
+  static final class AbstractLongAssertIsEqualToOne {
     @BeforeTemplate
     AbstractLongAssert<?> before(AbstractLongAssert<?> longAssert) {
       return longAssert.isOne();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJMapRules.java
@@ -15,6 +15,7 @@ import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractCollectionAssert;
 import org.assertj.core.api.AbstractMapAssert;
 import org.assertj.core.api.MapAssert;
+import org.assertj.core.api.ObjectAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.matchers.IsEmpty;
 
@@ -23,19 +24,20 @@ import tech.picnic.errorprone.refaster.matchers.IsEmpty;
 final class AssertJMapRules {
   private AssertJMapRules() {}
 
-  static final class AbstractMapAssertIsEmpty<K, V> {
+  /** Prefer {@link AbstractMapAssert#isEmpty()} over more contrived alternatives. */
+  static final class AbstractMapAssertIsEmpty<K, V, M extends K, N extends V, T extends K> {
     @BeforeTemplate
     void before(
         AbstractMapAssert<?, ?, K, V> mapAssert,
-        @Matches(IsEmpty.class) Map<? extends K, ? extends V> wellTypedMap,
-        @Matches(IsEmpty.class) Map<?, ?> arbitrarilyTypedMap,
-        @Matches(IsEmpty.class) Iterable<? extends K> keys) {
+        @Matches(IsEmpty.class) Map<M, N> emptyMap,
+        @Matches(IsEmpty.class) Map<?, ?> emptyOther,
+        @Matches(IsEmpty.class) Iterable<T> emptyKeys) {
       Refaster.anyOf(
-          mapAssert.containsExactlyEntriesOf(wellTypedMap),
-          mapAssert.containsExactlyInAnyOrderEntriesOf(wellTypedMap),
-          mapAssert.hasSameSizeAs(arbitrarilyTypedMap),
-          mapAssert.isEqualTo(arbitrarilyTypedMap),
-          mapAssert.containsOnlyKeys(keys),
+          mapAssert.containsExactlyEntriesOf(emptyMap),
+          mapAssert.containsExactlyInAnyOrderEntriesOf(emptyMap),
+          mapAssert.hasSameSizeAs(emptyOther),
+          mapAssert.isEqualTo(emptyOther),
+          mapAssert.containsOnlyKeys(emptyKeys),
           mapAssert.containsExactly(),
           mapAssert.containsOnly(),
           mapAssert.containsOnlyKeys());
@@ -47,33 +49,35 @@ final class AssertJMapRules {
     }
   }
 
-  static final class AssertThatMapIsEmpty<K, V> {
+  /** Prefer {@code assertThat(map).isEmpty()} over more contrived alternatives. */
+  static final class AssertThatIsEmpty<K, V> {
     @BeforeTemplate
-    void before(Map<K, V> map) {
+    void before(Map<K, V> actual) {
       Refaster.anyOf(
-          assertThat(map).hasSize(0),
-          assertThat(map.isEmpty()).isTrue(),
-          assertThat(map.size()).isEqualTo(0L),
-          assertThat(map.size()).isNotPositive());
+          assertThat(actual).hasSize(0),
+          assertThat(actual.isEmpty()).isTrue(),
+          assertThat(actual.size()).isEqualTo(0L),
+          assertThat(actual.size()).isNotPositive());
     }
 
     @BeforeTemplate
-    void before2(Map<K, V> map) {
-      assertThat(Refaster.anyOf(map.keySet(), map.values(), map.entrySet())).isEmpty();
+    void before2(Map<K, V> actual) {
+      assertThat(Refaster.anyOf(actual.keySet(), actual.values(), actual.entrySet())).isEmpty();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Map<K, V> map) {
-      assertThat(map).isEmpty();
+    void after(Map<K, V> actual) {
+      assertThat(actual).isEmpty();
     }
   }
 
+  /** Prefer {@link AbstractMapAssert#isNotEmpty()} over more contrived alternatives. */
   static final class AbstractMapAssertIsNotEmpty<K, V> {
     @BeforeTemplate
     AbstractMapAssert<?, ?, K, V> before(
-        AbstractMapAssert<?, ?, K, V> mapAssert, @Matches(IsEmpty.class) Map<?, ?> map) {
-      return mapAssert.isNotEqualTo(map);
+        AbstractMapAssert<?, ?, K, V> mapAssert, @Matches(IsEmpty.class) Map<?, ?> emptyOther) {
+      return mapAssert.isNotEqualTo(emptyOther);
     }
 
     @AfterTemplate
@@ -82,161 +86,180 @@ final class AssertJMapRules {
     }
   }
 
-  static final class AssertThatMapIsNotEmpty<K, V> {
+  /** Prefer {@code assertThat(map).isNotEmpty()} over more contrived alternatives. */
+  static final class AssertThatIsNotEmpty<K, V> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Map<K, V> map) {
+    AbstractAssert<?, ?> before(Map<K, V> actual) {
       return Refaster.anyOf(
-          assertThat(map.isEmpty()).isFalse(),
-          assertThat(map.size()).isNotEqualTo(0),
-          assertThat(map.size()).isPositive(),
-          assertThat(Refaster.anyOf(map.keySet(), map.values(), map.entrySet())).isNotEmpty());
+          assertThat(actual.isEmpty()).isFalse(),
+          assertThat(actual.size()).isNotEqualTo(0),
+          assertThat(actual.size()).isPositive(),
+          assertThat(Refaster.anyOf(actual.keySet(), actual.values(), actual.entrySet()))
+              .isNotEmpty());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map) {
-      return assertThat(map).isNotEmpty();
+    MapAssert<K, V> after(Map<K, V> actual) {
+      return assertThat(actual).isNotEmpty();
     }
   }
 
-  static final class AbstractMapAssertContainsExactlyInAnyOrderEntriesOf<K, V> {
+  /**
+   * Prefer {@link AbstractMapAssert#containsExactlyInAnyOrderEntriesOf(Map)} over less explicit
+   * alternatives.
+   */
+  static final class AbstractMapAssertContainsExactlyInAnyOrderEntriesOf<
+      K, V, M extends K, N extends V> {
     @BeforeTemplate
-    AbstractMapAssert<?, ?, K, V> before(
-        AbstractMapAssert<?, ?, K, V> mapAssert, Map<? extends K, ? extends V> map) {
+    AbstractMapAssert<?, ?, K, V> before(AbstractMapAssert<?, ?, K, V> mapAssert, Map<M, N> map) {
       return mapAssert.isEqualTo(map);
     }
 
     @AfterTemplate
-    AbstractMapAssert<?, ?, K, V> after(
-        AbstractMapAssert<?, ?, K, V> mapAssert, Map<? extends K, ? extends V> map) {
+    AbstractMapAssert<?, ?, K, V> after(AbstractMapAssert<?, ?, K, V> mapAssert, Map<M, N> map) {
       return mapAssert.containsExactlyInAnyOrderEntriesOf(map);
     }
   }
 
-  static final class AbstractMapAssertContainsExactlyEntriesOf<K, V> {
+  /**
+   * Prefer {@link AbstractMapAssert#containsExactlyEntriesOf(Map)} over less explicit alternatives.
+   */
+  static final class AbstractMapAssertContainsExactlyEntriesOfImmutableMapOf<K, V> {
     @BeforeTemplate
-    AbstractMapAssert<?, ?, K, V> before(AbstractMapAssert<?, ?, K, V> mapAssert, K key, V value) {
-      return mapAssert.containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(key, value));
+    AbstractMapAssert<?, ?, K, V> before(AbstractMapAssert<?, ?, K, V> mapAssert, K k1, V v1) {
+      return mapAssert.containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(k1, v1));
     }
 
     @AfterTemplate
-    AbstractMapAssert<?, ?, K, V> after(AbstractMapAssert<?, ?, K, V> mapAssert, K key, V value) {
-      return mapAssert.containsExactlyEntriesOf(ImmutableMap.of(key, value));
+    AbstractMapAssert<?, ?, K, V> after(AbstractMapAssert<?, ?, K, V> mapAssert, K k1, V v1) {
+      return mapAssert.containsExactlyEntriesOf(ImmutableMap.of(k1, v1));
     }
   }
 
-  static final class AssertThatMapHasSize<K, V> {
+  /** Prefer {@code assertThat(map).hasSize(int)} over more contrived alternatives. */
+  static final class AssertThatHasSize<K, V> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Map<K, V> map, int length) {
+    AbstractAssert<?, ?> before(Map<K, V> actual, int expected) {
       return Refaster.anyOf(
-          assertThat(map.size()).isEqualTo(length),
-          assertThat(Refaster.anyOf(map.keySet(), map.values(), map.entrySet())).hasSize(length));
+          assertThat(actual.size()).isEqualTo(expected),
+          assertThat(Refaster.anyOf(actual.keySet(), actual.values(), actual.entrySet()))
+              .hasSize(expected));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, int length) {
-      return assertThat(map).hasSize(length);
+    MapAssert<K, V> after(Map<K, V> actual, int expected) {
+      return assertThat(actual).hasSize(expected);
     }
   }
 
+  /** Prefer {@link AbstractMapAssert#hasSameSizeAs(Map)} over more contrived alternatives. */
   static final class AbstractMapAssertHasSameSizeAs<K, V> {
     @BeforeTemplate
-    AbstractMapAssert<?, ?, K, V> before(AbstractMapAssert<?, ?, K, V> mapAssert, Map<?, ?> map) {
-      return mapAssert.hasSize(map.size());
+    AbstractMapAssert<?, ?, K, V> before(AbstractMapAssert<?, ?, K, V> mapAssert, Map<?, ?> other) {
+      return mapAssert.hasSize(other.size());
     }
 
     @AfterTemplate
-    AbstractMapAssert<?, ?, K, V> after(AbstractMapAssert<?, ?, K, V> mapAssert, Map<?, ?> map) {
-      return mapAssert.hasSameSizeAs(map);
+    AbstractMapAssert<?, ?, K, V> after(AbstractMapAssert<?, ?, K, V> mapAssert, Map<?, ?> other) {
+      return mapAssert.hasSameSizeAs(other);
     }
   }
 
-  static final class AssertThatMapContainsKey<K, V> {
+  /** Prefer {@code assertThat(map).containsKey(Object)} over more contrived alternatives. */
+  static final class AssertThatContainsKey<K, V> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Map<K, V> map, K key) {
+    AbstractAssert<?, ?> before(Map<K, V> actual, K key) {
       return Refaster.anyOf(
-          assertThat(map.containsKey(key)).isTrue(), assertThat(map.keySet()).contains(key));
+          assertThat(actual.containsKey(key)).isTrue(), assertThat(actual.keySet()).contains(key));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, K key) {
-      return assertThat(map).containsKey(key);
+    MapAssert<K, V> after(Map<K, V> actual, K key) {
+      return assertThat(actual).containsKey(key);
     }
   }
 
-  static final class AssertThatMapDoesNotContainKey<K, V> {
+  /** Prefer {@code assertThat(map).doesNotContainKey(Object)} over more contrived alternatives. */
+  static final class AssertThatDoesNotContainKey<K, V> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Map<K, V> map, K key) {
+    AbstractAssert<?, ?> before(Map<K, V> actual, K key) {
       return Refaster.anyOf(
-          assertThat(map.containsKey(key)).isFalse(), assertThat(map.keySet()).doesNotContain(key));
+          assertThat(actual.containsKey(key)).isFalse(),
+          assertThat(actual.keySet()).doesNotContain(key));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, K key) {
-      return assertThat(map).doesNotContainKey(key);
+    MapAssert<K, V> after(Map<K, V> actual, K key) {
+      return assertThat(actual).doesNotContainKey(key);
     }
   }
 
-  // XXX: Strictly speaking this rule could be merged into `AssertThatMapContainsOnlyKeys` below,
-  // but that rule targets another `containsOnlyKeys` overload. Review how cases like this should
-  // impact the preferred naming scheme.
-  static final class AssertThatMapContainsOnlyKey<K, V> {
+  /** Prefer {@code assertThat(map).containsOnlyKeys(Object)} over more contrived alternatives. */
+  static final class AssertThatContainsOnlyKeysObject<K, V> {
     @BeforeTemplate
-    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before(Map<K, V> map, K key) {
-      return assertThat(map.keySet()).containsExactly(key);
+    AbstractCollectionAssert<?, Collection<? extends K>, K, ObjectAssert<K>> before(
+        Map<K, V> actual, K key) {
+      return assertThat(actual.keySet()).containsExactly(key);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, K key) {
-      return assertThat(map).containsOnlyKeys(key);
+    MapAssert<K, V> after(Map<K, V> actual, K key) {
+      return assertThat(actual).containsOnlyKeys(key);
     }
   }
 
-  static final class AssertThatMapContainsOnlyKeys<K, V> {
+  /** Prefer {@code assertThat(map).containsOnlyKeys(Iterable)} over more contrived alternatives. */
+  static final class AssertThatContainsOnlyKeysIterable<K, V, T extends K> {
     @BeforeTemplate
-    AbstractCollectionAssert<?, Collection<? extends K>, K, ?> before(
-        Map<K, V> map, Iterable<? extends K> keys) {
-      return assertThat(map.keySet()).hasSameElementsAs(keys);
+    AbstractCollectionAssert<?, Collection<? extends K>, K, ObjectAssert<K>> before(
+        Map<K, V> actual, Iterable<T> keys) {
+      return assertThat(actual.keySet()).hasSameElementsAs(keys);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, Iterable<? extends K> keys) {
-      return assertThat(map).containsOnlyKeys(keys);
+    MapAssert<K, V> after(Map<K, V> actual, Iterable<T> keys) {
+      return assertThat(actual).containsOnlyKeys(keys);
     }
   }
 
-  static final class AssertThatMapContainsValue<K, V> {
+  /** Prefer {@code assertThat(map).containsValue(Object)} over more contrived alternatives. */
+  static final class AssertThatContainsValue<K, V> {
     @BeforeTemplate
     AbstractAssert<? extends AbstractAssert<?, ?>, ? extends Object> before(
-        Map<K, V> map, V value) {
+        Map<K, V> actual, V value) {
       return Refaster.anyOf(
-          assertThat(map.containsValue(value)).isTrue(), assertThat(map.values()).contains(value));
+          assertThat(actual.containsValue(value)).isTrue(),
+          assertThat(actual.values()).contains(value));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, V value) {
-      return assertThat(map).containsValue(value);
+    MapAssert<K, V> after(Map<K, V> actual, V value) {
+      return assertThat(actual).containsValue(value);
     }
   }
 
-  static final class AssertThatMapDoesNotContainValue<K, V> {
+  /**
+   * Prefer {@code assertThat(map).doesNotContainValue(Object)} over more contrived alternatives.
+   */
+  static final class AssertThatDoesNotContainValue<K, V> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Map<K, V> map, V value) {
+    AbstractAssert<?, ?> before(Map<K, V> actual, V value) {
       return Refaster.anyOf(
-          assertThat(map.containsValue(value)).isFalse(),
-          assertThat(map.values()).doesNotContain(value));
+          assertThat(actual.containsValue(value)).isFalse(),
+          assertThat(actual.values()).doesNotContain(value));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, V value) {
-      return assertThat(map).doesNotContainValue(value);
+    MapAssert<K, V> after(Map<K, V> actual, V value) {
+      return assertThat(actual).doesNotContainValue(value);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJNumberRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJNumberRules.java
@@ -27,6 +27,7 @@ import tech.picnic.errorprone.refaster.matchers.IsCharacter;
 final class AssertJNumberRules {
   private AssertJNumberRules() {}
 
+  /** Prefer {@link NumberAssert#isPositive()} over less explicit alternatives. */
   static final class NumberAssertIsPositive {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> numberAssert) {
@@ -78,6 +79,7 @@ final class AssertJNumberRules {
     }
   }
 
+  /** Prefer {@link NumberAssert#isNotPositive()} over less explicit alternatives. */
   static final class NumberAssertIsNotPositive {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> numberAssert) {
@@ -129,6 +131,7 @@ final class AssertJNumberRules {
     }
   }
 
+  /** Prefer {@link NumberAssert#isNegative()} over less explicit alternatives. */
   static final class NumberAssertIsNegative {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> numberAssert) {
@@ -180,6 +183,7 @@ final class AssertJNumberRules {
     }
   }
 
+  /** Prefer {@link NumberAssert#isNotNegative()} over less explicit alternatives. */
   static final class NumberAssertIsNotNegative {
     @BeforeTemplate
     AbstractByteAssert<?> before(AbstractByteAssert<?> numberAssert) {
@@ -233,51 +237,51 @@ final class AssertJNumberRules {
 
   /**
    * Prefer {@link AbstractLongAssert#isOdd()} (and similar methods for other {@link NumberAssert}
-   * subtypes) over alternatives with less informative error messages.
+   * subtypes) over less explicit alternatives.
    *
    * <p>Note that {@link org.assertj.core.api.AbstractCharacterAssert} does not implement {@link
    * NumberAssert} and does not provide an {@code isOdd} test.
    */
   static final class AssertThatIsOdd {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(@NotMatches(IsCharacter.class) int number) {
-      return assertThat(number % 2).isEqualTo(1);
+    AbstractIntegerAssert<?> before(@NotMatches(IsCharacter.class) int actual) {
+      return assertThat(actual % 2).isEqualTo(1);
     }
 
     @BeforeTemplate
-    AbstractLongAssert<?> before(long number) {
-      return assertThat(number % 2).isEqualTo(1);
+    AbstractLongAssert<?> before(long actual) {
+      return assertThat(actual % 2).isEqualTo(1);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    NumberAssert<?, ?> after(long number) {
-      return assertThat(number).isOdd();
+    AbstractLongAssert<?> after(long actual) {
+      return assertThat(actual).isOdd();
     }
   }
 
   /**
    * Prefer {@link AbstractLongAssert#isEven()} (and similar methods for other {@link NumberAssert}
-   * subtypes) over alternatives with less informative error messages.
+   * subtypes) over less explicit alternatives.
    *
    * <p>Note that {@link org.assertj.core.api.AbstractCharacterAssert} does not implement {@link
    * NumberAssert} and does not provide an {@code isEven} test.
    */
   static final class AssertThatIsEven {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(@NotMatches(IsCharacter.class) int number) {
-      return assertThat(number % 2).isEqualTo(0);
+    AbstractIntegerAssert<?> before(@NotMatches(IsCharacter.class) int actual) {
+      return assertThat(actual % 2).isEqualTo(0);
     }
 
     @BeforeTemplate
-    AbstractLongAssert<?> before(long number) {
-      return assertThat(number % 2).isEqualTo(0);
+    AbstractLongAssert<?> before(long actual) {
+      return assertThat(actual % 2).isEqualTo(0);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    NumberAssert<?, ?> after(long number) {
-      return assertThat(number).isEven();
+    AbstractLongAssert<?> after(long actual) {
+      return assertThat(actual).isEven();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJObjectRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJObjectRules.java
@@ -18,161 +18,172 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJObjectRules {
   private AssertJObjectRules() {}
 
+  /** Prefer {@link ObjectAssert#isInstanceOf(Class)} over more contrived alternatives. */
+  static final class AssertThatIsInstanceOfClass<S, T> {
+    @BeforeTemplate
+    AbstractBooleanAssert<?> before(S actual) {
+      return assertThat(Refaster.<T>isInstance(actual)).isTrue();
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ObjectAssert<S> after(S actual) {
+      return assertThat(actual).isInstanceOf(Refaster.<T>clazz());
+    }
+  }
+
+  /** Prefer {@link ObjectAssert#isInstanceOf(Class)} over more contrived alternatives. */
   static final class AssertThatIsInstanceOf<S, T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(S object) {
-      return assertThat(Refaster.<T>isInstance(object)).isTrue();
+    AbstractBooleanAssert<?> before(T actual, Class<S> type) {
+      return assertThat(type.isInstance(actual)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<S> after(S object) {
-      return assertThat(object).isInstanceOf(Refaster.<T>clazz());
+    ObjectAssert<T> after(T actual, Class<S> type) {
+      return assertThat(actual).isInstanceOf(type);
     }
   }
 
-  static final class AssertThatIsInstanceOf2<S, T> {
+  /** Prefer {@link ObjectAssert#isNotInstanceOf(Class)} over more contrived alternatives. */
+  static final class AssertThatIsNotInstanceOfClass<S, T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(T object, Class<S> clazz) {
-      return assertThat(clazz.isInstance(object)).isTrue();
+    AbstractBooleanAssert<?> before(S actual) {
+      return assertThat(Refaster.<T>isInstance(actual)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<T> after(T object, Class<S> clazz) {
-      return assertThat(object).isInstanceOf(clazz);
+    ObjectAssert<S> after(S actual) {
+      return assertThat(actual).isNotInstanceOf(Refaster.<T>clazz());
     }
   }
 
-  static final class AssertThatIsNotInstanceOf<S, T> {
+  /** Prefer {@link ObjectAssert#isEqualTo(Object)} over more contrived alternatives. */
+  static final class AssertThatIsEqualTo<S, T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(S object) {
-      return assertThat(Refaster.<T>isInstance(object)).isFalse();
+    AbstractBooleanAssert<?> before(S actual, T expected) {
+      return assertThat(actual.equals(expected)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<S> after(S object) {
-      return assertThat(object).isNotInstanceOf(Refaster.<T>clazz());
+    ObjectAssert<S> after(S actual, T expected) {
+      return assertThat(actual).isEqualTo(expected);
     }
   }
 
-  static final class AssertThatIsIsEqualTo<S, T> {
+  /** Prefer {@link ObjectAssert#isNotEqualTo(Object)} over more contrived alternatives. */
+  static final class AssertThatIsNotEqualTo<S, T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(S object1, T object2) {
-      return assertThat(object1.equals(object2)).isTrue();
+    AbstractBooleanAssert<?> before(S actual, T other) {
+      return assertThat(actual.equals(other)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<S> after(S object1, T object2) {
-      return assertThat(object1).isEqualTo(object2);
+    ObjectAssert<S> after(S actual, T other) {
+      return assertThat(actual).isNotEqualTo(other);
     }
   }
 
-  static final class AssertThatIsIsNotEqualTo<S, T> {
-    @BeforeTemplate
-    AbstractBooleanAssert<?> before(S object1, T object2) {
-      return assertThat(object1.equals(object2)).isFalse();
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<S> after(S object1, T object2) {
-      return assertThat(object1).isNotEqualTo(object2);
-    }
-  }
-
+  /** Prefer {@link ObjectAssert#hasToString(String)} over more contrived alternatives. */
   static final class AssertThatHasToString<T> {
     @BeforeTemplate
-    AbstractStringAssert<?> before(T object, String str) {
-      return assertThat(object.toString()).isEqualTo(str);
+    AbstractStringAssert<?> before(T actual, String expectedToString) {
+      return assertThat(actual.toString()).isEqualTo(expectedToString);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<T> after(T object, String str) {
-      return assertThat(object).hasToString(str);
+    ObjectAssert<T> after(T actual, String expectedToString) {
+      return assertThat(actual).hasToString(expectedToString);
     }
   }
 
+  /** Prefer {@link ObjectAssert#isSameAs(Object)} over more contrived alternatives. */
   static final class AssertThatIsSameAs<T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(T object1, T object2) {
+    AbstractBooleanAssert<?> before(T actual, T expected) {
       return Refaster.anyOf(
-          assertThat(object1 == object2).isTrue(), assertThat(object1 != object2).isFalse());
+          assertThat(actual == expected).isTrue(), assertThat(actual != expected).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<T> after(T object1, T object2) {
-      return assertThat(object1).isSameAs(object2);
+    ObjectAssert<T> after(T actual, T expected) {
+      return assertThat(actual).isSameAs(expected);
     }
   }
 
+  /** Prefer {@link ObjectAssert#isNotSameAs(Object)} over more contrived alternatives. */
   static final class AssertThatIsNotSameAs<T> {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(T object1, T object2) {
+    AbstractBooleanAssert<?> before(T actual, T other) {
       return Refaster.anyOf(
-          assertThat(object1 == object2).isFalse(), assertThat(object1 != object2).isTrue());
+          assertThat(actual == other).isFalse(), assertThat(actual != other).isTrue());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<T> after(T object1, T object2) {
-      return assertThat(object1).isNotSameAs(object2);
+    ObjectAssert<T> after(T actual, T other) {
+      return assertThat(actual).isNotSameAs(other);
     }
   }
 
-  // XXX This rule is redundant when the `AssertThatIsSameAs` rule is used in combination with the
+  /** Prefer {@link ObjectAssert#isNull()} over more contrived alternatives. */
+  // XXX: This rule is redundant when the `AssertThatIsSameAs` rule is used in combination with the
   // `AssertJNullnessAssertion` check. It's retained for use with OpenRewrite.
   static final class AssertThatIsNull<T> {
     @BeforeTemplate
     @SuppressWarnings("AssertThatIsSameAs" /* This is a more specific template. */)
-    void before(T object) {
-      assertThat(object == null).isTrue();
+    void before(T actual) {
+      assertThat(actual == null).isTrue();
     }
 
     @BeforeTemplate
     @SuppressWarnings("AssertThatIsSameAs" /* This is a more specific template. */)
-    void before2(T object) {
-      assertThat(object != null).isFalse();
+    void before2(T actual) {
+      assertThat(actual != null).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(T object) {
-      assertThat(object).isNull();
+    void after(T actual) {
+      assertThat(actual).isNull();
     }
   }
 
-  // XXX This rule is redundant when the `AssertThatIsNotSameAs` rule is used in combination with
+  /** Prefer {@link ObjectAssert#isNotNull()} over more contrived alternatives. */
+  // XXX: This rule is redundant when the `AssertThatIsNotSameAs` rule is used in combination with
   // the `AssertJNullnessAssertion` check. It's retained for use with OpenRewrite.
   static final class AssertThatIsNotNull<T> {
     @BeforeTemplate
     @SuppressWarnings("AssertThatIsNotSameAs" /* This is a more specific template. */)
-    AbstractBooleanAssert<? extends AbstractBooleanAssert<?>> before(T object) {
+    AbstractBooleanAssert<? extends AbstractBooleanAssert<?>> before(T actual) {
       return Refaster.anyOf(
-          assertThat(object == null).isFalse(), assertThat(object != null).isTrue());
+          assertThat(actual == null).isFalse(), assertThat(actual != null).isTrue());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<T> after(T object) {
-      return assertThat(object).isNotNull();
+    ObjectAssert<T> after(T actual) {
+      return assertThat(actual).isNotNull();
     }
   }
 
+  /** Prefer {@link ObjectAssert#hasSameHashCodeAs(Object)} over more contrived alternatives. */
   static final class AssertThatHasSameHashCodeAs<T> {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(T object1, T object2) {
-      return assertThat(object1.hashCode()).isEqualTo(object2.hashCode());
+    AbstractIntegerAssert<?> before(T actual, T other) {
+      return assertThat(actual.hashCode()).isEqualTo(other.hashCode());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectAssert<T> after(T object1, T object2) {
-      return assertThat(object1).hasSameHashCodeAs(object2);
+    ObjectAssert<T> after(T actual, T other) {
+      return assertThat(actual).hasSameHashCodeAs(other);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJObjectRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJObjectRules.java
@@ -60,7 +60,13 @@ final class AssertJObjectRules {
     }
   }
 
-  /** Prefer {@link ObjectAssert#isEqualTo(Object)} over more contrived alternatives. */
+  /**
+   * Prefer {@link ObjectAssert#isEqualTo(Object)} over more contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if {@code actual} is {@code null}:
+   * the original code throws a {@link NullPointerException}, while the replacement handles the
+   * comparison gracefully.
+   */
   static final class AssertThatIsEqualTo<S, T> {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(S actual, T expected) {
@@ -74,7 +80,13 @@ final class AssertJObjectRules {
     }
   }
 
-  /** Prefer {@link ObjectAssert#isNotEqualTo(Object)} over more contrived alternatives. */
+  /**
+   * Prefer {@link ObjectAssert#isNotEqualTo(Object)} over more contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if {@code actual} is {@code null}:
+   * the original code throws a {@link NullPointerException}, while the replacement handles the
+   * comparison gracefully.
+   */
   static final class AssertThatIsNotEqualTo<S, T> {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(S actual, T other) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJOptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJOptionalRules.java
@@ -12,6 +12,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Predicate;
 import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractOptionalAssert;
 import org.assertj.core.api.ObjectAssert;
@@ -25,22 +26,25 @@ import tech.picnic.errorprone.refaster.matchers.ThrowsCheckedException;
 final class AssertJOptionalRules {
   private AssertJOptionalRules() {}
 
-  static final class AssertThatOptional<T> {
+  /** Prefer {@code assertThat(optional).get()} over more contrived alternatives. */
+  static final class AssertThatGet<T> {
     @BeforeTemplate
-    ObjectAssert<T> before(Optional<T> optional) {
-      return assertThat(optional.orElseThrow());
+    ObjectAssert<T> before(Optional<T> actual) {
+      return assertThat(actual.orElseThrow());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, T> after(Optional<T> optional) {
-      return assertThat(optional).get();
+    AbstractObjectAssert<?, T> after(Optional<T> actual) {
+      return assertThat(actual).get();
     }
   }
 
+  /** Prefer {@link AbstractOptionalAssert#isPresent()} over more contrived alternatives. */
   static final class AbstractOptionalAssertIsPresent<T> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(AbstractOptionalAssert<?, T> optionalAssert) {
+    AbstractOptionalAssert<? extends AbstractOptionalAssert<?, T>, T> before(
+        AbstractOptionalAssert<?, T> optionalAssert) {
       return Refaster.anyOf(
           optionalAssert.isNotEmpty(), optionalAssert.isNotEqualTo(Optional.empty()));
     }
@@ -51,23 +55,26 @@ final class AssertJOptionalRules {
     }
   }
 
-  static final class AssertThatOptionalIsPresent<T> {
+  /** Prefer {@code assertThat(optional).isPresent()} over more contrived alternatives. */
+  static final class AssertThatIsPresent<T> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Optional<T> optional) {
+    AbstractBooleanAssert<? extends AbstractBooleanAssert<?>> before(Optional<T> actual) {
       return Refaster.anyOf(
-          assertThat(optional.isPresent()).isTrue(), assertThat(optional.isEmpty()).isFalse());
+          assertThat(actual.isPresent()).isTrue(), assertThat(actual.isEmpty()).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    OptionalAssert<T> after(Optional<T> optional) {
-      return assertThat(optional).isPresent();
+    OptionalAssert<T> after(Optional<T> actual) {
+      return assertThat(actual).isPresent();
     }
   }
 
+  /** Prefer {@link AbstractOptionalAssert#isEmpty()} over more contrived alternatives. */
   static final class AbstractOptionalAssertIsEmpty<T> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(AbstractOptionalAssert<?, T> optionalAssert) {
+    AbstractOptionalAssert<? extends AbstractOptionalAssert<?, T>, T> before(
+        AbstractOptionalAssert<?, T> optionalAssert) {
       return Refaster.anyOf(
           optionalAssert.isNotPresent(), optionalAssert.isEqualTo(Optional.empty()));
     }
@@ -78,46 +85,54 @@ final class AssertJOptionalRules {
     }
   }
 
-  static final class AssertThatOptionalIsEmpty<T> {
+  /** Prefer {@code assertThat(optional).isEmpty()} over more contrived alternatives. */
+  static final class AssertThatIsEmpty<T> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(Optional<T> optional) {
+    AbstractBooleanAssert<? extends AbstractBooleanAssert<?>> before(Optional<T> actual) {
       return Refaster.anyOf(
-          assertThat(optional.isEmpty()).isTrue(), assertThat(optional.isPresent()).isFalse());
+          assertThat(actual.isEmpty()).isTrue(), assertThat(actual.isPresent()).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    OptionalAssert<T> after(Optional<T> optional) {
-      return assertThat(optional).isEmpty();
+    OptionalAssert<T> after(Optional<T> actual) {
+      return assertThat(actual).isEmpty();
     }
   }
 
+  /** Prefer {@link AbstractOptionalAssert#hasValue(Object)} over more contrived alternatives. */
   static final class AbstractOptionalAssertHasValue<T> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(AbstractOptionalAssert<?, T> optionalAssert, T value) {
+    AbstractAssert<?, ?> before(AbstractOptionalAssert<?, T> optionalAssert, T expectedValue) {
       return Refaster.anyOf(
-          optionalAssert.get().isEqualTo(value),
-          optionalAssert.isEqualTo(Optional.of(value)),
-          optionalAssert.contains(value),
-          optionalAssert.isPresent().hasValue(value));
+          optionalAssert.get().isEqualTo(expectedValue),
+          optionalAssert.isEqualTo(Optional.of(expectedValue)),
+          optionalAssert.contains(expectedValue),
+          optionalAssert.isPresent().hasValue(expectedValue));
     }
 
     @AfterTemplate
-    AbstractOptionalAssert<?, T> after(AbstractOptionalAssert<?, T> optionalAssert, T value) {
-      return optionalAssert.hasValue(value);
+    AbstractOptionalAssert<?, T> after(
+        AbstractOptionalAssert<?, T> optionalAssert, T expectedValue) {
+      return optionalAssert.hasValue(expectedValue);
     }
   }
 
+  /**
+   * Prefer {@link AbstractOptionalAssert#containsSame(Object)} over more contrived alternatives.
+   */
   static final class AbstractOptionalAssertContainsSame<T> {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(AbstractOptionalAssert<?, T> optionalAssert, T value) {
+    AbstractAssert<?, ?> before(AbstractOptionalAssert<?, T> optionalAssert, T expectedValue) {
       return Refaster.anyOf(
-          optionalAssert.get().isSameAs(value), optionalAssert.isPresent().isSameAs(value));
+          optionalAssert.get().isSameAs(expectedValue),
+          optionalAssert.isPresent().isSameAs(expectedValue));
     }
 
     @AfterTemplate
-    AbstractOptionalAssert<?, T> after(AbstractOptionalAssert<?, T> optionalAssert, T value) {
-      return optionalAssert.containsSame(value);
+    AbstractOptionalAssert<?, T> after(
+        AbstractOptionalAssert<?, T> optionalAssert, T expectedValue) {
+      return optionalAssert.containsSame(expectedValue);
     }
   }
 
@@ -146,16 +161,19 @@ final class AssertJOptionalRules {
     }
   }
 
-  static final class AssertThatOptionalHasValueMatching<T> {
+  /**
+   * Prefer {@code assertThat(optional).get().matches(predicate)} over more contrived alternatives.
+   */
+  static final class AssertThatGetMatches<S, T extends S> {
     @BeforeTemplate
-    AbstractOptionalAssert<?, T> before(Optional<T> optional, Predicate<? super T> predicate) {
-      return assertThat(optional.filter(predicate)).isPresent();
+    OptionalAssert<T> before(Optional<T> actual, Predicate<S> predicate) {
+      return assertThat(actual.filter(predicate)).isPresent();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, T> after(Optional<T> optional, Predicate<? super T> predicate) {
-      return assertThat(optional).get().matches(predicate);
+    AbstractObjectAssert<?, T> after(Optional<T> actual, Predicate<S> predicate) {
+      return assertThat(actual).get().matches(predicate);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPathRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPathRules.java
@@ -12,16 +12,12 @@ import org.assertj.core.api.AbstractPathAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/**
- * Refaster rules related to AssertJ assertions over {@link Path}s.
- *
- * <p>These rules simplify and improve the readability of tests by using {@link Path}-specific
- * AssertJ assertion methods instead of generic assertions.
- */
+/** Refaster rules related to AssertJ assertions over {@link Path}s. */
 @OnlineDocumentation
 final class AssertJPathRules {
   private AssertJPathRules() {}
 
+  /** Prefer {@link AbstractPathAssert#exists()} over more contrived alternatives. */
   static final class AssertThatExists {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -34,6 +30,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#doesNotExist()} over more contrived alternatives. */
   static final class AssertThatDoesNotExist {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -46,6 +43,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isRegularFile()} over more contrived alternatives. */
   static final class AssertThatIsRegularFile {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -58,6 +56,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isDirectory()} over more contrived alternatives. */
   static final class AssertThatIsDirectory {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -70,6 +69,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isSymbolicLink()} over more contrived alternatives. */
   static final class AssertThatIsSymbolicLink {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -82,6 +82,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isAbsolute()} over more contrived alternatives. */
   static final class AssertThatIsAbsolute {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -94,6 +95,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isRelative()} over more contrived alternatives. */
   static final class AssertThatIsRelative {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -106,6 +108,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isReadable()} over more contrived alternatives. */
   static final class AssertThatIsReadable {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -118,6 +121,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isWritable()} over more contrived alternatives. */
   static final class AssertThatIsWritable {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -130,6 +134,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#isExecutable()} over more contrived alternatives. */
   static final class AssertThatIsExecutable {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual) {
@@ -142,7 +147,12 @@ final class AssertJPathRules {
     }
   }
 
-  // XXX: This rule changes the `Path` against which subsequent assertions are made.
+  /**
+   * Prefer {@link AbstractPathAssert#hasFileName(String)} over more contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes the {@link Path} against which subsequent
+   * assertions are made.
+   */
   static final class AssertThatHasFileName {
     @BeforeTemplate
     AbstractPathAssert<?> before(Path actual, String fileName) {
@@ -155,7 +165,12 @@ final class AssertJPathRules {
     }
   }
 
-  // XXX: This rule changes the `Path` against which subsequent assertions are made.
+  /**
+   * Prefer {@link AbstractPathAssert#hasParentRaw(Path)} over more contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes the {@link Path} against which subsequent
+   * assertions are made.
+   */
   static final class AssertThatHasParentRaw {
     @BeforeTemplate
     AbstractPathAssert<?> before(Path actual, Path expected) {
@@ -168,6 +183,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#hasNoParent()} over more contrived alternatives. */
   static final class AssertThatHasNoParent {
     @BeforeTemplate
     void before(Path actual) {
@@ -180,6 +196,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#startsWithRaw(Path)} over more contrived alternatives. */
   static final class AssertThatStartsWithRaw {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual, Path other) {
@@ -192,6 +209,7 @@ final class AssertJPathRules {
     }
   }
 
+  /** Prefer {@link AbstractPathAssert#endsWithRaw(Path)} over more contrived alternatives. */
   static final class AssertThatEndsWithRaw {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(Path actual, Path other) {
@@ -204,10 +222,7 @@ final class AssertJPathRules {
     }
   }
 
-  /**
-   * Prefer using {@link AbstractPathAssert#hasExtension(String)} over more verbose and less
-   * accurate alternatives.
-   */
+  /** Prefer {@link AbstractPathAssert#hasExtension(String)} over more contrived alternatives. */
   static final class AssertThatHasExtension {
     @BeforeTemplate
     AbstractStringAssert<?> before(Path actual, String expectedExtension) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRules.java
@@ -22,53 +22,46 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJPrimitiveRules {
   private AssertJPrimitiveRules() {}
 
+  /** Prefer {@code isEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(boolean actual, boolean expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @BeforeTemplate
     AbstractByteAssert<?> before(byte actual, byte expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @BeforeTemplate
     AbstractCharacterAssert<?> before(char actual, char expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @BeforeTemplate
     AbstractShortAssert<?> before(short actual, short expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @BeforeTemplate
     AbstractIntegerAssert<?> before(int actual, int expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @BeforeTemplate
     AbstractLongAssert<?> before(long actual, long expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @BeforeTemplate
     AbstractFloatAssert<?> before(float actual, float expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @BeforeTemplate
     AbstractDoubleAssert<?> before(double actual, double expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isSameAs(expected), assertThat(actual).isSameAs(expected));
+      return assertThat(actual).isSameAs(expected);
     }
 
     @AfterTemplate
@@ -78,115 +71,112 @@ final class AssertJPrimitiveRules {
     }
   }
 
+  /** Prefer {@code isNotEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsNotEqualTo {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(boolean actual, boolean expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractBooleanAssert<?> before(boolean actual, boolean other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @BeforeTemplate
-    AbstractByteAssert<?> before(byte actual, byte expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractByteAssert<?> before(byte actual, byte other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @BeforeTemplate
-    AbstractCharacterAssert<?> before(char actual, char expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractCharacterAssert<?> before(char actual, char other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @BeforeTemplate
-    AbstractShortAssert<?> before(short actual, short expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractShortAssert<?> before(short actual, short other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(int actual, int expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractIntegerAssert<?> before(int actual, int other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @BeforeTemplate
-    AbstractLongAssert<?> before(long actual, long expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractLongAssert<?> before(long actual, long other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @BeforeTemplate
-    AbstractFloatAssert<?> before(float actual, float expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractFloatAssert<?> before(float actual, float other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @BeforeTemplate
-    AbstractDoubleAssert<? extends AbstractDoubleAssert<?>> before(double actual, double expected) {
-      return Refaster.anyOf(
-          assertThat(actual).isNotSameAs(expected), assertThat(actual).isNotSameAs(expected));
+    AbstractDoubleAssert<?> before(double actual, double other) {
+      return assertThat(actual).isNotSameAs(other);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractBooleanAssert<?> after(boolean actual, boolean expected) {
-      return assertThat(actual).isNotEqualTo(expected);
+    AbstractBooleanAssert<?> after(boolean actual, boolean other) {
+      return assertThat(actual).isNotEqualTo(other);
     }
   }
 
+  /** Prefer {@code isLessThan} over less idiomatic alternatives. */
   static final class AssertThatIsLessThan {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(double actual, double expected) {
+    AbstractBooleanAssert<?> before(double actual, double other) {
       return Refaster.anyOf(
-          assertThat(actual < expected).isTrue(), assertThat(actual >= expected).isFalse());
+          assertThat(actual < other).isTrue(), assertThat(actual >= other).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractDoubleAssert<?> after(double actual, double expected) {
-      return assertThat(actual).isLessThan(expected);
+    AbstractDoubleAssert<?> after(double actual, double other) {
+      return assertThat(actual).isLessThan(other);
     }
   }
 
+  /** Prefer {@code isLessThanOrEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsLessThanOrEqualTo {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(double actual, double expected) {
+    AbstractBooleanAssert<?> before(double actual, double other) {
       return Refaster.anyOf(
-          assertThat(actual <= expected).isTrue(), assertThat(actual > expected).isFalse());
+          assertThat(actual <= other).isTrue(), assertThat(actual > other).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractDoubleAssert<?> after(double actual, double expected) {
-      return assertThat(actual).isLessThanOrEqualTo(expected);
+    AbstractDoubleAssert<?> after(double actual, double other) {
+      return assertThat(actual).isLessThanOrEqualTo(other);
     }
   }
 
+  /** Prefer {@code isGreaterThan} over less idiomatic alternatives. */
   static final class AssertThatIsGreaterThan {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(double actual, double expected) {
+    AbstractBooleanAssert<?> before(double actual, double other) {
       return Refaster.anyOf(
-          assertThat(actual > expected).isTrue(), assertThat(actual <= expected).isFalse());
+          assertThat(actual > other).isTrue(), assertThat(actual <= other).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractDoubleAssert<?> after(double actual, double expected) {
-      return assertThat(actual).isGreaterThan(expected);
+    AbstractDoubleAssert<?> after(double actual, double other) {
+      return assertThat(actual).isGreaterThan(other);
     }
   }
 
+  /** Prefer {@code isGreaterThanOrEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsGreaterThanOrEqualTo {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(double actual, double expected) {
+    AbstractBooleanAssert<?> before(double actual, double other) {
       return Refaster.anyOf(
-          assertThat(actual >= expected).isTrue(), assertThat(actual < expected).isFalse());
+          assertThat(actual >= other).isTrue(), assertThat(actual < other).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractDoubleAssert<?> after(double actual, double expected) {
-      return assertThat(actual).isGreaterThanOrEqualTo(expected);
+    AbstractDoubleAssert<?> after(double actual, double other) {
+      return assertThat(actual).isGreaterThanOrEqualTo(other);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRules.java
@@ -71,7 +71,7 @@ final class AssertJPrimitiveRules {
     }
   }
 
-  /** Prefer {@link AbstractBooleanAssert#lisNotEqualTo} over less idiomatic alternatives. */
+  /** Prefer {@link AbstractBooleanAssert#isNotEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsNotEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(boolean actual, boolean other) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRules.java
@@ -22,7 +22,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJPrimitiveRules {
   private AssertJPrimitiveRules() {}
 
-  /** Prefer {@code isEqualTo} over less idiomatic alternatives. */
+  /** Prefer {@link AbstractBooleanAssert#isEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(boolean actual, boolean expected) {
@@ -71,7 +71,7 @@ final class AssertJPrimitiveRules {
     }
   }
 
-  /** Prefer {@code isNotEqualTo} over less idiomatic alternatives. */
+  /** Prefer {@link AbstractBooleanAssert#lisNotEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsNotEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(boolean actual, boolean other) {
@@ -120,7 +120,7 @@ final class AssertJPrimitiveRules {
     }
   }
 
-  /** Prefer {@code isLessThan} over less idiomatic alternatives. */
+  /** Prefer {@link AbstractDoubleAssert#isLessThan} over less idiomatic alternatives. */
   static final class AssertThatIsLessThan {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(double actual, double other) {
@@ -135,7 +135,7 @@ final class AssertJPrimitiveRules {
     }
   }
 
-  /** Prefer {@code isLessThanOrEqualTo} over less idiomatic alternatives. */
+  /** Prefer {@link AbstractDoubleAssert#isLessThanOrEqualTo} over less idiomatic alternatives. */
   static final class AssertThatIsLessThanOrEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(double actual, double other) {
@@ -150,7 +150,7 @@ final class AssertJPrimitiveRules {
     }
   }
 
-  /** Prefer {@code isGreaterThan} over less idiomatic alternatives. */
+  /** Prefer {@link AbstractDoubleAssert#isGreaterThan} over less idiomatic alternatives. */
   static final class AssertThatIsGreaterThan {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(double actual, double other) {
@@ -165,7 +165,9 @@ final class AssertJPrimitiveRules {
     }
   }
 
-  /** Prefer {@code isGreaterThanOrEqualTo} over less idiomatic alternatives. */
+  /**
+   * Prefer {@link AbstractDoubleAssert#isGreaterThanOrEqualTo} over less idiomatic alternatives.
+   */
   static final class AssertThatIsGreaterThanOrEqualTo {
     @BeforeTemplate
     AbstractBooleanAssert<?> before(double actual, double other) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
@@ -36,9 +36,6 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.matchers.IsArray;
 
 /** Refaster rules related to AssertJ expressions and statements. */
-// XXX: Most `AbstractIntegerAssert` rules can also be applied for other primitive types. Generate
-// these in separate files.
-// XXX: Also do for BigInteger/BigDecimal?
 // XXX: `assertThat(cmp.compare(a, b)).isZero()` -> make something nicer.
 // ^ And variants.
 // XXX: Consider splitting this class into multiple classes.
@@ -48,7 +45,6 @@ import tech.picnic.errorprone.refaster.matchers.IsArray;
 // XXX: Handle `.isEqualTo(explicitlyEnumeratedCollection)`. Can be considered equivalent to
 // `.containsOnly(elements)`. (This does mean the auto-generated code needs to be more advanced.
 // Ponder this.)
-// XXX: Most/all of those Iterable rules can also be applied to arrays.
 // XXX: Elsewhere add a rule to disallow `Collection.emptyList()` and variants as well as
 // `Arrays.asList()` and `Arrays.asList(singleElement)`, maybe other obviously-varargs cases.
 // XXX: Can we better handle Multimaps?
@@ -105,18 +101,19 @@ final class AssertJRules {
   // OptionalDouble
   //
 
+  /** Prefer {@link OptionalDoubleAssert#hasValue(double)} over more fragile alternatives. */
   // XXX: There are several other variations that can also be optimized so as to avoid
   // unconditionally calling `getAsDouble`.
-  static final class AssertThatOptionalDouble {
+  static final class AssertThatHasValueOptionalDouble {
     @BeforeTemplate
-    AbstractDoubleAssert<?> before(OptionalDouble optional, double expected) {
-      return assertThat(optional.getAsDouble()).isEqualTo(expected);
+    AbstractDoubleAssert<?> before(OptionalDouble actual, double expectedValue) {
+      return assertThat(actual.getAsDouble()).isEqualTo(expectedValue);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    OptionalDoubleAssert after(OptionalDouble optional, double expected) {
-      return assertThat(optional).hasValue(expected);
+    OptionalDoubleAssert after(OptionalDouble actual, double expectedValue) {
+      return assertThat(actual).hasValue(expectedValue);
     }
   }
 
@@ -124,18 +121,19 @@ final class AssertJRules {
   // OptionalInt
   //
 
+  /** Prefer {@link OptionalIntAssert#hasValue(int)} over more fragile alternatives. */
   // XXX: There are several other variations that can also be optimized so as to avoid
   // unconditionally calling `getAsInt`.
-  static final class AssertThatOptionalInt {
+  static final class AssertThatHasValueOptionalInt {
     @BeforeTemplate
-    AbstractIntegerAssert<?> before(OptionalInt optional, int expected) {
-      return assertThat(optional.getAsInt()).isEqualTo(expected);
+    AbstractIntegerAssert<?> before(OptionalInt actual, int expectedValue) {
+      return assertThat(actual.getAsInt()).isEqualTo(expectedValue);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    OptionalIntAssert after(OptionalInt optional, int expected) {
-      return assertThat(optional).hasValue(expected);
+    OptionalIntAssert after(OptionalInt actual, int expectedValue) {
+      return assertThat(actual).hasValue(expectedValue);
     }
   }
 
@@ -143,18 +141,19 @@ final class AssertJRules {
   // OptionalLong
   //
 
+  /** Prefer {@link OptionalLongAssert#hasValue(long)} over more fragile alternatives. */
   // XXX: There are several other variations that can also be optimized so as to avoid
   // unconditionally calling `getAsLong`.
-  static final class AssertThatOptionalLong {
+  static final class AssertThatHasValueOptionalLong {
     @BeforeTemplate
-    AbstractLongAssert<?> before(OptionalLong optional, long expected) {
-      return assertThat(optional.getAsLong()).isEqualTo(expected);
+    AbstractLongAssert<?> before(OptionalLong actual, long expectedValue) {
+      return assertThat(actual.getAsLong()).isEqualTo(expectedValue);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    OptionalLongAssert after(OptionalLong optional, long expected) {
-      return assertThat(optional).hasValue(expected);
+    OptionalLongAssert after(OptionalLong actual, long expectedValue) {
+      return assertThat(actual).hasValue(expectedValue);
     }
   }
 
@@ -162,62 +161,79 @@ final class AssertJRules {
   // ObjectEnumerable
   //
 
-  static final class ObjectEnumerableContainsOneElement<S, T extends S> {
-    @BeforeTemplate
-    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ObjectEnumerableAssert<?, S> before(ObjectEnumerableAssert<?, S> iterAssert, T element) {
-      return Refaster.anyOf(
-          iterAssert.containsAnyOf(element),
-          iterAssert.containsSequence(element),
-          iterAssert.containsSubsequence(element));
-    }
-
-    @AfterTemplate
-    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ObjectEnumerableAssert<?, S> after(ObjectEnumerableAssert<?, S> iterAssert, T element) {
-      return iterAssert.contains(element);
-    }
-  }
-
-  static final class ObjectEnumerableDoesNotContainOneElement<S, T extends S> {
-    @BeforeTemplate
-    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ObjectEnumerableAssert<?, S> before(ObjectEnumerableAssert<?, S> iterAssert, T element) {
-      return iterAssert.doesNotContainSequence(element);
-    }
-
-    @AfterTemplate
-    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ObjectEnumerableAssert<?, S> after(ObjectEnumerableAssert<?, S> iterAssert, T element) {
-      return iterAssert.doesNotContain(element);
-    }
-  }
-
-  static final class ObjectEnumerableContainsExactlyOneElement<S, T extends S> {
+  /** Prefer {@link ObjectEnumerableAssert#contains(Object[])} over more contrived alternatives. */
+  static final class ObjectEnumerableAssertContains<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
     ObjectEnumerableAssert<?, S> before(
-        ObjectEnumerableAssert<?, S> iterAssert, @NotMatches(IsArray.class) T element) {
-      return iterAssert.containsExactlyInAnyOrder(element);
+        ObjectEnumerableAssert<?, S> objectEnumerableAssert, T element) {
+      return Refaster.anyOf(
+          objectEnumerableAssert.containsAnyOf(element),
+          objectEnumerableAssert.containsSequence(element),
+          objectEnumerableAssert.containsSubsequence(element));
     }
 
     @AfterTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ObjectEnumerableAssert<?, S> after(ObjectEnumerableAssert<?, S> iterAssert, T element) {
-      return iterAssert.containsExactly(element);
+    ObjectEnumerableAssert<?, S> after(
+        ObjectEnumerableAssert<?, S> objectEnumerableAssert, T element) {
+      return objectEnumerableAssert.contains(element);
     }
   }
 
-  static final class AssertThatSetContainsExactlyOneElement<S, T extends S> {
+  /**
+   * Prefer {@link ObjectEnumerableAssert#doesNotContain(Object[])} over more contrived
+   * alternatives.
+   */
+  static final class ObjectEnumerableAssertDoesNotContain<S, T extends S> {
     @BeforeTemplate
-    ObjectEnumerableAssert<?, S> before(Set<S> set, T element) {
-      return assertThat(set).containsOnly(element);
+    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
+    ObjectEnumerableAssert<?, S> before(
+        ObjectEnumerableAssert<?, S> objectEnumerableAssert, T element) {
+      return objectEnumerableAssert.doesNotContainSequence(element);
+    }
+
+    @AfterTemplate
+    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
+    ObjectEnumerableAssert<?, S> after(
+        ObjectEnumerableAssert<?, S> objectEnumerableAssert, T element) {
+      return objectEnumerableAssert.doesNotContain(element);
+    }
+  }
+
+  /**
+   * Prefer {@link ObjectEnumerableAssert#containsExactly(Object[])} over more contrived
+   * alternatives.
+   */
+  static final class ObjectEnumerableAssertContainsExactly<S, T extends S> {
+    @BeforeTemplate
+    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
+    ObjectEnumerableAssert<?, S> before(
+        ObjectEnumerableAssert<?, S> objectEnumerableAssert, @NotMatches(IsArray.class) T element) {
+      return objectEnumerableAssert.containsExactlyInAnyOrder(element);
+    }
+
+    @AfterTemplate
+    @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
+    ObjectEnumerableAssert<?, S> after(
+        ObjectEnumerableAssert<?, S> objectEnumerableAssert, T element) {
+      return objectEnumerableAssert.containsExactly(element);
+    }
+  }
+
+  /** Prefer {@code assertThat(set).containsExactly(element)} over less explicit alternatives. */
+  static final class AssertThatContainsExactlySet<S, T extends S> {
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends S>, S, ObjectAssert<S>> before(
+        Set<S> actual, T element) {
+      return assertThat(actual).containsOnly(element);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ObjectEnumerableAssert<?, S> after(Set<S> set, T element) {
-      return assertThat(set).containsExactly(element);
+    AbstractCollectionAssert<?, Collection<? extends S>, S, ObjectAssert<S>> after(
+        Set<S> actual, T element) {
+      return assertThat(actual).containsExactly(element);
     }
   }
 
@@ -225,16 +241,19 @@ final class AssertJRules {
   // List
   //
 
-  static final class AssertThatListsAreEqual<S, T extends S> {
+  /**
+   * Prefer {@link ListAssert#containsExactlyElementsOf(Iterable)} over less explicit alternatives.
+   */
+  static final class AssertThatContainsExactlyElementsOfList<S, T extends S> {
     @BeforeTemplate
-    ListAssert<S> before(List<S> list1, Iterable<T> list2) {
-      return assertThat(list1).isEqualTo(list2);
+    ListAssert<S> before(List<S> actual, Iterable<T> iterable) {
+      return assertThat(actual).isEqualTo(iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(List<S> list1, Iterable<T> list2) {
-      return assertThat(list1).containsExactlyElementsOf(list2);
+    ListAssert<S> after(List<S> actual, Iterable<T> iterable) {
+      return assertThat(actual).containsExactlyElementsOf(iterable);
     }
   }
 
@@ -242,18 +261,28 @@ final class AssertJRules {
   // Set
   //
 
-  static final class AssertThatSetsAreEqual<S, T extends S> {
+  /**
+   * Prefer {@link AbstractCollectionAssert#hasSameElementsAs(Iterable)} over less explicit or more
+   * contrived alternatives.
+   */
+  static final class AssertThatHasSameElementsAsSet<S, T extends S> {
     @BeforeTemplate
-    AbstractCollectionAssert<?, ?, S, ?> before(Set<S> set1, Iterable<T> set2) {
+    AbstractCollectionAssert<
+            ? extends AbstractCollectionAssert<?, Collection<? extends S>, S, ObjectAssert<S>>,
+            Collection<? extends S>,
+            S,
+            ObjectAssert<S>>
+        before(Set<S> actual, Iterable<T> iterable) {
       return Refaster.anyOf(
-          assertThat(set1).isEqualTo(set2),
-          assertThat(set1).containsExactlyInAnyOrderElementsOf(set2));
+          assertThat(actual).isEqualTo(iterable),
+          assertThat(actual).containsExactlyInAnyOrderElementsOf(iterable));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractCollectionAssert<?, ?, S, ?> after(Set<S> set1, Iterable<T> set2) {
-      return assertThat(set1).hasSameElementsAs(set2);
+    AbstractCollectionAssert<?, Collection<? extends S>, S, ObjectAssert<S>> after(
+        Set<S> actual, Iterable<T> iterable) {
+      return assertThat(actual).hasSameElementsAs(iterable);
     }
   }
 
@@ -261,16 +290,22 @@ final class AssertJRules {
   // Multiset
   //
 
-  static final class AssertThatMultisetsAreEqual<S, T extends S> {
+  /**
+   * Prefer {@link AbstractCollectionAssert#containsExactlyInAnyOrderElementsOf(Iterable)} over less
+   * explicit alternatives.
+   */
+  static final class AssertThatContainsExactlyInAnyOrderElementsOfMultiset<S, T extends S> {
     @BeforeTemplate
-    AbstractCollectionAssert<?, ?, S, ?> before(Multiset<S> multiset1, Iterable<T> multiset2) {
-      return assertThat(multiset1).isEqualTo(multiset2);
+    AbstractCollectionAssert<?, Collection<? extends S>, S, ObjectAssert<S>> before(
+        Multiset<S> actual, Iterable<T> values) {
+      return assertThat(actual).isEqualTo(values);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractCollectionAssert<?, ?, S, ?> after(Multiset<S> multiset1, Iterable<T> multiset2) {
-      return assertThat(multiset1).containsExactlyInAnyOrderElementsOf(multiset2);
+    AbstractCollectionAssert<?, Collection<? extends S>, S, ObjectAssert<S>> after(
+        Multiset<S> actual, Iterable<T> values) {
+      return assertThat(actual).containsExactlyInAnyOrderElementsOf(values);
     }
   }
 
@@ -278,18 +313,19 @@ final class AssertJRules {
   // Map
   //
 
+  /** Prefer {@link MapAssert#containsEntry(Object, Object)} over more contrived alternatives. */
   // XXX: To match in all cases there'll need to be a `@BeforeTemplate` variant for each
   // `assertThat` overload. Consider defining a `BugChecker` instead.
-  static final class AssertThatMapContainsEntry<K, V> {
+  static final class AssertThatContainsEntry<K, V> {
     @BeforeTemplate
-    ObjectAssert<V> before(Map<K, V> map, K key, V value) {
-      return assertThat(map.get(key)).isEqualTo(value);
+    ObjectAssert<V> before(Map<K, V> actual, K key, V value) {
+      return assertThat(actual.get(key)).isEqualTo(value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    MapAssert<K, V> after(Map<K, V> map, K key, V value) {
-      return assertThat(map).containsEntry(key, value);
+    MapAssert<K, V> after(Map<K, V> actual, K key, V value) {
+      return assertThat(actual).containsEntry(key, value);
     }
   }
 
@@ -297,666 +333,691 @@ final class AssertJRules {
   // Stream
   //
 
+  /** Prefer {@link ListAssert#containsAnyElementsOf(Iterable)} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsAnyElementsOf<S, T extends S, U extends T> {
+  static final class AssertThatContainsAnyElementsOf<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyElementsOf(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyElementsOf(iterable);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
+        Stream<S> actual,
         Iterable<U> iterable,
         Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyElementsOf(iterable);
+      return assertThat(actual.collect(collector)).containsAnyElementsOf(iterable);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyElementsOf(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyElementsOf(iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).containsAnyElementsOf(iterable);
+    ListAssert<S> after(Stream<S> actual, Iterable<U> iterable) {
+      return assertThat(actual).containsAnyElementsOf(iterable);
     }
   }
 
+  /** Prefer {@link ListAssert#containsAnyOf(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsAnyOf<S, T extends S, U extends T> {
+  static final class AssertThatContainsAnyOf<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyOf(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyOf(array);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyOf(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyOf(array);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyOf(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyOf(array);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, U[] array) {
-      return assertThat(stream).containsAnyOf(array);
+    ListAssert<S> after(Stream<S> actual, U[] array) {
+      return assertThat(actual).containsAnyOf(array);
     }
   }
 
+  /** Prefer {@link ListAssert#containsAnyOf(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsAnyOfVarArgs<S, T extends S, U extends T> {
+  static final class AssertThatContainsAnyOfVarargs<S, T extends S, U extends T> {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsAnyOf" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContainsAnyOf" /* Varargs converted to array. */)
     IterableAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyOf(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyOf(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsAnyOf" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContainsAnyOf" /* Varargs converted to array. */)
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
-        @Repeated U elements,
-        Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyOf(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyOf(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsAnyOf" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContainsAnyOf" /* Varargs converted to array. */)
     ListAssert<T> before3(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAnyOf(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAnyOf(Refaster.asVarargs(values));
     }
 
     @AfterTemplate
-    @SuppressWarnings("ObjectEnumerableContainsOneElement" /* Not a true singleton. */)
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).containsAnyOf(elements);
+    ListAssert<S> after(Stream<S> actual, @Repeated U values) {
+      return assertThat(actual).containsAnyOf(Refaster.asVarargs(values));
     }
   }
 
+  /** Prefer {@link ListAssert#containsAll(Iterable)} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsAll<S, T extends S, U extends T> {
+  static final class AssertThatContainsAll<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAll(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAll(iterable);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
+        Stream<S> actual,
         Iterable<U> iterable,
         Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAll(iterable);
+      return assertThat(actual.collect(collector)).containsAll(iterable);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsAll(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsAll(iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).containsAll(iterable);
+    ListAssert<S> after(Stream<S> actual, Iterable<U> iterable) {
+      return assertThat(actual).containsAll(iterable);
     }
   }
 
+  /** Prefer {@link ListAssert#contains(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContains<S, T extends S, U extends T> {
+  static final class AssertThatContains<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).contains(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).contains(array);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).contains(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).contains(array);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).contains(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).contains(array);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, U[] array) {
-      return assertThat(stream).contains(array);
+    ListAssert<S> after(Stream<S> actual, U[] array) {
+      return assertThat(actual).contains(array);
     }
   }
 
+  /** Prefer {@link ListAssert#contains(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsVarArgs<S, T extends S, U extends T> {
+  static final class AssertThatContainsVarargs<S, T extends S, U extends T> {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContains" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContains" /* Varargs converted to array. */)
     IterableAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).contains(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).contains(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContains" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContains" /* Varargs converted to array. */)
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
-        @Repeated U elements,
-        Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).contains(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).contains(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContains" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContains" /* Varargs converted to array. */)
     ListAssert<T> before3(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).contains(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).contains(Refaster.asVarargs(values));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).contains(elements);
+    ListAssert<S> after(Stream<S> actual, @Repeated U values) {
+      return assertThat(actual).contains(Refaster.asVarargs(values));
     }
   }
 
+  /**
+   * Prefer {@link ListAssert#containsExactlyElementsOf(Iterable)} over less efficient alternatives.
+   */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsExactlyElementsOf<S, T extends S, U extends T> {
+  static final class AssertThatContainsExactlyElementsOfStream<S, T extends S, U extends T> {
     @BeforeTemplate
     ListAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsExactlyElementsOf(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsExactlyElementsOf(iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).containsExactlyElementsOf(iterable);
+    ListAssert<S> after(Stream<S> actual, Iterable<U> iterable) {
+      return assertThat(actual).containsExactlyElementsOf(iterable);
     }
   }
 
+  /** Prefer {@link ListAssert#containsExactly(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsExactly<S, T extends S, U extends T> {
+  static final class AssertThatContainsExactlyStream<S, T extends S, U extends T> {
     @BeforeTemplate
     ListAssert<T> before(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsExactly(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsExactly(array);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, U[] array) {
-      return assertThat(stream).containsExactly(array);
+    ListAssert<S> after(Stream<S> actual, U[] array) {
+      return assertThat(actual).containsExactly(array);
     }
   }
 
+  /** Prefer {@link ListAssert#containsExactly(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsExactlyVarargs<S, T extends S, U extends T> {
+  static final class AssertThatContainsExactlyVarargs<S, T extends S, U extends T> {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsExactly" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContainsExactlyStream" /* Varargs converted to array. */)
     ListAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsExactly(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsExactly(Refaster.asVarargs(values));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).containsExactly(elements);
+    ListAssert<S> after(Stream<S> actual, @Repeated U values) {
+      return assertThat(actual).containsExactly(Refaster.asVarargs(values));
     }
   }
 
+  /**
+   * Prefer {@link ListAssert#containsExactlyInAnyOrderElementsOf(Iterable)} over less efficient
+   * alternatives.
+   */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsExactlyInAnyOrderElementsOf<
+  static final class AssertThatContainsExactlyInAnyOrderElementsOfStream<
       S, T extends S, U extends T> {
     @BeforeTemplate
     ListAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsExactlyInAnyOrderElementsOf(iterable);
-    }
-
-    @BeforeTemplate
-    AbstractCollectionAssert<?, ?, T, ?> before2(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends Multiset<T>> collector) {
-      return assertThat(stream.collect(collector)).containsExactlyInAnyOrderElementsOf(iterable);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).containsExactlyInAnyOrderElementsOf(iterable);
-    }
-  }
-
-  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsExactlyInAnyOrder<S, T extends S, U extends T> {
-    @BeforeTemplate
-    ListAssert<T> before(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsExactlyInAnyOrder(array);
-    }
-
-    @BeforeTemplate
-    AbstractCollectionAssert<?, ?, T, ?> before2(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Multiset<T>> collector) {
-      return assertThat(stream.collect(collector)).containsExactlyInAnyOrder(array);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, U[] array) {
-      return assertThat(stream).containsExactlyInAnyOrder(array);
-    }
-  }
-
-  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsExactlyInAnyOrderVarArgs<S, T extends S, U extends T> {
-    @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsExactlyInAnyOrder" /* Varargs converted to array. */)
-    ListAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector))
-          .containsExactlyInAnyOrder(Refaster.asVarargs(elements));
-    }
-
-    @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsExactlyInAnyOrder" /* Varargs converted to array. */)
-    AbstractCollectionAssert<?, ?, T, ?> before2(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends Multiset<T>> collector) {
-      return assertThat(stream.collect(collector))
-          .containsExactlyInAnyOrder(Refaster.asVarargs(elements));
-    }
-
-    @AfterTemplate
-    @SuppressWarnings("ObjectEnumerableContainsExactlyOneElement" /* Not a true singleton. */)
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).containsExactlyInAnyOrder(elements);
-    }
-  }
-
-  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsSequence<S, T extends S, U extends T> {
-    @BeforeTemplate
-    ListAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsSequence(iterable);
-    }
-
-    @BeforeTemplate
-    ListAssert<T> before(
-        Stream<S> stream, U[] iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsSequence(iterable);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).containsSequence(iterable);
-    }
-  }
-
-  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsSequenceVarArgs<S, T extends S, U extends T> {
-    @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsSequence" /* Varargs converted to array. */)
-    ListAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsSequence(Refaster.asVarargs(elements));
-    }
-
-    @AfterTemplate
-    @SuppressWarnings("ObjectEnumerableContainsOneElement" /* Not a true singleton. */)
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).containsSequence(elements);
-    }
-  }
-
-  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsSubsequence<S, T extends S, U extends T> {
-    @BeforeTemplate
-    ListAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsSubsequence(iterable);
-    }
-
-    @BeforeTemplate
-    ListAssert<T> before(
-        Stream<S> stream, U[] iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsSubsequence(iterable);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).containsSubsequence(iterable);
-    }
-  }
-
-  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsSubsequenceVarArgs<S, T extends S, U extends T> {
-    @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsSubsequence" /* Varargs converted to array. */)
-    ListAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector))
-          .containsSubsequence(Refaster.asVarargs(elements));
-    }
-
-    @AfterTemplate
-    @SuppressWarnings("ObjectEnumerableContainsOneElement" /* Not a true singleton. */)
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).containsSubsequence(elements);
-    }
-  }
-
-  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamDoesNotContainAnyElementsOf<S, T extends S, U extends T> {
-    @BeforeTemplate
-    IterableAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContainAnyElementsOf(iterable);
+        Stream<S> actual, Iterable<U> values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsExactlyInAnyOrderElementsOf(values);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
+        Stream<S> actual, Iterable<U> values, Collector<S, ?, ? extends Multiset<T>> collector) {
+      return assertThat(actual.collect(collector)).containsExactlyInAnyOrderElementsOf(values);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ListAssert<S> after(Stream<S> actual, Iterable<U> values) {
+      return assertThat(actual).containsExactlyInAnyOrderElementsOf(values);
+    }
+  }
+
+  /**
+   * Prefer {@link ListAssert#containsExactlyInAnyOrder(Object[])} over less efficient alternatives.
+   */
+  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
+  static final class AssertThatContainsExactlyInAnyOrder<S, T extends S, U extends T> {
+    @BeforeTemplate
+    ListAssert<T> before(
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsExactlyInAnyOrder(array);
+    }
+
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Multiset<T>> collector) {
+      return assertThat(actual.collect(collector)).containsExactlyInAnyOrder(array);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ListAssert<S> after(Stream<S> actual, U[] array) {
+      return assertThat(actual).containsExactlyInAnyOrder(array);
+    }
+  }
+
+  /**
+   * Prefer {@link ListAssert#containsExactlyInAnyOrder(Object[])} over less efficient alternatives.
+   */
+  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
+  static final class AssertThatContainsExactlyInAnyOrderVarargs<S, T extends S, U extends T> {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatContainsExactlyInAnyOrder" /* Varargs converted to array. */)
+    ListAssert<T> before(
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector))
+          .containsExactlyInAnyOrder(Refaster.asVarargs(values));
+    }
+
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatContainsExactlyInAnyOrder" /* Varargs converted to array. */)
+    AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Multiset<T>> collector) {
+      return assertThat(actual.collect(collector))
+          .containsExactlyInAnyOrder(Refaster.asVarargs(values));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ListAssert<S> after(Stream<S> actual, @Repeated U values) {
+      return assertThat(actual).containsExactlyInAnyOrder(Refaster.asVarargs(values));
+    }
+  }
+
+  /** Prefer {@link ListAssert#containsSequence(Iterable)} over less efficient alternatives. */
+  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
+  static final class AssertThatContainsSequence<S, T extends S, U extends T> {
+    @BeforeTemplate
+    ListAssert<T> before(
+        Stream<S> actual, Iterable<U> sequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsSequence(sequence);
+    }
+
+    @BeforeTemplate
+    ListAssert<T> before(
+        Stream<S> actual, U[] sequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsSequence(sequence);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ListAssert<S> after(Stream<S> actual, Iterable<U> sequence) {
+      return assertThat(actual).containsSequence(sequence);
+    }
+  }
+
+  /** Prefer {@link ListAssert#containsSequence(Object[])} over less efficient alternatives. */
+  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
+  static final class AssertThatContainsSequenceVarargs<S, T extends S, U extends T> {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatContainsSequence" /* Varargs converted to array. */)
+    ListAssert<T> before(
+        Stream<S> actual, @Repeated U sequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsSequence(Refaster.asVarargs(sequence));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ListAssert<S> after(Stream<S> actual, @Repeated U sequence) {
+      return assertThat(actual).containsSequence(Refaster.asVarargs(sequence));
+    }
+  }
+
+  /** Prefer {@link ListAssert#containsSubsequence(Iterable)} over less efficient alternatives. */
+  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
+  static final class AssertThatContainsSubsequence<S, T extends S, U extends T> {
+    @BeforeTemplate
+    ListAssert<T> before(
+        Stream<S> actual, Iterable<U> subsequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsSubsequence(subsequence);
+    }
+
+    @BeforeTemplate
+    ListAssert<T> before(
+        Stream<S> actual, U[] subsequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsSubsequence(subsequence);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ListAssert<S> after(Stream<S> actual, Iterable<U> subsequence) {
+      return assertThat(actual).containsSubsequence(subsequence);
+    }
+  }
+
+  /** Prefer {@link ListAssert#containsSubsequence(Object[])} over less efficient alternatives. */
+  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
+  static final class AssertThatContainsSubsequenceVarargs<S, T extends S, U extends T> {
+    @BeforeTemplate
+    @SuppressWarnings("AssertThatContainsSubsequence" /* Varargs converted to array. */)
+    ListAssert<T> before(
+        Stream<S> actual, @Repeated U subsequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector))
+          .containsSubsequence(Refaster.asVarargs(subsequence));
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    ListAssert<S> after(Stream<S> actual, @Repeated U subsequence) {
+      return assertThat(actual).containsSubsequence(Refaster.asVarargs(subsequence));
+    }
+  }
+
+  /**
+   * Prefer {@link ListAssert#doesNotContainAnyElementsOf(Iterable)} over less efficient
+   * alternatives.
+   */
+  // XXX: This rule assumes the `collector` doesn't completely discard certain values.
+  static final class AssertThatDoesNotContainAnyElementsOf<S, T extends S, U extends T> {
+    @BeforeTemplate
+    IterableAssert<T> before(
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContainAnyElementsOf(iterable);
+    }
+
+    @BeforeTemplate
+    AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
+        Stream<S> actual,
         Iterable<U> iterable,
         Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContainAnyElementsOf(iterable);
+      return assertThat(actual.collect(collector)).doesNotContainAnyElementsOf(iterable);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContainAnyElementsOf(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContainAnyElementsOf(iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).doesNotContainAnyElementsOf(iterable);
+    ListAssert<S> after(Stream<S> actual, Iterable<U> iterable) {
+      return assertThat(actual).doesNotContainAnyElementsOf(iterable);
     }
   }
 
+  /** Prefer {@link ListAssert#doesNotContain(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamDoesNotContain<S, T extends S, U extends T> {
+  static final class AssertThatDoesNotContain<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContain(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContain(array);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContain(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContain(array);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContain(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContain(array);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, U[] array) {
-      return assertThat(stream).doesNotContain(array);
+    ListAssert<S> after(Stream<S> actual, U[] array) {
+      return assertThat(actual).doesNotContain(array);
     }
   }
 
+  /** Prefer {@link ListAssert#doesNotContain(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamDoesNotContainVarArgs<S, T extends S, U extends T> {
+  static final class AssertThatDoesNotContainVarargs<S, T extends S, U extends T> {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamDoesNotContain" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatDoesNotContain" /* Varargs converted to array. */)
     IterableAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContain(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContain(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamDoesNotContain" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatDoesNotContain" /* Varargs converted to array. */)
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
-        @Repeated U elements,
-        Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContain(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContain(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamDoesNotContain" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatDoesNotContain" /* Varargs converted to array. */)
     ListAssert<T> before3(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContain(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContain(Refaster.asVarargs(values));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).doesNotContain(elements);
+    ListAssert<S> after(Stream<S> actual, @Repeated U values) {
+      return assertThat(actual).doesNotContain(Refaster.asVarargs(values));
     }
   }
 
+  /**
+   * Prefer {@link ListAssert#doesNotContainSequence(Iterable)} over less efficient alternatives.
+   */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamDoesNotContainSequence<S, T extends S, U extends T> {
+  static final class AssertThatDoesNotContainSequence<S, T extends S, U extends T> {
     @BeforeTemplate
     ListAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContainSequence(iterable);
+        Stream<S> actual, Iterable<U> sequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContainSequence(sequence);
     }
 
     @BeforeTemplate
     ListAssert<T> before(
-        Stream<S> stream, U[] iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).doesNotContainSequence(iterable);
+        Stream<S> actual, U[] sequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).doesNotContainSequence(sequence);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).doesNotContainSequence(iterable);
+    ListAssert<S> after(Stream<S> actual, Iterable<U> sequence) {
+      return assertThat(actual).doesNotContainSequence(sequence);
     }
   }
 
+  /**
+   * Prefer {@link ListAssert#doesNotContainSequence(Object[])} over less efficient alternatives.
+   */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamDoesNotContainSequenceVarArgs<S, T extends S, U extends T> {
+  static final class AssertThatDoesNotContainSequenceVarargs<S, T extends S, U extends T> {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamDoesNotContainSequence" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatDoesNotContainSequence" /* Varargs converted to array. */)
     ListAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector))
-          .doesNotContainSequence(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U sequence, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector))
+          .doesNotContainSequence(Refaster.asVarargs(sequence));
     }
 
     @AfterTemplate
-    @SuppressWarnings("ObjectEnumerableDoesNotContainOneElement" /* Not a true singleton. */)
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).doesNotContainSequence(elements);
+    ListAssert<S> after(Stream<S> actual, @Repeated U sequence) {
+      return assertThat(actual).doesNotContainSequence(Refaster.asVarargs(sequence));
     }
   }
 
+  /** Prefer {@link ListAssert#hasSameElementsAs(Iterable)} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamHasSameElementsAs<S, T extends S, U extends T> {
+  static final class AssertThatHasSameElementsAsStream<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).hasSameElementsAs(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).hasSameElementsAs(iterable);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
+        Stream<S> actual,
         Iterable<U> iterable,
         Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).hasSameElementsAs(iterable);
+      return assertThat(actual.collect(collector)).hasSameElementsAs(iterable);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).hasSameElementsAs(iterable);
+        Stream<S> actual, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).hasSameElementsAs(iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, Iterable<U> iterable) {
-      return assertThat(stream).hasSameElementsAs(iterable);
+    ListAssert<S> after(Stream<S> actual, Iterable<U> iterable) {
+      return assertThat(actual).hasSameElementsAs(iterable);
     }
   }
 
+  /** Prefer {@link ListAssert#containsOnly(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsOnly<S, T extends S, U extends T> {
+  static final class AssertThatContainsOnly<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).containsOnly(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).containsOnly(array);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).containsOnly(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).containsOnly(array);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, U[] array, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsOnly(array);
+        Stream<S> actual, U[] array, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsOnly(array);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, U[] array) {
-      return assertThat(stream).containsOnly(array);
+    ListAssert<S> after(Stream<S> actual, U[] array) {
+      return assertThat(actual).containsOnly(array);
     }
   }
 
+  /** Prefer {@link ListAssert#containsOnly(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamContainsOnlyVarArgs<S, T extends S, U extends T> {
+  static final class AssertThatContainsOnlyVarargs<S, T extends S, U extends T> {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsOnly" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContainsOnly" /* Varargs converted to array. */)
     IterableAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).containsOnly(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).containsOnly(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsOnly" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContainsOnly" /* Varargs converted to array. */)
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
-        @Repeated U elements,
-        Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).containsOnly(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).containsOnly(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamContainsOnly" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatContainsOnly" /* Varargs converted to array. */)
     ListAssert<T> before3(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).containsOnly(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).containsOnly(Refaster.asVarargs(values));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).containsOnly(elements);
+    ListAssert<S> after(Stream<S> actual, @Repeated U values) {
+      return assertThat(actual).containsOnly(Refaster.asVarargs(values));
     }
   }
 
+  /** Prefer {@link ListAssert#isSubsetOf(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamIsSubsetOf<S, T extends S, U extends T> {
+  static final class AssertThatIsSubsetOf<S, T extends S, U extends T> {
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(iterable);
+        Stream<S> actual, Iterable<U> values, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(values);
     }
 
     @BeforeTemplate
     IterableAssert<T> before(
-        Stream<S> stream, U[] iterable, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(iterable);
+        Stream<S> actual, U[] values, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(values);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
-        Iterable<U> iterable,
-        Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(iterable);
+        Stream<S> actual, Iterable<U> values, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(values);
     }
 
     @BeforeTemplate
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream, U[] iterable, Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(iterable);
+        Stream<S> actual, U[] values, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(values);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, Iterable<U> iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(iterable);
+        Stream<S> actual, Iterable<U> values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(values);
     }
 
     @BeforeTemplate
     ListAssert<T> before3(
-        Stream<S> stream, U[] iterable, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(iterable);
+        Stream<S> actual, U[] values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(values);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, U[] iterable) {
-      return assertThat(stream).isSubsetOf(iterable);
+    ListAssert<S> after(Stream<S> actual, U[] values) {
+      return assertThat(actual).isSubsetOf(values);
     }
   }
 
+  /** Prefer {@link ListAssert#isSubsetOf(Object[])} over less efficient alternatives. */
   // XXX: This rule assumes the `collector` doesn't completely discard certain values.
-  static final class AssertThatStreamIsSubsetOfVarArgs<S, T extends S, U extends T> {
+  static final class AssertThatIsSubsetOfVarargs<S, T extends S, U extends T> {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamIsSubsetOf" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatIsSubsetOf" /* Varargs converted to array. */)
     IterableAssert<T> before(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends Iterable<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Iterable<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamIsSubsetOf" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatIsSubsetOf" /* Varargs converted to array. */)
     AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> before2(
-        Stream<S> stream,
-        @Repeated U elements,
-        Collector<S, ?, ? extends Collection<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends Collection<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(Refaster.asVarargs(values));
     }
 
     @BeforeTemplate
-    @SuppressWarnings("AssertThatStreamIsSubsetOf" /* Varargs converted to array. */)
+    @SuppressWarnings("AssertThatIsSubsetOf" /* Varargs converted to array. */)
     ListAssert<T> before3(
-        Stream<S> stream, @Repeated U elements, Collector<S, ?, ? extends List<T>> collector) {
-      return assertThat(stream.collect(collector)).isSubsetOf(Refaster.asVarargs(elements));
+        Stream<S> actual, @Repeated U values, Collector<S, ?, ? extends List<T>> collector) {
+      return assertThat(actual.collect(collector)).isSubsetOf(Refaster.asVarargs(values));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<S> after(Stream<S> stream, @Repeated U elements) {
-      return assertThat(stream).isSubsetOf(elements);
+    ListAssert<S> after(Stream<S> actual, @Repeated U values) {
+      return assertThat(actual).isSubsetOf(Refaster.asVarargs(values));
     }
   }
 
@@ -964,29 +1025,31 @@ final class AssertJRules {
   // Predicate
   //
 
-  static final class AssertThatPredicateAccepts<T> {
+  /** Prefer {@code assertThat(predicate).accepts(object)} over less explicit alternatives. */
+  static final class AssertThatAccepts<T> {
     @BeforeTemplate
-    void before(Predicate<T> predicate, T object) {
-      assertThat(predicate.test(object)).isTrue();
+    void before(Predicate<T> actual, T object) {
+      assertThat(actual.test(object)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Predicate<T> predicate, T object) {
-      assertThat(predicate).accepts(object);
+    void after(Predicate<T> actual, T object) {
+      assertThat(actual).accepts(object);
     }
   }
 
-  static final class AssertThatPredicateRejects<T> {
+  /** Prefer {@code assertThat(predicate).rejects(object)} over less explicit alternatives. */
+  static final class AssertThatRejects<T> {
     @BeforeTemplate
-    void before(Predicate<T> predicate, T object) {
-      assertThat(predicate.test(object)).isFalse();
+    void before(Predicate<T> actual, T object) {
+      assertThat(actual.test(object)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Predicate<T> predicate, T object) {
-      assertThat(predicate).rejects(object);
+    void after(Predicate<T> actual, T object) {
+      assertThat(actual).rejects(object);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJRules.java
@@ -243,6 +243,10 @@ final class AssertJRules {
 
   /**
    * Prefer {@link ListAssert#containsExactlyElementsOf(Iterable)} over less explicit alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if {@code iterable} is not a {@link
+   * List}: {@link List#equals(Object)} returns {@code false} for non-{@code List} iterables, while
+   * {@link ListAssert#containsExactlyElementsOf(Iterable)} accepts any {@link Iterable}.
    */
   static final class AssertThatContainsExactlyElementsOfList<S, T extends S> {
     @BeforeTemplate
@@ -264,6 +268,11 @@ final class AssertJRules {
   /**
    * Prefer {@link AbstractCollectionAssert#hasSameElementsAs(Iterable)} over less explicit or more
    * contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior when {@code iterable} contains
+   * duplicates: {@link AbstractCollectionAssert#containsExactlyInAnyOrderElementsOf(Iterable)} is
+   * then guaranteed to fail, while {@link AbstractCollectionAssert#hasSameElementsAs(Iterable)} may
+   * not.
    */
   static final class AssertThatHasSameElementsAsSet<S, T extends S> {
     @BeforeTemplate
@@ -293,6 +302,11 @@ final class AssertJRules {
   /**
    * Prefer {@link AbstractCollectionAssert#containsExactlyInAnyOrderElementsOf(Iterable)} over less
    * explicit alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if {@code values} is not a {@link
+   * Multiset}: {@link Multiset#equals} returns {@code false} for non-{@code Multiset} iterables,
+   * while {@link AbstractCollectionAssert#containsExactlyInAnyOrderElementsOf(Iterable)} accepts
+   * any {@link Iterable}.
    */
   static final class AssertThatContainsExactlyInAnyOrderElementsOfMultiset<S, T extends S> {
     @BeforeTemplate
@@ -313,7 +327,14 @@ final class AssertJRules {
   // Map
   //
 
-  /** Prefer {@link MapAssert#containsEntry(Object, Object)} over more contrived alternatives. */
+  /**
+   * Prefer {@link MapAssert#containsEntry(Object, Object)} over more contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior when {@code value} is {@code null}
+   * and {@code key} is absent from the map: the original code passes (as {@link Map#get} returns
+   * {@code null} for absent keys), while {@link MapAssert#containsEntry(Object, Object)} requires
+   * the key to be explicitly present.
+   */
   // XXX: To match in all cases there'll need to be a `@BeforeTemplate` variant for each
   // `assertThat` overload. Consider defining a `BugChecker` instead.
   static final class AssertThatContainsEntry<K, V> {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJShortRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJShortRules.java
@@ -14,34 +14,38 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJShortRules {
   private AssertJShortRules() {}
 
+  /** Prefer {@link AbstractShortAssert#isEqualTo(short)} over less explicit alternatives. */
   static final class AbstractShortAssertIsEqualTo {
     @BeforeTemplate
-    AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert, short n) {
+    AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert, short expected) {
       return Refaster.anyOf(
-          shortAssert.isCloseTo(n, offset((short) 0)), shortAssert.isCloseTo(n, withPercentage(0)));
+          shortAssert.isCloseTo(expected, offset((short) 0)),
+          shortAssert.isCloseTo(expected, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractShortAssert<?> after(AbstractShortAssert<?> shortAssert, short n) {
-      return shortAssert.isEqualTo(n);
+    AbstractShortAssert<?> after(AbstractShortAssert<?> shortAssert, short expected) {
+      return shortAssert.isEqualTo(expected);
     }
   }
 
+  /** Prefer {@link AbstractShortAssert#isNotEqualTo(short)} over less explicit alternatives. */
   static final class AbstractShortAssertIsNotEqualTo {
     @BeforeTemplate
-    AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert, short n) {
+    AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert, short other) {
       return Refaster.anyOf(
-          shortAssert.isNotCloseTo(n, offset((short) 0)),
-          shortAssert.isNotCloseTo(n, withPercentage(0)));
+          shortAssert.isNotCloseTo(other, offset((short) 0)),
+          shortAssert.isNotCloseTo(other, withPercentage(0)));
     }
 
     @AfterTemplate
-    AbstractShortAssert<?> after(AbstractShortAssert<?> shortAssert, short n) {
-      return shortAssert.isNotEqualTo(n);
+    AbstractShortAssert<?> after(AbstractShortAssert<?> shortAssert, short other) {
+      return shortAssert.isNotEqualTo(other);
     }
   }
 
-  static final class AbstractShortAssertIsZero {
+  /** Prefer {@link AbstractShortAssert#isEqualTo(short)} over less explicit alternatives. */
+  static final class AbstractShortAssertIsEqualToZero {
     @BeforeTemplate
     AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert) {
       return shortAssert.isZero();
@@ -53,7 +57,8 @@ final class AssertJShortRules {
     }
   }
 
-  static final class AbstractShortAssertIsNotZero {
+  /** Prefer {@link AbstractShortAssert#isNotEqualTo(short)} over less explicit alternatives. */
+  static final class AbstractShortAssertIsNotEqualToZero {
     @BeforeTemplate
     AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert) {
       return shortAssert.isNotZero();
@@ -65,7 +70,8 @@ final class AssertJShortRules {
     }
   }
 
-  static final class AbstractShortAssertIsOne {
+  /** Prefer {@link AbstractShortAssert#isEqualTo(short)} over less explicit alternatives. */
+  static final class AbstractShortAssertIsEqualToOne {
     @BeforeTemplate
     AbstractShortAssert<?> before(AbstractShortAssert<?> shortAssert) {
       return shortAssert.isOne();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStreamRules.java
@@ -17,6 +17,7 @@ import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractCollectionAssert;
 import org.assertj.core.api.AbstractLongAssert;
 import org.assertj.core.api.ListAssert;
+import org.assertj.core.api.ObjectAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to AssertJ assertions over {@link Stream}s. */
@@ -24,156 +25,161 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJStreamRules {
   private AssertJStreamRules() {}
 
+  /** Prefer {@code assertThat(stream).isEmpty()} over less efficient alternatives. */
   static final class AssertThatIsEmpty<T, S> {
     @BeforeTemplate
-    void before(Stream<T> stream) {
-      assertThat(stream.findAny()).isEmpty();
+    void before(Stream<T> actual) {
+      assertThat(actual.findAny()).isEmpty();
     }
 
     @BeforeTemplate
-    void before2(Stream<T> stream) {
-      assertThat(stream.findFirst()).isEmpty();
+    void before2(Stream<T> actual) {
+      assertThat(actual.findFirst()).isEmpty();
     }
 
     @BeforeTemplate
-    void before3(Stream<T> stream) {
-      assertThat(stream.toArray()).isEmpty();
+    void before3(Stream<T> actual) {
+      assertThat(actual.toArray()).isEmpty();
     }
 
     @BeforeTemplate
-    void before4(Stream<T> stream, IntFunction<S[]> generator) {
-      assertThat(stream.toArray(generator)).isEmpty();
+    void before4(Stream<T> actual, IntFunction<S[]> function) {
+      assertThat(actual.toArray(function)).isEmpty();
     }
 
     @BeforeTemplate
-    void before5(Stream<T> stream) {
-      assertThat(stream.toList()).isEmpty();
-    }
-
-    // XXX: This template assumes that `collector` doesn't completely discard certain values.
-    @BeforeTemplate
-    void before6(Stream<T> stream, Collector<T, ?, ? extends Iterable<S>> collector) {
-      assertThat(stream.collect(collector)).isEmpty();
+    void before5(Stream<T> actual) {
+      assertThat(actual.toList()).isEmpty();
     }
 
     // XXX: This template assumes that `collector` doesn't completely discard certain values.
     @BeforeTemplate
-    void before7(Stream<T> stream, Collector<T, ?, ? extends Collection<S>> collector) {
-      assertThat(stream.collect(collector)).isEmpty();
+    void before6(Stream<T> actual, Collector<T, ?, ? extends Iterable<S>> collector) {
+      assertThat(actual.collect(collector)).isEmpty();
     }
 
     // XXX: This template assumes that `collector` doesn't completely discard certain values.
     @BeforeTemplate
-    void before8(Stream<T> stream, Collector<T, ?, ? extends List<S>> collector) {
-      assertThat(stream.collect(collector)).isEmpty();
+    void before7(Stream<T> actual, Collector<T, ?, ? extends Collection<S>> collector) {
+      assertThat(actual.collect(collector)).isEmpty();
+    }
+
+    // XXX: This template assumes that `collector` doesn't completely discard certain values.
+    @BeforeTemplate
+    void before8(Stream<T> actual, Collector<T, ?, ? extends List<S>> collector) {
+      assertThat(actual.collect(collector)).isEmpty();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Stream<T> stream) {
-      assertThat(stream).isEmpty();
+    void after(Stream<T> actual) {
+      assertThat(actual).isEmpty();
     }
   }
 
+  /** Prefer {@code assertThat(stream).isNotEmpty()} over less efficient alternatives. */
   static final class AssertThatIsNotEmpty<T, S> {
     @BeforeTemplate
-    void before(Stream<T> stream) {
-      assertThat(stream.count()).isNotEqualTo(0);
+    void before(Stream<T> actual) {
+      assertThat(actual.count()).isNotEqualTo(0);
     }
 
     @BeforeTemplate
-    void before2(Stream<T> stream) {
-      assertThat(stream.findAny()).isPresent();
+    void before2(Stream<T> actual) {
+      assertThat(actual.findAny()).isPresent();
     }
 
     @BeforeTemplate
-    void before3(Stream<T> stream) {
-      assertThat(stream.findFirst()).isPresent();
+    void before3(Stream<T> actual) {
+      assertThat(actual.findFirst()).isPresent();
     }
 
     @BeforeTemplate
-    void before4(Stream<T> stream) {
-      assertThat(stream.toArray()).isNotEmpty();
+    void before4(Stream<T> actual) {
+      assertThat(actual.toArray()).isNotEmpty();
     }
 
     @BeforeTemplate
-    void before5(Stream<T> stream, IntFunction<S[]> generator) {
-      assertThat(stream.toArray(generator)).isNotEmpty();
+    void before5(Stream<T> actual, IntFunction<S[]> function) {
+      assertThat(actual.toArray(function)).isNotEmpty();
     }
 
     @BeforeTemplate
-    void before6(Stream<T> stream) {
-      assertThat(stream.toList()).isNotEmpty();
-    }
-
-    // XXX: This template assumes that `collector` doesn't completely discard certain values.
-    @BeforeTemplate
-    void before7(Stream<T> stream, Collector<? super T, ?, ? extends Iterable<S>> collector) {
-      assertThat(stream.collect(collector)).isNotEmpty();
+    void before6(Stream<T> actual) {
+      assertThat(actual.toList()).isNotEmpty();
     }
 
     // XXX: This template assumes that `collector` doesn't completely discard certain values.
     @BeforeTemplate
-    void before8(Stream<T> stream, Collector<? super T, ?, ? extends Collection<S>> collector) {
-      assertThat(stream.collect(collector)).isNotEmpty();
+    void before7(Stream<T> actual, Collector<T, ?, ? extends Iterable<S>> collector) {
+      assertThat(actual.collect(collector)).isNotEmpty();
     }
 
     // XXX: This template assumes that `collector` doesn't completely discard certain values.
     @BeforeTemplate
-    void before9(Stream<T> stream, Collector<? super T, ?, ? extends List<S>> collector) {
-      assertThat(stream.collect(collector)).isNotEmpty();
+    void before8(Stream<T> actual, Collector<T, ?, ? extends Collection<S>> collector) {
+      assertThat(actual.collect(collector)).isNotEmpty();
+    }
+
+    // XXX: This template assumes that `collector` doesn't completely discard certain values.
+    @BeforeTemplate
+    void before9(Stream<T> actual, Collector<T, ?, ? extends List<S>> collector) {
+      assertThat(actual.collect(collector)).isNotEmpty();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Stream<T> stream) {
-      assertThat(stream).isNotEmpty();
+    void after(Stream<T> actual) {
+      assertThat(actual).isNotEmpty();
     }
   }
 
+  /** Prefer {@code assertThat(stream).hasSize(size)} over more contrived alternatives. */
   static final class AssertThatHasSize<T> {
     @BeforeTemplate
-    AbstractLongAssert<?> before(Stream<T> stream, int size) {
-      return assertThat(stream.count()).isEqualTo(size);
+    AbstractLongAssert<?> before(Stream<T> actual, int expected) {
+      return assertThat(actual.count()).isEqualTo(expected);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<T> after(Stream<T> stream, int size) {
-      return assertThat(stream).hasSize(size);
+    ListAssert<T> after(Stream<T> actual, int expected) {
+      return assertThat(actual).hasSize(expected);
     }
   }
 
-  static final class AssertThatFilteredOn<T> {
+  /** Prefer {@code assertThat(stream).filteredOn(predicate)} over more contrived alternatives. */
+  static final class AssertThatFilteredOn<S, T extends S> {
     @BeforeTemplate
-    ListAssert<T> before(Stream<T> stream, Predicate<? super T> predicate) {
-      return assertThat(stream.filter(predicate));
+    ListAssert<T> before(Stream<T> actual, Predicate<S> predicate) {
+      return assertThat(actual.filter(predicate));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<T> after(Stream<T> stream, Predicate<? super T> predicate) {
-      return assertThat(stream).filteredOn(predicate);
+    ListAssert<T> after(Stream<T> actual, Predicate<S> predicate) {
+      return assertThat(actual).filteredOn(predicate);
     }
   }
 
-  static final class AssertThatNoneMatch<T> {
+  /** Prefer {@code assertThat(stream).noneMatch(predicate)} over more contrived alternatives. */
+  static final class AssertThatNoneMatch<S, T extends S> {
     @BeforeTemplate
-    void before(Stream<T> stream, Predicate<? super T> predicate) {
-      assertThat(stream).filteredOn(predicate).isEmpty();
+    void before(Stream<T> actual, Predicate<S> predicate) {
+      assertThat(actual).filteredOn(predicate).isEmpty();
     }
 
     @BeforeTemplate
-    void before2(Stream<T> stream, Predicate<? super T> predicate) {
+    void before2(Stream<T> actual, Predicate<S> predicate) {
       Refaster.anyOf(
-          assertThat(stream.anyMatch(predicate)).isFalse(),
-          assertThat(stream.noneMatch(predicate)).isTrue());
+          assertThat(actual.anyMatch(predicate)).isFalse(),
+          assertThat(actual.noneMatch(predicate)).isTrue());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Stream<T> stream, Predicate<? super T> predicate) {
-      assertThat(stream).noneMatch(predicate);
+    void after(Stream<T> actual, Predicate<S> predicate) {
+      assertThat(actual).noneMatch(predicate);
     }
   }
 
@@ -191,37 +197,40 @@ final class AssertJStreamRules {
     }
   }
 
-  static final class AssertThatAnyMatch<T> {
+  /** Prefer {@code assertThat(stream).anyMatch(predicate)} over more contrived alternatives. */
+  static final class AssertThatAnyMatch<S, T extends S> {
     @BeforeTemplate
-    ListAssert<T> before(Stream<T> stream, Predicate<? super T> predicate) {
-      return assertThat(stream).filteredOn(predicate).isNotEmpty();
+    ListAssert<T> before(Stream<T> actual, Predicate<S> predicate) {
+      return assertThat(actual).filteredOn(predicate).isNotEmpty();
     }
 
     @BeforeTemplate
-    AbstractBooleanAssert<?> before2(Stream<T> stream, Predicate<? super T> predicate) {
+    AbstractBooleanAssert<?> before2(Stream<T> actual, Predicate<S> predicate) {
       return Refaster.anyOf(
-          assertThat(stream.anyMatch(predicate)).isTrue(),
-          assertThat(stream.noneMatch(predicate)).isFalse());
+          assertThat(actual.anyMatch(predicate)).isTrue(),
+          assertThat(actual.noneMatch(predicate)).isFalse());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    ListAssert<T> after(Stream<T> stream, Predicate<? super T> predicate) {
-      return assertThat(stream).anyMatch(predicate);
+    ListAssert<T> after(Stream<T> actual, Predicate<S> predicate) {
+      return assertThat(actual).anyMatch(predicate);
     }
   }
 
+  /** Prefer {@code assertThat(collection)} over more contrived alternatives. */
   // XXX: Consider moving this rule to a new `AssertJCollectionRules` class.
-  static final class AssertThatCollection<T> {
+  static final class AssertThat<T> {
     @BeforeTemplate
-    ListAssert<T> before(Collection<T> collection) {
-      return assertThat(collection.stream());
+    ListAssert<T> before(Collection<T> actual) {
+      return assertThat(actual.stream());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractCollectionAssert<?, ?, T, ?> after(Collection<T> collection) {
-      return assertThat(collection);
+    AbstractCollectionAssert<?, Collection<? extends T>, T, ObjectAssert<T>> after(
+        Collection<T> actual) {
+      return assertThat(actual);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJStringRules.java
@@ -11,7 +11,6 @@ import java.io.IOException;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import org.assertj.core.api.AbstractAssert;
 import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.AbstractStringAssert;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
@@ -21,7 +20,8 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJStringRules {
   private AssertJStringRules() {}
 
-  static final class AbstractStringAssertStringIsEmpty {
+  /** Prefer {@link AbstractStringAssert#isEmpty()} over less explicit alternatives. */
+  static final class AbstractStringAssertIsEmpty {
     @BeforeTemplate
     void before(AbstractStringAssert<?> stringAssert) {
       stringAssert.isEqualTo("");
@@ -33,7 +33,8 @@ final class AssertJStringRules {
     }
   }
 
-  static final class AbstractStringAssertStringIsNotEmpty {
+  /** Prefer {@link AbstractStringAssert#isNotEmpty()} over less explicit alternatives. */
+  static final class AbstractStringAssertIsNotEmpty {
     @BeforeTemplate
     AbstractStringAssert<?> before(AbstractStringAssert<?> stringAssert) {
       return stringAssert.isNotEqualTo("");
@@ -45,81 +46,102 @@ final class AssertJStringRules {
     }
   }
 
-  static final class AssertThatStringStartsWith {
+  /**
+   * Prefer {@link AbstractStringAssert#startsWith(CharSequence)} over more contrived alternatives.
+   */
+  static final class AssertThatStartsWith {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, String prefix) {
-      return assertThat(string.startsWith(prefix)).isTrue();
+    AbstractBooleanAssert<?> before(String actual, String prefix) {
+      return assertThat(actual.startsWith(prefix)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, String prefix) {
-      return assertThat(string).startsWith(prefix);
+    AbstractStringAssert<?> after(String actual, String prefix) {
+      return assertThat(actual).startsWith(prefix);
     }
   }
 
-  static final class AssertThatStringDoesNotStartWith {
+  /**
+   * Prefer {@link AbstractStringAssert#doesNotStartWith(CharSequence)} over more contrived
+   * alternatives.
+   */
+  static final class AssertThatDoesNotStartWith {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, String prefix) {
-      return assertThat(string.startsWith(prefix)).isFalse();
+    AbstractBooleanAssert<?> before(String actual, String prefix) {
+      return assertThat(actual.startsWith(prefix)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, String prefix) {
-      return assertThat(string).doesNotStartWith(prefix);
+    AbstractStringAssert<?> after(String actual, String prefix) {
+      return assertThat(actual).doesNotStartWith(prefix);
     }
   }
 
-  static final class AssertThatStringEndsWith {
+  /**
+   * Prefer {@link AbstractStringAssert#endsWith(CharSequence)} over more contrived alternatives.
+   */
+  static final class AssertThatEndsWith {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, String prefix) {
-      return assertThat(string.endsWith(prefix)).isTrue();
+    AbstractBooleanAssert<?> before(String actual, String suffix) {
+      return assertThat(actual.endsWith(suffix)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, String prefix) {
-      return assertThat(string).endsWith(prefix);
+    AbstractStringAssert<?> after(String actual, String suffix) {
+      return assertThat(actual).endsWith(suffix);
     }
   }
 
-  static final class AssertThatStringDoesNotEndWith {
+  /**
+   * Prefer {@link AbstractStringAssert#doesNotEndWith(CharSequence)} over more contrived
+   * alternatives.
+   */
+  static final class AssertThatDoesNotEndWith {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, String prefix) {
-      return assertThat(string.endsWith(prefix)).isFalse();
+    AbstractBooleanAssert<?> before(String actual, String suffix) {
+      return assertThat(actual.endsWith(suffix)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, String prefix) {
-      return assertThat(string).doesNotEndWith(prefix);
+    AbstractStringAssert<?> after(String actual, String suffix) {
+      return assertThat(actual).doesNotEndWith(suffix);
     }
   }
 
-  static final class AssertThatStringContains {
+  /**
+   * Prefer {@link AbstractStringAssert#contains(CharSequence...)} over more contrived alternatives.
+   */
+  static final class AssertThatContains {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, CharSequence substring) {
-      return assertThat(string.contains(substring)).isTrue();
+    AbstractBooleanAssert<?> before(String actual, CharSequence s) {
+      return assertThat(actual.contains(s)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, CharSequence substring) {
-      return assertThat(string).contains(substring);
+    AbstractStringAssert<?> after(String actual, CharSequence s) {
+      return assertThat(actual).contains(s);
     }
   }
 
-  static final class AssertThatStringDoesNotContain {
+  /**
+   * Prefer {@link AbstractStringAssert#doesNotContain(CharSequence...)} over more contrived
+   * alternatives.
+   */
+  static final class AssertThatDoesNotContain {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, CharSequence substring) {
-      return assertThat(string.contains(substring)).isFalse();
+    AbstractBooleanAssert<?> before(String actual, CharSequence s) {
+      return assertThat(actual.contains(s)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, CharSequence substring) {
-      return assertThat(string).doesNotContain(substring);
+    AbstractStringAssert<?> after(String actual, CharSequence s) {
+      return assertThat(actual).doesNotContain(s);
     }
   }
 
@@ -129,14 +151,14 @@ final class AssertJStringRules {
    */
   static final class AssertThatIsEqualToIgnoringCase {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, String other) {
-      return assertThat(string.equalsIgnoreCase(other)).isTrue();
+    AbstractBooleanAssert<?> before(String actual, String expected) {
+      return assertThat(actual.equalsIgnoreCase(expected)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, String other) {
-      return assertThat(string).isEqualToIgnoringCase(other);
+    AbstractStringAssert<?> after(String actual, String expected) {
+      return assertThat(actual).isEqualToIgnoringCase(expected);
     }
   }
 
@@ -146,94 +168,101 @@ final class AssertJStringRules {
    */
   static final class AssertThatIsNotEqualToIgnoringCase {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string, String other) {
-      return assertThat(string.equalsIgnoreCase(other)).isFalse();
+    AbstractBooleanAssert<?> before(String actual, String expected) {
+      return assertThat(actual.equalsIgnoreCase(expected)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string, String other) {
-      return assertThat(string).isNotEqualToIgnoringCase(other);
+    AbstractStringAssert<?> after(String actual, String expected) {
+      return assertThat(actual).isNotEqualToIgnoringCase(expected);
     }
   }
 
   /** Prefer {@link AbstractStringAssert#isBlank()} over less explicit alternatives. */
   static final class AssertThatIsBlank {
     @BeforeTemplate
-    void before(String string) {
-      assertThat(string.isBlank()).isTrue();
+    void before(String actual) {
+      assertThat(actual.isBlank()).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(String string) {
-      assertThat(string).isBlank();
+    void after(String actual) {
+      assertThat(actual).isBlank();
     }
   }
 
   /** Prefer {@link AbstractStringAssert#isNotBlank()} over less explicit alternatives. */
   static final class AssertThatIsNotBlank {
     @BeforeTemplate
-    AbstractBooleanAssert<?> before(String string) {
-      return assertThat(string.isBlank()).isFalse();
+    AbstractBooleanAssert<?> before(String actual) {
+      return assertThat(actual.isBlank()).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(String string) {
-      return assertThat(string).isNotBlank();
+    AbstractStringAssert<?> after(String actual) {
+      return assertThat(actual).isNotBlank();
     }
   }
 
+  /** Prefer {@link AbstractStringAssert#matches(CharSequence)} over more contrived alternatives. */
   static final class AssertThatMatches {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(String string, String regex) {
-      return assertThat(string.matches(regex)).isTrue();
+    AbstractBooleanAssert<?> before(String actual, String regex) {
+      return assertThat(actual.matches(regex)).isTrue();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractAssert<?, ?> after(String string, String regex) {
-      return assertThat(string).matches(regex);
+    AbstractStringAssert<?> after(String actual, String regex) {
+      return assertThat(actual).matches(regex);
     }
   }
 
+  /**
+   * Prefer {@link AbstractStringAssert#doesNotMatch(CharSequence)} over more contrived
+   * alternatives.
+   */
   static final class AssertThatDoesNotMatch {
     @BeforeTemplate
-    AbstractAssert<?, ?> before(String string, String regex) {
-      return assertThat(string.matches(regex)).isFalse();
+    AbstractBooleanAssert<?> before(String actual, String regex) {
+      return assertThat(actual.matches(regex)).isFalse();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractAssert<?, ?> after(String string, String regex) {
-      return assertThat(string).doesNotMatch(regex);
+    AbstractStringAssert<?> after(String actual, String regex) {
+      return assertThat(actual).doesNotMatch(regex);
     }
   }
 
-  static final class AssertThatPathContent {
+  /** Prefer {@code assertThat(path).content(charset)} over more contrived alternatives. */
+  static final class AssertThatContent {
     @BeforeTemplate
-    AbstractStringAssert<?> before(Path path, Charset charset) throws IOException {
-      return assertThat(Files.readString(path, charset));
+    AbstractStringAssert<?> before(Path actual, Charset charset) throws IOException {
+      return assertThat(Files.readString(actual, charset));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(Path path, Charset charset) {
-      return assertThat(path).content(charset);
+    AbstractStringAssert<?> after(Path actual, Charset charset) {
+      return assertThat(actual).content(charset);
     }
   }
 
-  static final class AssertThatPathContentUtf8 {
+  /** Prefer {@code assertThat(path).content(UTF_8)} over more contrived alternatives. */
+  static final class AssertThatContentUtf8 {
     @BeforeTemplate
-    AbstractStringAssert<?> before(Path path) throws IOException {
-      return assertThat(Files.readString(path));
+    AbstractStringAssert<?> before(Path actual) throws IOException {
+      return assertThat(Files.readString(actual));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractStringAssert<?> after(Path path) {
-      return assertThat(path).content(UTF_8);
+    AbstractStringAssert<?> after(Path actual) {
+      return assertThat(actual).content(UTF_8);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRules.java
@@ -16,7 +16,6 @@ import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Repeated;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.io.IOException;
-import org.assertj.core.api.AbstractObjectAssert;
 import org.assertj.core.api.AbstractThrowableAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.assertj.core.api.ThrowableAssertAlternative;
@@ -35,742 +34,929 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssertJThrowingCallableRules {
   private AssertJThrowingCallableRules() {}
 
+  /**
+   * Prefer {@link org.assertj.core.api.AbstractAssert#isInstanceOf} over more contrived
+   * alternatives.
+   */
   static final class AssertThatThrownByIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(ThrowingCallable throwingCallable, Class<T> exceptionType) {
+    void before(ThrowingCallable shouldRaiseThrowable, Class<T> type) {
       Refaster.anyOf(
-          assertThatThrownBy(throwingCallable).asInstanceOf(throwable(exceptionType)),
-          assertThatThrownBy(throwingCallable).asInstanceOf(type(exceptionType)));
+          assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(throwable(type)),
+          assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(type(type)));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable, Class<T> exceptionType) {
-      assertThatThrownBy(throwingCallable).isInstanceOf(exceptionType);
+    void after(ThrowingCallable shouldRaiseThrowable, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(type);
     }
   }
 
-  static final class AssertThatThrownByIllegalArgumentException {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass {
     @BeforeTemplate
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable) {
-      return assertThatIllegalArgumentException().isThrownBy(throwingCallable);
+    ThrowableAssertAlternative<IllegalArgumentException> before(
+        ThrowingCallable shouldRaiseThrowable) {
+      return assertThatIllegalArgumentException().isThrownBy(shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable) {
-      return assertThatThrownBy(throwingCallable).isInstanceOf(IllegalArgumentException.class);
+    AbstractThrowableAssert<?, ? extends Throwable> after(ThrowingCallable shouldRaiseThrowable) {
+      return assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(IllegalArgumentException.class);
     }
   }
 
-  static final class AssertThatThrownByIllegalArgumentExceptionHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessage {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalArgumentException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
-      return assertThatIllegalArgumentException().isThrownBy(throwingCallable).withMessage(message);
+        "AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalArgumentException> before(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatIllegalArgumentException()
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByIllegalArgumentExceptionRootCauseHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final
+  class AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassRootCauseHasMessage {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalArgumentException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<?> before(ThrowingCallable shouldRaiseThrowable, String message) {
       return assertThatIllegalArgumentException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .havingRootCause()
           .withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ?> after(ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalArgumentException.class)
           .rootCause()
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByIllegalArgumentExceptionHasMessageParameters {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageVarargs {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalArgumentException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
+        "AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalArgumentException> before(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
       return assertThatIllegalArgumentException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .withMessage(message, parameters);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessage(message, parameters);
     }
   }
 
-  static final class AssertThatThrownByIllegalArgumentExceptionHasMessageStartingWith {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final
+  class AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageStartingWith {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalArgumentException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalArgumentException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
       return assertThatIllegalArgumentException()
-          .isThrownBy(throwingCallable)
-          .withMessageStartingWith(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageStartingWith(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageStartingWith(message);
+          .hasMessageStartingWith(description);
     }
   }
 
-  static final class AssertThatThrownByIllegalArgumentExceptionHasMessageContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final
+  class AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageContaining {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalArgumentException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalArgumentException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
       return assertThatIllegalArgumentException()
-          .isThrownBy(throwingCallable)
-          .withMessageContaining(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageContaining(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalArgumentException.class)
-          .hasMessageContaining(message);
+          .hasMessageContaining(description);
     }
   }
 
-  static final class AssertThatThrownByIllegalArgumentExceptionHasMessageNotContainingAny {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final
+  class AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageNotContainingAny {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalArgumentException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable, @Repeated CharSequence values) {
+        "AssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalArgumentException> before(
+        ThrowingCallable shouldRaiseThrowable, @Repeated CharSequence values) {
       return assertThatIllegalArgumentException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .withMessageNotContainingAny(values);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable, @Repeated CharSequence values) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, @Repeated CharSequence values) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalArgumentException.class)
           .hasMessageNotContainingAny(values);
     }
   }
 
-  static final class AssertThatThrownByIllegalStateException {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalStateExceptionClass {
     @BeforeTemplate
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable) {
-      return assertThatIllegalStateException().isThrownBy(throwingCallable);
+    ThrowableAssertAlternative<IllegalStateException> before(
+        ThrowingCallable shouldRaiseThrowable) {
+      return assertThatIllegalStateException().isThrownBy(shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable) {
-      return assertThatThrownBy(throwingCallable).isInstanceOf(IllegalStateException.class);
+    AbstractThrowableAssert<?, ? extends Throwable> after(ThrowingCallable shouldRaiseThrowable) {
+      return assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(IllegalStateException.class);
     }
   }
 
-  static final class AssertThatThrownByIllegalStateExceptionHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessage {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalStateException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
-      return assertThatIllegalStateException().isThrownBy(throwingCallable).withMessage(message);
+        "AssertThatThrownByIsInstanceOfIllegalStateExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalStateException> before(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatIllegalStateException()
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalStateException.class)
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByIllegalStateExceptionRootCauseHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalStateExceptionClassRootCauseHasMessage {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalStateException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfIllegalStateExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<?> before(ThrowingCallable shouldRaiseThrowable, String message) {
       return assertThatIllegalStateException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .havingRootCause()
           .withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ?> after(ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalStateException.class)
           .rootCause()
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByIllegalStateExceptionHasMessageParameters {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageVarargs {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalStateException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
+        "AssertThatThrownByIsInstanceOfIllegalStateExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalStateException> before(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
       return assertThatIllegalStateException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .withMessage(message, parameters);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalStateException.class)
           .hasMessage(message, parameters);
     }
   }
 
-  static final class AssertThatThrownByIllegalStateExceptionHasMessageStartingWith {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final
+  class AssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageStartingWith {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalStateException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfIllegalStateExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalStateException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
       return assertThatIllegalStateException()
-          .isThrownBy(throwingCallable)
-          .withMessageStartingWith(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageStartingWith(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageStartingWith(message);
+          .hasMessageStartingWith(description);
     }
   }
 
-  static final class AssertThatThrownByIllegalStateExceptionHasMessageContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageContaining {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalStateException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfIllegalStateExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalStateException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
       return assertThatIllegalStateException()
-          .isThrownBy(throwingCallable)
-          .withMessageContaining(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageContaining(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageContaining(message);
+          .hasMessageContaining(description);
     }
   }
 
-  static final class AssertThatThrownByIllegalStateExceptionHasMessageNotContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final
+  class AssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageNotContaining {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByIllegalStateException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfIllegalStateExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IllegalStateException> before(
+        ThrowingCallable shouldRaiseThrowable, String content) {
       return assertThatIllegalStateException()
-          .isThrownBy(throwingCallable)
-          .withMessageNotContaining(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageNotContaining(content);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String content) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IllegalStateException.class)
-          .hasMessageNotContaining(message);
+          .hasMessageNotContaining(content);
     }
   }
 
-  static final class AssertThatThrownByNullPointerException {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfNullPointerExceptionClass {
     @BeforeTemplate
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable) {
-      return assertThatNullPointerException().isThrownBy(throwingCallable);
+    ThrowableAssertAlternative<NullPointerException> before(ThrowingCallable shouldRaiseThrowable) {
+      return assertThatNullPointerException().isThrownBy(shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable) {
-      return assertThatThrownBy(throwingCallable).isInstanceOf(NullPointerException.class);
+    AbstractThrowableAssert<?, ? extends Throwable> after(ThrowingCallable shouldRaiseThrowable) {
+      return assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(NullPointerException.class);
     }
   }
 
-  static final class AssertThatThrownByNullPointerExceptionHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessage {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
-      return assertThatNullPointerException().isThrownBy(throwingCallable).withMessage(message);
+        "AssertThatThrownByIsInstanceOfNullPointerExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<NullPointerException> before(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatNullPointerException().isThrownBy(shouldRaiseThrowable).withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(NullPointerException.class)
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByNullPointerExceptionRootCauseHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfNullPointerExceptionClassRootCauseHasMessage {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfNullPointerExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<?> before(ThrowingCallable shouldRaiseThrowable, String message) {
       return assertThatNullPointerException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .havingRootCause()
           .withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ?> after(ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(NullPointerException.class)
           .rootCause()
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByNullPointerExceptionHasMessageParameters {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageVarargs {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
+        "AssertThatThrownByIsInstanceOfNullPointerExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<NullPointerException> before(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
       return assertThatNullPointerException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .withMessage(message, parameters);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(NullPointerException.class)
           .hasMessage(message, parameters);
     }
   }
 
-  static final class AssertThatThrownByNullPointerExceptionHasMessageStartingWith {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageStartingWith {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfNullPointerExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<NullPointerException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
       return assertThatNullPointerException()
-          .isThrownBy(throwingCallable)
-          .withMessageStartingWith(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageStartingWith(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(NullPointerException.class)
-          .hasMessageStartingWith(message);
+          .hasMessageStartingWith(description);
     }
   }
 
-  static final class AssertThatThrownByNullPointerExceptionHasMessageContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageContaining {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfNullPointerExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<NullPointerException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
       return assertThatNullPointerException()
-          .isThrownBy(throwingCallable)
-          .withMessageContaining(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageContaining(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(NullPointerException.class)
-          .hasMessageContaining(message);
+          .hasMessageContaining(description);
     }
   }
 
-  static final class AssertThatThrownByNullPointerExceptionHasMessageNotContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final
+  class AssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageNotContaining {
     @BeforeTemplate
     @SuppressWarnings(
-        "AssertThatThrownByNullPointerException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+        "AssertThatThrownByIsInstanceOfNullPointerExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<NullPointerException> before(
+        ThrowingCallable shouldRaiseThrowable, String content) {
       return assertThatNullPointerException()
-          .isThrownBy(throwingCallable)
-          .withMessageNotContaining(message);
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageNotContaining(content);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String content) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(NullPointerException.class)
-          .hasMessageNotContaining(message);
+          .hasMessageNotContaining(content);
     }
   }
 
-  static final class AssertThatThrownByIOException {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIOExceptionClass {
     @BeforeTemplate
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable) {
-      return assertThatIOException().isThrownBy(throwingCallable);
+    ThrowableAssertAlternative<IOException> before(ThrowingCallable shouldRaiseThrowable) {
+      return assertThatIOException().isThrownBy(shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable) {
-      return assertThatThrownBy(throwingCallable).isInstanceOf(IOException.class);
+    AbstractThrowableAssert<?, ? extends Throwable> after(ThrowingCallable shouldRaiseThrowable) {
+      return assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(IOException.class);
     }
   }
 
-  static final class AssertThatThrownByIOExceptionHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIOExceptionClassHasMessage {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
-      return assertThatIOException().isThrownBy(throwingCallable).withMessage(message);
+    @SuppressWarnings(
+        "AssertThatThrownByIsInstanceOfIOExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IOException> before(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatIOException().isThrownBy(shouldRaiseThrowable).withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IOException.class)
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByIOExceptionRootCauseHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIOExceptionClassRootCauseHasMessage {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
+    @SuppressWarnings(
+        "AssertThatThrownByIsInstanceOfIOExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<?> before(ThrowingCallable shouldRaiseThrowable, String message) {
       return assertThatIOException()
-          .isThrownBy(throwingCallable)
+          .isThrownBy(shouldRaiseThrowable)
           .havingRootCause()
           .withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ?> after(ThrowingCallable shouldRaiseThrowable, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IOException.class)
           .rootCause()
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByIOExceptionHasMessageParameters {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIOExceptionClassHasMessageVarargs {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
-      return assertThatIOException().isThrownBy(throwingCallable).withMessage(message, parameters);
+    @SuppressWarnings(
+        "AssertThatThrownByIsInstanceOfIOExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IOException> before(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
+      return assertThatIOException()
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessage(message, parameters);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable, String message, @Repeated Object parameters) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String message, @Repeated Object parameters) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IOException.class)
           .hasMessage(message, parameters);
     }
   }
 
-  static final class AssertThatThrownByIOExceptionHasMessageStartingWith {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIOExceptionClassHasMessageStartingWith {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
-      return assertThatIOException().isThrownBy(throwingCallable).withMessageStartingWith(message);
+    @SuppressWarnings(
+        "AssertThatThrownByIsInstanceOfIOExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IOException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatIOException()
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageStartingWith(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IOException.class)
-          .hasMessageStartingWith(message);
+          .hasMessageStartingWith(description);
     }
   }
 
-  static final class AssertThatThrownByIOExceptionHasMessageContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIOExceptionClassHasMessageContaining {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
-      return assertThatIOException().isThrownBy(throwingCallable).withMessageContaining(message);
+    @SuppressWarnings(
+        "AssertThatThrownByIsInstanceOfIOExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IOException> before(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatIOException()
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageContaining(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IOException.class)
-          .hasMessageContaining(message);
+          .hasMessageContaining(description);
     }
   }
 
-  static final class AssertThatThrownByIOExceptionHasMessageNotContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfIOExceptionClassHasMessageNotContaining {
     @BeforeTemplate
-    @SuppressWarnings("AssertThatThrownByIOException" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(ThrowingCallable throwingCallable, String message) {
-      return assertThatIOException().isThrownBy(throwingCallable).withMessageNotContaining(message);
+    @SuppressWarnings(
+        "AssertThatThrownByIsInstanceOfIOExceptionClass" /* This is a more specific template. */)
+    ThrowableAssertAlternative<IOException> before(
+        ThrowingCallable shouldRaiseThrowable, String content) {
+      return assertThatIOException()
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageNotContaining(content);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(ThrowingCallable throwingCallable, String message) {
-      return assertThatThrownBy(throwingCallable)
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, String content) {
+      return assertThatThrownBy(shouldRaiseThrowable)
           .isInstanceOf(IOException.class)
-          .hasMessageNotContaining(message);
+          .hasMessageNotContaining(content);
     }
   }
 
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
   static final class AssertThatThrownByAsInstanceOfThrowable<T extends Throwable> {
     @BeforeTemplate
+    ThrowableAssertAlternative<T> before(ThrowingCallable shouldRaiseThrowable, Class<T> type) {
+      return assertThatExceptionOfType(type).isThrownBy(shouldRaiseThrowable);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    AbstractThrowableAssert<?, T> after(ThrowingCallable shouldRaiseThrowable, Class<T> type) {
+      return assertThatThrownBy(shouldRaiseThrowable).asInstanceOf(throwable(type));
+    }
+  }
+
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfHasMessage<T extends Throwable> {
+    @BeforeTemplate
+    @SuppressWarnings(
+        "AssertThatThrownByAsInstanceOfThrowable" /* This is a more specific template. */)
     ThrowableAssertAlternative<T> before(
-        ThrowingCallable throwingCallable, Class<T> exceptionType) {
-      return assertThatExceptionOfType(exceptionType).isThrownBy(throwingCallable);
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String message) {
+      return assertThatExceptionOfType(type).isThrownBy(shouldRaiseThrowable).withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractThrowableAssert<?, T> after(ThrowingCallable throwingCallable, Class<T> exceptionType) {
-      return assertThatThrownBy(throwingCallable).asInstanceOf(throwable(exceptionType));
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(type).hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByHasMessage {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfRootCauseHasMessage<T extends Throwable> {
     @BeforeTemplate
     @SuppressWarnings(
         "AssertThatThrownByAsInstanceOfThrowable" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatExceptionOfType(exceptionType)
-          .isThrownBy(throwingCallable)
-          .withMessage(message);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatThrownBy(throwingCallable).isInstanceOf(exceptionType).hasMessage(message);
-    }
-  }
-
-  static final class AssertThatThrownByRootCauseHasMessage {
-    @BeforeTemplate
-    @SuppressWarnings(
-        "AssertThatThrownByAsInstanceOfThrowable" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatExceptionOfType(exceptionType)
-          .isThrownBy(throwingCallable)
+    ThrowableAssertAlternative<?> before(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String message) {
+      return assertThatExceptionOfType(type)
+          .isThrownBy(shouldRaiseThrowable)
           .havingRootCause()
           .withMessage(message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatThrownBy(throwingCallable)
-          .isInstanceOf(exceptionType)
+    AbstractThrowableAssert<?, ?> after(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String message) {
+      return assertThatThrownBy(shouldRaiseThrowable)
+          .isInstanceOf(type)
           .rootCause()
           .hasMessage(message);
     }
   }
 
-  static final class AssertThatThrownByHasMessageParameters {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfHasMessageVarargs<T extends Throwable> {
     @BeforeTemplate
     @SuppressWarnings(
         "AssertThatThrownByAsInstanceOfThrowable" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
+    ThrowableAssertAlternative<T> before(
+        ThrowingCallable shouldRaiseThrowable,
+        Class<T> type,
         String message,
         @Repeated Object parameters) {
-      return assertThatExceptionOfType(exceptionType)
-          .isThrownBy(throwingCallable)
+      return assertThatExceptionOfType(type)
+          .isThrownBy(shouldRaiseThrowable)
           .withMessage(message, parameters);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable,
+        Class<T> type,
         String message,
         @Repeated Object parameters) {
-      return assertThatThrownBy(throwingCallable)
-          .isInstanceOf(exceptionType)
+      return assertThatThrownBy(shouldRaiseThrowable)
+          .isInstanceOf(type)
           .hasMessage(message, parameters);
     }
   }
 
-  static final class AssertThatThrownByHasMessageStartingWith {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfHasMessageStartingWith<T extends Throwable> {
     @BeforeTemplate
     @SuppressWarnings(
         "AssertThatThrownByAsInstanceOfThrowable" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatExceptionOfType(exceptionType)
-          .isThrownBy(throwingCallable)
-          .withMessageStartingWith(message);
+    ThrowableAssertAlternative<T> before(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String description) {
+      return assertThatExceptionOfType(type)
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageStartingWith(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatThrownBy(throwingCallable)
-          .isInstanceOf(exceptionType)
-          .hasMessageStartingWith(message);
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
+          .isInstanceOf(type)
+          .hasMessageStartingWith(description);
     }
   }
 
-  static final class AssertThatThrownByHasMessageContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfHasMessageContaining<T extends Throwable> {
     @BeforeTemplate
     @SuppressWarnings(
         "AssertThatThrownByAsInstanceOfThrowable" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatExceptionOfType(exceptionType)
-          .isThrownBy(throwingCallable)
-          .withMessageContaining(message);
+    ThrowableAssertAlternative<T> before(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String description) {
+      return assertThatExceptionOfType(type)
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageContaining(description);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatThrownBy(throwingCallable)
-          .isInstanceOf(exceptionType)
-          .hasMessageContaining(message);
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String description) {
+      return assertThatThrownBy(shouldRaiseThrowable)
+          .isInstanceOf(type)
+          .hasMessageContaining(description);
     }
   }
 
-  static final class AssertThatThrownByHasMessageNotContaining {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#assertThatThrownBy} over less idiomatic
+   * alternatives.
+   */
+  static final class AssertThatThrownByIsInstanceOfHasMessageNotContaining<T extends Throwable> {
     @BeforeTemplate
     @SuppressWarnings(
         "AssertThatThrownByAsInstanceOfThrowable" /* This is a more specific template. */)
-    AbstractObjectAssert<?, ?> before(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatExceptionOfType(exceptionType)
-          .isThrownBy(throwingCallable)
-          .withMessageNotContaining(message);
+    ThrowableAssertAlternative<T> before(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String content) {
+      return assertThatExceptionOfType(type)
+          .isThrownBy(shouldRaiseThrowable)
+          .withMessageNotContaining(content);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    AbstractObjectAssert<?, ?> after(
-        ThrowingCallable throwingCallable,
-        Class<? extends Throwable> exceptionType,
-        String message) {
-      return assertThatThrownBy(throwingCallable)
-          .isInstanceOf(exceptionType)
-          .hasMessageNotContaining(message);
+    AbstractThrowableAssert<?, ? extends Throwable> after(
+        ThrowingCallable shouldRaiseThrowable, Class<T> type, String content) {
+      return assertThatThrownBy(shouldRaiseThrowable)
+          .isInstanceOf(type)
+          .hasMessageNotContaining(content);
     }
   }
 
+  /**
+   * Prefer {@link AbstractThrowableAssert#hasMessage(String, Object...)} over less efficient
+   * alternatives.
+   */
   // XXX: Drop this rule in favour of a generic Error Prone check that flags `String.format(...)`
   // arguments to a wide range of format methods.
   static final class AbstractThrowableAssertHasMessage {
     @BeforeTemplate
     AbstractThrowableAssert<?, ? extends Throwable> before(
-        AbstractThrowableAssert<?, ? extends Throwable> abstractThrowableAssert,
+        AbstractThrowableAssert<?, ? extends Throwable> throwableAssert,
         String message,
         @Repeated Object parameters) {
-      return abstractThrowableAssert.hasMessage(message.formatted(parameters));
+      return throwableAssert.hasMessage(message.formatted(parameters));
     }
 
     @AfterTemplate
     AbstractThrowableAssert<?, ? extends Throwable> after(
-        AbstractThrowableAssert<?, ? extends Throwable> abstractThrowableAssert,
+        AbstractThrowableAssert<?, ? extends Throwable> throwableAssert,
         String message,
         @Repeated Object parameters) {
-      return abstractThrowableAssert.hasMessage(message, parameters);
+      return throwableAssert.hasMessage(message, parameters);
     }
   }
 
+  /**
+   * Prefer {@link AbstractThrowableAssert#withFailMessage(String, Object...)} over less efficient
+   * alternatives.
+   */
   // XXX: Drop this rule in favour of a generic Error Prone check that flags `String.format(...)`
   // arguments to a wide range of format methods.
   static final class AbstractThrowableAssertWithFailMessage {
     @BeforeTemplate
     AbstractThrowableAssert<?, ? extends Throwable> before(
-        AbstractThrowableAssert<?, ? extends Throwable> abstractThrowableAssert,
-        String message,
+        AbstractThrowableAssert<?, ? extends Throwable> throwableAssert,
+        String newErrorMessage,
         @Repeated Object args) {
-      return abstractThrowableAssert.withFailMessage(message.formatted(args));
+      return throwableAssert.withFailMessage(newErrorMessage.formatted(args));
     }
 
     @AfterTemplate
     AbstractThrowableAssert<?, ? extends Throwable> after(
-        AbstractThrowableAssert<?, ? extends Throwable> abstractThrowableAssert,
-        String message,
+        AbstractThrowableAssert<?, ? extends Throwable> throwableAssert,
+        String newErrorMessage,
         @Repeated Object args) {
-      return abstractThrowableAssert.withFailMessage(message, args);
+      return throwableAssert.withFailMessage(newErrorMessage, args);
     }
   }
 
+  /** Prefer {@code throwableAssert.cause().isSameAs(expected)} over deprecated alternatives. */
   // XXX: This rule changes the `Throwable` against which subsequent assertions are made.
   static final class AbstractThrowableAssertCauseIsSameAs {
     @BeforeTemplate
-    @SuppressWarnings("deprecation" /* This deprecated API will be rewritten. */)
+    @SuppressWarnings("deprecation" /* This deprecated API usage will be rewritten. */)
     AbstractThrowableAssert<?, ? extends Throwable> before(
         AbstractThrowableAssert<?, ? extends Throwable> throwableAssert, Throwable expected) {
       return throwableAssert.hasCauseReference(expected);
     }
 
     @AfterTemplate
-    AbstractThrowableAssert<?, ? extends Throwable> after(
+    AbstractThrowableAssert<?, ?> after(
         AbstractThrowableAssert<?, ? extends Throwable> throwableAssert, Throwable expected) {
       return throwableAssert.cause().isSameAs(expected);
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssortedRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssortedRules.java
@@ -26,43 +26,43 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class AssortedRules {
   private AssortedRules() {}
 
-  /** Prefer {@link Objects#checkIndex(int, int)} over the Guava alternative. */
-  static final class CheckIndex {
+  /** Prefer {@link Objects#checkIndex(int, int)} over non-JDK alternatives. */
+  static final class CheckIndexExpression {
     @BeforeTemplate
-    int before(int index, int size) {
-      return checkElementIndex(index, size);
+    int before(int index, int length) {
+      return checkElementIndex(index, length);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    int after(int index, int size) {
-      return checkIndex(index, size);
+    int after(int index, int length) {
+      return checkIndex(index, length);
     }
   }
 
   /**
-   * Prefer {@link Objects#checkIndex(int, int)} over less descriptive or more verbose alternatives.
+   * Prefer {@link Objects#checkIndex(int, int)} over less explicit alternatives.
    *
    * <p>If a custom error message is desired, consider using Guava's {@link
    * com.google.common.base.Preconditions#checkElementIndex(int, int, String)}.
    */
-  static final class CheckIndexConditional {
+  static final class CheckIndexBlock {
     @BeforeTemplate
-    void before(int index, int size) {
-      if (index < 0 || index >= size) {
+    void before(int index, int length) {
+      if (index < 0 || index >= length) {
         throw new IndexOutOfBoundsException();
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(int index, int size) {
-      checkIndex(index, size);
+    void after(int index, int length) {
+      checkIndex(index, length);
     }
   }
 
   /** Prefer {@link Iterators#getNext(Iterator, Object)} over more contrived alternatives. */
-  static final class IteratorGetNextOrDefault<T> {
+  static final class IteratorsGetNext<T> {
     @BeforeTemplate
     T before(Iterator<T> iterator, T defaultValue) {
       return Refaster.anyOf(
@@ -77,27 +77,27 @@ final class AssortedRules {
     }
   }
 
-  /** Don't unnecessarily repeat boolean expressions. */
+  /** Prefer {@code firstTest || secondTest} over more contrived alternatives. */
   // XXX: This rule captures only the simplest case. `@AlsoNegation` doesn't help. Consider
   // contributing a Refaster patch, which handles the negation in the `@BeforeTemplate` more
   // intelligently.
-  static final class LogicalImplication {
+  static final class Or {
     @BeforeTemplate
     @SuppressWarnings("java:S2589" /* This violation will be rewritten. */)
-    boolean before(boolean firstTest, boolean secondTest) {
-      return firstTest || (!firstTest && secondTest);
+    boolean before(boolean b1, boolean b2) {
+      return b1 || (!b1 && b2);
     }
 
     @AfterTemplate
-    boolean after(boolean firstTest, boolean secondTest) {
-      return firstTest || secondTest;
+    boolean after(boolean b1, boolean b2) {
+      return b1 || b2;
     }
   }
 
   /**
    * Prefer {@link Stream#generate(java.util.function.Supplier)} over more contrived alternatives.
    */
-  static final class UnboundedSingleElementStream<T> {
+  static final class StreamGenerate<T> {
     @BeforeTemplate
     Stream<T> before(T object) {
       return Streams.stream(Iterables.cycle(object));
@@ -110,7 +110,7 @@ final class AssortedRules {
   }
 
   /** Prefer {@link Iterables#isEmpty(Iterable)} over more contrived alternatives. */
-  static final class IterableIsEmpty<T> {
+  static final class IterablesIsEmpty<T> {
     @BeforeTemplate
     boolean before(Iterable<T> iterable) {
       return !iterable.iterator().hasNext();
@@ -123,17 +123,16 @@ final class AssortedRules {
   }
 
   /** Prefer {@link Splitter#splitToStream(CharSequence)} over less efficient alternatives. */
-  static final class SplitToStream {
+  static final class SplitterSplitToStream {
     @BeforeTemplate
-    Stream<String> before(Splitter splitter, CharSequence charSequence) {
+    Stream<String> before(Splitter splitter, CharSequence sequence) {
       return Refaster.anyOf(
-          Streams.stream(splitter.split(charSequence)),
-          splitter.splitToList(charSequence).stream());
+          Streams.stream(splitter.split(sequence)), splitter.splitToList(sequence).stream());
     }
 
     @AfterTemplate
-    Stream<String> after(Splitter splitter, CharSequence charSequence) {
-      return splitter.splitToStream(charSequence);
+    Stream<String> after(Splitter splitter, CharSequence sequence) {
+      return splitter.splitToStream(sequence);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -103,7 +103,7 @@ final class BigDecimalRules {
   }
 
   /**
-   * Prefer a {@link BigDecimal#signum()} comparison to 0 over less efficient or less clear
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over less efficient or less explicit
    * alternatives.
    */
   static final class BigDecimalSignumIsPositive {
@@ -124,7 +124,7 @@ final class BigDecimalRules {
   }
 
   /**
-   * Prefer a {@link BigDecimal#signum()} comparison to 0 over less efficient or less clear
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over less efficient or less explicit
    * alternatives.
    */
   static final class BigDecimalSignumIsNegative {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BigDecimalRules.java
@@ -12,7 +12,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class BigDecimalRules {
   private BigDecimalRules() {}
 
-  /** Prefer using the constant {@link BigDecimal#ZERO} when possible. */
+  /** Prefer {@link BigDecimal#ZERO} over less efficient alternatives. */
   static final class BigDecimalZero {
     @BeforeTemplate
     BigDecimal before() {
@@ -25,7 +25,7 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer using the constant {@link BigDecimal#ONE} when possible. */
+  /** Prefer {@link BigDecimal#ONE} over less efficient alternatives. */
   static final class BigDecimalOne {
     @BeforeTemplate
     BigDecimal before() {
@@ -38,7 +38,7 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer using the constant {@link BigDecimal#TWO} when possible. */
+  /** Prefer {@link BigDecimal#TWO} over less efficient alternatives. */
   static final class BigDecimalTwo {
     @BeforeTemplate
     BigDecimal before() {
@@ -51,7 +51,7 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer using the constant {@link BigDecimal#TEN} when possible. */
+  /** Prefer {@link BigDecimal#TEN} over less efficient alternatives. */
   static final class BigDecimalTen {
     @BeforeTemplate
     BigDecimal before() {
@@ -64,77 +64,83 @@ final class BigDecimalRules {
     }
   }
 
-  /** Prefer {@link BigDecimal#valueOf(double)} over the associated constructor. */
+  /**
+   * Prefer {@link BigDecimal#valueOf(double)} over the associated constructor.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes the {@link BigDecimal} value created, as
+   * {@link BigDecimal#valueOf(double)} uses the double's canonical string representation, while
+   * {@link BigDecimal#BigDecimal(double)} uses the exact binary floating-point value.
+   */
   // XXX: Ideally we also rewrite `new BigDecimal("<some-integer-value>")` in cases where the
   // specified number can be represented as an `int` or `long`, but that requires a custom
   // `BugChecker`.
   static final class BigDecimalValueOf {
     @BeforeTemplate
     @SuppressWarnings("java:S2111" /* This violation will be rewritten. */)
-    BigDecimal before(double value) {
-      return new BigDecimal(value);
+    BigDecimal before(double val) {
+      return new BigDecimal(val);
     }
 
     @AfterTemplate
-    BigDecimal after(double value) {
-      return BigDecimal.valueOf(value);
+    BigDecimal after(double val) {
+      return BigDecimal.valueOf(val);
     }
   }
 
-  /** Prefer using {@link BigDecimal#signum()} over more contrived alternatives. */
-  static final class BigDecimalSignumIsZero {
+  /** Prefer a {@link BigDecimal#signum()} comparison to 0 over less explicit alternatives. */
+  static final class BigDecimalSignumEqualToZero {
     @BeforeTemplate
-    boolean before(BigDecimal value) {
+    boolean before(BigDecimal val) {
       return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) == 0, BigDecimal.ZERO.compareTo(value) == 0);
+          val.compareTo(BigDecimal.ZERO) == 0, BigDecimal.ZERO.compareTo(val) == 0);
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(BigDecimal value) {
-      return value.signum() == 0;
+    boolean after(BigDecimal val) {
+      return val.signum() == 0;
     }
   }
 
   /**
-   * Prefer a {@link BigDecimal#signum()} comparison to 0 over more contrived or less idiomatic
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over less efficient or less clear
    * alternatives.
    */
   static final class BigDecimalSignumIsPositive {
     @BeforeTemplate
-    boolean before(BigDecimal value) {
+    boolean before(BigDecimal val) {
       return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) > 0,
-          BigDecimal.ZERO.compareTo(value) < 0,
-          value.signum() == 1,
-          value.signum() >= 1);
+          val.compareTo(BigDecimal.ZERO) > 0,
+          BigDecimal.ZERO.compareTo(val) < 0,
+          val.signum() == 1,
+          val.signum() >= 1);
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(BigDecimal value) {
-      return value.signum() > 0;
+    boolean after(BigDecimal val) {
+      return val.signum() > 0;
     }
   }
 
   /**
-   * Prefer a {@link BigDecimal#signum()} comparison to -1 over more contrived or less idiomatic
+   * Prefer a {@link BigDecimal#signum()} comparison to 0 over less efficient or less clear
    * alternatives.
    */
   static final class BigDecimalSignumIsNegative {
     @BeforeTemplate
-    boolean before(BigDecimal value) {
+    boolean before(BigDecimal val) {
       return Refaster.anyOf(
-          value.compareTo(BigDecimal.ZERO) < 0,
-          BigDecimal.ZERO.compareTo(value) > 0,
-          value.signum() == -1,
-          value.signum() <= -1);
+          val.compareTo(BigDecimal.ZERO) < 0,
+          BigDecimal.ZERO.compareTo(val) > 0,
+          val.signum() == -1,
+          val.signum() <= -1);
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(BigDecimal value) {
-      return value.signum() < 0;
+    boolean after(BigDecimal val) {
+      return val.signum() < 0;
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
@@ -1,7 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
-import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChooser;
 import com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.refaster.Refaster;
@@ -21,27 +20,27 @@ import tech.picnic.errorprone.utils.SourceCode;
 final class BugCheckerRules {
   private BugCheckerRules() {}
 
-  /**
-   * Avoid calling {@link BugCheckerRefactoringTestHelper#setFixChooser(FixChooser)} or {@link
-   * BugCheckerRefactoringTestHelper#setImportOrder(String)} with their respective default values.
-   */
+  /** Prefer the {@link BugCheckerRefactoringTestHelper} as-is over more verbose alternatives. */
   static final class BugCheckerRefactoringTestHelperIdentity {
     @BeforeTemplate
-    BugCheckerRefactoringTestHelper before(BugCheckerRefactoringTestHelper helper) {
+    BugCheckerRefactoringTestHelper before(
+        BugCheckerRefactoringTestHelper bugCheckerRefactoringTestHelper) {
       return Refaster.anyOf(
-          helper.setFixChooser(FixChoosers.FIRST), helper.setImportOrder("static-first"));
+          bugCheckerRefactoringTestHelper.setFixChooser(FixChoosers.FIRST),
+          bugCheckerRefactoringTestHelper.setImportOrder("static-first"));
     }
 
     @AfterTemplate
     @CanIgnoreReturnValue
-    BugCheckerRefactoringTestHelper after(BugCheckerRefactoringTestHelper helper) {
-      return helper;
+    BugCheckerRefactoringTestHelper after(
+        BugCheckerRefactoringTestHelper bugCheckerRefactoringTestHelper) {
+      return bugCheckerRefactoringTestHelper;
     }
   }
 
   /**
-   * Prefer {@link BugCheckerRefactoringTestHelper.ExpectOutput#expectUnchanged()} over repeating
-   * the input.
+   * Prefer {@link BugCheckerRefactoringTestHelper.ExpectOutput#expectUnchanged()} over more verbose
+   * alternatives.
    */
   // XXX: This rule assumes that the full source code is specified as a single string, e.g. using a
   // text block. Support for multi-line source code input would require a `BugChecker`
@@ -49,23 +48,22 @@ final class BugCheckerRules {
   static final class BugCheckerRefactoringTestHelperAddInputLinesExpectUnchanged {
     @BeforeTemplate
     BugCheckerRefactoringTestHelper before(
-        BugCheckerRefactoringTestHelper helper, String path, String source) {
-      return helper.addInputLines(path, source).addOutputLines(path, source);
+        BugCheckerRefactoringTestHelper bugCheckerRefactoringTestHelper, String path, String str) {
+      return bugCheckerRefactoringTestHelper.addInputLines(path, str).addOutputLines(path, str);
     }
 
     @AfterTemplate
     BugCheckerRefactoringTestHelper after(
-        BugCheckerRefactoringTestHelper helper, String path, String source) {
-      return helper.addInputLines(path, source).expectUnchanged();
+        BugCheckerRefactoringTestHelper bugCheckerRefactoringTestHelper, String path, String str) {
+      return bugCheckerRefactoringTestHelper.addInputLines(path, str).expectUnchanged();
     }
   }
 
   /**
    * Prefer {@link SourceCode#toStringConstantExpression(Object,
-   * com.google.errorprone.VisitorState)} over alternatives that unnecessarily escape single quote
-   * characters.
+   * com.google.errorprone.VisitorState)} over more contrived alternatives.
    */
-  static final class ConstantsFormat {
+  static final class SourceCodeToStringConstantExpression {
     @BeforeTemplate
     String before(CharSequence value) {
       return Constants.format(value);
@@ -86,25 +84,26 @@ final class BugCheckerRules {
   /** Prefer {@link Name#contentEquals(CharSequence)} over more verbose alternatives. */
   static final class NameContentEquals {
     @BeforeTemplate
-    boolean before(Name name, CharSequence string) {
-      return name.toString().equals(string.toString());
+    boolean before(Name name, CharSequence anObject) {
+      return Refaster.anyOf(
+          name.toString().equals(anObject.toString()), anObject.toString().equals(name.toString()));
     }
 
     @BeforeTemplate
-    boolean before(Name name, String string) {
-      return name.toString().equals(string);
+    boolean before(Name name, String anObject) {
+      return Refaster.anyOf(name.toString().equals(anObject), anObject.equals(name.toString()));
     }
 
     @AfterTemplate
-    boolean after(Name name, CharSequence string) {
-      return name.contentEquals(string);
+    boolean after(Name name, CharSequence anObject) {
+      return name.contentEquals(anObject);
     }
   }
 
-  /** Prefer {@link ASTHelpers#getStartPosition(Tree)} over alternatives that require casting. */
+  /** Prefer {@link ASTHelpers#getStartPosition(Tree)} over more fragile alternatives. */
   static final class ASTHelpersGetStartPosition<T extends DiagnosticPosition> {
     @BeforeTemplate
-    @SuppressWarnings("unchecked" /* We also want to replace unchecked casts. */)
+    @SuppressWarnings("unchecked" /* This violation will be rewritten. */)
     int before(Tree tree) {
       return ((T) tree).getStartPosition();
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
@@ -17,7 +17,7 @@ import tech.picnic.errorprone.utils.SourceCode;
 
 /** Refaster rules related to {@link com.google.errorprone.bugpatterns.BugChecker} classes. */
 @OnlineDocumentation
-final class BugCheckerRules {
+final class zBugCheckerRules {
   private BugCheckerRules() {}
 
   /** Prefer the {@link BugCheckerRefactoringTestHelper} as-is over more verbose alternatives. */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/BugCheckerRules.java
@@ -17,7 +17,7 @@ import tech.picnic.errorprone.utils.SourceCode;
 
 /** Refaster rules related to {@link com.google.errorprone.bugpatterns.BugChecker} classes. */
 @OnlineDocumentation
-final class zBugCheckerRules {
+final class BugCheckerRules {
   private BugCheckerRules() {}
 
   /** Prefer the {@link BugCheckerRefactoringTestHelper} as-is over more verbose alternatives. */

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CharSequenceRules.java
@@ -11,10 +11,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class CharSequenceRules {
   private CharSequenceRules() {}
 
-  /**
-   * Prefer {@link CharSequence#isEmpty()} over alternatives that consult the char sequence's
-   * length.
-   */
+  /** Prefer {@link CharSequence#isEmpty()} over less explicit alternatives. */
   // XXX: Drop this rule once we (and OpenRewrite) no longer support projects targeting Java 14 or
   // below.
   static final class CharSequenceIsEmpty {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
@@ -7,13 +7,13 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/** Refaster rules related to expressions dealing with classes. */
+/** Refaster rules related to expressions dealing with {@link Class}es. */
 @OnlineDocumentation
 final class ClassRules {
   private ClassRules() {}
 
-  /** Prefer {@link Class#isInstance(Object)} over more contrived alternatives. */
-  static final class ClassIsInstance<T, S> {
+  /** Prefer {@link Class#isInstance(Object)} over more contrived or more fragile alternatives. */
+  static final class ClassIsInstanceWithClassAndObject<T, S> {
     @BeforeTemplate
     boolean before(Class<T> clazz, S object) {
       return clazz.isAssignableFrom(object.getClass());
@@ -26,7 +26,7 @@ final class ClassRules {
   }
 
   /** Prefer using the {@code instanceof} keyword over less idiomatic alternatives. */
-  static final class Instanceof<T, S> {
+  static final class RefasterIsInstance<T, S> {
     @BeforeTemplate
     boolean before(S object) {
       return Refaster.<T>clazz().isInstance(object);
@@ -38,13 +38,8 @@ final class ClassRules {
     }
   }
 
-  /**
-   * Prefer {@link Class#isInstance(Object)} method references over lambda expressions that require
-   * naming a variable.
-   */
-  // XXX: Once the `ClassReferenceIsInstancePredicate` rule is dropped, rename this rule to just
-  // `ClassIsInstancePredicate`.
-  static final class ClassLiteralIsInstancePredicate<T, S> {
+  /** Prefer {@link Class#isInstance(Object)} method references over more verbose alternatives. */
+  static final class ClassIsInstance<T, S> {
     @BeforeTemplate
     Predicate<S> before() {
       return o -> Refaster.<T>isInstance(o);
@@ -56,12 +51,9 @@ final class ClassRules {
     }
   }
 
-  /**
-   * Prefer {@link Class#isInstance(Object)} method references over lambda expressions that require
-   * naming a variable.
-   */
+  /** Prefer {@link Class#isInstance(Object)} method references over more verbose alternatives. */
   // XXX: Drop this rule once the `MethodReferenceUsage` rule is enabled by default.
-  static final class ClassReferenceIsInstancePredicate<T, S> {
+  static final class ClassIsInstanceWithClass<T, S> {
     @BeforeTemplate
     Predicate<S> before(Class<T> clazz) {
       return o -> clazz.isInstance(o);
@@ -73,19 +65,16 @@ final class ClassRules {
     }
   }
 
-  /**
-   * Prefer {@link Class#cast(Object)} method references over lambda expressions that require naming
-   * a variable.
-   */
+  /** Prefer {@link Class#cast(Object)} method references over more verbose alternatives. */
   // XXX: Drop this rule once the `MethodReferenceUsage` rule is enabled by default.
-  static final class ClassReferenceCast<T, S> {
+  static final class ClassCast<T, S, U extends S> {
     @BeforeTemplate
-    Function<T, S> before(Class<? extends S> clazz) {
+    Function<T, S> before(Class<U> clazz) {
       return o -> clazz.cast(o);
     }
 
     @AfterTemplate
-    Function<T, S> after(Class<? extends S> clazz) {
+    Function<T, S> after(Class<U> clazz) {
       return clazz::cast;
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ClassRules.java
@@ -38,7 +38,7 @@ final class ClassRules {
     }
   }
 
-  /** Prefer {@link Class#isInstance(Object)} method references over more verbose alternatives. */
+  /** Prefer {@code Refaster.<T>clazz()::isInstance} over more verbose alternatives. */
   static final class ClassIsInstance<T, S> {
     @BeforeTemplate
     Predicate<S> before() {
@@ -51,7 +51,7 @@ final class ClassRules {
     }
   }
 
-  /** Prefer {@link Class#isInstance(Object)} method references over more verbose alternatives. */
+  /** Prefer {@code clazz::isInstance} over more verbose alternatives. */
   // XXX: Drop this rule once the `MethodReferenceUsage` rule is enabled by default.
   static final class ClassIsInstanceWithClass<T, S> {
     @BeforeTemplate
@@ -65,7 +65,7 @@ final class ClassRules {
     }
   }
 
-  /** Prefer {@link Class#cast(Object)} method references over more verbose alternatives. */
+  /** Prefer {@code clazz::cast} over more verbose alternatives. */
   // XXX: Drop this rule once the `MethodReferenceUsage` rule is enabled by default.
   static final class ClassCast<T, S, U extends S> {
     @BeforeTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/CollectionRules.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import com.google.common.collect.Sets.SetView;
 import com.google.common.collect.Streams;
+import com.google.common.collect.UnmodifiableIterator;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.AlsoNegation;
@@ -27,6 +28,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NavigableSet;
+import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Queue;
 import java.util.SequencedCollection;
@@ -38,7 +40,7 @@ import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.matchers.IsRefasterAsVarargs;
 
-/** Refaster rules related to expressions dealing with (arbitrary) collections. */
+/** Refaster rules related to expressions dealing with {@link Collection}s. */
 // XXX: There are other Guava `Iterables` methods that should not be called if the input is known to
 // be a `Collection`. Add those here.
 @OnlineDocumentation
@@ -46,31 +48,30 @@ final class CollectionRules {
   private CollectionRules() {}
 
   /**
-   * Prefer {@link Collection#isEmpty()} over alternatives that consult the collection's size or are
-   * otherwise more contrived.
+   * Prefer {@link Collection#isEmpty()} over non-JDK, less efficient, or more verbose alternatives.
    */
   static final class CollectionIsEmpty<T> {
     @BeforeTemplate
     @SuppressWarnings({
       "java:S1155" /* This violation will be rewritten. */,
       "LexicographicalAnnotationAttributeListing" /* `key-*` entry must remain last. */,
-      "OptionalFirstCollectionElement" /* This is a more specific template. */,
+      "CollectionStreamFindFirst" /* This is a more specific template. */,
       "StreamFindAnyIsEmpty" /* This is a more specific template. */,
       "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
     })
-    boolean before(Collection<T> collection) {
+    boolean before(Collection<T> iterable) {
       return Refaster.anyOf(
-          collection.size() == 0,
-          collection.size() <= 0,
-          collection.size() < 1,
-          Iterables.isEmpty(collection),
-          collection.stream().findAny().isEmpty(),
-          collection.stream().findFirst().isEmpty());
+          iterable.size() == 0,
+          iterable.size() <= 0,
+          iterable.size() < 1,
+          Iterables.isEmpty(iterable),
+          iterable.stream().findAny().isEmpty(),
+          iterable.stream().findFirst().isEmpty());
     }
 
     @BeforeTemplate
-    boolean before(ImmutableCollection<T> collection) {
-      return collection.asList().isEmpty();
+    boolean before(ImmutableCollection<T> iterable) {
+      return iterable.asList().isEmpty();
     }
 
     // XXX: Consider introducing similar templates for other `SetView` methods that derive a
@@ -85,36 +86,36 @@ final class CollectionRules {
     // `IsEmpty` matcher implementation. (Note that `equals()` and `hashCode()` may need special
     // handling, as they depend on the collection type produced.)
     @BeforeTemplate
-    boolean before(SetView<T> collection) {
-      return collection.immutableCopy().isEmpty();
+    boolean before(SetView<T> iterable) {
+      return iterable.immutableCopy().isEmpty();
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(Collection<T> collection) {
-      return collection.isEmpty();
+    boolean after(Collection<T> iterable) {
+      return iterable.isEmpty();
     }
   }
 
-  /** Prefer {@link Collection#size()} over more contrived alternatives. */
+  /** Prefer {@link Collection#size()} over non-JDK or more verbose alternatives. */
   static final class CollectionSize<T> {
     @BeforeTemplate
-    int before(Collection<T> collection) {
-      return Iterables.size(collection);
+    int before(Collection<T> iterable) {
+      return Iterables.size(iterable);
     }
 
     @BeforeTemplate
-    int before(ImmutableCollection<T> collection) {
-      return collection.asList().size();
+    int before(ImmutableCollection<T> iterable) {
+      return iterable.asList().size();
     }
 
     @AfterTemplate
-    int after(Collection<T> collection) {
-      return collection.size();
+    int after(Collection<T> iterable) {
+      return iterable.size();
     }
   }
 
-  /** Prefer {@link Collection#contains(Object)} over more contrived alternatives. */
+  /** Prefer {@link Collection#contains(Object)} over less efficient alternatives. */
   static final class CollectionContains<T, S> {
     @BeforeTemplate
     boolean before(Collection<T> collection, S value) {
@@ -131,36 +132,33 @@ final class CollectionRules {
    * Prefer {@link Collections#disjoint(Collection, Collection)} over non-JDK or less efficient
    * alternatives.
    */
-  static final class CollectionsDisjoint<T> {
+  static final class Disjoint<T> {
     @BeforeTemplate
-    boolean before(Set<T> collection1, Set<T> collection2) {
-      return Sets.intersection(collection1, collection2).isEmpty();
+    boolean before(Set<T> c1, Set<T> c2) {
+      return Sets.intersection(c1, c2).isEmpty();
     }
 
     // XXX: Other copy operations could be elided too, but these are the most common ones. If we
     // ever introduce a generic "makes a copy" stand-in, use it here.
     @BeforeTemplate
-    boolean before(Collection<T> collection1, Collection<T> collection2) {
+    boolean before(Collection<T> c1, Collection<T> c2) {
       return Refaster.anyOf(
-          collection1.stream().noneMatch(collection2::contains),
-          disjoint(ImmutableSet.copyOf(collection1), collection2),
-          disjoint(new HashSet<>(collection1), collection2),
-          disjoint(collection1, ImmutableSet.copyOf(collection2)),
-          disjoint(collection1, new HashSet<>(collection2)));
+          c1.stream().noneMatch(c2::contains),
+          disjoint(ImmutableSet.copyOf(c1), c2),
+          disjoint(new HashSet<>(c1), c2),
+          disjoint(c1, ImmutableSet.copyOf(c2)),
+          disjoint(c1, new HashSet<>(c2)));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    boolean after(Collection<T> collection1, Collection<T> collection2) {
-      return disjoint(collection1, collection2);
+    boolean after(Collection<T> c1, Collection<T> c2) {
+      return disjoint(c1, c2);
     }
   }
 
-  /**
-   * Don't call {@link Iterables#addAll(Collection, Iterable)} when the elements to be added are
-   * already part of a {@link Collection}.
-   */
-  static final class CollectionAddAllToCollectionExpression<T, S extends T> {
+  /** Prefer {@link Collection#addAll(Collection)} over non-JDK alternatives. */
+  static final class CollectionAddAllExpression<T, S extends T> {
     @BeforeTemplate
     boolean before(Collection<T> addTo, Collection<S> elementsToAdd) {
       return Iterables.addAll(addTo, elementsToAdd);
@@ -172,60 +170,59 @@ final class CollectionRules {
     }
   }
 
-  static final class CollectionAddAllToCollectionBlock<T, S extends T> {
+  /** Prefer {@link Collection#addAll(Collection)} over more verbose alternatives. */
+  static final class CollectionAddAllBlock<T, S extends T> {
     @BeforeTemplate
-    void before(Collection<T> addTo, Collection<S> elementsToAdd) {
-      elementsToAdd.forEach(addTo::add);
+    void before(Collection<T> collection1, Collection<S> collection2) {
+      collection2.forEach(collection1::add);
     }
 
     @BeforeTemplate
-    void before2(Collection<T> addTo, Collection<S> elementsToAdd) {
-      for (T element : elementsToAdd) {
-        addTo.add(element);
+    void before2(Collection<T> collection1, Collection<S> collection2) {
+      for (T element : collection2) {
+        collection1.add(element);
       }
     }
 
     // XXX: This method is identical to `before2` except for the loop type. Make Refaster smarter so
     // that this is supported out of the box.
     @BeforeTemplate
-    void before3(Collection<T> addTo, Collection<S> elementsToAdd) {
-      for (S element : elementsToAdd) {
-        addTo.add(element);
+    void before3(Collection<T> collection1, Collection<S> collection2) {
+      for (S element : collection2) {
+        collection1.add(element);
       }
     }
 
     @AfterTemplate
-    void after(Collection<T> addTo, Collection<S> elementsToAdd) {
-      addTo.addAll(elementsToAdd);
+    void after(Collection<T> collection1, Collection<S> collection2) {
+      collection1.addAll(collection2);
     }
   }
 
-  /**
-   * Don't call {@link Iterables#removeAll(Iterable, Collection)} when the elements to be removed
-   * are already part of a {@link Collection}.
-   */
-  static final class CollectionRemoveAllFromCollectionExpression<T, S extends T> {
+  /** Prefer {@link Collection#removeAll(Collection)} over non-JDK alternatives. */
+  static final class CollectionRemoveAllExpression<T, S extends T> {
     @BeforeTemplate
-    boolean before(Collection<T> removeTo, Collection<S> elementsToRemove) {
-      return Iterables.removeAll(removeTo, elementsToRemove);
+    boolean before(Collection<T> removeFrom, Collection<S> elementsToRemove) {
+      return Iterables.removeAll(removeFrom, elementsToRemove);
     }
 
     @AfterTemplate
-    boolean after(Collection<T> removeTo, Collection<S> elementsToRemove) {
-      return removeTo.removeAll(elementsToRemove);
+    boolean after(Collection<T> removeFrom, Collection<S> elementsToRemove) {
+      return removeFrom.removeAll(elementsToRemove);
     }
   }
 
-  static final class CollectionRemoveAllFromCollectionBlock<T, S extends T> {
+  /** Prefer {@link Collection#removeAll(Collection)} over more verbose alternatives. */
+  static final class CollectionRemoveAllBlock<T, S extends T> {
     @BeforeTemplate
-    void before(Collection<T> removeFrom, Collection<S> elementsToRemove) {
-      elementsToRemove.forEach(removeFrom::remove);
+    void before(Collection<T> collection1, Collection<S> collection2) {
+      collection2.forEach(collection1::remove);
     }
 
     @BeforeTemplate
-    void before2(Collection<T> removeFrom, Collection<S> elementsToRemove) {
-      for (T element : elementsToRemove) {
-        removeFrom.remove(element);
+    void before2(Collection<T> collection1, Collection<S> collection2) {
+      for (T element : collection2) {
+        collection1.remove(element);
       }
     }
 
@@ -233,19 +230,19 @@ final class CollectionRules {
     // that this is supported out of the box. After doing so, also drop the `S extends T` type
     // constraint; ideally this check applies to any `S`.
     @BeforeTemplate
-    void before3(Collection<T> removeFrom, Collection<S> elementsToRemove) {
-      for (S element : elementsToRemove) {
-        removeFrom.remove(element);
+    void before3(Collection<T> collection1, Collection<S> collection2) {
+      for (S element : collection2) {
+        collection1.remove(element);
       }
     }
 
     @AfterTemplate
-    void after(Collection<T> removeFrom, Collection<S> elementsToRemove) {
-      removeFrom.removeAll(elementsToRemove);
+    void after(Collection<T> collection1, Collection<S> collection2) {
+      collection1.removeAll(collection2);
     }
   }
 
-  /** Don't unnecessarily call {@link Stream#distinct()} on an already-unique stream of elements. */
+  /** Prefer {@link Set#stream()} over less efficient alternatives. */
   // XXX: This rule assumes that the `Set` relies on `Object#equals`, rather than a custom
   // equivalence relation.
   // XXX: Expressions that drop or reorder elements from the stream, such as `.filter`, `.skip` and
@@ -253,23 +250,23 @@ final class CollectionRules {
   // check.
   static final class SetStream<T> {
     @BeforeTemplate
-    Stream<?> before(Set<T> set) {
+    Stream<T> before(Set<T> set) {
       return set.stream().distinct();
     }
 
     @AfterTemplate
-    Stream<?> after(Set<T> set) {
+    Stream<T> after(Set<T> set) {
       return set.stream();
     }
   }
 
-  /** Prefer {@link Set#of(Object[])} over more contrived alternatives. */
+  /** Prefer {@link Set#of(Object[])} over less efficient alternatives. */
   // XXX: Ideally we rewrite both of these expressions directly to `ImmutableSet.of(..)` (and
   // locate this rule in `ImmutableSetRules`), but for now this rule is included as-is for use with
   // OpenRewrite.
   // XXX: The replacement code throws `IllegalArgumentException` on duplicate elements, while the
   // original code deduplicates them.
-  static final class SetOfVarargs<T> {
+  static final class SetOf<T> {
     @BeforeTemplate
     Set<T> before(@Repeated T elements) {
       return Stream.of(Refaster.asVarargs(elements)).collect(toUnmodifiableSet());
@@ -281,38 +278,35 @@ final class CollectionRules {
     }
   }
 
-  /** Prefer {@link ArrayList#ArrayList(Collection)} over the Guava alternative. */
+  /** Prefer {@link ArrayList#ArrayList(Collection)} over non-JDK alternatives. */
   @SuppressWarnings(
       "NonApiType" /* Matching against `List` would unnecessarily constrain the rule. */)
-  static final class NewArrayListFromCollection<T> {
+  static final class NewArrayList<T> {
     @BeforeTemplate
-    ArrayList<T> before(Collection<T> collection) {
-      return Lists.newArrayList(collection);
+    ArrayList<T> before(Collection<T> elements) {
+      return Lists.newArrayList(elements);
     }
 
     @AfterTemplate
-    ArrayList<T> after(Collection<T> collection) {
-      return new ArrayList<>(collection);
+    ArrayList<T> after(Collection<T> elements) {
+      return new ArrayList<>(elements);
     }
   }
 
-  /** Prefer {@link ImmutableCollection#asList()} over the more verbose alternative. */
+  /** Prefer {@link ImmutableCollection#asList()} over more verbose alternatives. */
   static final class ImmutableCollectionAsList<T> {
     @BeforeTemplate
-    ImmutableList<T> before(ImmutableCollection<T> collection) {
-      return ImmutableList.copyOf(collection);
+    ImmutableList<T> before(ImmutableCollection<T> elements) {
+      return ImmutableList.copyOf(elements);
     }
 
     @AfterTemplate
-    ImmutableList<T> after(ImmutableCollection<T> collection) {
-      return collection.asList();
+    ImmutableList<T> after(ImmutableCollection<T> elements) {
+      return elements.asList();
     }
   }
 
-  /**
-   * Don't call {@link ImmutableCollection#asList()} if the result is going to be streamed; stream
-   * directly.
-   */
+  /** Prefer {@link ImmutableCollection#stream()} over more verbose alternatives. */
   static final class ImmutableCollectionStream<T> {
     @BeforeTemplate
     Stream<T> before(ImmutableCollection<T> collection) {
@@ -325,26 +319,20 @@ final class CollectionRules {
     }
   }
 
-  /**
-   * Don't call {@link ImmutableCollection#asList()} if {@link Collection#contains(Object)} is
-   * called on the result; call it directly.
-   */
+  /** Prefer {@link ImmutableCollection#contains(Object)} over more verbose alternatives. */
   static final class ImmutableCollectionContains<T, S> {
     @BeforeTemplate
-    boolean before(ImmutableCollection<T> collection, S elem) {
-      return collection.asList().contains(elem);
+    boolean before(ImmutableCollection<T> collection, S object) {
+      return collection.asList().contains(object);
     }
 
     @AfterTemplate
-    boolean after(ImmutableCollection<T> collection, S elem) {
-      return collection.contains(elem);
+    boolean after(ImmutableCollection<T> collection, S object) {
+      return collection.contains(object);
     }
   }
 
-  /**
-   * Don't call {@link ImmutableCollection#asList()} if {@link ImmutableCollection#parallelStream()}
-   * is called on the result; call it directly.
-   */
+  /** Prefer {@link ImmutableCollection#parallelStream()} over more verbose alternatives. */
   static final class ImmutableCollectionParallelStream<T> {
     @BeforeTemplate
     Stream<T> before(ImmutableCollection<T> collection) {
@@ -357,10 +345,7 @@ final class CollectionRules {
     }
   }
 
-  /**
-   * Don't call {@link ImmutableCollection#asList()} if {@link ImmutableCollection#toString()} is
-   * called on the result; call it directly.
-   */
+  /** Prefer {@link ImmutableCollection#toString()} over more verbose alternatives. */
   static final class ImmutableCollectionToString<T> {
     @BeforeTemplate
     String before(ImmutableCollection<T> collection) {
@@ -373,7 +358,7 @@ final class CollectionRules {
     }
   }
 
-  /** Prefer {@link Arrays#asList(Object[])} over more contrived alternatives. */
+  /** Prefer {@link Arrays#asList(Object[])} over less efficient alternatives. */
   // XXX: Consider moving this rule to `ImmutableListRules` and having it suggest
   // `ImmutableList#copyOf`. That would retain immutability, at the cost of no longer handling
   // `null`s.
@@ -390,7 +375,7 @@ final class CollectionRules {
     }
   }
 
-  /** Prefer calling {@link Collection#toArray()} over more contrived alternatives. */
+  /** Prefer {@link Collection#toArray()} over less efficient or more verbose alternatives. */
   static final class CollectionToArray<T> {
     @BeforeTemplate
     Object[] before(Collection<T> collection, int size) {
@@ -409,27 +394,21 @@ final class CollectionRules {
     }
   }
 
-  /**
-   * Don't call {@link ImmutableCollection#asList()} if {@link
-   * ImmutableCollection#toArray(Object[])}` is called on the result; call it directly.
-   */
-  static final class ImmutableCollectionToArrayWithArray<T, S> {
+  /** Prefer {@link ImmutableCollection#toArray(Object[])} over more verbose alternatives. */
+  static final class ImmutableCollectionToArrayObject<T, S> {
     @BeforeTemplate
-    Object[] before(ImmutableCollection<T> collection, S[] array) {
-      return collection.asList().toArray(array);
+    S[] before(ImmutableCollection<T> collection, S[] other) {
+      return collection.asList().toArray(other);
     }
 
     @AfterTemplate
-    Object[] after(ImmutableCollection<T> collection, S[] array) {
-      return collection.toArray(array);
+    S[] after(ImmutableCollection<T> collection, S[] other) {
+      return collection.toArray(other);
     }
   }
 
-  /**
-   * Don't call {@link ImmutableCollection#asList()} if {@link
-   * ImmutableCollection#toArray(IntFunction)}} is called on the result; call it directly.
-   */
-  static final class ImmutableCollectionToArrayWithGenerator<T, S> {
+  /** Prefer {@link ImmutableCollection#toArray(IntFunction)} over more verbose alternatives. */
+  static final class ImmutableCollectionToArrayIntFunction<T, S> {
     @BeforeTemplate
     S[] before(ImmutableCollection<T> collection, IntFunction<S[]> generator) {
       return collection.asList().toArray(generator);
@@ -441,7 +420,7 @@ final class CollectionRules {
     }
   }
 
-  /** Prefer {@link Collection#iterator()} over more contrived or less efficient alternatives. */
+  /** Prefer {@link Collection#iterator()} over less efficient or more verbose alternatives. */
   static final class CollectionIterator<T> {
     @BeforeTemplate
     Iterator<T> before(Collection<T> collection) {
@@ -449,7 +428,7 @@ final class CollectionRules {
     }
 
     @BeforeTemplate
-    Iterator<T> before(ImmutableCollection<T> collection) {
+    UnmodifiableIterator<T> before(ImmutableCollection<T> collection) {
       return collection.asList().iterator();
     }
 
@@ -460,12 +439,9 @@ final class CollectionRules {
   }
 
   /**
-   * Don't use the ternary operator to extract the first element of a possibly-empty {@link
-   * Collection} as an {@link Optional}, and (when applicable) prefer {@link Stream#findFirst()}
-   * over {@link Stream#findAny()} to communicate that the collection's first element (if any,
-   * according to iteration order) will be returned.
+   * Prefer {@code collection.stream().findFirst()} over less explicit or more verbose alternatives.
    */
-  static final class OptionalFirstCollectionElement<T> {
+  static final class CollectionStreamFindFirst<T> {
     @BeforeTemplate
     Optional<T> before(Collection<T> collection) {
       return Refaster.anyOf(
@@ -490,10 +466,9 @@ final class CollectionRules {
   }
 
   /**
-   * Avoid contrived constructions when peeking at the first element of a possibly empty {@link
-   * Queue}.
+   * Prefer {@link Optional#ofNullable(Object)} over less efficient or more contrived alternatives.
    */
-  static final class OptionalFirstQueueElement<T> {
+  static final class OptionalOfNullableQueuePeek<T> {
     @BeforeTemplate
     Optional<T> before(Queue<T> queue) {
       return Refaster.anyOf(
@@ -509,29 +484,24 @@ final class CollectionRules {
     }
   }
 
-  /**
-   * Avoid contrived constructions when extracting the first element from a possibly empty {@link
-   * NavigableSet}.
-   */
-  static final class RemoveOptionalFirstNavigableSetElement<T> {
+  /** Prefer {@link Optional#ofNullable(Object)} over more contrived alternatives. */
+  static final class OptionalOfNullableNavigableSetPollFirst<T> {
     @BeforeTemplate
-    Optional<T> before(NavigableSet<T> set) {
-      return set.isEmpty()
+    Optional<T> before(NavigableSet<T> navigableSet) {
+      return navigableSet.isEmpty()
           ? Optional.empty()
-          : Refaster.anyOf(Optional.of(set.pollFirst()), Optional.ofNullable(set.pollFirst()));
+          : Refaster.anyOf(
+              Optional.of(navigableSet.pollFirst()), Optional.ofNullable(navigableSet.pollFirst()));
     }
 
     @AfterTemplate
-    Optional<T> after(NavigableSet<T> set) {
-      return Optional.ofNullable(set.pollFirst());
+    Optional<T> after(NavigableSet<T> navigableSet) {
+      return Optional.ofNullable(navigableSet.pollFirst());
     }
   }
 
-  /**
-   * Avoid contrived constructions when extracting the first element from a possibly empty {@link
-   * Queue}.
-   */
-  static final class RemoveOptionalFirstQueueElement<T> {
+  /** Prefer {@link Optional#ofNullable(Object)} over more contrived alternatives. */
+  static final class OptionalOfNullableQueuePoll<T> {
     @BeforeTemplate
     Optional<T> before(Queue<T> queue) {
       return queue.isEmpty()
@@ -547,153 +517,161 @@ final class CollectionRules {
     }
   }
 
-  /** Prefer {@link Collection#forEach(Consumer)} over more contrived alternatives. */
-  static final class CollectionForEach<T> {
+  /** Prefer {@link Collection#forEach(Consumer)} over less efficient alternatives. */
+  static final class CollectionForEach<S, T extends S> {
     @BeforeTemplate
-    void before(Collection<T> collection, Consumer<? super T> consumer) {
-      collection.stream().forEach(consumer);
+    void before(Collection<T> collection, Consumer<S> action) {
+      collection.stream().forEach(action);
     }
 
     @AfterTemplate
-    void after(Collection<T> collection, Consumer<? super T> consumer) {
-      collection.forEach(consumer);
+    void after(Collection<T> collection, Consumer<S> action) {
+      collection.forEach(action);
     }
   }
 
-  /** Prefer {@code collection.iterator().next()} over more contrived alternatives. */
-  static final class CollectionIteratorNext<S, T extends S> {
+  /** Prefer {@code collection.iterator().next()} over less efficient alternatives. */
+  static final class CollectionIteratorNext<T> {
     @BeforeTemplate
-    S before(Collection<T> collection) {
+    T before(Collection<T> collection) {
       return collection.stream().findFirst().orElseThrow();
     }
 
     @AfterTemplate
-    S after(Collection<T> collection) {
+    T after(Collection<T> collection) {
       return collection.iterator().next();
     }
   }
 
   /** Prefer {@link SequencedCollection#getFirst()} over less idiomatic alternatives. */
-  static final class SequencedCollectionGetFirst<S, T extends S> {
+  static final class SequencedCollectionGetFirst<T> {
     @BeforeTemplate
-    S before(SequencedCollection<T> collection) {
+    T before(SequencedCollection<T> collection) {
       return collection.iterator().next();
     }
 
     @BeforeTemplate
-    S before(List<T> collection) {
+    T before(List<T> collection) {
       return collection.get(0);
     }
 
     @AfterTemplate
-    S after(SequencedCollection<T> collection) {
+    T after(SequencedCollection<T> collection) {
       return collection.getFirst();
     }
   }
 
-  /** Prefer {@link SequencedCollection#getLast()} over less idiomatic alternatives. */
-  static final class SequencedCollectionGetLast<S, T extends S> {
+  /**
+   * Prefer {@link SequencedCollection#getLast()} over less idiomatic or more verbose alternatives.
+   */
+  static final class SequencedCollectionGetLast<T> {
     @BeforeTemplate
-    S before(SequencedCollection<T> collection) {
+    T before(SequencedCollection<T> collection) {
       return Refaster.anyOf(
           collection.reversed().getFirst(), Streams.findLast(collection.stream()).orElseThrow());
     }
 
     @BeforeTemplate
-    S before(List<T> collection) {
+    T before(List<T> collection) {
       return collection.get(collection.size() - 1);
     }
 
     @AfterTemplate
-    S after(SequencedCollection<T> collection) {
+    T after(SequencedCollection<T> collection) {
       return collection.getLast();
     }
   }
 
   /** Prefer {@link List#addFirst(Object)} over less idiomatic alternatives. */
-  static final class ListAddFirst<S, T extends S> {
+  static final class ListAddFirst<T> {
     @BeforeTemplate
-    void before(List<S> list, T element) {
-      list.add(0, element);
+    void before(List<T> list, T e) {
+      list.add(0, e);
     }
 
     @AfterTemplate
-    void after(List<S> list, T element) {
-      list.addFirst(element);
+    void after(List<T> list, T e) {
+      list.addFirst(e);
     }
   }
 
-  /** Prefer {@link List#add(Object)} over less idiomatic alternatives. */
-  static final class ListAdd<S, T extends S> {
+  /** Prefer {@link List#add(Object)} over less idiomatic or more verbose alternatives. */
+  static final class ListAdd<T> {
     @BeforeTemplate
-    void before(List<S> list, T element) {
-      list.addLast(element);
+    void before(List<T> list, T e) {
+      list.addLast(e);
     }
 
     @BeforeTemplate
-    void before2(List<S> list, T element) {
-      list.add(list.size(), element);
+    void before2(List<T> list, T e) {
+      list.add(list.size(), e);
     }
 
     @AfterTemplate
-    void after(List<S> list, T element) {
-      list.add(element);
+    void after(List<T> list, T e) {
+      list.add(e);
     }
   }
 
-  /** Prefer {@link List#removeFirst()}} over less idiomatic alternatives. */
-  // XXX: This rule changes the exception thrown for empty lists from `IndexOutOfBoundsException` to
-  // `NoSuchElementException`.
-  static final class ListRemoveFirst<S, T extends S> {
+  /**
+   * Prefer {@link List#removeFirst()} over less idiomatic alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes the exception thrown for empty lists from
+   * {@link IndexOutOfBoundsException} to {@link NoSuchElementException}.
+   */
+  static final class ListRemoveFirst<T> {
     @BeforeTemplate
-    S before(List<T> list) {
+    T before(List<T> list) {
       return list.remove(0);
     }
 
     @AfterTemplate
-    S after(List<T> list) {
+    T after(List<T> list) {
       return list.removeFirst();
     }
   }
 
-  /** Prefer {@link List#removeLast()}} over less idiomatic alternatives. */
-  // XXX: This rule changes the exception thrown for empty lists from `IndexOutOfBoundsException` to
-  // `NoSuchElementException`.
-  static final class ListRemoveLast<S, T extends S> {
+  /**
+   * Prefer {@link List#removeLast()} over less idiomatic alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes the exception thrown for empty lists from
+   * {@link IndexOutOfBoundsException} to {@link NoSuchElementException}.
+   */
+  static final class ListRemoveLast<T> {
     @BeforeTemplate
-    S before(List<T> list) {
+    T before(List<T> list) {
       return list.remove(list.size() - 1);
     }
 
     @AfterTemplate
-    S after(List<T> list) {
+    T after(List<T> list) {
       return list.removeLast();
     }
   }
 
-  /** Prefer {@link SortedSet#first()} over more verbose alternatives. */
-  static final class SortedSetFirst<S, T extends S> {
+  /** Prefer {@link SortedSet#first()} over less idiomatic alternatives. */
+  static final class SortedSetFirst<T> {
     @BeforeTemplate
-    S before(SortedSet<T> set) {
-      return set.getFirst();
+    T before(SortedSet<T> sortedSet) {
+      return sortedSet.getFirst();
     }
 
     @AfterTemplate
-    S after(SortedSet<T> set) {
-      return set.first();
+    T after(SortedSet<T> sortedSet) {
+      return sortedSet.first();
     }
   }
 
-  /** Prefer {@link SortedSet#last()} over more verbose alternatives. */
-  static final class SortedSetLast<S, T extends S> {
+  /** Prefer {@link SortedSet#last()} over less idiomatic alternatives. */
+  static final class SortedSetLast<T> {
     @BeforeTemplate
-    S before(SortedSet<T> set) {
-      return set.getLast();
+    T before(SortedSet<T> sortedSet) {
+      return sortedSet.getLast();
     }
 
     @AfterTemplate
-    S after(SortedSet<T> set) {
-      return set.last();
+    T after(SortedSet<T> sortedSet) {
+      return sortedSet.last();
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -103,7 +103,6 @@ final class ComparatorRules {
 
     @AfterTemplate
     @CanIgnoreReturnValue
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     Comparator<T> after(Comparator<T> keyComparator) {
       return keyComparator;
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -37,6 +37,7 @@ import java.util.function.ToDoubleFunction;
 import java.util.function.ToIntFunction;
 import java.util.function.ToLongFunction;
 import java.util.stream.Collector;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.matchers.IsIdentityOperation;
@@ -46,14 +47,19 @@ import tech.picnic.errorprone.refaster.matchers.IsIdentityOperation;
 final class ComparatorRules {
   private ComparatorRules() {}
 
-  /** Prefer {@link Comparator#naturalOrder()} over more complicated constructs. */
-  static final class NaturalOrder<T extends Comparable<? super T>> {
+  /**
+   * Prefer {@link Comparator#naturalOrder()} over less explicit, more verbose, or more contrived
+   * alternatives.
+   */
+  static final class NaturalOrder<T extends Comparable<? super T>, U extends T> {
+    // XXX: Ideally `? super T` would also be replaced by a class-level type parameter, but Java
+    // does not allow a type variable to be followed by other bounds.
     @BeforeTemplate
     Comparator<T> before(
-        @Matches(IsIdentityOperation.class) Function<? super T, ? extends T> keyExtractor) {
+        @Matches(IsIdentityOperation.class) Function<? super T, U> identityKeyExtractor) {
       return Refaster.anyOf(
           T::compareTo,
-          comparing(keyExtractor),
+          comparing(identityKeyExtractor),
           Collections.<T>reverseOrder(reverseOrder()),
           Comparator.<T>reverseOrder().reversed());
     }
@@ -65,7 +71,10 @@ final class ComparatorRules {
     }
   }
 
-  /** Prefer {@link Comparator#reverseOrder()} over more complicated constructs. */
+  /**
+   * Prefer {@link Comparator#reverseOrder()} over less explicit, more verbose, or more contrived
+   * alternatives.
+   */
   static final class ReverseOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
     Comparator<T> before() {
@@ -83,24 +92,25 @@ final class ComparatorRules {
     }
   }
 
-  static final class CustomComparator<T> {
+  /** Prefer using the {@link Comparator} as-is over more contrived alternatives. */
+  static final class ComparatorIdentity<S, T extends S, U extends T> {
     @BeforeTemplate
     Comparator<T> before(
-        Comparator<T> cmp,
-        @Matches(IsIdentityOperation.class) Function<? super T, ? extends T> keyExtractor) {
-      return comparing(keyExtractor, cmp);
+        Comparator<T> keyComparator,
+        @Matches(IsIdentityOperation.class) Function<S, U> identityKeyExtractor) {
+      return comparing(identityKeyExtractor, keyComparator);
     }
 
     @AfterTemplate
     @CanIgnoreReturnValue
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Comparator<T> after(Comparator<T> cmp) {
-      return cmp;
+    Comparator<T> after(Comparator<T> keyComparator) {
+      return keyComparator;
     }
   }
 
-  /** Don't explicitly compare enums by their ordinal. */
-  abstract static class ComparingEnum<E extends Enum<E>, T> {
+  /** Prefer {@link Comparator#comparing(Function)} over less explicit alternatives. */
+  abstract static class Comparing<E extends Enum<E>, T> {
     @Placeholder(allowsIdentity = true)
     abstract E toEnumFunction(@MayOptionallyUse T value);
 
@@ -117,112 +127,122 @@ final class ComparatorRules {
     }
   }
 
-  /** Don't explicitly create {@link Comparator}s unnecessarily. */
-  static final class ThenComparing<S, T extends Comparable<? super T>> {
+  /** Prefer {@link Comparator#thenComparing(Function)} over more verbose alternatives. */
+  static final class ComparatorThenComparing<
+      R, S extends R, T extends Comparable<? super T>, U extends T> {
     @BeforeTemplate
-    Comparator<S> before(Comparator<S> cmp, Function<? super S, ? extends T> function) {
-      return cmp.thenComparing(comparing(function));
+    Comparator<S> before(Comparator<S> cmp, Function<R, U> keyExtractor) {
+      return cmp.thenComparing(comparing(keyExtractor));
     }
 
     @AfterTemplate
-    Comparator<S> after(Comparator<S> cmp, Function<? super S, ? extends T> function) {
-      return cmp.thenComparing(function);
-    }
-  }
-
-  /** Don't explicitly create {@link Comparator}s unnecessarily. */
-  static final class ThenComparingReversed<S, T extends Comparable<? super T>> {
-    @BeforeTemplate
-    Comparator<S> before(Comparator<S> cmp, Function<? super S, ? extends T> function) {
-      return cmp.thenComparing(comparing(function).reversed());
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Comparator<S> after(Comparator<S> cmp, Function<? super S, ? extends T> function) {
-      return cmp.thenComparing(function, reverseOrder());
-    }
-  }
-
-  /** Don't explicitly create {@link Comparator}s unnecessarily. */
-  static final class ThenComparingCustom<S, T> {
-    @BeforeTemplate
-    Comparator<S> before(
-        Comparator<S> cmp, Function<? super S, ? extends T> function, Comparator<? super T> cmp2) {
-      return cmp.thenComparing(comparing(function, cmp2));
-    }
-
-    @AfterTemplate
-    Comparator<S> after(
-        Comparator<S> cmp, Function<? super S, ? extends T> function, Comparator<? super T> cmp2) {
-      return cmp.thenComparing(function, cmp2);
-    }
-  }
-
-  /** Don't explicitly create {@link Comparator}s unnecessarily. */
-  static final class ThenComparingCustomReversed<S, T> {
-    @BeforeTemplate
-    Comparator<S> before(
-        Comparator<S> cmp, Function<? super S, ? extends T> function, Comparator<? super T> cmp2) {
-      return cmp.thenComparing(comparing(function, cmp2).reversed());
-    }
-
-    @AfterTemplate
-    Comparator<S> after(
-        Comparator<S> cmp, Function<? super S, ? extends T> function, Comparator<? super T> cmp2) {
-      return cmp.thenComparing(function, cmp2.reversed());
-    }
-  }
-
-  /** Don't explicitly create {@link Comparator}s unnecessarily. */
-  static final class ThenComparingDouble<T> {
-    @BeforeTemplate
-    Comparator<T> before(Comparator<T> cmp, ToDoubleFunction<? super T> function) {
-      return cmp.thenComparing(comparingDouble(function));
-    }
-
-    @AfterTemplate
-    Comparator<T> after(Comparator<T> cmp, ToDoubleFunction<? super T> function) {
-      return cmp.thenComparingDouble(function);
-    }
-  }
-
-  /** Don't explicitly create {@link Comparator}s unnecessarily. */
-  static final class ThenComparingInt<T> {
-    @BeforeTemplate
-    Comparator<T> before(Comparator<T> cmp, ToIntFunction<? super T> function) {
-      return cmp.thenComparing(comparingInt(function));
-    }
-
-    @AfterTemplate
-    Comparator<T> after(Comparator<T> cmp, ToIntFunction<? super T> function) {
-      return cmp.thenComparingInt(function);
-    }
-  }
-
-  /** Don't explicitly create {@link Comparator}s unnecessarily. */
-  static final class ThenComparingLong<T> {
-    @BeforeTemplate
-    Comparator<T> before(Comparator<T> cmp, ToLongFunction<? super T> function) {
-      return cmp.thenComparing(comparingLong(function));
-    }
-
-    @AfterTemplate
-    Comparator<T> after(Comparator<T> cmp, ToLongFunction<? super T> function) {
-      return cmp.thenComparingLong(function);
+    Comparator<S> after(Comparator<S> cmp, Function<R, U> keyExtractor) {
+      return cmp.thenComparing(keyExtractor);
     }
   }
 
   /**
-   * Where applicable, prefer {@link Comparator#naturalOrder()} over identity function-based
-   * comparisons, as the former more clearly states intent.
+   * Prefer {@link Comparator#thenComparing(Function, Comparator)} over more verbose alternatives.
    */
-  static final class ThenComparingNaturalOrder<T extends Comparable<? super T>> {
+  static final class ComparatorThenComparingReverseOrder<
+      R, S extends R, T extends Comparable<? super T>, U extends T> {
+    @BeforeTemplate
+    Comparator<S> before(Comparator<S> cmp, Function<R, U> keyExtractor) {
+      return cmp.thenComparing(comparing(keyExtractor).reversed());
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    Comparator<S> after(Comparator<S> cmp, Function<R, U> keyExtractor) {
+      return cmp.thenComparing(keyExtractor, reverseOrder());
+    }
+  }
+
+  /**
+   * Prefer {@link Comparator#thenComparing(Function, Comparator)} over more verbose alternatives.
+   */
+  static final class ComparatorThenComparingWithComparator<R, S extends R, V, U extends V> {
+    @BeforeTemplate
+    Comparator<S> before(
+        Comparator<S> cmp, Function<R, U> keyExtractor, Comparator<V> keyComparator) {
+      return cmp.thenComparing(comparing(keyExtractor, keyComparator));
+    }
+
+    @AfterTemplate
+    Comparator<S> after(
+        Comparator<S> cmp, Function<R, U> keyExtractor, Comparator<V> keyComparator) {
+      return cmp.thenComparing(keyExtractor, keyComparator);
+    }
+  }
+
+  /**
+   * Prefer {@link Comparator#thenComparing(Function, Comparator)} over more contrived alternatives.
+   */
+  static final class ComparatorThenComparingComparatorReversed<R, S extends R, V, U extends V> {
+    @BeforeTemplate
+    Comparator<S> before(
+        Comparator<S> cmp, Function<R, U> keyExtractor, Comparator<V> keyComparator) {
+      return cmp.thenComparing(comparing(keyExtractor, keyComparator).reversed());
+    }
+
+    @AfterTemplate
+    Comparator<S> after(
+        Comparator<S> cmp, Function<R, U> keyExtractor, Comparator<V> keyComparator) {
+      return cmp.thenComparing(keyExtractor, keyComparator.reversed());
+    }
+  }
+
+  /**
+   * Prefer {@link Comparator#thenComparingDouble(ToDoubleFunction)} over more verbose alternatives.
+   */
+  static final class ComparatorThenComparingDouble<S, T extends S> {
+    @BeforeTemplate
+    Comparator<T> before(Comparator<T> cmp, ToDoubleFunction<S> keyExtractor) {
+      return cmp.thenComparing(comparingDouble(keyExtractor));
+    }
+
+    @AfterTemplate
+    Comparator<T> after(Comparator<T> cmp, ToDoubleFunction<S> keyExtractor) {
+      return cmp.thenComparingDouble(keyExtractor);
+    }
+  }
+
+  /** Prefer {@link Comparator#thenComparingInt(ToIntFunction)} over more verbose alternatives. */
+  static final class ComparatorThenComparingInt<S, T extends S> {
+    @BeforeTemplate
+    Comparator<T> before(Comparator<T> cmp, ToIntFunction<S> keyExtractor) {
+      return cmp.thenComparing(comparingInt(keyExtractor));
+    }
+
+    @AfterTemplate
+    Comparator<T> after(Comparator<T> cmp, ToIntFunction<S> keyExtractor) {
+      return cmp.thenComparingInt(keyExtractor);
+    }
+  }
+
+  /** Prefer {@link Comparator#thenComparingLong(ToLongFunction)} over more verbose alternatives. */
+  static final class ComparatorThenComparingLong<S, T extends S> {
+    @BeforeTemplate
+    Comparator<T> before(Comparator<T> cmp, ToLongFunction<S> keyExtractor) {
+      return cmp.thenComparing(comparingLong(keyExtractor));
+    }
+
+    @AfterTemplate
+    Comparator<T> after(Comparator<T> cmp, ToLongFunction<S> keyExtractor) {
+      return cmp.thenComparingLong(keyExtractor);
+    }
+  }
+
+  /** Prefer {@link Comparator#thenComparing(Comparator)} over less explicit alternatives. */
+  static final class ComparatorThenComparingNaturalOrder<
+      T extends Comparable<? super T>, U extends T> {
+    // XXX: Ideally `? super T` would also be replaced by a class-level type parameter, but Java
+    // does not allow a type variable to be followed by other bounds.
     @BeforeTemplate
     Comparator<T> before(
         Comparator<T> cmp,
-        @Matches(IsIdentityOperation.class) Function<? super T, ? extends T> keyExtractor) {
-      return cmp.thenComparing(keyExtractor);
+        @Matches(IsIdentityOperation.class) Function<? super T, U> identityKeyExtractor) {
+      return cmp.thenComparing(identityKeyExtractor);
     }
 
     @AfterTemplate
@@ -232,8 +252,8 @@ final class ComparatorRules {
     }
   }
 
-  /** Prefer {@link Comparable#compareTo(Object)}} over more verbose alternatives. */
-  static final class CompareTo<T extends Comparable<? super T>> {
+  /** Prefer {@link Comparable#compareTo(Object)} over more verbose alternatives. */
+  static final class ComparableCompareTo<T extends Comparable<? super T>> {
     @BeforeTemplate
     int before(T value1, T value2) {
       return Refaster.anyOf(
@@ -250,267 +270,249 @@ final class ComparatorRules {
   /** Prefer {@link Collections#sort(List)} over more verbose alternatives. */
   static final class CollectionsSort<T extends Comparable<? super T>> {
     @BeforeTemplate
-    void before(List<T> collection) {
-      Collections.sort(collection, naturalOrder());
+    void before(List<T> list) {
+      Collections.sort(list, naturalOrder());
     }
 
     @AfterTemplate
-    void after(List<T> collection) {
-      Collections.sort(collection);
+    void after(List<T> list) {
+      Collections.sort(list);
     }
   }
 
-  /** Prefer {@link Collections#min(Collection)} over more verbose alternatives. */
+  /**
+   * Prefer {@link Collections#min(Collection)} over more verbose or more contrived alternatives.
+   */
   static final class CollectionsMin<T extends Comparable<? super T>> {
     @BeforeTemplate
-    T before(Collection<T> collection) {
+    T before(Collection<T> coll) {
       return Refaster.anyOf(
-          Collections.min(collection, naturalOrder()), Collections.max(collection, reverseOrder()));
+          Collections.min(coll, naturalOrder()), Collections.max(coll, reverseOrder()));
     }
 
     @AfterTemplate
-    T after(Collection<T> collection) {
-      return Collections.min(collection);
+    T after(Collection<T> coll) {
+      return Collections.min(coll);
     }
   }
 
-  /**
-   * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
-   * of values.
-   */
-  static final class MinOfArray<S, T extends S> {
+  /** Prefer {@link Collections#min(Collection, Comparator)} over less efficient alternatives. */
+  static final class CollectionsMinArraysAsList<S, T extends S> {
     @BeforeTemplate
-    T before(T[] array, Comparator<S> cmp) {
-      return Arrays.stream(array).min(cmp).orElseThrow();
+    T before(T[] array, Comparator<S> comp) {
+      return Arrays.stream(array).min(comp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(T[] array, Comparator<S> cmp) {
-      return Collections.min(Arrays.asList(array), cmp);
+    T after(T[] array, Comparator<S> comp) {
+      return Collections.min(Arrays.asList(array), comp);
     }
   }
 
-  /**
-   * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
-   * of values.
-   */
+  /** Prefer {@link Collections#min(Collection, Comparator)} over less efficient alternatives. */
   static final class CollectionsMinWithComparator<S, T extends S> {
     @BeforeTemplate
-    T before(Collection<T> collection, Comparator<S> cmp) {
-      return collection.stream().min(cmp).orElseThrow();
+    T before(Collection<T> coll, Comparator<S> comp) {
+      return coll.stream().min(comp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(Collection<T> collection, Comparator<S> cmp) {
-      return Collections.min(collection, cmp);
+    T after(Collection<T> coll, Comparator<S> comp) {
+      return Collections.min(coll, comp);
+    }
+  }
+
+  /** Prefer {@link Collections#min(Collection, Comparator)} over less efficient alternatives. */
+  static final class CollectionsMinArraysAsListVarargs<S, T extends S> {
+    @BeforeTemplate
+    T before(@Repeated T a, Comparator<S> comp) {
+      return Stream.of(Refaster.asVarargs(a)).min(comp).orElseThrow();
+    }
+
+    @AfterTemplate
+    T after(@Repeated T a, Comparator<S> comp) {
+      return Collections.min(Arrays.asList(Refaster.asVarargs(a)), comp);
     }
   }
 
   /**
-   * Avoid unnecessary creation of a {@link Stream} to determine the minimum of a known collection
-   * of values.
+   * Prefer {@link Comparators#min(Comparable, Comparable)} over less efficient, more verbose, or
+   * more contrived alternatives.
    */
-  static final class MinOfVarargs<S, T extends S> {
-    @BeforeTemplate
-    T before(@Repeated T value, Comparator<S> cmp) {
-      return Stream.of(Refaster.asVarargs(value)).min(cmp).orElseThrow();
-    }
-
-    @AfterTemplate
-    T after(@Repeated T value, Comparator<S> cmp) {
-      return Collections.min(Arrays.asList(value), cmp);
-    }
-  }
-
-  /** Prefer {@link Comparators#min(Comparable, Comparable)}} over more verbose alternatives. */
-  static final class MinOfPairNaturalOrder<T extends Comparable<? super T>> {
+  static final class ComparatorsMin2<T extends Comparable<? super T>> {
     @BeforeTemplate
     @SuppressWarnings("java:S1067" /* The conditional operators are independent. */)
-    T before(T value1, T value2) {
+    T before(T a, T b) {
       return Refaster.anyOf(
-          value1.compareTo(value2) <= 0 ? value1 : value2,
-          value1.compareTo(value2) > 0 ? value2 : value1,
-          value2.compareTo(value1) < 0 ? value2 : value1,
-          value2.compareTo(value1) >= 0 ? value1 : value2,
-          Comparators.min(value1, value2, naturalOrder()),
-          Comparators.max(value1, value2, reverseOrder()),
+          a.compareTo(b) <= 0 ? a : b,
+          a.compareTo(b) > 0 ? b : a,
+          b.compareTo(a) < 0 ? b : a,
+          b.compareTo(a) >= 0 ? a : b,
+          Comparators.min(a, b, naturalOrder()),
+          Comparators.max(a, b, reverseOrder()),
           Collections.min(
-              Refaster.anyOf(
-                  Arrays.asList(value1, value2),
-                  ImmutableList.of(value1, value2),
-                  ImmutableSet.of(value1, value2))));
+              Refaster.anyOf(Arrays.asList(a, b), ImmutableList.of(a, b), ImmutableSet.of(a, b))));
     }
 
     @AfterTemplate
-    T after(T value1, T value2) {
-      return Comparators.min(value1, value2);
+    T after(T a, T b) {
+      return Comparators.min(a, b);
     }
   }
 
   /**
-   * Prefer {@link Comparators#min(Object, Object, Comparator)}}} over more verbose alternatives.
+   * Prefer {@link Comparators#min(Object, Object, Comparator)} over less efficient or more verbose
+   * alternatives.
    */
-  static final class MinOfPairCustomOrder<T> {
+  static final class ComparatorsMin3<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S1067" /* The conditional operators are independent. */)
-    T before(T value1, T value2, Comparator<? super T> cmp) {
+    T before(T a, T b, Comparator<S> comparator) {
       return Refaster.anyOf(
-          cmp.compare(value1, value2) <= 0 ? value1 : value2,
-          cmp.compare(value1, value2) > 0 ? value2 : value1,
-          cmp.compare(value2, value1) < 0 ? value2 : value1,
-          cmp.compare(value2, value1) >= 0 ? value1 : value2,
+          comparator.compare(a, b) <= 0 ? a : b,
+          comparator.compare(a, b) > 0 ? b : a,
+          comparator.compare(b, a) < 0 ? b : a,
+          comparator.compare(b, a) >= 0 ? a : b,
           Collections.min(
-              Refaster.anyOf(
-                  Arrays.asList(value1, value2),
-                  ImmutableList.of(value1, value2),
-                  ImmutableSet.of(value1, value2)),
-              cmp));
+              Refaster.anyOf(Arrays.asList(a, b), ImmutableList.of(a, b), ImmutableSet.of(a, b)),
+              comparator));
     }
 
     @AfterTemplate
-    T after(T value1, T value2, Comparator<? super T> cmp) {
-      return Comparators.min(value1, value2, cmp);
+    T after(T a, T b, Comparator<S> comparator) {
+      return Comparators.min(a, b, comparator);
     }
   }
 
-  /** Prefer {@link Collections#max(Collection)} over more verbose alternatives. */
+  /**
+   * Prefer {@link Collections#max(Collection)} over more verbose or more contrived alternatives.
+   */
   static final class CollectionsMax<T extends Comparable<? super T>> {
     @BeforeTemplate
-    T before(Collection<T> collection) {
+    T before(Collection<T> coll) {
       return Refaster.anyOf(
-          Collections.max(collection, naturalOrder()), Collections.min(collection, reverseOrder()));
+          Collections.max(coll, naturalOrder()), Collections.min(coll, reverseOrder()));
     }
 
     @AfterTemplate
-    T after(Collection<T> collection) {
-      return Collections.max(collection);
+    T after(Collection<T> coll) {
+      return Collections.max(coll);
     }
   }
 
-  /**
-   * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
-   * of values.
-   */
-  static final class MaxOfArray<S, T extends S> {
+  /** Prefer {@link Collections#max(Collection, Comparator)} over less efficient alternatives. */
+  static final class CollectionsMaxArraysAsList<S, T extends S> {
     @BeforeTemplate
-    T before(T[] array, Comparator<S> cmp) {
-      return Arrays.stream(array).max(cmp).orElseThrow();
+    T before(T[] array, Comparator<S> comp) {
+      return Arrays.stream(array).max(comp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(T[] array, Comparator<S> cmp) {
-      return Collections.max(Arrays.asList(array), cmp);
+    T after(T[] array, Comparator<S> comp) {
+      return Collections.max(Arrays.asList(array), comp);
     }
   }
 
-  /**
-   * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
-   * of values.
-   */
+  /** Prefer {@link Collections#max(Collection, Comparator)} over less efficient alternatives. */
   static final class CollectionsMaxWithComparator<S, T extends S> {
     @BeforeTemplate
-    T before(Collection<T> collection, Comparator<S> cmp) {
-      return collection.stream().max(cmp).orElseThrow();
+    T before(Collection<T> coll, Comparator<S> comp) {
+      return coll.stream().max(comp).orElseThrow();
     }
 
     @AfterTemplate
-    T after(Collection<T> collection, Comparator<S> cmp) {
-      return Collections.max(collection, cmp);
+    T after(Collection<T> coll, Comparator<S> comp) {
+      return Collections.max(coll, comp);
+    }
+  }
+
+  /** Prefer {@link Collections#max(Collection, Comparator)} over less efficient alternatives. */
+  static final class CollectionsMaxArraysAsListVarargs<S, T extends S> {
+    @BeforeTemplate
+    T before(@Repeated T a, Comparator<S> comp) {
+      return Stream.of(Refaster.asVarargs(a)).max(comp).orElseThrow();
+    }
+
+    @AfterTemplate
+    T after(@Repeated T a, Comparator<S> comp) {
+      return Collections.max(Arrays.asList(Refaster.asVarargs(a)), comp);
     }
   }
 
   /**
-   * Avoid unnecessary creation of a {@link Stream} to determine the maximum of a known collection
-   * of values.
+   * Prefer {@link Comparators#max(Comparable, Comparable)} over less efficient, more verbose, or
+   * more contrived alternatives.
    */
-  static final class MaxOfVarargs<S, T extends S> {
-    @BeforeTemplate
-    T before(@Repeated T value, Comparator<S> cmp) {
-      return Stream.of(Refaster.asVarargs(value)).max(cmp).orElseThrow();
-    }
-
-    @AfterTemplate
-    T after(@Repeated T value, Comparator<S> cmp) {
-      return Collections.max(Arrays.asList(value), cmp);
-    }
-  }
-
-  /** Prefer {@link Comparators#max(Comparable, Comparable)}} over more verbose alternatives. */
-  static final class MaxOfPairNaturalOrder<T extends Comparable<? super T>> {
+  static final class ComparatorsMax2<T extends Comparable<? super T>> {
     @BeforeTemplate
     @SuppressWarnings("java:S1067" /* The conditional operators are independent. */)
-    T before(T value1, T value2) {
+    T before(T a, T b) {
       return Refaster.anyOf(
-          value1.compareTo(value2) >= 0 ? value1 : value2,
-          value1.compareTo(value2) < 0 ? value2 : value1,
-          value2.compareTo(value1) > 0 ? value2 : value1,
-          value2.compareTo(value1) <= 0 ? value1 : value2,
-          Comparators.max(value1, value2, naturalOrder()),
-          Comparators.min(value1, value2, reverseOrder()),
+          a.compareTo(b) >= 0 ? a : b,
+          a.compareTo(b) < 0 ? b : a,
+          b.compareTo(a) > 0 ? b : a,
+          b.compareTo(a) <= 0 ? a : b,
+          Comparators.max(a, b, naturalOrder()),
+          Comparators.min(a, b, reverseOrder()),
           Collections.max(
-              Refaster.anyOf(
-                  Arrays.asList(value1, value2),
-                  ImmutableList.of(value1, value2),
-                  ImmutableSet.of(value1, value2))));
+              Refaster.anyOf(Arrays.asList(a, b), ImmutableList.of(a, b), ImmutableSet.of(a, b))));
     }
 
     @AfterTemplate
-    T after(T value1, T value2) {
-      return Comparators.max(value1, value2);
+    T after(T a, T b) {
+      return Comparators.max(a, b);
     }
   }
 
   /**
-   * Prefer {@link Comparators#max(Object, Object, Comparator)}}} over more verbose alternatives.
+   * Prefer {@link Comparators#max(Object, Object, Comparator)} over less efficient or more verbose
+   * alternatives.
    */
-  static final class MaxOfPairCustomOrder<T> {
+  static final class ComparatorsMax3<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S1067" /* The conditional operators are independent. */)
-    T before(T value1, T value2, Comparator<? super T> cmp) {
+    T before(T a, T b, Comparator<S> comparator) {
       return Refaster.anyOf(
-          cmp.compare(value1, value2) >= 0 ? value1 : value2,
-          cmp.compare(value1, value2) < 0 ? value2 : value1,
-          cmp.compare(value2, value1) > 0 ? value2 : value1,
-          cmp.compare(value2, value1) <= 0 ? value1 : value2,
+          comparator.compare(a, b) >= 0 ? a : b,
+          comparator.compare(a, b) < 0 ? b : a,
+          comparator.compare(b, a) > 0 ? b : a,
+          comparator.compare(b, a) <= 0 ? a : b,
           Collections.max(
-              Refaster.anyOf(
-                  Arrays.asList(value1, value2),
-                  ImmutableList.of(value1, value2),
-                  ImmutableSet.of(value1, value2)),
-              cmp));
+              Refaster.anyOf(Arrays.asList(a, b), ImmutableList.of(a, b), ImmutableSet.of(a, b)),
+              comparator));
     }
 
     @AfterTemplate
-    T after(T value1, T value2, Comparator<? super T> cmp) {
-      return Comparators.max(value1, value2, cmp);
+    T after(T a, T b, Comparator<S> comparator) {
+      return Comparators.max(a, b, comparator);
     }
   }
 
   /** Prefer {@link Comparators#least(int, Comparator)} over more contrived alternatives. */
   static final class Least<S, T extends S> {
     @BeforeTemplate
-    Collector<T, ?, List<T>> before(int n, Comparator<S> cmp) {
-      return greatest(n, cmp.reversed());
+    Collector<T, ?, List<T>> before(int k, Comparator<S> comparator) {
+      return greatest(k, comparator.reversed());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Collector<T, ?, List<T>> after(int n, Comparator<S> cmp) {
-      return least(n, cmp);
+    Collector<T, ?, List<T>> after(int k, Comparator<S> comparator) {
+      return least(k, comparator);
     }
   }
 
   /** Prefer {@link Comparators#greatest(int, Comparator)} over more contrived alternatives. */
   static final class Greatest<S, T extends S> {
     @BeforeTemplate
-    Collector<T, ?, List<T>> before(int n, Comparator<S> cmp) {
-      return least(n, cmp.reversed());
+    Collector<T, ?, List<T>> before(int k, Comparator<S> comparator) {
+      return least(k, comparator.reversed());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Collector<T, ?, List<T>> after(int n, Comparator<S> cmp) {
-      return greatest(n, cmp);
+    Collector<T, ?, List<T>> after(int k, Comparator<S> comparator) {
+      return greatest(k, comparator);
     }
   }
 
@@ -520,14 +522,14 @@ final class ComparatorRules {
    */
   static final class LeastNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
-    Collector<T, ?, List<T>> before(int n) {
-      return greatest(n, reverseOrder());
+    Collector<T, ?, List<T>> before(int k) {
+      return greatest(k, reverseOrder());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Collector<T, ?, List<T>> after(int n) {
-      return least(n, naturalOrder());
+    Collector<T, ?, List<T>> after(int k) {
+      return least(k, naturalOrder());
     }
   }
 
@@ -537,22 +539,19 @@ final class ComparatorRules {
    */
   static final class GreatestNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
-    Collector<T, ?, List<T>> before(int n) {
-      return least(n, reverseOrder());
+    Collector<T, ?, List<T>> before(int k) {
+      return least(k, reverseOrder());
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Collector<T, ?, List<T>> after(int n) {
-      return greatest(n, naturalOrder());
+    Collector<T, ?, List<T>> after(int k) {
+      return greatest(k, naturalOrder());
     }
   }
 
-  /**
-   * Prefer a method reference to {@link Comparators#min(Comparable, Comparable)} over calling
-   * {@link BinaryOperator#minBy(Comparator)} with {@link Comparator#naturalOrder()}.
-   */
-  static final class ComparatorsMin<T extends Comparable<? super T>> {
+  /** Prefer {@link Comparators#min(Comparable, Comparable)} over more verbose alternatives. */
+  static final class ComparatorsMin0<T extends Comparable<? super T>> {
     @BeforeTemplate
     BinaryOperator<T> before() {
       return BinaryOperator.minBy(naturalOrder());
@@ -564,11 +563,8 @@ final class ComparatorRules {
     }
   }
 
-  /**
-   * Prefer a method reference to {@link Comparators#max(Comparable, Comparable)} over calling
-   * {@link BinaryOperator#minBy(Comparator)} with {@link Comparator#naturalOrder()}.
-   */
-  static final class ComparatorsMax<T extends Comparable<? super T>> {
+  /** Prefer {@link Comparators#max(Comparable, Comparable)} over more verbose alternatives. */
+  static final class ComparatorsMax0<T extends Comparable<? super T>> {
     @BeforeTemplate
     BinaryOperator<T> before() {
       return BinaryOperator.maxBy(naturalOrder());
@@ -581,7 +577,8 @@ final class ComparatorRules {
   }
 
   /**
-   * Prefer {@link Comparator#naturalOrder()} over {@link Comparator#reverseOrder()} where possible.
+   * Prefer {@link Collectors#minBy(Comparator)} with {@link Comparator#naturalOrder()} over less
+   * explicit or more contrived alternatives.
    */
   static final class MinByNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
@@ -597,7 +594,8 @@ final class ComparatorRules {
   }
 
   /**
-   * Prefer {@link Comparator#naturalOrder()} over {@link Comparator#reverseOrder()} where possible.
+   * Prefer {@link Collectors#maxBy(Comparator)} with {@link Comparator#naturalOrder()} over less
+   * explicit or more contrived alternatives.
    */
   static final class MaxByNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
@@ -612,33 +610,33 @@ final class ComparatorRules {
     }
   }
 
-  /** Don't explicitly compare enums by their ordinal. */
-  static final class IsLessThan<E extends Enum<E>> {
+  /** Prefer {@link Enum#compareTo(Enum)} over less explicit alternatives. */
+  static final class EnumIsLessThan<E extends Enum<E>> {
     @BeforeTemplate
     @SuppressWarnings("EnumOrdinal" /* This violation will be rewritten. */)
-    boolean before(E value1, E value2) {
-      return value1.ordinal() < value2.ordinal();
+    boolean before(E value1, E o) {
+      return value1.ordinal() < o.ordinal();
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(E value1, E value2) {
-      return value1.compareTo(value2) < 0;
+    boolean after(E value1, E o) {
+      return value1.compareTo(o) < 0;
     }
   }
 
-  /** Don't explicitly compare enums by their ordinal. */
-  static final class IsLessThanOrEqualTo<E extends Enum<E>> {
+  /** Prefer {@link Enum#compareTo(Enum)} over less explicit alternatives. */
+  static final class EnumIsLessThanOrEqualTo<E extends Enum<E>> {
     @BeforeTemplate
     @SuppressWarnings("EnumOrdinal" /* This violation will be rewritten. */)
-    boolean before(E value1, E value2) {
-      return value1.ordinal() <= value2.ordinal();
+    boolean before(E value1, E o) {
+      return value1.ordinal() <= o.ordinal();
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(E value1, E value2) {
-      return value1.compareTo(value2) <= 0;
+    boolean after(E value1, E o) {
+      return value1.compareTo(o) <= 0;
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/DequeRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/DequeRules.java
@@ -16,7 +16,7 @@ import tech.picnic.errorprone.refaster.matchers.IsList;
 final class DequeRules {
   private DequeRules() {}
 
-  /** Prefer {@link Deque#addLast(Object)} over less clear alternatives. */
+  /** Prefer {@link Deque#addFirst(Object)} over less explicit alternatives. */
   static final class DequeAddFirst<S, T extends S> {
     @BeforeTemplate
     void before(Deque<S> deque, T element) {
@@ -30,7 +30,7 @@ final class DequeRules {
   }
 
   /**
-   * Prefer {@link Deque#addLast(Object)} over less clear alternatives.
+   * Prefer {@link Deque#addLast(Object)} over less explicit alternatives.
    *
    * <p>Note: this rule does not match instances of type {@link java.util.List} (including {@link
    * java.util.LinkedList}, which also implements {@link Deque}), as {@link
@@ -48,20 +48,20 @@ final class DequeRules {
     }
   }
 
-  /** Prefer {@link Deque#removeFirst()} over less clear alternatives. */
+  /** Prefer {@link Deque#removeFirst()} over less explicit alternatives. */
   static final class DequeRemoveFirst<S, T extends S> {
     @BeforeTemplate
-    S before(Deque<T> deque) {
+    T before(Deque<T> deque) {
       return Refaster.anyOf(deque.pop(), deque.remove());
     }
 
     @AfterTemplate
-    S after(Deque<T> deque) {
+    T after(Deque<T> deque) {
       return deque.removeFirst();
     }
   }
 
-  /** Prefer {@link Deque#offerLast(Object)} over less clear alternatives. */
+  /** Prefer {@link Deque#offerLast(Object)} over less explicit alternatives. */
   static final class DequeOfferLast<S, T extends S> {
     @BeforeTemplate
     boolean before(Deque<S> deque, T element) {
@@ -74,55 +74,55 @@ final class DequeRules {
     }
   }
 
-  /** Prefer {@link Deque#pollFirst()} over less clear alternatives. */
+  /** Prefer {@link Deque#pollFirst()} over less explicit alternatives. */
   static final class DequePollFirst<S, T extends S> {
     @BeforeTemplate
-    @Nullable S before(Deque<T> deque) {
+    @Nullable T before(Deque<T> deque) {
       return deque.poll();
     }
 
     @AfterTemplate
-    @Nullable S after(Deque<T> deque) {
+    @Nullable T after(Deque<T> deque) {
       return deque.pollFirst();
     }
   }
 
-  /** Prefer {@link Deque#pollFirst()} over less clear alternatives. */
+  /** Prefer {@link Deque#getFirst()} over less explicit alternatives. */
   static final class DequeGetFirst<S, T extends S> {
     @BeforeTemplate
-    S before(Deque<T> deque) {
+    T before(Deque<T> deque) {
       return deque.element();
     }
 
     @AfterTemplate
-    S after(Deque<T> deque) {
+    T after(Deque<T> deque) {
       return deque.getFirst();
     }
   }
 
-  /** Prefer {@link Deque#peekFirst()} over less clear alternatives. */
+  /** Prefer {@link Deque#peekFirst()} over less explicit alternatives. */
   static final class DequePeekFirst<S, T extends S> {
     @BeforeTemplate
-    @Nullable S before(Deque<T> deque) {
+    @Nullable T before(Deque<T> deque) {
       return deque.peek();
     }
 
     @AfterTemplate
-    @Nullable S after(Deque<T> deque) {
+    @Nullable T after(Deque<T> deque) {
       return deque.peekFirst();
     }
   }
 
-  /** Prefer {@link Deque#removeFirstOccurrence(Object)} over less clear alternatives. */
-  static final class DequeRemoveFirstOccurrence<S, T extends S> {
+  /** Prefer {@link Deque#removeFirstOccurrence(Object)} over less explicit alternatives. */
+  static final class DequeRemoveFirstOccurrence<T> {
     @BeforeTemplate
-    boolean before(Deque<S> deque, T element) {
-      return deque.remove(element);
+    boolean before(Deque<T> deque, Object object) {
+      return deque.remove(object);
     }
 
     @AfterTemplate
-    boolean after(Deque<S> deque, T element) {
-      return deque.removeFirstOccurrence(element);
+    boolean after(Deque<T> deque, Object object) {
+      return deque.removeFirstOccurrence(object);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/DoubleStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/DoubleStreamRules.java
@@ -20,8 +20,8 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class DoubleStreamRules {
   private DoubleStreamRules() {}
 
-  /** Don't unnecessarily call {@link Streams#concat(DoubleStream...)}. */
-  static final class ConcatOneDoubleStream {
+  /** Prefer using {@link DoubleStream}s as-is over more contrived alternatives. */
+  static final class DoubleStreamIdentity {
     @BeforeTemplate
     DoubleStream before(DoubleStream stream) {
       return Streams.concat(stream);
@@ -34,21 +34,21 @@ final class DoubleStreamRules {
     }
   }
 
-  /** Prefer {@link DoubleStream#concat(DoubleStream, DoubleStream)} over the Guava alternative. */
-  static final class ConcatTwoDoubleStreams {
+  /** Prefer {@link DoubleStream#concat(DoubleStream, DoubleStream)} over non-JDK alternatives. */
+  static final class DoubleStreamConcat {
     @BeforeTemplate
-    DoubleStream before(DoubleStream s1, DoubleStream s2) {
-      return Streams.concat(s1, s2);
+    DoubleStream before(DoubleStream a, DoubleStream b) {
+      return Streams.concat(a, b);
     }
 
     @AfterTemplate
-    DoubleStream after(DoubleStream s1, DoubleStream s2) {
-      return DoubleStream.concat(s1, s2);
+    DoubleStream after(DoubleStream a, DoubleStream b) {
+      return DoubleStream.concat(a, b);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link DoubleStream#filter(DoublePredicate)} operations. */
-  abstract static class FilterOuterDoubleStreamAfterFlatMap {
+  /** Prefer {@link DoubleStream#filter(DoublePredicate)} over more contrived alternatives. */
+  abstract static class DoubleStreamFlatMapFilter {
     @Placeholder
     abstract DoubleStream toDoubleStreamFunction(@MayOptionallyUse double element);
 
@@ -63,8 +63,8 @@ final class DoubleStreamRules {
     }
   }
 
-  /** Avoid unnecessary nesting of {@link DoubleStream#filter(DoublePredicate)} operations. */
-  abstract static class FilterOuterStreamAfterFlatMapToDouble<T> {
+  /** Prefer {@link DoubleStream#filter(DoublePredicate)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToDoubleFilter<T> {
     @Placeholder(allowsIdentity = true)
     abstract DoubleStream toDoubleStreamFunction(@MayOptionallyUse T element);
 
@@ -79,73 +79,73 @@ final class DoubleStreamRules {
     }
   }
 
-  /** Avoid unnecessary nesting of {@link DoubleStream#map(DoubleUnaryOperator)} operations. */
-  abstract static class MapOuterDoubleStreamAfterFlatMap {
+  /** Prefer {@link DoubleStream#map(DoubleUnaryOperator)} over more contrived alternatives. */
+  abstract static class DoubleStreamFlatMapMap {
     @Placeholder
     abstract DoubleStream toDoubleStreamFunction(@MayOptionallyUse double element);
 
     @BeforeTemplate
-    DoubleStream before(DoubleStream stream, DoubleUnaryOperator function) {
-      return stream.flatMap(v -> toDoubleStreamFunction(v).map(function));
+    DoubleStream before(DoubleStream stream, DoubleUnaryOperator unaryOperator) {
+      return stream.flatMap(v -> toDoubleStreamFunction(v).map(unaryOperator));
     }
 
     @AfterTemplate
-    DoubleStream after(DoubleStream stream, DoubleUnaryOperator function) {
-      return stream.flatMap(v -> toDoubleStreamFunction(v)).map(function);
+    DoubleStream after(DoubleStream stream, DoubleUnaryOperator unaryOperator) {
+      return stream.flatMap(v -> toDoubleStreamFunction(v)).map(unaryOperator);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link DoubleStream#map(DoubleUnaryOperator)} operations. */
-  abstract static class MapOuterStreamAfterFlatMapToDouble<T> {
+  /** Prefer {@link DoubleStream#map(DoubleUnaryOperator)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToDoubleMap<T> {
     @Placeholder(allowsIdentity = true)
     abstract DoubleStream toDoubleStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    DoubleStream before(Stream<T> stream, DoubleUnaryOperator function) {
-      return stream.flatMapToDouble(v -> toDoubleStreamFunction(v).map(function));
+    DoubleStream before(Stream<T> stream, DoubleUnaryOperator unaryOperator) {
+      return stream.flatMapToDouble(v -> toDoubleStreamFunction(v).map(unaryOperator));
     }
 
     @AfterTemplate
-    DoubleStream after(Stream<T> stream, DoubleUnaryOperator function) {
-      return stream.flatMapToDouble(v -> toDoubleStreamFunction(v)).map(function);
+    DoubleStream after(Stream<T> stream, DoubleUnaryOperator unaryOperator) {
+      return stream.flatMapToDouble(v -> toDoubleStreamFunction(v)).map(unaryOperator);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link DoubleStream#flatMap(DoubleFunction)} operations. */
-  abstract static class FlatMapOuterDoubleStreamAfterFlatMap {
+  /** Prefer {@link DoubleStream#flatMap(DoubleFunction)} over more contrived alternatives. */
+  abstract static class DoubleStreamFlatMapFlatMap<S extends DoubleStream> {
     @Placeholder
     abstract DoubleStream toDoubleStreamFunction(@MayOptionallyUse double element);
 
     @BeforeTemplate
-    DoubleStream before(DoubleStream stream, DoubleFunction<? extends DoubleStream> function) {
+    DoubleStream before(DoubleStream stream, DoubleFunction<S> function) {
       return stream.flatMap(v -> toDoubleStreamFunction(v).flatMap(function));
     }
 
     @AfterTemplate
-    DoubleStream after(DoubleStream stream, DoubleFunction<? extends DoubleStream> function) {
+    DoubleStream after(DoubleStream stream, DoubleFunction<S> function) {
       return stream.flatMap(v -> toDoubleStreamFunction(v)).flatMap(function);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link DoubleStream#flatMap(DoubleFunction)} operations. */
-  abstract static class FlatMapOuterStreamAfterFlatMapToDouble<T> {
+  /** Prefer {@link DoubleStream#flatMap(DoubleFunction)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToDoubleFlatMap<T, S extends DoubleStream> {
     @Placeholder(allowsIdentity = true)
     abstract DoubleStream toDoubleStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    DoubleStream before(Stream<T> stream, DoubleFunction<? extends DoubleStream> function) {
+    DoubleStream before(Stream<T> stream, DoubleFunction<S> function) {
       return stream.flatMapToDouble(v -> toDoubleStreamFunction(v).flatMap(function));
     }
 
     @AfterTemplate
-    DoubleStream after(Stream<T> stream, DoubleFunction<? extends DoubleStream> function) {
+    DoubleStream after(Stream<T> stream, DoubleFunction<S> function) {
       return stream.flatMapToDouble(v -> toDoubleStreamFunction(v)).flatMap(function);
     }
   }
 
   /**
-   * Apply {@link DoubleStream#filter(DoublePredicate)} before {@link DoubleStream#sorted()} to
-   * reduce the number of elements to sort.
+   * Prefer {@link DoubleStream#filter(DoublePredicate)} before {@link DoubleStream#sorted()} over
+   * less efficient alternatives.
    */
   static final class DoubleStreamFilterSorted {
     @BeforeTemplate
@@ -159,8 +159,8 @@ final class DoubleStreamRules {
     }
   }
 
-  /** In order to test whether a stream has any element, simply try to find one. */
-  static final class DoubleStreamIsEmpty {
+  /** Prefer {@link DoubleStream#findAny()} over less efficient alternatives. */
+  static final class DoubleStreamFindAnyIsEmpty {
     @BeforeTemplate
     boolean before(DoubleStream stream) {
       return Refaster.anyOf(
@@ -176,8 +176,8 @@ final class DoubleStreamRules {
     }
   }
 
-  /** In order to test whether a stream has any element, simply try to find one. */
-  static final class DoubleStreamIsNotEmpty {
+  /** Prefer {@link DoubleStream#findAny()} over less efficient alternatives. */
+  static final class DoubleStreamFindAnyIsPresent {
     @BeforeTemplate
     boolean before(DoubleStream stream) {
       return Refaster.anyOf(
@@ -193,6 +193,7 @@ final class DoubleStreamRules {
     }
   }
 
+  /** Prefer {@link DoubleStream#min()} over less efficient alternatives. */
   static final class DoubleStreamMin {
     @BeforeTemplate
     OptionalDouble before(DoubleStream stream) {
@@ -206,7 +207,7 @@ final class DoubleStreamRules {
   }
 
   /** Prefer {@link DoubleStream#noneMatch(DoublePredicate)} over more contrived alternatives. */
-  static final class DoubleStreamNoneMatch {
+  static final class DoubleStreamNoneMatchWithDoublePredicate {
     @BeforeTemplate
     boolean before(DoubleStream stream, DoublePredicate predicate) {
       return Refaster.anyOf(
@@ -221,7 +222,8 @@ final class DoubleStreamRules {
     }
   }
 
-  abstract static class DoubleStreamNoneMatch2 {
+  /** Prefer {@link DoubleStream#noneMatch(DoublePredicate)} over less explicit alternatives. */
+  abstract static class DoubleStreamNoneMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse double element);
 
@@ -251,7 +253,8 @@ final class DoubleStreamRules {
     }
   }
 
-  static final class DoubleStreamAllMatch {
+  /** Prefer {@link DoubleStream#allMatch(DoublePredicate)} over more contrived alternatives. */
+  static final class DoubleStreamAllMatchWithDoublePredicate {
     @BeforeTemplate
     boolean before(DoubleStream stream, DoublePredicate predicate) {
       return stream.noneMatch(predicate.negate());
@@ -263,7 +266,8 @@ final class DoubleStreamRules {
     }
   }
 
-  abstract static class DoubleStreamAllMatch2 {
+  /** Prefer {@link DoubleStream#allMatch(DoublePredicate)} over less explicit alternatives. */
+  abstract static class DoubleStreamAllMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse double element);
 
@@ -278,6 +282,7 @@ final class DoubleStreamRules {
     }
   }
 
+  /** Prefer {@link DoubleStream#takeWhile(DoublePredicate)} over more verbose alternatives. */
   static final class DoubleStreamTakeWhile {
     @BeforeTemplate
     DoubleStream before(DoubleStream stream, DoublePredicate predicate) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/EqualityRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/EqualityRules.java
@@ -20,9 +20,9 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class EqualityRules {
   private EqualityRules() {}
 
-  /** Prefer reference-based equality for enums. */
+  /** Prefer enum {@code ==} comparison over less idiomatic alternatives. */
   // Primitive value comparisons are not matched, because Error Prone flags those out of the box.
-  static final class EnumReferenceEquality<T extends Enum<T>> {
+  static final class EqualToWithEnum<T extends Enum<T>> {
     /**
      * Enums can be compared by reference. It is safe to do so even in the face of refactorings,
      * because if the type is ever converted to a non-enum, then Error-Prone will complain about any
@@ -32,39 +32,40 @@ final class EqualityRules {
     // work around the issue by selecting the "largest replacements". See the `Refaster` check.
     @BeforeTemplate
     @SuppressWarnings("EnumOrdinal" /* This violation will be rewritten. */)
-    boolean before(T a, T b) {
-      return Refaster.anyOf(a.equals(b), Objects.equals(a, b), a.ordinal() == b.ordinal());
+    boolean before(T a, T other) {
+      return Refaster.anyOf(
+          a.equals(other), Objects.equals(a, other), a.ordinal() == other.ordinal());
     }
 
     @AfterTemplate
     @AlsoNegation
     @SuppressWarnings("java:S1698" /* Reference comparison is valid for enums. */)
-    boolean after(T a, T b) {
-      return a == b;
+    boolean after(T a, T other) {
+      return a == other;
     }
   }
 
-  /** Prefer reference-based equality for enums. */
-  static final class EnumReferenceEqualityLambda<T extends Enum<T>> {
+  /** Prefer enum {@code ==} comparison over less idiomatic alternatives. */
+  static final class EqualTo<T extends Enum<T>> {
     @BeforeTemplate
-    Predicate<T> before(T e) {
-      return Refaster.anyOf(isEqual(e), e::equals);
+    Predicate<T> before(T targetRef) {
+      return Refaster.anyOf(isEqual(targetRef), targetRef::equals);
     }
 
     @AfterTemplate
     @SuppressWarnings("java:S1698" /* Reference comparison is valid for enums. */)
-    Predicate<T> after(T e) {
-      return v -> v == e;
+    Predicate<T> after(T targetRef) {
+      return v -> v == targetRef;
     }
   }
 
-  /** Prefer {@link Object#equals(Object)} over the equivalent lambda function. */
+  /** Prefer {@link Object#equals(Object)} method references over more verbose alternatives. */
   // XXX: As it stands, this rule is a special case of what `MethodReferenceUsage` tries to achieve.
   // If/when `MethodReferenceUsage` becomes production ready, we should simply drop this check.
   // XXX: Alternatively, the rule should be replaced with a plugin that also identifies cases where
   // the arguments are swapped but simplification is possible anyway, by virtue of `v` being
   // non-null.
-  static final class EqualsPredicate<T> {
+  static final class ObjectEquals<T> {
     @BeforeTemplate
     Predicate<T> before(T v) {
       return e -> v.equals(e);
@@ -76,8 +77,8 @@ final class EqualityRules {
     }
   }
 
-  /** Avoid double negations; this is not Javascript. */
-  static final class DoubleNegation {
+  /** Prefer using the boolean expression as-is over more contrived alternatives. */
+  static final class BooleanIdentity {
     @BeforeTemplate
     @SuppressWarnings("java:S2761" /* This violation will be rewritten. */)
     boolean before(boolean b) {
@@ -91,73 +92,64 @@ final class EqualityRules {
     }
   }
 
-  /**
-   * Don't negate an equality test or use the ternary operator to compare two booleans; directly
-   * test for inequality instead.
-   */
+  /** Prefer {@code !=} over more contrived alternatives. */
   // XXX: Replacing `a ? !b : b` with `a != b` changes semantics if both `a` and `b` are boxed
   // booleans.
   @SuppressWarnings("java:S1940" /* This violation will be rewritten. */)
-  static final class Negation {
+  static final class NotEqualTo {
     @BeforeTemplate
-    boolean before(boolean a, boolean b) {
-      return Refaster.anyOf(!(a == b), a ? !b : b);
+    boolean before(boolean b1, boolean b2) {
+      return Refaster.anyOf(!(b1 == b2), b1 ? !b2 : b2);
     }
 
     @BeforeTemplate
     @SuppressWarnings(
         "java:S1244" /* The equality check is fragile, but may be seen in the wild. */)
-    boolean before(double a, double b) {
-      return !(a == b);
+    boolean before(double b1, double b2) {
+      return !(b1 == b2);
     }
 
     @BeforeTemplate
-    boolean before(Object a, Object b) {
-      return !(a == b);
+    boolean before(Object b1, Object b2) {
+      return !(b1 == b2);
     }
 
     @AfterTemplate
-    boolean after(boolean a, boolean b) {
-      return a != b;
+    boolean after(boolean b1, boolean b2) {
+      return b1 != b2;
     }
   }
 
-  /**
-   * Don't negate an inequality test or use the ternary operator to compare two booleans; directly
-   * test for equality instead.
-   */
+  /** Prefer {@code ==} over more contrived alternatives. */
   // XXX: Replacing `a ? b : !b` with `a == b` changes semantics if both `a` and `b` are boxed
   // booleans.
   @SuppressWarnings("java:S1940" /* This violation will be rewritten. */)
-  static final class IndirectDoubleNegation {
+  static final class EqualToWithBoolean {
     @BeforeTemplate
-    boolean before(boolean a, boolean b) {
-      return Refaster.anyOf(!(a != b), a ? b : !b);
+    boolean before(boolean b1, boolean b2) {
+      return Refaster.anyOf(!(b1 != b2), b1 ? b2 : !b2);
     }
 
     @BeforeTemplate
     @SuppressWarnings(
         "java:S1244" /* The inequality check is fragile, but may be seen in the wild. */)
-    boolean before(double a, double b) {
-      return !(a != b);
+    boolean before(double b1, double b2) {
+      return !(b1 != b2);
     }
 
     @BeforeTemplate
-    boolean before(Object a, Object b) {
-      return !(a != b);
+    boolean before(Object b1, Object b2) {
+      return !(b1 != b2);
     }
 
     @AfterTemplate
-    boolean after(boolean a, boolean b) {
-      return a == b;
+    boolean after(boolean b1, boolean b2) {
+      return b1 == b2;
     }
   }
 
-  /**
-   * Don't pass a lambda expression to {@link Predicate#not(Predicate)}; instead push the negation
-   * into the lambda expression.
-   */
-  abstract static class PredicateLambda<T> {
+  /** Prefer negated lambda expressions over more contrived alternatives. */
+  abstract static class Not<T> {
     @Placeholder(allowsIdentity = true)
     abstract boolean predicate(@MayOptionallyUse T value);
 
@@ -172,32 +164,32 @@ final class EqualityRules {
     }
   }
 
-  /** Avoid contrived ways of handling {@code null} values during equality testing. */
-  static final class Equals<T, S> {
+  /** Prefer {@link Object#equals(Object)} over more contrived alternatives. */
+  static final class ObjectEqualsWithObject<T, S> {
     @BeforeTemplate
-    boolean before(T value1, S value2) {
+    boolean before(T value, S obj) {
       return Refaster.anyOf(
-          Optional.of(value1).equals(Optional.of(value2)),
-          Optional.of(value1).equals(Optional.ofNullable(value2)),
-          Optional.ofNullable(value2).equals(Optional.of(value1)));
+          Optional.of(value).equals(Optional.of(obj)),
+          Optional.of(value).equals(Optional.ofNullable(obj)),
+          Optional.ofNullable(obj).equals(Optional.of(value)));
     }
 
     @AfterTemplate
-    boolean after(T value1, S value2) {
-      return value1.equals(value2);
+    boolean after(T value, S obj) {
+      return value.equals(obj);
     }
   }
 
-  /** Avoid contrived ways of handling {@code null} values during equality testing. */
+  /** Prefer {@link Objects#equals(Object, Object)} over more contrived alternatives. */
   static final class ObjectsEquals<T, S> {
     @BeforeTemplate
-    boolean before(T value1, S value2) {
-      return Optional.ofNullable(value1).equals(Optional.ofNullable(value2));
+    boolean before(T a, S b) {
+      return Optional.ofNullable(a).equals(Optional.ofNullable(b));
     }
 
     @AfterTemplate
-    boolean after(T value1, S value2) {
-      return Objects.equals(value1, value2);
+    boolean after(T a, S b) {
+      return Objects.equals(a, b);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -31,8 +31,8 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class FileRules {
   private FileRules() {}
 
-  /** Prefer the more idiomatic {@link Path#of(URI)} over {@link Paths#get(URI)}. */
-  static final class PathOfUri {
+  /** Prefer {@link Path#of(URI)} over less idiomatic alternatives. */
+  static final class PathOf {
     @BeforeTemplate
     Path before(URI uri) {
       return Paths.get(uri);
@@ -44,25 +44,22 @@ final class FileRules {
     }
   }
 
-  /**
-   * Prefer the more idiomatic {@link Path#of(String, String...)} over {@link Paths#get(String,
-   * String...)}.
-   */
-  static final class PathOfString {
+  /** Prefer {@link Path#of(String, String...)} over less idiomatic alternatives. */
+  static final class PathOfVarargs {
     @BeforeTemplate
     Path before(String first, @Repeated String more) {
-      return Paths.get(first, more);
+      return Paths.get(first, Refaster.asVarargs(more));
     }
 
     @AfterTemplate
     Path after(String first, @Repeated String more) {
-      return Path.of(first, more);
+      return Path.of(first, Refaster.asVarargs(more));
     }
   }
 
-  /** Avoid redundant conversions from {@link Path} to {@link File}. */
+  /** Prefer the {@link Path} as-is over more contrived alternatives. */
   // XXX: Review whether a rule such as this one is better handled by the `IdentityConversion` rule.
-  static final class PathInstance {
+  static final class PathIdentity {
     @BeforeTemplate
     Path before(Path path) {
       return path.toFile().toPath();
@@ -74,9 +71,13 @@ final class FileRules {
     }
   }
 
-  /** Prefer {@link Path#resolveSibling(Path)} over more verbose alternatives. */
-  // XXX: Contrary to the original code, the alternative code gracefully handles the case where
-  // `path` has no parent.
+  /**
+   * Prefer {@link Path#resolveSibling(Path)} over more fragile or more verbose alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior when {@code path} has no parent: the
+   * original code throws a {@link NullPointerException}, while the replacement handles this case
+   * gracefully.
+   */
   static final class PathResolveSiblingPath {
     @BeforeTemplate
     @SuppressWarnings(
@@ -91,9 +92,13 @@ final class FileRules {
     }
   }
 
-  /** Prefer {@link Path#resolveSibling(String)} over the more verbose alternatives. */
-  // XXX: Contrary to the original code, the alternative code gracefully handles the case where
-  // `path` has no parent.
+  /**
+   * Prefer {@link Path#resolveSibling(String)} over more fragile or more verbose alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior when {@code path} has no parent: the
+   * original code throws a {@link NullPointerException}, while the replacement handles this case
+   * gracefully.
+   */
   static final class PathResolveSiblingString {
     @BeforeTemplate
     @SuppressWarnings(
@@ -111,13 +116,13 @@ final class FileRules {
   /** Prefer {@link Files#readString(Path, Charset)} over more contrived alternatives. */
   static final class FilesReadStringWithCharset {
     @BeforeTemplate
-    String before(Path path, Charset charset) throws IOException {
-      return new String(Files.readAllBytes(path), charset);
+    String before(Path path, Charset cs) throws IOException {
+      return new String(Files.readAllBytes(path), cs);
     }
 
     @AfterTemplate
-    String after(Path path, Charset charset) throws IOException {
-      return Files.readString(path, charset);
+    String after(Path path, Charset cs) throws IOException {
+      return Files.readString(path, cs);
     }
   }
 
@@ -135,8 +140,8 @@ final class FileRules {
   }
 
   /**
-   * Prefer {@link Files#createTempFile(String, String, FileAttribute[])} over alternatives that
-   * create files with more liberal permissions.
+   * Prefer {@link Files#createTempFile(String, String, FileAttribute[])} over less secure
+   * alternatives.
    *
    * <p>Note that {@link File#createTempFile} treats the given prefix as a path, and ignores all but
    * its file name. That is, the actual prefix used is derived from all characters following the
@@ -147,7 +152,7 @@ final class FileRules {
   static final class FilesCreateTempFileToFile {
     @BeforeTemplate
     @SuppressWarnings({
-      "FilesCreateTempFileInCustomDirectoryToFile" /* This is a more specific template. */,
+      "FilesCreateTempFileFileToPathToFile" /* This is a more specific template. */,
       "java:S5443" /* This violation will be rewritten. */,
       "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
     })
@@ -165,8 +170,8 @@ final class FileRules {
   }
 
   /**
-   * Prefer {@link Files#createTempFile(Path, String, String, FileAttribute[])} over alternatives
-   * that create files with more liberal permissions.
+   * Prefer {@link Files#createTempFile(Path, String, String, FileAttribute[])} over less secure
+   * alternatives.
    *
    * <p>Note that {@link File#createTempFile} treats the given prefix as a path, and ignores all but
    * its file name. That is, the actual prefix used is derived from all characters following the
@@ -174,7 +179,7 @@ final class FileRules {
    * will instead throw an {@link IllegalArgumentException} if the prefix contains any file
    * separators.
    */
-  static final class FilesCreateTempFileInCustomDirectoryToFile {
+  static final class FilesCreateTempFileFileToPathToFile {
     @BeforeTemplate
     File before(File directory, String prefix, String suffix) throws IOException {
       return File.createTempFile(prefix, suffix, directory);
@@ -187,10 +192,10 @@ final class FileRules {
   }
 
   /**
-   * Invoke {@link File#mkdirs()} before {@link Files#exists(Path, LinkOption...)} to avoid
-   * concurrency issues.
+   * Prefer this evaluation order of {@link File#mkdirs()} and {@link Files#exists(Path,
+   * LinkOption...)} over more fragile alternatives.
    */
-  static final class PathToFileMkDirsFilesExists {
+  static final class PathToFileMkdirsOrFilesExists {
     @BeforeTemplate
     boolean before(Path path) {
       return Files.exists(path) || path.toFile().mkdirs();
@@ -203,8 +208,11 @@ final class FileRules {
     }
   }
 
-  /** Invoke {@link File#mkdirs()} before {@link File#exists()} to avoid concurrency issues. */
-  static final class FileMkDirsFileExists {
+  /**
+   * Prefer this evaluation order of {@link File#mkdirs()} and {@link File#exists()} over more
+   * fragile alternatives.
+   */
+  static final class FileMkdirsOrFileExists {
     @BeforeTemplate
     boolean before(File file) {
       return file.exists() || file.mkdirs();
@@ -223,23 +231,23 @@ final class FileRules {
     @BeforeTemplate
     @SuppressWarnings(
         "java:S2095" /* Matched expressions are in practice embedded in a larger context. */)
-    InputStream before(String path) throws FileNotFoundException {
-      return new FileInputStream(path);
+    FileInputStream before(String first) throws FileNotFoundException {
+      return new FileInputStream(first);
     }
 
     @AfterTemplate
-    InputStream after(String path) throws IOException {
-      return Files.newInputStream(Path.of(path));
+    InputStream after(String first) throws IOException {
+      return Files.newInputStream(Path.of(first));
     }
   }
 
   /** Prefer {@link Files#newInputStream(Path, OpenOption...)} over less idiomatic alternatives. */
   // XXX: The replacement code throws a `NoSuchFileException` instead of a `FileNotFoundException`.
-  static final class FilesNewInputStreamToPath {
+  static final class FilesNewInputStreamFileToPath {
     @BeforeTemplate
     @SuppressWarnings(
         "java:S2095" /* Matched expressions are in practice embedded in a larger context. */)
-    InputStream before(File file) throws FileNotFoundException {
+    FileInputStream before(File file) throws FileNotFoundException {
       return new FileInputStream(file);
     }
 
@@ -255,23 +263,23 @@ final class FileRules {
     @BeforeTemplate
     @SuppressWarnings(
         "java:S2095" /* Matched expressions are in practice embedded in a larger context. */)
-    OutputStream before(String path) throws FileNotFoundException {
-      return new FileOutputStream(path);
+    FileOutputStream before(String first) throws FileNotFoundException {
+      return new FileOutputStream(first);
     }
 
     @AfterTemplate
-    OutputStream after(String path) throws IOException {
-      return Files.newOutputStream(Path.of(path));
+    OutputStream after(String first) throws IOException {
+      return Files.newOutputStream(Path.of(first));
     }
   }
 
   /** Prefer {@link Files#newOutputStream(Path, OpenOption...)} over less idiomatic alternatives. */
   // XXX: The replacement code throws a `NoSuchFileException` instead of a `FileNotFoundException`.
-  static final class FilesNewOutputStreamToPath {
+  static final class FilesNewOutputStreamFileToPath {
     @BeforeTemplate
     @SuppressWarnings(
         "java:S2095" /* Matched expressions are in practice embedded in a larger context. */)
-    OutputStream before(File file) throws FileNotFoundException {
+    FileOutputStream before(File file) throws FileNotFoundException {
       return new FileOutputStream(file);
     }
 
@@ -281,9 +289,12 @@ final class FileRules {
     }
   }
 
-  /** Prefer {@link Files#newBufferedReader(Path)} over more verbose or contrived alternatives. */
-  // XXX: This rule changes semantics in cases where no charset is specified, as the replacement
-  // code uses UTF-8 rather than the default charset.
+  /**
+   * Prefer {@link Files#newBufferedReader(Path)} over more verbose or contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior when no charset is specified: the
+   * original code uses the default charset, while the replacement always uses UTF-8.
+   */
   static final class FilesNewBufferedReader {
     @BeforeTemplate
     @SuppressWarnings({
@@ -307,13 +318,13 @@ final class FileRules {
   /** Prefer {@link Files#newBufferedReader(Path, Charset)} over more contrived alternatives. */
   static final class FilesNewBufferedReaderWithCharset {
     @BeforeTemplate
-    BufferedReader before(Path path, Charset charset) throws IOException {
-      return new BufferedReader(new InputStreamReader(Files.newInputStream(path), charset));
+    BufferedReader before(Path path, Charset cs) throws IOException {
+      return new BufferedReader(new InputStreamReader(Files.newInputStream(path), cs));
     }
 
     @AfterTemplate
-    BufferedReader after(Path path, Charset charset) throws IOException {
-      return Files.newBufferedReader(path, charset);
+    BufferedReader after(Path path, Charset cs) throws IOException {
+      return Files.newBufferedReader(path, cs);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableEnumSetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableEnumSetRules.java
@@ -17,10 +17,7 @@ import java.util.EnumSet;
 import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/**
- * Refaster rules related to expressions dealing with {@code
- * com.google.common.collect.ImmutableEnumSet}s.
- */
+/** Refaster rules related to expressions dealing with {@link ImmutableSet}s of enums. */
 // XXX: Some of the rules defined here impact iteration order. That's a rather subtle change. Should
 // we emit a comment warning about this fact? (This may produce a lot of noise. A bug checker could
 // in some cases determine whether iteration order is important.)
@@ -32,8 +29,7 @@ final class ImmutableEnumSetRules {
   private ImmutableEnumSetRules() {}
 
   /**
-   * Prefer {@link Sets#immutableEnumSet(Iterable)} for enum collections to take advantage of the
-   * internally used {@link EnumSet}.
+   * Prefer {@link Sets#immutableEnumSet(Iterable)} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the
    * original code produces a set that iterates over its elements in the same order as the input
@@ -57,8 +53,7 @@ final class ImmutableEnumSetRules {
   }
 
   /**
-   * Prefer {@link Sets#immutableEnumSet(Iterable)} for enum collections to take advantage of the
-   * internally used {@link EnumSet}.
+   * Prefer {@code Sets.immutableEnumSet(Arrays.asList(array))} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the
    * original code produces a set that iterates over its elements in the same order as defined in
@@ -76,27 +71,23 @@ final class ImmutableEnumSetRules {
     }
   }
 
-  /**
-   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} for enum collections to take advantage of
-   * the internally used {@link EnumSet}.
-   */
+  /** Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} over less efficient alternatives. */
   static final class SetsImmutableEnumSet1<T extends Enum<T>> {
     @BeforeTemplate
     @SuppressWarnings("SetsImmutableEnumSetIterable" /* This is a more specific template. */)
-    ImmutableSet<T> before(T e1) {
-      return Refaster.anyOf(ImmutableSet.of(e1), ImmutableSet.copyOf(EnumSet.of(e1)));
+    ImmutableSet<T> before(T anElement) {
+      return Refaster.anyOf(ImmutableSet.of(anElement), ImmutableSet.copyOf(EnumSet.of(anElement)));
     }
 
     @AfterTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ImmutableSet<T> after(T e1) {
-      return Sets.immutableEnumSet(e1);
+    ImmutableSet<T> after(T anElement) {
+      return Sets.immutableEnumSet(anElement);
     }
   }
 
   /**
-   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} for enum collections to take advantage of
-   * the internally used {@link EnumSet}.
+   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the {@link
    * ImmutableSet#of} expression produces a set that iterates over its elements in the listed order,
@@ -105,20 +96,20 @@ final class ImmutableEnumSetRules {
   static final class SetsImmutableEnumSet2<T extends Enum<T>> {
     @BeforeTemplate
     @SuppressWarnings("SetsImmutableEnumSetIterable" /* This is a more specific template. */)
-    ImmutableSet<T> before(T e1, T e2) {
-      return Refaster.anyOf(ImmutableSet.of(e1, e2), ImmutableSet.copyOf(EnumSet.of(e1, e2)));
+    ImmutableSet<T> before(T anElement, T e2) {
+      return Refaster.anyOf(
+          ImmutableSet.of(anElement, e2), ImmutableSet.copyOf(EnumSet.of(anElement, e2)));
     }
 
     @AfterTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ImmutableSet<T> after(T e1, T e2) {
-      return Sets.immutableEnumSet(e1, e2);
+    ImmutableSet<T> after(T anElement, T e2) {
+      return Sets.immutableEnumSet(anElement, e2);
     }
   }
 
   /**
-   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} for enum collections to take advantage of
-   * the internally used {@link EnumSet}.
+   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the {@link
    * ImmutableSet#of} expression produces a set that iterates over its elements in the listed order,
@@ -127,21 +118,20 @@ final class ImmutableEnumSetRules {
   static final class SetsImmutableEnumSet3<T extends Enum<T>> {
     @BeforeTemplate
     @SuppressWarnings("SetsImmutableEnumSetIterable" /* This is a more specific template. */)
-    ImmutableSet<T> before(T e1, T e2, T e3) {
+    ImmutableSet<T> before(T anElement, T e2, T e3) {
       return Refaster.anyOf(
-          ImmutableSet.of(e1, e2, e3), ImmutableSet.copyOf(EnumSet.of(e1, e2, e3)));
+          ImmutableSet.of(anElement, e2, e3), ImmutableSet.copyOf(EnumSet.of(anElement, e2, e3)));
     }
 
     @AfterTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ImmutableSet<T> after(T e1, T e2, T e3) {
-      return Sets.immutableEnumSet(e1, e2, e3);
+    ImmutableSet<T> after(T anElement, T e2, T e3) {
+      return Sets.immutableEnumSet(anElement, e2, e3);
     }
   }
 
   /**
-   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} for enum collections to take advantage of
-   * the internally used {@link EnumSet}.
+   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the {@link
    * ImmutableSet#of} expression produces a set that iterates over its elements in the listed order,
@@ -150,21 +140,21 @@ final class ImmutableEnumSetRules {
   static final class SetsImmutableEnumSet4<T extends Enum<T>> {
     @BeforeTemplate
     @SuppressWarnings("SetsImmutableEnumSetIterable" /* This is a more specific template. */)
-    ImmutableSet<T> before(T e1, T e2, T e3, T e4) {
+    ImmutableSet<T> before(T anElement, T e2, T e3, T e4) {
       return Refaster.anyOf(
-          ImmutableSet.of(e1, e2, e3, e4), ImmutableSet.copyOf(EnumSet.of(e1, e2, e3, e4)));
+          ImmutableSet.of(anElement, e2, e3, e4),
+          ImmutableSet.copyOf(EnumSet.of(anElement, e2, e3, e4)));
     }
 
     @AfterTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ImmutableSet<T> after(T e1, T e2, T e3, T e4) {
-      return Sets.immutableEnumSet(e1, e2, e3, e4);
+    ImmutableSet<T> after(T anElement, T e2, T e3, T e4) {
+      return Sets.immutableEnumSet(anElement, e2, e3, e4);
     }
   }
 
   /**
-   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} for enum collections to take advantage of
-   * the internally used {@link EnumSet}.
+   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the {@link
    * ImmutableSet#of} expression produces a set that iterates over its elements in the listed order,
@@ -173,21 +163,21 @@ final class ImmutableEnumSetRules {
   static final class SetsImmutableEnumSet5<T extends Enum<T>> {
     @BeforeTemplate
     @SuppressWarnings("SetsImmutableEnumSetIterable" /* This is a more specific template. */)
-    ImmutableSet<T> before(T e1, T e2, T e3, T e4, T e5) {
+    ImmutableSet<T> before(T anElement, T e2, T e3, T e4, T e5) {
       return Refaster.anyOf(
-          ImmutableSet.of(e1, e2, e3, e4, e5), ImmutableSet.copyOf(EnumSet.of(e1, e2, e3, e4, e5)));
+          ImmutableSet.of(anElement, e2, e3, e4, e5),
+          ImmutableSet.copyOf(EnumSet.of(anElement, e2, e3, e4, e5)));
     }
 
     @AfterTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ImmutableSet<T> after(T e1, T e2, T e3, T e4, T e5) {
-      return Sets.immutableEnumSet(e1, e2, e3, e4, e5);
+    ImmutableSet<T> after(T anElement, T e2, T e3, T e4, T e5) {
+      return Sets.immutableEnumSet(anElement, e2, e3, e4, e5);
     }
   }
 
   /**
-   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} for enum collections to take advantage of
-   * the internally used {@link EnumSet}.
+   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the
    * original code produces a set that iterates over its elements in the listed order, the
@@ -195,43 +185,39 @@ final class ImmutableEnumSetRules {
    */
   static final class SetsImmutableEnumSet6<T extends Enum<T>> {
     @BeforeTemplate
-    ImmutableSet<T> before(T e1, T e2, T e3, T e4, T e5, T e6) {
-      return ImmutableSet.of(e1, e2, e3, e4, e5, e6);
+    ImmutableSet<T> before(T anElement, T e2, T e3, T e4, T e5, T e6) {
+      return ImmutableSet.of(anElement, e2, e3, e4, e5, e6);
     }
 
     @AfterTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
-    ImmutableSet<T> after(T e1, T e2, T e3, T e4, T e5, T e6) {
-      return Sets.immutableEnumSet(e1, e2, e3, e4, e5, e6);
+    ImmutableSet<T> after(T anElement, T e2, T e3, T e4, T e5, T e6) {
+      return Sets.immutableEnumSet(anElement, e2, e3, e4, e5, e6);
     }
   }
 
-  /**
-   * Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} for enum collections to take advantage of
-   * the internally used {@link EnumSet}.
-   */
-  static final class SetsImmutableEnumSetVarArgs<T extends Enum<T>> {
+  /** Prefer {@link Sets#immutableEnumSet(Enum, Enum[])} over less efficient alternatives. */
+  static final class SetsImmutableEnumSetVarargs<T extends Enum<T>> {
     @BeforeTemplate
     @SuppressWarnings("SetsImmutableEnumSetIterable" /* This is a more specific template. */)
-    ImmutableSet<T> before(T e1, @Repeated T elements) {
-      return ImmutableSet.copyOf(EnumSet.of(e1, Refaster.asVarargs(elements)));
+    ImmutableSet<T> before(T anElement, @Repeated T otherElements) {
+      return ImmutableSet.copyOf(EnumSet.of(anElement, Refaster.asVarargs(otherElements)));
     }
 
     @AfterTemplate
-    ImmutableSet<T> after(T e1, @Repeated T elements) {
-      return Sets.immutableEnumSet(e1, Refaster.asVarargs(elements));
+    ImmutableSet<T> after(T anElement, @Repeated T otherElements) {
+      return Sets.immutableEnumSet(anElement, Refaster.asVarargs(otherElements));
     }
   }
 
   /**
-   * Use {@link Sets#toImmutableEnumSet()} when possible, as it is more efficient than {@link
-   * ImmutableSet#toImmutableSet()} and produces a more compact object.
+   * Prefer {@link Sets#toImmutableEnumSet()} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rule is not completely behavior preserving: while the
    * original code produces a set that iterates over its elements in encounter order, the
    * replacement code iterates over the elements in enum definition order.
    */
-  static final class StreamToImmutableEnumSet<T extends Enum<T>> {
+  static final class StreamCollectToImmutableEnumSet<T extends Enum<T>> {
     @BeforeTemplate
     ImmutableSet<T> before(Stream<T> stream) {
       return stream.collect(toImmutableSet());

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableListMultimapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableListMultimapRules.java
@@ -33,8 +33,8 @@ final class ImmutableListMultimapRules {
   private ImmutableListMultimapRules() {}
 
   /**
-   * Prefer {@link ImmutableListMultimap#builder()} over the associated constructor on constructions
-   * that produce a less-specific type.
+   * Prefer {@link ImmutableListMultimap#builder()} over the associated constructor or imprecisely
+   * typed alternatives.
    */
   // XXX: This rule may drop generic type information, leading to non-compilable code.
   static final class ImmutableListMultimapBuilder<K, V> {
@@ -53,9 +53,10 @@ final class ImmutableListMultimapRules {
   }
 
   /**
-   * Prefer {@link ImmutableListMultimap#of()} over more contrived or less-specific alternatives.
+   * Prefer {@link ImmutableListMultimap#of()} over imprecisely typed or less efficient
+   * alternatives.
    */
-  static final class EmptyImmutableListMultimap<K, V> {
+  static final class ImmutableListMultimapOf0<K, V> {
     @BeforeTemplate
     ImmutableMultimap<K, V> before() {
       return Refaster.anyOf(ImmutableListMultimap.<K, V>builder().build(), ImmutableMultimap.of());
@@ -68,33 +69,33 @@ final class ImmutableListMultimapRules {
   }
 
   /**
-   * Prefer {@link ImmutableListMultimap#of(Object, Object)} over more contrived or less-specific
-   * alternatives.
+   * Prefer {@link ImmutableListMultimap#of(Object, Object)} over imprecisely typed or less
+   * efficient alternatives.
    */
   // XXX: One can define variants for more than one key-value pair, but at some point the builder
   // actually produces nicer code. So it's not clear we should add Refaster rules for those
   // variants.
-  static final class PairToImmutableListMultimap<K, V> {
+  static final class ImmutableListMultimapOf2<K, V> {
     @BeforeTemplate
-    ImmutableMultimap<K, V> before(K key, V value) {
+    ImmutableMultimap<K, V> before(K k1, V v1) {
       return Refaster.anyOf(
-          ImmutableListMultimap.<K, V>builder().put(key, value).build(),
-          ImmutableMultimap.of(key, value));
+          ImmutableListMultimap.<K, V>builder().put(k1, v1).build(), ImmutableMultimap.of(k1, v1));
     }
 
     @AfterTemplate
-    ImmutableListMultimap<K, V> after(K key, V value) {
-      return ImmutableListMultimap.of(key, value);
+    ImmutableListMultimap<K, V> after(K k1, V v1) {
+      return ImmutableListMultimap.of(k1, v1);
     }
   }
 
   /**
-   * Prefer {@link ImmutableListMultimap#of(Object, Object)} over more contrived or less-specific
+   * Prefer {@link ImmutableListMultimap#of(Object, Object)} over less efficient or more contrived
    * alternatives.
    */
-  static final class EntryToImmutableListMultimap<K, V> {
+  static final class ImmutableListMultimapOfEntryGetKeyEntryGetValue<
+      K, V, K2 extends K, V2 extends V> {
     @BeforeTemplate
-    ImmutableListMultimap<K, V> before(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableListMultimap<K, V> before(Map.Entry<K2, V2> entry) {
       return Refaster.anyOf(
           ImmutableListMultimap.<K, V>builder().put(entry).build(),
           Stream.of(entry)
@@ -102,51 +103,51 @@ final class ImmutableListMultimapRules {
     }
 
     @AfterTemplate
-    ImmutableListMultimap<K, V> after(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableListMultimap<K, V> after(Map.Entry<K2, V2> entry) {
       return ImmutableListMultimap.of(entry.getKey(), entry.getValue());
     }
   }
 
-  /** Prefer {@link ImmutableListMultimap#copyOf(Iterable)} over more contrived alternatives. */
-  static final class IterableToImmutableListMultimap<K, V> {
+  /**
+   * Prefer {@link ImmutableListMultimap#copyOf(Iterable)} over less efficient or more contrived
+   * alternatives.
+   */
+  static final class ImmutableListMultimapCopyOf<
+      K, V, K2 extends K, V2 extends V, E extends Map.Entry<K2, V2>> {
     @BeforeTemplate
-    ImmutableMultimap<K, V> before(Multimap<? extends K, ? extends V> iterable) {
+    ImmutableMultimap<K, V> before(Multimap<K2, V2> entries) {
       return Refaster.anyOf(
-          ImmutableListMultimap.copyOf(iterable.entries()),
-          ImmutableListMultimap.<K, V>builder().putAll(iterable).build(),
-          ImmutableMultimap.copyOf(iterable),
-          ImmutableMultimap.copyOf(iterable.entries()));
+          ImmutableListMultimap.copyOf(entries.entries()),
+          ImmutableListMultimap.<K, V>builder().putAll(entries).build(),
+          ImmutableMultimap.copyOf(entries),
+          ImmutableMultimap.copyOf(entries.entries()));
     }
 
     @BeforeTemplate
-    ImmutableMultimap<K, V> before(
-        Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
+    ImmutableMultimap<K, V> before(Iterable<E> entries) {
       return Refaster.anyOf(
-          ImmutableListMultimap.<K, V>builder().putAll(iterable).build(),
-          Streams.stream(iterable)
+          ImmutableListMultimap.<K, V>builder().putAll(entries).build(),
+          Streams.stream(entries)
               .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue)),
-          ImmutableMultimap.copyOf(iterable));
+          ImmutableMultimap.copyOf(entries));
     }
 
     @BeforeTemplate
-    ImmutableListMultimap<K, V> before(
-        Collection<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return iterable.stream()
+    ImmutableListMultimap<K, V> before(Collection<E> entries) {
+      return entries.stream()
           .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @AfterTemplate
-    ImmutableListMultimap<K, V> after(
-        Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return ImmutableListMultimap.copyOf(iterable);
+    ImmutableListMultimap<K, V> after(Iterable<E> entries) {
+      return ImmutableListMultimap.copyOf(entries);
     }
   }
 
   /**
-   * Don't map stream's elements to map entries, only to subsequently collect them into an {@link
-   * ImmutableListMultimap}. The collection can be performed directly.
+   * Prefer {@code stream.collect(toImmutableListMultimap(...))} over more contrived alternatives.
    */
-  abstract static class StreamOfMapEntriesToImmutableListMultimap<E, K, V> {
+  abstract static class StreamCollectToImmutableListMultimap<E, K, V> {
     @Placeholder(allowsIdentity = true)
     abstract K keyFunction(@MayOptionallyUse E element);
 
@@ -170,118 +171,117 @@ final class ImmutableListMultimapRules {
   }
 
   /**
-   * Prefer {@link Multimaps#index(Iterable, com.google.common.base.Function)} over the stream-based
-   * alternative.
+   * Prefer {@link Multimaps#index(Iterable, com.google.common.base.Function)} over more contrived
+   * alternatives.
    */
-  static final class IndexIterableToImmutableListMultimap<K, V> {
+  static final class MultimapsIndex<S, K, V extends S, K2 extends K, V2 extends V> {
     @BeforeTemplate
     ImmutableListMultimap<K, V> before(
-        Iterator<V> iterable,
-        Function<? super V, ? extends K> keyFunction,
-        @Matches(IsIdentityOperation.class) Function<? super V, ? extends V> valueFunction) {
-      return Streams.stream(iterable).collect(toImmutableListMultimap(keyFunction, valueFunction));
+        Iterable<V> values,
+        Function<S, K2> keyFunction,
+        @Matches(IsIdentityOperation.class) Function<S, V2> identityValueFunction) {
+      return Streams.stream(values)
+          .collect(toImmutableListMultimap(keyFunction, identityValueFunction));
     }
 
     @BeforeTemplate
     ImmutableListMultimap<K, V> before(
-        Iterable<V> iterable,
-        Function<? super V, ? extends K> keyFunction,
-        @Matches(IsIdentityOperation.class) Function<? super V, ? extends V> valueFunction) {
-      return Streams.stream(iterable).collect(toImmutableListMultimap(keyFunction, valueFunction));
+        Collection<V> values,
+        Function<S, K2> keyFunction,
+        @Matches(IsIdentityOperation.class) Function<S, V2> identityValueFunction) {
+      return values.stream().collect(toImmutableListMultimap(keyFunction, identityValueFunction));
     }
 
     @BeforeTemplate
     ImmutableListMultimap<K, V> before(
-        Collection<V> iterable,
-        Function<? super V, ? extends K> keyFunction,
-        @Matches(IsIdentityOperation.class) Function<? super V, ? extends V> valueFunction) {
-      return iterable.stream().collect(toImmutableListMultimap(keyFunction, valueFunction));
+        Iterator<V> values,
+        Function<S, K2> keyFunction,
+        @Matches(IsIdentityOperation.class) Function<S, V2> identityValueFunction) {
+      return Streams.stream(values)
+          .collect(toImmutableListMultimap(keyFunction, identityValueFunction));
     }
 
     @AfterTemplate
     ImmutableListMultimap<K, V> after(
-        Iterable<V> iterable, com.google.common.base.Function<? super V, K> keyFunction) {
-      return Multimaps.index(iterable, keyFunction);
+        Iterable<V> values, com.google.common.base.Function<S, K> keyFunction) {
+      return Multimaps.index(values, keyFunction);
     }
   }
 
   /**
-   * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
-   * com.google.common.base.Function)} over creating and directly collecting a stream.
+   * Prefer an immutable copy of {@link Multimaps#transformValues(Multimap,
+   * com.google.common.base.Function)} over more contrived alternatives.
    */
-  abstract static class TransformMultimapValuesToImmutableListMultimap<K, V1, V2> {
+  abstract static class ImmutableListMultimapCopyOfMultimapsTransformValues<K, V1, V2> {
     @Placeholder(allowsIdentity = true)
     abstract V2 valueTransformation(@MayOptionallyUse V1 value);
 
     @BeforeTemplate
-    ImmutableListMultimap<K, V2> before(Multimap<K, V1> multimap) {
-      return multimap.entries().stream()
+    ImmutableListMultimap<K, V2> before(Multimap<K, V1> fromMultimap) {
+      return fromMultimap.entries().stream()
           .collect(
               toImmutableListMultimap(Map.Entry::getKey, e -> valueTransformation(e.getValue())));
     }
 
     @AfterTemplate
-    ImmutableListMultimap<K, V2> after(Multimap<K, V1> multimap) {
+    ImmutableListMultimap<K, V2> after(Multimap<K, V1> fromMultimap) {
       return ImmutableListMultimap.copyOf(
-          Multimaps.transformValues(multimap, v -> valueTransformation(v)));
+          Multimaps.transformValues(fromMultimap, v -> valueTransformation(v)));
     }
   }
 
   /**
-   * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
-   * com.google.common.base.Function)} over creating and directly collecting a stream.
+   * Prefer an immutable copy of {@link Multimaps#transformValues(Multimap,
+   * com.google.common.base.Function)} over more contrived alternatives.
    */
-  static final class TransformMultimapValuesToImmutableListMultimap2<K, V1, V2> {
+  static final class ImmutableListMultimapCopyOfMultimapsTransformValuesWithFunction<
+      S, K, V1 extends S, V2, T extends V2> {
     // XXX: Drop the `Refaster.anyOf` if we decide to rewrite one to the other.
     @BeforeTemplate
-    ImmutableListMultimap<K, V2> before(
-        Multimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Refaster.anyOf(multimap.asMap(), Multimaps.asMap(multimap)).entrySet().stream()
+    ImmutableListMultimap<K, V2> before(Multimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Refaster.anyOf(fromMultimap.asMap(), Multimaps.asMap(fromMultimap)).entrySet().stream()
           .collect(
               flatteningToImmutableListMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
+    }
+
+    @BeforeTemplate
+    ImmutableListMultimap<K, V2> before(ListMultimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Multimaps.asMap(fromMultimap).entrySet().stream()
+          .collect(
+              flatteningToImmutableListMultimap(
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
+    }
+
+    @BeforeTemplate
+    ImmutableListMultimap<K, V2> before(SetMultimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Multimaps.asMap(fromMultimap).entrySet().stream()
+          .collect(
+              flatteningToImmutableListMultimap(
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
     }
 
     @BeforeTemplate
     ImmutableListMultimap<K, V2> before(
-        ListMultimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Multimaps.asMap(multimap).entrySet().stream()
+        SortedSetMultimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Multimaps.asMap(fromMultimap).entrySet().stream()
           .collect(
               flatteningToImmutableListMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
-    }
-
-    @BeforeTemplate
-    ImmutableListMultimap<K, V2> before(
-        SetMultimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Multimaps.asMap(multimap).entrySet().stream()
-          .collect(
-              flatteningToImmutableListMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
-    }
-
-    @BeforeTemplate
-    ImmutableListMultimap<K, V2> before(
-        SortedSetMultimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Multimaps.asMap(multimap).entrySet().stream()
-          .collect(
-              flatteningToImmutableListMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
     }
 
     @AfterTemplate
     ImmutableListMultimap<K, V2> after(
-        Multimap<K, V1> multimap,
-        com.google.common.base.Function<? super V1, ? extends V2> transformation) {
-      return ImmutableListMultimap.copyOf(Multimaps.transformValues(multimap, transformation));
+        Multimap<K, V1> fromMultimap, com.google.common.base.Function<S, V2> function) {
+      return ImmutableListMultimap.copyOf(Multimaps.transformValues(fromMultimap, function));
     }
   }
 
   /**
-   * Prefer {@link ImmutableListMultimap.Builder#put(Object, Object)} over more contrived or less
-   * efficient alternatives.
+   * Prefer {@link ImmutableListMultimap.Builder#put(Object, Object)} over more contrived
+   * alternatives.
    */
-  static final class ImmutableListMultimapBuilderPut<K, V> {
+  static final class BuilderPut<K, V> {
     @BeforeTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
     ImmutableListMultimap.Builder<K, V> before(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableListRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableListRules.java
@@ -8,7 +8,6 @@ import static java.util.Collections.singletonList;
 import static java.util.Comparator.naturalOrder;
 
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
 import com.google.common.collect.UnmodifiableIterator;
 import com.google.errorprone.refaster.Refaster;
@@ -43,43 +42,44 @@ final class ImmutableListRules {
   }
 
   /**
-   * Prefer {@link ImmutableList#copyOf(Iterable)} and variants over more contrived alternatives.
+   * Prefer {@link ImmutableList#copyOf(Iterable)} and variants over less efficient or more
+   * contrived alternatives.
    */
-  static final class IterableToImmutableList<T> {
+  static final class ImmutableListCopyOf<T> {
     @BeforeTemplate
-    ImmutableList<T> before(T[] iterable) {
+    ImmutableList<T> before(T[] elements) {
       return Refaster.anyOf(
-          ImmutableList.<T>builder().add(iterable).build(),
-          Arrays.stream(iterable).collect(toImmutableList()));
+          ImmutableList.<T>builder().add(elements).build(),
+          Arrays.stream(elements).collect(toImmutableList()));
     }
 
     @BeforeTemplate
-    ImmutableList<T> before(Iterator<T> iterable) {
+    ImmutableList<T> before(Iterator<T> elements) {
       return Refaster.anyOf(
-          ImmutableList.<T>builder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableList()));
+          ImmutableList.<T>builder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableList()));
     }
 
     @BeforeTemplate
-    ImmutableList<T> before(Iterable<T> iterable) {
+    ImmutableList<T> before(Iterable<T> elements) {
       return Refaster.anyOf(
-          ImmutableList.<T>builder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableList()));
+          ImmutableList.<T>builder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableList()));
     }
 
     @BeforeTemplate
-    ImmutableList<T> before(Collection<T> iterable) {
-      return iterable.stream().collect(toImmutableList());
+    ImmutableList<T> before(Collection<T> elements) {
+      return elements.stream().collect(toImmutableList());
     }
 
     @AfterTemplate
-    ImmutableList<T> after(Iterable<T> iterable) {
-      return ImmutableList.copyOf(iterable);
+    ImmutableList<T> after(Iterable<T> elements) {
+      return ImmutableList.copyOf(elements);
     }
   }
 
   /** Prefer {@link ImmutableList#toImmutableList()} over less idiomatic alternatives. */
-  static final class StreamToImmutableList<T> {
+  static final class StreamCollectToImmutableList<T> {
     @BeforeTemplate
     ImmutableList<T> before(Stream<T> stream) {
       return ImmutableList.copyOf(stream.iterator());
@@ -92,44 +92,47 @@ final class ImmutableListRules {
     }
   }
 
-  /** Prefer {@link ImmutableList#sortedCopyOf(Iterable)} over more contrived alternatives. */
+  /**
+   * Prefer {@link ImmutableList#sortedCopyOf(Iterable)} over more verbose or less efficient
+   * alternatives.
+   */
   static final class ImmutableListSortedCopyOf<T extends Comparable<? super T>> {
     @BeforeTemplate
-    ImmutableList<T> before(Iterable<T> iterable) {
+    ImmutableList<T> before(Iterable<T> elements) {
       return Refaster.anyOf(
-          ImmutableList.sortedCopyOf(naturalOrder(), iterable),
-          Streams.stream(iterable).sorted().collect(toImmutableList()));
+          ImmutableList.sortedCopyOf(naturalOrder(), elements),
+          Streams.stream(elements).sorted().collect(toImmutableList()));
     }
 
     @BeforeTemplate
-    ImmutableList<T> before(Collection<T> iterable) {
-      return iterable.stream().sorted().collect(toImmutableList());
+    ImmutableList<T> before(Collection<T> elements) {
+      return elements.stream().sorted().collect(toImmutableList());
     }
 
     @AfterTemplate
-    ImmutableList<T> after(Collection<T> iterable) {
-      return ImmutableList.sortedCopyOf(iterable);
+    ImmutableList<T> after(Collection<T> elements) {
+      return ImmutableList.sortedCopyOf(elements);
     }
   }
 
   /**
-   * Prefer {@link ImmutableList#sortedCopyOf(Comparator, Iterable)} over more contrived
+   * Prefer {@link ImmutableList#sortedCopyOf(Comparator, Iterable)} over less efficient
    * alternatives.
    */
-  static final class ImmutableListSortedCopyOfWithCustomComparator<T> {
+  static final class ImmutableListSortedCopyOfWithComparator<S, T extends S> {
     @BeforeTemplate
-    ImmutableList<T> before(Comparator<T> cmp, Iterable<T> iterable) {
-      return Streams.stream(iterable).sorted(cmp).collect(toImmutableList());
+    ImmutableList<T> before(Comparator<S> comparator, Iterable<T> elements) {
+      return Streams.stream(elements).sorted(comparator).collect(toImmutableList());
     }
 
     @BeforeTemplate
-    ImmutableList<T> before(Comparator<T> cmp, Collection<T> iterable) {
-      return iterable.stream().sorted(cmp).collect(toImmutableList());
+    ImmutableList<T> before(Comparator<S> comparator, Collection<T> elements) {
+      return elements.stream().sorted(comparator).collect(toImmutableList());
     }
 
     @AfterTemplate
-    ImmutableList<T> after(Comparator<? super T> cmp, Collection<T> iterable) {
-      return ImmutableList.sortedCopyOf(cmp, iterable);
+    ImmutableList<T> after(Comparator<S> comparator, Collection<T> elements) {
+      return ImmutableList.sortedCopyOf(comparator, elements);
     }
   }
 
@@ -139,18 +142,18 @@ final class ImmutableListRules {
    */
   static final class ImmutableListSortedCopyOfIterator<T extends Comparable<? super T>> {
     @BeforeTemplate
-    Iterator<T> before(Iterable<T> iterable) {
-      return Streams.stream(iterable).sorted().iterator();
+    Iterator<T> before(Iterable<T> elements) {
+      return Streams.stream(elements).sorted().iterator();
     }
 
     @BeforeTemplate
-    Iterator<T> before(Collection<T> iterable) {
-      return iterable.stream().sorted().iterator();
+    Iterator<T> before(Collection<T> elements) {
+      return elements.stream().sorted().iterator();
     }
 
     @AfterTemplate
-    UnmodifiableIterator<T> after(Iterable<T> iterable) {
-      return ImmutableList.sortedCopyOf(iterable).iterator();
+    UnmodifiableIterator<T> after(Iterable<T> elements) {
+      return ImmutableList.sortedCopyOf(elements).iterator();
     }
   }
 
@@ -160,27 +163,23 @@ final class ImmutableListRules {
    */
   static final class ImmutableListSortedCopyOfIteratorWithComparator<S, T extends S> {
     @BeforeTemplate
-    Iterator<T> before(Comparator<S> cmp, Iterable<T> iterable) {
-      return Streams.stream(iterable).sorted(cmp).iterator();
+    Iterator<T> before(Comparator<S> comparator, Iterable<T> elements) {
+      return Streams.stream(elements).sorted(comparator).iterator();
     }
 
     @BeforeTemplate
-    Iterator<T> before(Comparator<S> cmp, Collection<T> iterable) {
-      return iterable.stream().sorted(cmp).iterator();
+    Iterator<T> before(Comparator<S> comparator, Collection<T> elements) {
+      return elements.stream().sorted(comparator).iterator();
     }
 
     @AfterTemplate
-    UnmodifiableIterator<T> after(Comparator<S> cmp, Iterable<T> iterable) {
-      return ImmutableList.sortedCopyOf(cmp, iterable).iterator();
+    UnmodifiableIterator<T> after(Comparator<S> comparator, Iterable<T> elements) {
+      return ImmutableList.sortedCopyOf(comparator, elements).iterator();
     }
   }
 
-  /**
-   * Collecting to an {@link ImmutableSet} and converting the result to an {@link ImmutableList} may
-   * be more efficient than deduplicating a stream and collecting the result to an {@link
-   * ImmutableList}.
-   */
-  static final class StreamToDistinctImmutableList<T> {
+  /** Prefer {@code stream.collect(toImmutableSet()).asList()} over less efficient alternatives. */
+  static final class StreamCollectToImmutableSetAsList<T> {
     @BeforeTemplate
     ImmutableList<T> before(Stream<T> stream) {
       return stream.distinct().collect(toImmutableList());
@@ -193,13 +192,10 @@ final class ImmutableListRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableList#of()} over more contrived alternatives or alternatives that don't
-   * communicate the immutability of the resulting list at the type level.
-   */
+  /** Prefer {@link ImmutableList#of()} over imprecisely typed or less efficient alternatives. */
   // XXX: The `Stream` variant may be too contrived to warrant inclusion. Review its usage if/when
   // this and similar Refaster rules are replaced with an Error Prone check.
-  static final class ImmutableListOf<T> {
+  static final class ImmutableListOf0<T> {
     @BeforeTemplate
     List<T> before() {
       return Refaster.anyOf(
@@ -216,8 +212,7 @@ final class ImmutableListRules {
   }
 
   /**
-   * Prefer {@link ImmutableList#of(Object)} over more contrived alternatives or alternatives that
-   * don't communicate the immutability of the resulting list at the type level.
+   * Prefer {@link ImmutableList#of(Object)} over imprecisely typed or less efficient alternatives.
    */
   // XXX: Note that the replacement of `Collections#singletonList` is incorrect for nullable
   // elements.
@@ -234,10 +229,7 @@ final class ImmutableListRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableList#of(Object, Object)} over alternatives that don't communicate the
-   * immutability of the resulting list at the type level.
-   */
+  /** Prefer {@link ImmutableList#of(Object, Object)} over imprecisely typed alternatives. */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableList.builder()` usages.
   static final class ImmutableListOf2<T> {
@@ -253,8 +245,7 @@ final class ImmutableListRules {
   }
 
   /**
-   * Prefer {@link ImmutableList#of(Object, Object, Object)} over alternatives that don't
-   * communicate the immutability of the resulting list at the type level.
+   * Prefer {@link ImmutableList#of(Object, Object, Object)} over imprecisely typed alternatives.
    */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableList.builder()` usages.
@@ -271,8 +262,8 @@ final class ImmutableListRules {
   }
 
   /**
-   * Prefer {@link ImmutableList#of(Object, Object, Object, Object)} over alternatives that don't
-   * communicate the immutability of the resulting list at the type level.
+   * Prefer {@link ImmutableList#of(Object, Object, Object, Object)} over imprecisely typed
+   * alternatives.
    */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableList.builder()` usages.
@@ -289,8 +280,8 @@ final class ImmutableListRules {
   }
 
   /**
-   * Prefer {@link ImmutableList#of(Object, Object, Object, Object, Object)} over alternatives that
-   * don't communicate the immutability of the resulting list at the type level.
+   * Prefer {@link ImmutableList#of(Object, Object, Object, Object, Object)} over imprecisely typed
+   * alternatives.
    */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableList.builder()` usages.

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMapRules.java
@@ -46,11 +46,8 @@ final class ImmutableMapRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableMap.Builder#buildOrThrow()} over the less explicit {@link
-   * ImmutableMap.Builder#build()}.
-   */
-  static final class ImmutableMapBuilderBuildOrThrow<K, V> {
+  /** Prefer {@link ImmutableMap.Builder#buildOrThrow()} over less explicit alternatives. */
+  static final class BuilderBuildOrThrow<K, V> {
     @BeforeTemplate
     ImmutableMap<K, V> before(ImmutableMap.Builder<K, V> builder) {
       return builder.build();
@@ -63,16 +60,16 @@ final class ImmutableMapRules {
   }
 
   /** Prefer {@link ImmutableMap#of(Object, Object)} over more contrived alternatives. */
-  static final class EntryToImmutableMap<K, V> {
+  static final class ImmutableMapOfEntryGetKeyEntryGetValue<K, V, K2 extends K, V2 extends V> {
     @BeforeTemplate
-    ImmutableMap<K, V> before(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableMap<K, V> before(Map.Entry<K2, V2> entry) {
       return Refaster.anyOf(
           ImmutableMap.<K, V>builder().put(entry).buildOrThrow(),
           Stream.of(entry).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     @AfterTemplate
-    ImmutableMap<K, V> after(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableMap<K, V> after(Map.Entry<K2, V2> entry) {
       return ImmutableMap.of(entry.getKey(), entry.getValue());
     }
   }
@@ -81,77 +78,77 @@ final class ImmutableMapRules {
    * Prefer {@link Maps#toMap(Iterable, com.google.common.base.Function)} over more contrived
    * alternatives.
    */
-  static final class IterableToImmutableMap<K, V> {
+  static final class MapsToMap<S, K extends S, V, V2 extends V, K2 extends K> {
     @BeforeTemplate
     ImmutableMap<K, V> before(
-        Iterator<K> iterable,
-        Function<? super K, ? extends V> valueFunction,
-        @Matches(IsIdentityOperation.class) Function<? super K, ? extends K> keyFunction) {
-      return Streams.stream(iterable).collect(toImmutableMap(keyFunction, valueFunction));
+        Iterator<K> keys,
+        Function<S, V2> valueFunction,
+        @Matches(IsIdentityOperation.class) Function<S, K2> identityKeyFunction) {
+      return Streams.stream(keys).collect(toImmutableMap(identityKeyFunction, valueFunction));
     }
 
     @BeforeTemplate
     ImmutableMap<K, V> before(
-        Iterable<K> iterable,
-        Function<? super K, ? extends V> valueFunction,
-        @Matches(IsIdentityOperation.class) Function<? super K, ? extends K> keyFunction) {
-      return Streams.stream(iterable).collect(toImmutableMap(keyFunction, valueFunction));
+        Iterable<K> keys,
+        Function<S, V2> valueFunction,
+        @Matches(IsIdentityOperation.class) Function<S, K2> identityKeyFunction) {
+      return Streams.stream(keys).collect(toImmutableMap(identityKeyFunction, valueFunction));
     }
 
     @BeforeTemplate
     ImmutableMap<K, V> before(
-        Collection<K> iterable,
-        Function<? super K, ? extends V> valueFunction,
-        @Matches(IsIdentityOperation.class) Function<? super K, ? extends K> keyFunction) {
-      return iterable.stream().collect(toImmutableMap(keyFunction, valueFunction));
+        Collection<K> keys,
+        Function<S, V2> valueFunction,
+        @Matches(IsIdentityOperation.class) Function<S, K2> identityKeyFunction) {
+      return keys.stream().collect(toImmutableMap(identityKeyFunction, valueFunction));
     }
 
     @BeforeTemplate
-    ImmutableMap<K, V> before(
-        Set<K> iterable, com.google.common.base.Function<? super K, V> valueFunction) {
-      return ImmutableMap.copyOf(Maps.asMap(iterable, valueFunction));
+    ImmutableMap<K, V> before(Set<K> keys, com.google.common.base.Function<S, V> valueFunction) {
+      return ImmutableMap.copyOf(Maps.asMap(keys, valueFunction));
     }
 
     @AfterTemplate
     ImmutableMap<K, V> after(
-        Iterable<K> iterable, com.google.common.base.Function<? super K, V> valueFunction) {
-      return Maps.toMap(iterable, valueFunction);
-    }
-  }
-
-  /** Prefer {@link ImmutableMap#copyOf(Iterable)} over more contrived alternatives. */
-  static final class EntryIterableToImmutableMap<K, V> {
-    @BeforeTemplate
-    Map<K, V> before(Map<? extends K, ? extends V> iterable) {
-      return Refaster.anyOf(
-          ImmutableMap.copyOf(iterable.entrySet()),
-          ImmutableMap.<K, V>builder().putAll(iterable).buildOrThrow(),
-          Map.copyOf(iterable));
-    }
-
-    @BeforeTemplate
-    ImmutableMap<K, V> before(Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return Refaster.anyOf(
-          ImmutableMap.<K, V>builder().putAll(iterable).buildOrThrow(),
-          Streams.stream(iterable).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
-    }
-
-    @BeforeTemplate
-    ImmutableMap<K, V> before(Collection<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return iterable.stream().collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
-    }
-
-    @AfterTemplate
-    ImmutableMap<K, V> after(Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return ImmutableMap.copyOf(iterable);
+        Iterable<K> keys, com.google.common.base.Function<S, V> valueFunction) {
+      return Maps.toMap(keys, valueFunction);
     }
   }
 
   /**
-   * Don't map a stream's elements to map entries, only to subsequently collect them into an {@link
-   * ImmutableMap}. The collection can be performed directly.
+   * Prefer {@link ImmutableMap#copyOf(Iterable)} over imprecisely typed or more contrived
+   * alternatives.
    */
-  abstract static class StreamOfMapEntriesToImmutableMap<E, K, V> {
+  static final class ImmutableMapCopyOf<
+      K, V, K2 extends K, V2 extends V, E extends Map.Entry<K2, V2>> {
+    @BeforeTemplate
+    Map<K, V> before(Map<K2, V2> entries) {
+      return Refaster.anyOf(
+          ImmutableMap.copyOf(entries.entrySet()),
+          ImmutableMap.<K, V>builder().putAll(entries).buildOrThrow(),
+          Map.copyOf(entries));
+    }
+
+    @BeforeTemplate
+    ImmutableMap<K, V> before(Iterable<E> entries) {
+      return Refaster.anyOf(
+          ImmutableMap.<K, V>builder().putAll(entries).buildOrThrow(),
+          Streams.stream(entries).collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    @BeforeTemplate
+    ImmutableMap<K, V> before(Collection<E> entries) {
+      return entries.stream().collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
+    }
+
+    @AfterTemplate
+    ImmutableMap<K, V> after(Iterable<E> entries) {
+      return ImmutableMap.copyOf(entries);
+    }
+  }
+
+  /** Prefer {@code stream.collect(toImmutableMap(...))} over more contrived alternatives. */
+  abstract static class StreamCollectToImmutableMap<E, K, V> {
     @Placeholder(allowsIdentity = true)
     abstract K keyFunction(@MayOptionallyUse E element);
 
@@ -173,46 +170,46 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Prefer {@link Maps#uniqueIndex(Iterable, com.google.common.base.Function)} over the
-   * stream-based alternative.
+   * Prefer {@link Maps#uniqueIndex(Iterable, com.google.common.base.Function)} over more contrived
+   * alternatives.
    */
-  static final class IndexIterableToImmutableMap<K, V> {
+  static final class MapsUniqueIndex<S, K, V extends S, K2 extends K, V2 extends V> {
     @BeforeTemplate
     ImmutableMap<K, V> before(
-        Iterator<V> iterable,
-        Function<? super V, ? extends K> keyFunction,
-        @Matches(IsIdentityOperation.class) Function<? super V, ? extends V> valueFunction) {
-      return Streams.stream(iterable).collect(toImmutableMap(keyFunction, valueFunction));
+        Iterator<V> values,
+        Function<S, K2> keyFunction,
+        @Matches(IsIdentityOperation.class) Function<S, V2> identityValueFunction) {
+      return Streams.stream(values).collect(toImmutableMap(keyFunction, identityValueFunction));
     }
 
     @BeforeTemplate
     ImmutableMap<K, V> before(
-        Iterable<V> iterable,
-        Function<? super V, ? extends K> keyFunction,
-        @Matches(IsIdentityOperation.class) Function<? super V, ? extends V> valueFunction) {
-      return Streams.stream(iterable).collect(toImmutableMap(keyFunction, valueFunction));
+        Iterable<V> values,
+        Function<S, K2> keyFunction,
+        @Matches(IsIdentityOperation.class) Function<S, V2> identityValueFunction) {
+      return Streams.stream(values).collect(toImmutableMap(keyFunction, identityValueFunction));
     }
 
     @BeforeTemplate
     ImmutableMap<K, V> before(
-        Collection<V> iterable,
-        Function<? super V, ? extends K> keyFunction,
-        @Matches(IsIdentityOperation.class) Function<? super V, ? extends V> valueFunction) {
-      return iterable.stream().collect(toImmutableMap(keyFunction, valueFunction));
+        Collection<V> values,
+        Function<S, K2> keyFunction,
+        @Matches(IsIdentityOperation.class) Function<S, V2> identityValueFunction) {
+      return values.stream().collect(toImmutableMap(keyFunction, identityValueFunction));
     }
 
     @AfterTemplate
     ImmutableMap<K, V> after(
-        Iterable<V> iterable, com.google.common.base.Function<? super V, K> keyFunction) {
-      return Maps.uniqueIndex(iterable, keyFunction);
+        Iterable<V> values, com.google.common.base.Function<S, K> keyFunction) {
+      return Maps.uniqueIndex(values, keyFunction);
     }
   }
 
   /**
-   * Prefer creating an immutable copy of the result of {@link Maps#transformValues(Map,
-   * com.google.common.base.Function)} over more contrived alternatives.
+   * Prefer an immutable copy of {@link Maps#transformValues(Map, com.google.common.base.Function)}
+   * over more contrived alternatives.
    */
-  abstract static class TransformMapValuesToImmutableMap<K, V1, V2> {
+  abstract static class ImmutableMapCopyOfMapsTransformValues<K, V1, V2> {
     @Placeholder(allowsIdentity = true)
     abstract V2 valueTransformation(@MayOptionallyUse @Nullable V1 value);
 
@@ -220,24 +217,21 @@ final class ImmutableMapRules {
     // reason Refaster doesn't handle that case. This doesn't matter if we roll out use of
     // `MethodReferenceUsage`. Same observation applies to a lot of other Refaster checks.
     @BeforeTemplate
-    ImmutableMap<K, V2> before(Map<K, V1> map) {
+    ImmutableMap<K, V2> before(Map<K, V1> fromMap) {
       return Refaster.anyOf(
-          map.entrySet().stream()
+          fromMap.entrySet().stream()
               .collect(toImmutableMap(Map.Entry::getKey, e -> valueTransformation(e.getValue()))),
-          Maps.toMap(map.keySet(), key -> valueTransformation(map.get(key))));
+          Maps.toMap(fromMap.keySet(), key -> valueTransformation(fromMap.get(key))));
     }
 
     @AfterTemplate
-    ImmutableMap<K, V2> after(Map<K, V1> map) {
-      return ImmutableMap.copyOf(Maps.transformValues(map, v -> valueTransformation(v)));
+    ImmutableMap<K, V2> after(Map<K, V1> fromMap) {
+      return ImmutableMap.copyOf(Maps.transformValues(fromMap, v -> valueTransformation(v)));
     }
   }
 
-  /**
-   * Prefer {@link ImmutableMap#of()} over more contrived alternatives or alternatives that don't
-   * communicate the immutability of the resulting map at the type level.
-   */
-  static final class ImmutableMapOf<K, V> {
+  /** Prefer {@link ImmutableMap#of()} over more verbose or imprecisely typed alternatives. */
+  static final class ImmutableMapOf0<K, V> {
     @BeforeTemplate
     Map<K, V> before() {
       return Refaster.anyOf(
@@ -254,12 +248,12 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Prefer {@link ImmutableMap#of(Object, Object)} over more contrived alternatives or alternatives
-   * that don't communicate the immutability of the resulting map at the type level.
+   * Prefer {@link ImmutableMap#of(Object, Object)} over more verbose or imprecisely typed
+   * alternatives.
    */
   // XXX: Note that the replacement of `Collections#singletonMap` is incorrect for nullable
   // elements.
-  static final class ImmutableMapOf1<K, V> {
+  static final class ImmutableMapOf2<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1) {
       return Refaster.anyOf(
@@ -276,12 +270,12 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Prefer {@link ImmutableMap#of(Object, Object, Object, Object)} over alternatives that don't
-   * communicate the immutability of the resulting map at the type level.
+   * Prefer {@link ImmutableMap#of(Object, Object, Object, Object)} over more verbose or imprecisely
+   * typed alternatives.
    */
   // XXX: Consider introducing a `BugChecker` to replace these `ImmutableMapOfX` rules. That will
   // also make it easier to rewrite various `ImmutableMap.builder()` variants.
-  static final class ImmutableMapOf2<K, V> {
+  static final class ImmutableMapOf4<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2) {
       return Refaster.anyOf(
@@ -295,12 +289,12 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Prefer {@link ImmutableMap#of(Object, Object, Object, Object, Object, Object)} over
-   * alternatives that don't communicate the immutability of the resulting map at the type level.
+   * Prefer {@link ImmutableMap#of(Object, Object, Object, Object, Object, Object)} over more
+   * verbose or imprecisely typed alternatives.
    */
   // XXX: Consider introducing a `BugChecker` to replace these `ImmutableMapOfX` rules. That will
   // also make it easier to rewrite various `ImmutableMap.builder()` variants.
-  static final class ImmutableMapOf3<K, V> {
+  static final class ImmutableMapOf6<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2, K k3, V v3) {
       return Refaster.anyOf(
@@ -316,13 +310,12 @@ final class ImmutableMapRules {
 
   /**
    * Prefer {@link ImmutableMap#of(Object, Object, Object, Object, Object, Object, Object, Object)}
-   * over alternatives that don't communicate the immutability of the resulting map at the type
-   * level.
+   * over more verbose or imprecisely typed alternatives.
    */
   // XXX: Consider introducing a `BugChecker` to replace these `ImmutableMapOfX` rules. That will
   // also make it easier to rewrite various `ImmutableMap.builder()` variants.
   @SuppressWarnings("java:S107" /* Can't avoid many method parameters here. */)
-  static final class ImmutableMapOf4<K, V> {
+  static final class ImmutableMapOf8<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4) {
       return Refaster.anyOf(
@@ -339,13 +332,12 @@ final class ImmutableMapRules {
 
   /**
    * Prefer {@link ImmutableMap#of(Object, Object, Object, Object, Object, Object, Object, Object,
-   * Object, Object)} over alternatives that don't communicate the immutability of the resulting map
-   * at the type level.
+   * Object, Object)} over more verbose or imprecisely typed alternatives.
    */
   // XXX: Consider introducing a `BugChecker` to replace these `ImmutableMapOfX` rules. That will
   // also make it easier to rewrite various `ImmutableMap.builder()` variants.
   @SuppressWarnings("java:S107" /* Can't avoid many method parameters here. */)
-  static final class ImmutableMapOf5<K, V> {
+  static final class ImmutableMapOf10<K, V> {
     @BeforeTemplate
     Map<K, V> before(K k1, V v1, K k2, V v2, K k3, V v3, K k4, V v4, K k5, V v5) {
       return Refaster.anyOf(
@@ -365,65 +357,62 @@ final class ImmutableMapRules {
   }
 
   /**
-   * Prefer creation of an immutable submap using {@link Maps#filterKeys(Map, Predicate)} over more
-   * contrived alternatives.
+   * Prefer an immutable copy of {@link Maps#filterKeys(Map, Predicate)} over more contrived
+   * alternatives.
    */
   abstract static class ImmutableMapCopyOfMapsFilterKeys<K, V> {
     @Placeholder(allowsIdentity = true)
     abstract boolean keyFilter(@MayOptionallyUse K key);
 
     @BeforeTemplate
-    ImmutableMap<K, V> before(Map<K, V> map) {
-      return map.entrySet().stream()
+    ImmutableMap<K, V> before(Map<K, V> unfiltered) {
+      return unfiltered.entrySet().stream()
           .filter(e -> keyFilter(e.getKey()))
           .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @AfterTemplate
-    ImmutableMap<K, V> after(Map<K, V> map) {
-      return ImmutableMap.copyOf(Maps.filterKeys(map, k -> keyFilter(k)));
+    ImmutableMap<K, V> after(Map<K, V> unfiltered) {
+      return ImmutableMap.copyOf(Maps.filterKeys(unfiltered, k -> keyFilter(k)));
     }
   }
 
   /**
-   * Prefer creation of an immutable submap using {@link Maps#filterValues(Map, Predicate)} over
-   * more contrived alternatives.
+   * Prefer an immutable copy of {@link Maps#filterValues(Map, Predicate)} over more contrived
+   * alternatives.
    */
   abstract static class ImmutableMapCopyOfMapsFilterValues<K, V> {
     @Placeholder(allowsIdentity = true)
     abstract boolean valueFilter(@MayOptionallyUse V value);
 
     @BeforeTemplate
-    ImmutableMap<K, V> before(Map<K, V> map) {
-      return map.entrySet().stream()
+    ImmutableMap<K, V> before(Map<K, V> unfiltered) {
+      return unfiltered.entrySet().stream()
           .filter(e -> valueFilter(e.getValue()))
           .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @AfterTemplate
-    ImmutableMap<K, V> after(Map<K, V> map) {
-      return ImmutableMap.copyOf(Maps.filterValues(map, v -> valueFilter(v)));
+    ImmutableMap<K, V> after(Map<K, V> unfiltered) {
+      return ImmutableMap.copyOf(Maps.filterValues(unfiltered, v -> valueFilter(v)));
     }
   }
 
-  /**
-   * Prefer {@link ImmutableMap#ofEntries(Map.Entry[])} over alternatives that don't communicate the
-   * immutability of the resulting map at the type level.
-   */
-  static final class ImmutableMapOfEntries<K, V> {
+  /** Prefer {@link ImmutableMap#ofEntries(Map.Entry[])} over imprecisely typed alternatives. */
+  static final class ImmutableMapOfEntries<K, V, K2 extends K, V2 extends V> {
     @BeforeTemplate
-    Map<K, V> before(@Repeated Map.Entry<? extends K, ? extends V> entries) {
-      return Map.ofEntries(entries);
+    Map<K, V> before(@Repeated Map.Entry<K2, V2> entries) {
+      return Map.ofEntries(Refaster.asVarargs(entries));
     }
 
     @AfterTemplate
-    ImmutableMap<K, V> after(@Repeated Map.Entry<? extends K, ? extends V> entries) {
-      return ImmutableMap.ofEntries(entries);
+    ImmutableMap<K, V> after(@Repeated Map.Entry<K2, V2> entries) {
+      return ImmutableMap.ofEntries(Refaster.asVarargs(entries));
     }
   }
 
   /** Prefer {@link ImmutableMap.Builder#put(Object, Object)} over more contrived alternatives. */
-  static final class ImmutableMapBuilderPut<K, V> {
+  static final class BuilderPut<K, V> {
     @BeforeTemplate
     ImmutableMap.Builder<K, V> before(ImmutableMap.Builder<K, V> builder, K key, V value) {
       return Refaster.anyOf(
@@ -435,13 +424,4 @@ final class ImmutableMapRules {
       return builder.put(key, value);
     }
   }
-
-  // XXX: Add a rule for this:
-  // Maps.transformValues(streamOfEntries.collect(groupBy(fun)), ImmutableMap::copyOf)
-  // ->
-  // streamOfEntries.collect(groupBy(fun, toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)))
-  //
-  // map.entrySet().stream().filter(keyPred).forEach(mapBuilder::put)
-  // ->
-  // mapBuilder.putAll(Maps.filterKeys(map, pred))
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMultisetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableMultisetRules.java
@@ -34,8 +34,8 @@ final class ImmutableMultisetRules {
     }
   }
 
-  /** Prefer {@link ImmutableMultiset#of()} over more contrived alternatives. */
-  static final class EmptyImmutableMultiset<T> {
+  /** Prefer {@link ImmutableMultiset#of()} over less efficient alternatives. */
+  static final class ImmutableMultisetOf<T> {
     @BeforeTemplate
     ImmutableMultiset<T> before() {
       return Refaster.anyOf(
@@ -49,44 +49,44 @@ final class ImmutableMultisetRules {
   }
 
   /**
-   * Prefer {@link ImmutableMultiset#copyOf(Iterable)} and variants over more contrived
-   * alternatives.
+   * Prefer {@link ImmutableMultiset#copyOf(Iterable)} and variants over less efficient or more
+   * contrived alternatives.
    */
-  static final class IterableToImmutableMultiset<T> {
+  static final class ImmutableMultisetCopyOf<T> {
     @BeforeTemplate
-    ImmutableMultiset<T> before(T[] iterable) {
+    ImmutableMultiset<T> before(T[] elements) {
       return Refaster.anyOf(
-          ImmutableMultiset.<T>builder().add(iterable).build(),
-          Arrays.stream(iterable).collect(toImmutableMultiset()));
+          ImmutableMultiset.<T>builder().add(elements).build(),
+          Arrays.stream(elements).collect(toImmutableMultiset()));
     }
 
     @BeforeTemplate
-    ImmutableMultiset<T> before(Iterator<T> iterable) {
+    ImmutableMultiset<T> before(Iterator<T> elements) {
       return Refaster.anyOf(
-          ImmutableMultiset.<T>builder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableMultiset()));
+          ImmutableMultiset.<T>builder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableMultiset()));
     }
 
     @BeforeTemplate
-    ImmutableMultiset<T> before(Iterable<T> iterable) {
+    ImmutableMultiset<T> before(Iterable<T> elements) {
       return Refaster.anyOf(
-          ImmutableMultiset.<T>builder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableMultiset()));
+          ImmutableMultiset.<T>builder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableMultiset()));
     }
 
     @BeforeTemplate
-    ImmutableMultiset<T> before(Collection<T> iterable) {
-      return iterable.stream().collect(toImmutableMultiset());
+    ImmutableMultiset<T> before(Collection<T> elements) {
+      return elements.stream().collect(toImmutableMultiset());
     }
 
     @AfterTemplate
-    ImmutableMultiset<T> after(Iterable<T> iterable) {
-      return ImmutableMultiset.copyOf(iterable);
+    ImmutableMultiset<T> after(Iterable<T> elements) {
+      return ImmutableMultiset.copyOf(elements);
     }
   }
 
   /** Prefer {@link ImmutableMultiset#toImmutableMultiset()} over less idiomatic alternatives. */
-  static final class StreamToImmutableMultiset<T> {
+  static final class StreamCollectToImmutableMultiset<T> {
     @BeforeTemplate
     ImmutableMultiset<T> before(Stream<T> stream) {
       return ImmutableMultiset.copyOf(stream.iterator());

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRules.java
@@ -176,7 +176,7 @@ final class ImmutableSetMultimapRules {
    * com.google.common.base.Function)} over more contrived alternatives.
    */
   static final class ImmutableSetMultimapCopyOfMultimapsTransformValuesWithFunction<
-      K, S, V1 extends S, T extends V2, V2> {
+      K, S, V1 extends S, V2, T extends V2> {
     // XXX: Drop the `Refaster.anyOf` if we decide to rewrite one to the other.
     @BeforeTemplate
     ImmutableSetMultimap<K, V2> before(Multimap<K, V1> fromMultimap, Function<S, T> function) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRules.java
@@ -42,8 +42,8 @@ final class ImmutableSetMultimapRules {
     }
   }
 
-  /** Prefer {@link ImmutableSetMultimap#of()} over more contrived alternatives. */
-  static final class EmptyImmutableSetMultimap<K, V> {
+  /** Prefer {@link ImmutableSetMultimap#of()} over less efficient alternatives. */
+  static final class ImmutableSetMultimapOf0<K, V> {
     @BeforeTemplate
     ImmutableSetMultimap<K, V> before() {
       return ImmutableSetMultimap.<K, V>builder().build();
@@ -55,74 +55,78 @@ final class ImmutableSetMultimapRules {
     }
   }
 
-  /** Prefer {@link ImmutableSetMultimap#of(Object, Object)} over more contrived alternatives. */
+  /** Prefer {@link ImmutableSetMultimap#of(Object, Object)} over less efficient alternatives. */
   // XXX: One can define variants for more than one key-value pair, but at some point the builder
   // actually produces nicer code. So it's not clear we should add Refaster rules for those
   // variants.
-  static final class PairToImmutableSetMultimap<K, V> {
+  static final class ImmutableSetMultimapOf2<K, V> {
     @BeforeTemplate
-    ImmutableSetMultimap<K, V> before(K key, V value) {
-      return ImmutableSetMultimap.<K, V>builder().put(key, value).build();
+    ImmutableSetMultimap<K, V> before(K k1, V v1) {
+      return ImmutableSetMultimap.<K, V>builder().put(k1, v1).build();
     }
 
     @AfterTemplate
-    ImmutableSetMultimap<K, V> after(K key, V value) {
-      return ImmutableSetMultimap.of(key, value);
+    ImmutableSetMultimap<K, V> after(K k1, V v1) {
+      return ImmutableSetMultimap.of(k1, v1);
     }
   }
 
-  /** Prefer {@link ImmutableSetMultimap#of(Object, Object)} over more contrived alternatives. */
-  static final class EntryToImmutableSetMultimap<K, V> {
+  /**
+   * Prefer {@link ImmutableSetMultimap#of(Object, Object)} over less efficient or more contrived
+   * alternatives.
+   */
+  static final class ImmutableSetMultimapOfEntryGetKeyEntryGetValue<
+      K, V, K2 extends K, V2 extends V> {
     @BeforeTemplate
-    ImmutableSetMultimap<K, V> before(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableSetMultimap<K, V> before(Map.Entry<K2, V2> entry) {
       return Refaster.anyOf(
           ImmutableSetMultimap.<K, V>builder().put(entry).build(),
           Stream.of(entry).collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     @AfterTemplate
-    ImmutableSetMultimap<K, V> after(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableSetMultimap<K, V> after(Map.Entry<K2, V2> entry) {
       return ImmutableSetMultimap.of(entry.getKey(), entry.getValue());
     }
   }
 
-  /** Prefer {@link ImmutableSetMultimap#copyOf(Iterable)} over more contrived alternatives. */
-  static final class IterableToImmutableSetMultimap<K, V> {
+  /**
+   * Prefer {@link ImmutableSetMultimap#copyOf(Iterable)} over less efficient or more contrived
+   * alternatives.
+   */
+  static final class ImmutableSetMultimapCopyOf<
+      K, V, K2 extends K, V2 extends V, E extends Map.Entry<K2, V2>> {
     @BeforeTemplate
-    ImmutableSetMultimap<K, V> before(Multimap<? extends K, ? extends V> iterable) {
+    ImmutableSetMultimap<K, V> before(Multimap<K2, V2> entries) {
       return Refaster.anyOf(
-          ImmutableSetMultimap.copyOf(iterable.entries()),
-          ImmutableSetMultimap.<K, V>builder().putAll(iterable).build());
+          ImmutableSetMultimap.copyOf(entries.entries()),
+          ImmutableSetMultimap.<K, V>builder().putAll(entries).build());
     }
 
     @BeforeTemplate
-    ImmutableSetMultimap<K, V> before(
-        Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
+    ImmutableSetMultimap<K, V> before(Iterable<E> entries) {
       return Refaster.anyOf(
-          ImmutableSetMultimap.<K, V>builder().putAll(iterable).build(),
-          Streams.stream(iterable)
+          ImmutableSetMultimap.<K, V>builder().putAll(entries).build(),
+          Streams.stream(entries)
               .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     @BeforeTemplate
-    ImmutableSetMultimap<K, V> before(
-        Collection<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return iterable.stream()
+    ImmutableSetMultimap<K, V> before(Collection<E> entries) {
+      return entries.stream()
           .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @AfterTemplate
-    ImmutableSetMultimap<K, V> after(
-        Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return ImmutableSetMultimap.copyOf(iterable);
+    ImmutableSetMultimap<K, V> after(Iterable<E> entries) {
+      return ImmutableSetMultimap.copyOf(entries);
     }
   }
 
   /**
-   * Don't map a a stream's elements to map entries, only to subsequently collect them into an
-   * {@link ImmutableSetMultimap}. The collection can be performed directly.
+   * Prefer {@code stream.collect(toImmutableSetMultimap(...))} over more contrived alternatives.
    */
-  abstract static class StreamOfMapEntriesToImmutableSetMultimap<E, K, V> {
+  abstract static class StreamCollectToImmutableSetMultimap<E, K, V> {
     @Placeholder(allowsIdentity = true)
     abstract K keyFunction(@MayOptionallyUse E element);
 
@@ -146,74 +150,71 @@ final class ImmutableSetMultimapRules {
   }
 
   /**
-   * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
-   * com.google.common.base.Function)} over creating and directly collecting a stream.
+   * Prefer an immutable copy of {@link Multimaps#transformValues(Multimap,
+   * com.google.common.base.Function)} over more contrived alternatives.
    */
-  abstract static class TransformMultimapValuesToImmutableSetMultimap<K, V1, V2> {
+  abstract static class ImmutableSetMultimapCopyOfMultimapsTransformValues<K, V1, V2> {
     @Placeholder(allowsIdentity = true)
     abstract V2 valueTransformation(@MayOptionallyUse V1 value);
 
     @BeforeTemplate
-    ImmutableSetMultimap<K, V2> before(Multimap<K, V1> multimap) {
-      return multimap.entries().stream()
+    ImmutableSetMultimap<K, V2> before(Multimap<K, V1> fromMultimap) {
+      return fromMultimap.entries().stream()
           .collect(
               toImmutableSetMultimap(Map.Entry::getKey, e -> valueTransformation(e.getValue())));
     }
 
     @AfterTemplate
-    ImmutableSetMultimap<K, V2> after(Multimap<K, V1> multimap) {
+    ImmutableSetMultimap<K, V2> after(Multimap<K, V1> fromMultimap) {
       return ImmutableSetMultimap.copyOf(
-          Multimaps.transformValues(multimap, e -> valueTransformation(e)));
+          Multimaps.transformValues(fromMultimap, e -> valueTransformation(e)));
     }
   }
 
   /**
-   * Prefer creating an immutable copy of the result of {@link Multimaps#transformValues(Multimap,
-   * com.google.common.base.Function)} over creating and directly collecting a stream.
+   * Prefer an immutable copy of {@link Multimaps#transformValues(Multimap,
+   * com.google.common.base.Function)} over more contrived alternatives.
    */
-  static final class TransformMultimapValuesToImmutableSetMultimap2<K, V1, V2> {
+  static final class ImmutableSetMultimapCopyOfMultimapsTransformValuesWithFunction<
+      K, S, V1 extends S, T extends V2, V2> {
     // XXX: Drop the `Refaster.anyOf` if we decide to rewrite one to the other.
     @BeforeTemplate
-    ImmutableSetMultimap<K, V2> before(
-        Multimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Refaster.anyOf(multimap.asMap(), Multimaps.asMap(multimap)).entrySet().stream()
+    ImmutableSetMultimap<K, V2> before(Multimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Refaster.anyOf(fromMultimap.asMap(), Multimaps.asMap(fromMultimap)).entrySet().stream()
           .collect(
               flatteningToImmutableSetMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
+    }
+
+    @BeforeTemplate
+    ImmutableSetMultimap<K, V2> before(ListMultimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Multimaps.asMap(fromMultimap).entrySet().stream()
+          .collect(
+              flatteningToImmutableSetMultimap(
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
+    }
+
+    @BeforeTemplate
+    ImmutableSetMultimap<K, V2> before(SetMultimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Multimaps.asMap(fromMultimap).entrySet().stream()
+          .collect(
+              flatteningToImmutableSetMultimap(
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
     }
 
     @BeforeTemplate
     ImmutableSetMultimap<K, V2> before(
-        ListMultimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Multimaps.asMap(multimap).entrySet().stream()
+        SortedSetMultimap<K, V1> fromMultimap, Function<S, T> function) {
+      return Multimaps.asMap(fromMultimap).entrySet().stream()
           .collect(
               flatteningToImmutableSetMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
-    }
-
-    @BeforeTemplate
-    ImmutableSetMultimap<K, V2> before(
-        SetMultimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Multimaps.asMap(multimap).entrySet().stream()
-          .collect(
-              flatteningToImmutableSetMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
-    }
-
-    @BeforeTemplate
-    ImmutableSetMultimap<K, V2> before(
-        SortedSetMultimap<K, V1> multimap, Function<? super V1, ? extends V2> transformation) {
-      return Multimaps.asMap(multimap).entrySet().stream()
-          .collect(
-              flatteningToImmutableSetMultimap(
-                  Map.Entry::getKey, e -> e.getValue().stream().map(transformation)));
+                  Map.Entry::getKey, e -> e.getValue().stream().map(function)));
     }
 
     @AfterTemplate
     ImmutableSetMultimap<K, V2> after(
-        Multimap<K, V1> multimap,
-        com.google.common.base.Function<? super V1, ? extends V2> transformation) {
-      return ImmutableSetMultimap.copyOf(Multimaps.transformValues(multimap, transformation));
+        Multimap<K, V1> fromMultimap, com.google.common.base.Function<S, T> function) {
+      return ImmutableSetMultimap.copyOf(Multimaps.transformValues(fromMultimap, function));
     }
   }
 
@@ -221,7 +222,7 @@ final class ImmutableSetMultimapRules {
    * Prefer {@link ImmutableSetMultimap.Builder#put(Object, Object)} over more contrived
    * alternatives.
    */
-  static final class ImmutableSetMultimapBuilderPut<K, V> {
+  static final class BuilderPut<K, V> {
     @BeforeTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
     ImmutableSetMultimap.Builder<K, V> before(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSetRules.java
@@ -42,42 +42,48 @@ final class ImmutableSetRules {
     }
   }
 
-  /** Prefer {@link ImmutableSet#copyOf(Iterable)} and variants over more contrived alternatives. */
-  static final class IterableToImmutableSet<T> {
+  /**
+   * Prefer {@link ImmutableSet#copyOf(Iterable)} and variants over less efficient or more contrived
+   * alternatives.
+   */
+  static final class ImmutableSetCopyOf<T> {
     @BeforeTemplate
-    ImmutableSet<T> before(T[] iterable) {
+    ImmutableSet<T> before(T[] elements) {
       return Refaster.anyOf(
-          ImmutableSet.<T>builder().add(iterable).build(),
-          Arrays.stream(iterable).collect(toImmutableSet()));
+          ImmutableSet.<T>builder().add(elements).build(),
+          Arrays.stream(elements).collect(toImmutableSet()));
     }
 
     @BeforeTemplate
-    ImmutableSet<T> before(Iterator<T> iterable) {
+    ImmutableSet<T> before(Iterator<T> elements) {
       return Refaster.anyOf(
-          ImmutableSet.<T>builder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableSet()));
+          ImmutableSet.<T>builder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableSet()));
     }
 
     @BeforeTemplate
-    ImmutableSet<T> before(Iterable<T> iterable) {
+    ImmutableSet<T> before(Iterable<T> elements) {
       return Refaster.anyOf(
-          ImmutableSet.<T>builder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableSet()));
+          ImmutableSet.<T>builder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableSet()));
     }
 
     @BeforeTemplate
-    ImmutableSet<T> before(Collection<T> iterable) {
-      return iterable.stream().collect(toImmutableSet());
+    ImmutableSet<T> before(Collection<T> elements) {
+      return elements.stream().collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<T> after(Iterable<T> iterable) {
-      return ImmutableSet.copyOf(iterable);
+    ImmutableSet<T> after(Iterable<T> elements) {
+      return ImmutableSet.copyOf(elements);
     }
   }
 
-  /** Prefer {@link ImmutableSet#toImmutableSet()} over less idiomatic alternatives. */
-  static final class StreamToImmutableSet<T> {
+  /**
+   * Prefer {@link ImmutableSet#toImmutableSet()} over less efficient or less idiomatic
+   * alternatives.
+   */
+  static final class StreamCollectToImmutableSet<T> {
     @BeforeTemplate
     ImmutableSet<T> before(Stream<T> stream) {
       return Refaster.anyOf(
@@ -91,26 +97,26 @@ final class ImmutableSetRules {
     }
   }
 
-  /** Prefer {@link SetView#immutableCopy()} over the more verbose alternative. */
-  static final class ImmutableSetCopyOfSetView<T> {
+  /** Prefer {@link SetView#immutableCopy()} over more verbose alternatives. */
+  static final class SetViewImmutableCopy<T> {
     @BeforeTemplate
-    ImmutableSet<T> before(SetView<T> set) {
-      return ImmutableSet.copyOf(set);
+    ImmutableSet<T> before(SetView<T> elements) {
+      return ImmutableSet.copyOf(elements);
     }
 
     @AfterTemplate
-    ImmutableSet<T> after(SetView<T> set) {
-      return set.immutableCopy();
+    ImmutableSet<T> after(SetView<T> elements) {
+      return elements.immutableCopy();
     }
   }
 
   /**
-   * Prefer {@link ImmutableSet#of()} over more contrived alternatives or alternatives that don't
-   * communicate the immutability of the resulting set at the type level.
+   * Prefer {@link ImmutableSet#of()} over imprecisely typed, less efficient, or more contrived
+   * alternatives.
    */
   // XXX: The `Stream` variant may be too contrived to warrant inclusion. Review its usage if/when
   // this and similar Refaster rules are replaced with an Error Prone check.
-  static final class ImmutableSetOf<T> {
+  static final class ImmutableSetOf0<T> {
     @BeforeTemplate
     Set<T> before() {
       return Refaster.anyOf(
@@ -127,8 +133,7 @@ final class ImmutableSetRules {
   }
 
   /**
-   * Prefer {@link ImmutableSet#of(Object)} over more contrived alternatives or alternatives that
-   * don't communicate the immutability of the resulting set at the type level.
+   * Prefer {@link ImmutableSet#of(Object)} over imprecisely typed or more contrived alternatives.
    */
   // XXX: Note that the replacement of `Collections#singleton` is incorrect for nullable elements.
   static final class ImmutableSetOf1<T> {
@@ -143,10 +148,7 @@ final class ImmutableSetRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSet#of(Object, Object)} over alternatives that don't communicate the
-   * immutability of the resulting set at the type level.
-   */
+  /** Prefer {@link ImmutableSet#of(Object, Object)} over imprecisely typed alternatives. */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableSet.builder()` usages.
   static final class ImmutableSetOf2<T> {
@@ -161,10 +163,7 @@ final class ImmutableSetRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSet#of(Object, Object, Object)} over alternatives that don't communicate
-   * the immutability of the resulting set at the type level.
-   */
+  /** Prefer {@link ImmutableSet#of(Object, Object, Object)} over imprecisely typed alternatives. */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableSet.builder()` usages.
   static final class ImmutableSetOf3<T> {
@@ -180,8 +179,8 @@ final class ImmutableSetRules {
   }
 
   /**
-   * Prefer {@link ImmutableSet#of(Object, Object, Object, Object)} over alternatives that don't
-   * communicate the immutability of the resulting set at the type level.
+   * Prefer {@link ImmutableSet#of(Object, Object, Object, Object)} over imprecisely typed
+   * alternatives.
    */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableSet.builder()` usages.
@@ -198,8 +197,8 @@ final class ImmutableSetRules {
   }
 
   /**
-   * Prefer {@link ImmutableSet#of(Object, Object, Object, Object, Object)} over alternatives that
-   * don't communicate the immutability of the resulting set at the type level.
+   * Prefer {@link ImmutableSet#of(Object, Object, Object, Object, Object)} over imprecisely typed
+   * alternatives.
    */
   // XXX: Consider writing an Error Prone check that also flags straightforward
   // `ImmutableSet.builder()` usages.
@@ -216,9 +215,9 @@ final class ImmutableSetRules {
   }
 
   /**
-   * Prefer an immutable copy of {@link Sets#difference(Set, Set)} over more contrived alternatives.
+   * Prefer {@code Sets.difference(set1, set2).immutableCopy()} over less efficient alternatives.
    */
-  static final class SetsDifference<S, T> {
+  static final class SetsDifferenceImmutableCopy<S, T> {
     @BeforeTemplate
     ImmutableSet<S> before(Set<S> set1, Set<T> set2) {
       return set1.stream()
@@ -233,44 +232,45 @@ final class ImmutableSetRules {
   }
 
   /**
-   * Prefer an immutable copy of {@link Sets#difference(Set, Set)} over more contrived alternatives.
+   * Prefer {@code Sets.difference(set, map.keySet()).immutableCopy()} over less efficient
+   * alternatives.
    */
-  static final class SetsDifferenceMap<T, K, V> {
+  static final class SetsDifferenceMapKeySetImmutableCopy<T, K, V> {
     @BeforeTemplate
-    ImmutableSet<T> before(Set<T> set, Map<K, V> map) {
-      return set.stream()
+    ImmutableSet<T> before(Set<T> set1, Map<K, V> map) {
+      return set1.stream()
           .filter(Refaster.anyOf(not(map::containsKey), e -> !map.containsKey(e)))
           .collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<K> after(Set<K> set, Map<K, V> map) {
-      return Sets.difference(set, map.keySet()).immutableCopy();
+    ImmutableSet<T> after(Set<T> set1, Map<K, V> map) {
+      return Sets.difference(set1, map.keySet()).immutableCopy();
     }
   }
 
   /**
-   * Prefer an immutable copy of {@link Sets#difference(Set, Set)} over more contrived alternatives.
+   * Prefer {@code Sets.difference(set, multimap.keySet()).immutableCopy()} over less efficient
+   * alternatives.
    */
-  static final class SetsDifferenceMultimap<T, K, V> {
+  static final class SetsDifferenceMultimapKeySetImmutableCopy<T, K, V> {
     @BeforeTemplate
-    ImmutableSet<T> before(Set<T> set, Multimap<K, V> multimap) {
-      return set.stream()
+    ImmutableSet<T> before(Set<T> set1, Multimap<K, V> multimap) {
+      return set1.stream()
           .filter(Refaster.anyOf(not(multimap::containsKey), e -> !multimap.containsKey(e)))
           .collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<T> after(Set<T> set, Multimap<K, V> multimap) {
-      return Sets.difference(set, multimap.keySet()).immutableCopy();
+    ImmutableSet<T> after(Set<T> set1, Multimap<K, V> multimap) {
+      return Sets.difference(set1, multimap.keySet()).immutableCopy();
     }
   }
 
   /**
-   * Prefer an immutable copy of {@link Sets#intersection(Set, Set)} over more contrived
-   * alternatives.
+   * Prefer {@code Sets.intersection(set1, set2).immutableCopy()} over less efficient alternatives.
    */
-  static final class SetsIntersection<S, T> {
+  static final class SetsIntersectionImmutableCopy<S, T> {
     @BeforeTemplate
     ImmutableSet<S> before(Set<S> set1, Set<T> set2) {
       return set1.stream().filter(set2::contains).collect(toImmutableSet());
@@ -283,39 +283,39 @@ final class ImmutableSetRules {
   }
 
   /**
-   * Prefer an immutable copy of {@link Sets#intersection(Set, Set)} over more contrived
+   * Prefer {@code Sets.intersection(set, map.keySet()).immutableCopy()} over less efficient
    * alternatives.
    */
-  static final class SetsIntersectionMap<T, K, V> {
+  static final class SetsIntersectionMapKeySetImmutableCopy<T, K, V> {
     @BeforeTemplate
-    ImmutableSet<T> before(Set<T> set, Map<K, V> map) {
-      return set.stream().filter(map::containsKey).collect(toImmutableSet());
+    ImmutableSet<T> before(Set<T> set1, Map<K, V> map) {
+      return set1.stream().filter(map::containsKey).collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<T> after(Set<T> set, Map<K, V> map) {
-      return Sets.intersection(set, map.keySet()).immutableCopy();
+    ImmutableSet<T> after(Set<T> set1, Map<K, V> map) {
+      return Sets.intersection(set1, map.keySet()).immutableCopy();
     }
   }
 
   /**
-   * Prefer an immutable copy of {@link Sets#intersection(Set, Set)} over more contrived
+   * Prefer {@code Sets.intersection(set, multimap.keySet()).immutableCopy()} over less efficient
    * alternatives.
    */
-  static final class SetsIntersectionMultimap<T, K, V> {
+  static final class SetsIntersectionMultimapKeySetImmutableCopy<T, K, V> {
     @BeforeTemplate
-    ImmutableSet<T> before(Set<T> set, Multimap<K, V> multimap) {
-      return set.stream().filter(multimap::containsKey).collect(toImmutableSet());
+    ImmutableSet<T> before(Set<T> set1, Multimap<K, V> multimap) {
+      return set1.stream().filter(multimap::containsKey).collect(toImmutableSet());
     }
 
     @AfterTemplate
-    ImmutableSet<T> after(Set<T> set, Multimap<K, V> multimap) {
-      return Sets.intersection(set, multimap.keySet()).immutableCopy();
+    ImmutableSet<T> after(Set<T> set1, Multimap<K, V> multimap) {
+      return Sets.intersection(set1, multimap.keySet()).immutableCopy();
     }
   }
 
-  /** Prefer an immutable copy of {@link Sets#union(Set, Set)} over more contrived alternatives. */
-  static final class SetsUnion<S, T extends S, U extends S> {
+  /** Prefer {@code Sets.union(set1, set2).immutableCopy()} over less efficient alternatives. */
+  static final class SetsUnionImmutableCopy<S, T extends S, U extends S> {
     @BeforeTemplate
     ImmutableSet<S> before(Set<T> set1, Set<U> set2) {
       return Stream.concat(set1.stream(), set2.stream()).collect(toImmutableSet());

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRules.java
@@ -4,7 +4,6 @@ import static com.google.common.collect.ImmutableSortedMap.toImmutableSortedMap;
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static java.util.Comparator.naturalOrder;
 
-import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSortedMap;
 import com.google.common.collect.Streams;
 import com.google.errorprone.refaster.Refaster;
@@ -26,24 +25,21 @@ final class ImmutableSortedMapRules {
   private ImmutableSortedMapRules() {}
 
   /** Prefer {@link ImmutableSortedMap#orderedBy(Comparator)} over the associated constructor. */
-  static final class ImmutableSortedMapBuilder<K, V> {
+  static final class ImmutableSortedMapOrderedBy<K, V> {
     @BeforeTemplate
-    ImmutableSortedMap.Builder<K, V> before(Comparator<K> cmp) {
-      return new ImmutableSortedMap.Builder<>(cmp);
+    ImmutableSortedMap.Builder<K, V> before(Comparator<K> comparator) {
+      return new ImmutableSortedMap.Builder<>(comparator);
     }
 
     @AfterTemplate
-    ImmutableSortedMap.Builder<K, V> after(Comparator<K> cmp) {
-      return ImmutableSortedMap.orderedBy(cmp);
+    ImmutableSortedMap.Builder<K, V> after(Comparator<K> comparator) {
+      return ImmutableSortedMap.orderedBy(comparator);
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSortedMap#naturalOrder()} over the alternative that requires explicitly
-   * providing the {@link Comparator}.
-   */
+  /** Prefer {@link ImmutableSortedMap#naturalOrder()} over more verbose alternatives. */
   // XXX: This rule may drop generic type information, leading to non-compilable code.
-  static final class ImmutableSortedMapNaturalOrderBuilder<K extends Comparable<? super K>, V> {
+  static final class ImmutableSortedMapNaturalOrder<K extends Comparable<? super K>, V> {
     @BeforeTemplate
     ImmutableSortedMap.Builder<K, V> before() {
       return ImmutableSortedMap.orderedBy(Comparator.<K>naturalOrder());
@@ -55,12 +51,9 @@ final class ImmutableSortedMapRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSortedMap#reverseOrder()} over the alternative that requires explicitly
-   * providing the {@link Comparator}.
-   */
+  /** Prefer {@link ImmutableSortedMap#reverseOrder()} over more verbose alternatives. */
   // XXX: This rule may drop generic type information, leading to non-compilable code.
-  static final class ImmutableSortedMapReverseOrderBuilder<K extends Comparable<? super K>, V> {
+  static final class ImmutableSortedMapReverseOrder<K extends Comparable<? super K>, V> {
     @BeforeTemplate
     ImmutableSortedMap.Builder<K, V> before() {
       return ImmutableSortedMap.orderedBy(Comparator.<K>reverseOrder());
@@ -72,8 +65,8 @@ final class ImmutableSortedMapRules {
     }
   }
 
-  /** Prefer {@link ImmutableSortedMap#of()} over more contrived alternatives. */
-  static final class EmptyImmutableSortedMap<K extends Comparable<? super K>, V> {
+  /** Prefer {@link ImmutableSortedMap#of()} over less efficient alternatives. */
+  static final class ImmutableSortedMapOf<K extends Comparable<? super K>, V> {
     @BeforeTemplate
     ImmutableSortedMap<K, V> before() {
       return ImmutableSortedMap.<K, V>naturalOrder().buildOrThrow();
@@ -85,74 +78,79 @@ final class ImmutableSortedMapRules {
     }
   }
 
-  /** Prefer {@link ImmutableSortedMap#of(Object, Object)} over more contrived alternatives. */
+  /** Prefer {@link ImmutableSortedMap#of(Object, Object)} over less efficient alternatives. */
   // XXX: One can define variants for more than one key-value pair, but at some point the builder
   // actually produces nicer code. So it's not clear we should add Refaster rules for those
   // variants.
   // XXX: We could also rewrite builders with non-natural orders, but that would affect
   // `ImmutableSortedMap#comparator()`.
-  static final class PairToImmutableSortedMap<K extends Comparable<? super K>, V> {
+  static final class ImmutableSortedMapOfWithComparableAndObject<
+      K extends Comparable<? super K>, V> {
     @BeforeTemplate
-    ImmutableSortedMap<K, V> before(K key, V value) {
-      return ImmutableSortedMap.<K, V>naturalOrder().put(key, value).buildOrThrow();
+    ImmutableSortedMap<K, V> before(K k1, V v1) {
+      return ImmutableSortedMap.<K, V>naturalOrder().put(k1, v1).buildOrThrow();
     }
 
     @AfterTemplate
-    ImmutableSortedMap<K, V> after(K key, V value) {
-      return ImmutableSortedMap.of(key, value);
+    ImmutableSortedMap<K, V> after(K k1, V v1) {
+      return ImmutableSortedMap.of(k1, v1);
     }
   }
 
-  /** Prefer {@link ImmutableSortedMap#of(Object, Object)} over more contrived alternatives. */
+  /**
+   * Prefer {@link ImmutableSortedMap#of(Object, Object)} over less efficient or more contrived
+   * alternatives.
+   */
   // XXX: We could also rewrite builders with non-natural orders, but that would affect
   // `ImmutableSortedMap#comparator()`.
-  static final class EntryToImmutableSortedMap<K extends Comparable<? super K>, V> {
+  static final class ImmutableSortedMapOfEntryGetKeyEntryGetValue<
+      K extends Comparable<? super K>, V, K2 extends K, V2 extends V> {
     @BeforeTemplate
-    ImmutableSortedMap<K, V> before(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableSortedMap<K, V> before(Map.Entry<K2, V2> entry) {
       return Refaster.anyOf(
           ImmutableSortedMap.<K, V>naturalOrder().put(entry).buildOrThrow(),
           Stream.of(entry).collect(toImmutableSortedMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     @AfterTemplate
-    ImmutableSortedMap<K, V> after(Map.Entry<? extends K, ? extends V> entry) {
+    ImmutableSortedMap<K, V> after(Map.Entry<K2, V2> entry) {
       return ImmutableSortedMap.of(entry.getKey(), entry.getValue());
     }
   }
 
-  /** Prefer {@link ImmutableSortedMap#copyOf(Iterable)} over more contrived alternatives. */
+  /**
+   * Prefer {@link ImmutableSortedMap#copyOf(Iterable)} over more verbose, less efficient, or more
+   * contrived alternatives.
+   */
   // XXX: There's also a variant with a custom Comparator. (And some special cases with
   // `reverseOrder`.) Worth the hassle?
-  static final class IterableToImmutableSortedMap<K extends Comparable<? super K>, V> {
+  static final class ImmutableSortedMapCopyOf<
+      K extends Comparable<? super K>, V, K2 extends K, V2 extends V, E extends Map.Entry<K2, V2>> {
     @BeforeTemplate
-    ImmutableMap<K, V> before(Map<? extends K, ? extends V> iterable) {
+    ImmutableSortedMap<K, V> before(Map<K2, V2> entries) {
       return Refaster.anyOf(
-          ImmutableSortedMap.copyOf(iterable, naturalOrder()),
-          ImmutableSortedMap.copyOf(iterable.entrySet()),
-          ImmutableSortedMap.<K, V>naturalOrder().putAll(iterable).buildOrThrow());
+          ImmutableSortedMap.copyOf(entries, naturalOrder()),
+          ImmutableSortedMap.copyOf(entries.entrySet()),
+          ImmutableSortedMap.<K, V>naturalOrder().putAll(entries).buildOrThrow());
     }
 
     @BeforeTemplate
-    ImmutableSortedMap<K, V> before(
-        Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
+    ImmutableSortedMap<K, V> before(Iterable<E> entries) {
       return Refaster.anyOf(
-          ImmutableSortedMap.copyOf(iterable, naturalOrder()),
-          ImmutableSortedMap.<K, V>naturalOrder().putAll(iterable).buildOrThrow(),
-          Streams.stream(iterable)
+          ImmutableSortedMap.copyOf(entries, naturalOrder()),
+          ImmutableSortedMap.<K, V>naturalOrder().putAll(entries).buildOrThrow(),
+          Streams.stream(entries)
               .collect(toImmutableSortedMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     @BeforeTemplate
-    ImmutableSortedMap<K, V> before(
-        Collection<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return iterable.stream()
-          .collect(toImmutableSortedMap(Map.Entry::getKey, Map.Entry::getValue));
+    ImmutableSortedMap<K, V> before(Collection<E> entries) {
+      return entries.stream().collect(toImmutableSortedMap(Map.Entry::getKey, Map.Entry::getValue));
     }
 
     @AfterTemplate
-    ImmutableSortedMap<K, V> after(
-        Iterable<? extends Map.Entry<? extends K, ? extends V>> iterable) {
-      return ImmutableSortedMap.copyOf(iterable);
+    ImmutableSortedMap<K, V> after(Iterable<E> entries) {
+      return ImmutableSortedMap.copyOf(entries);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRules.java
@@ -25,23 +25,20 @@ final class ImmutableSortedMultisetRules {
   /**
    * Prefer {@link ImmutableSortedMultiset#orderedBy(Comparator)} over the associated constructor.
    */
-  static final class ImmutableSortedMultisetBuilder<T> {
+  static final class ImmutableSortedMultisetOrderedBy<T> {
     @BeforeTemplate
-    ImmutableSortedMultiset.Builder<T> before(Comparator<T> cmp) {
-      return new ImmutableSortedMultiset.Builder<>(cmp);
+    ImmutableSortedMultiset.Builder<T> before(Comparator<T> comparator) {
+      return new ImmutableSortedMultiset.Builder<>(comparator);
     }
 
     @AfterTemplate
-    ImmutableSortedMultiset.Builder<T> after(Comparator<T> cmp) {
-      return ImmutableSortedMultiset.orderedBy(cmp);
+    ImmutableSortedMultiset.Builder<T> after(Comparator<T> comparator) {
+      return ImmutableSortedMultiset.orderedBy(comparator);
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSortedMultiset#naturalOrder()} over the alternative that requires
-   * explicitly providing the {@link Comparator}.
-   */
-  static final class ImmutableSortedMultisetNaturalOrderBuilder<T extends Comparable<? super T>> {
+  /** Prefer {@link ImmutableSortedMultiset#naturalOrder()} over more verbose alternatives. */
+  static final class ImmutableSortedMultisetNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedMultiset.Builder<T> before() {
       return ImmutableSortedMultiset.orderedBy(Comparator.<T>naturalOrder());
@@ -53,11 +50,8 @@ final class ImmutableSortedMultisetRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSortedMultiset#reverseOrder()} over the alternative that requires
-   * explicitly providing the {@link Comparator}.
-   */
-  static final class ImmutableSortedMultisetReverseOrderBuilder<T extends Comparable<? super T>> {
+  /** Prefer {@link ImmutableSortedMultiset#reverseOrder()} over more verbose alternatives. */
+  static final class ImmutableSortedMultisetReverseOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedMultiset.Builder<T> before() {
       return ImmutableSortedMultiset.orderedBy(Comparator.<T>reverseOrder());
@@ -69,8 +63,10 @@ final class ImmutableSortedMultisetRules {
     }
   }
 
-  /** Prefer {@link ImmutableSortedMultiset#of()} over more contrived alternatives. */
-  static final class EmptyImmutableSortedMultiset<T extends Comparable<? super T>> {
+  /**
+   * Prefer {@link ImmutableSortedMultiset#of()} over less efficient or more contrived alternatives.
+   */
+  static final class ImmutableSortedMultisetOf<T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedMultiset<T> before() {
       return Refaster.anyOf(
@@ -85,43 +81,43 @@ final class ImmutableSortedMultisetRules {
   }
 
   /**
-   * Prefer {@link ImmutableSortedMultiset#copyOf(Iterable)} and variants over more contrived
-   * alternatives.
+   * Prefer {@link ImmutableSortedMultiset#copyOf(Iterable)} and variants over more verbose, less
+   * efficient, or more contrived alternatives.
    */
   // XXX: There's also a variant with a custom Comparator. (And some special cases with
   // `reverseOrder`.) Worth the hassle?
-  static final class IterableToImmutableSortedMultiset<T extends Comparable<? super T>> {
+  static final class ImmutableSortedMultisetCopyOf<T extends Comparable<? super T>> {
     @BeforeTemplate
-    ImmutableSortedMultiset<T> before(T[] iterable) {
+    ImmutableSortedMultiset<T> before(T[] elements) {
       return Refaster.anyOf(
-          ImmutableSortedMultiset.<T>naturalOrder().add(iterable).build(),
-          Arrays.stream(iterable).collect(toImmutableSortedMultiset(naturalOrder())));
+          ImmutableSortedMultiset.<T>naturalOrder().add(elements).build(),
+          Arrays.stream(elements).collect(toImmutableSortedMultiset(naturalOrder())));
     }
 
     @BeforeTemplate
-    ImmutableSortedMultiset<T> before(Iterator<T> iterable) {
+    ImmutableSortedMultiset<T> before(Iterator<T> elements) {
       return Refaster.anyOf(
-          ImmutableSortedMultiset.copyOf(naturalOrder(), iterable),
-          ImmutableSortedMultiset.<T>naturalOrder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableSortedMultiset(naturalOrder())));
+          ImmutableSortedMultiset.copyOf(naturalOrder(), elements),
+          ImmutableSortedMultiset.<T>naturalOrder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableSortedMultiset(naturalOrder())));
     }
 
     @BeforeTemplate
-    ImmutableSortedMultiset<T> before(Iterable<T> iterable) {
+    ImmutableSortedMultiset<T> before(Iterable<T> elements) {
       return Refaster.anyOf(
-          ImmutableSortedMultiset.copyOf(naturalOrder(), iterable),
-          ImmutableSortedMultiset.<T>naturalOrder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableSortedMultiset(naturalOrder())));
+          ImmutableSortedMultiset.copyOf(naturalOrder(), elements),
+          ImmutableSortedMultiset.<T>naturalOrder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableSortedMultiset(naturalOrder())));
     }
 
     @BeforeTemplate
-    ImmutableSortedMultiset<T> before(Collection<T> iterable) {
-      return iterable.stream().collect(toImmutableSortedMultiset(naturalOrder()));
+    ImmutableSortedMultiset<T> before(Collection<T> elements) {
+      return elements.stream().collect(toImmutableSortedMultiset(naturalOrder()));
     }
 
     @AfterTemplate
-    ImmutableSortedMultiset<T> after(Iterable<T> iterable) {
-      return ImmutableSortedMultiset.copyOf(iterable);
+    ImmutableSortedMultiset<T> after(Iterable<T> elements) {
+      return ImmutableSortedMultiset.copyOf(elements);
     }
   }
 
@@ -130,7 +126,8 @@ final class ImmutableSortedMultisetRules {
    * idiomatic alternatives.
    */
   // XXX: Also handle the variant with a custom comparator.
-  static final class StreamToImmutableSortedMultiset<T extends Comparable<? super T>> {
+  static final class StreamCollectToImmutableSortedMultisetNaturalOrder<
+      T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedMultiset<T> before(Stream<T> stream) {
       return ImmutableSortedMultiset.copyOf(stream.iterator());

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedSetRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableSortedSetRules.java
@@ -23,23 +23,20 @@ final class ImmutableSortedSetRules {
   private ImmutableSortedSetRules() {}
 
   /** Prefer {@link ImmutableSortedSet#orderedBy(Comparator)} over the associated constructor. */
-  static final class ImmutableSortedSetBuilder<T> {
+  static final class ImmutableSortedSetOrderedBy<T> {
     @BeforeTemplate
-    ImmutableSortedSet.Builder<T> before(Comparator<T> cmp) {
-      return new ImmutableSortedSet.Builder<>(cmp);
+    ImmutableSortedSet.Builder<T> before(Comparator<T> comparator) {
+      return new ImmutableSortedSet.Builder<>(comparator);
     }
 
     @AfterTemplate
-    ImmutableSortedSet.Builder<T> after(Comparator<T> cmp) {
-      return ImmutableSortedSet.orderedBy(cmp);
+    ImmutableSortedSet.Builder<T> after(Comparator<T> comparator) {
+      return ImmutableSortedSet.orderedBy(comparator);
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSortedSet#naturalOrder()} over the alternative that requires explicitly
-   * providing the {@link Comparator}.
-   */
-  static final class ImmutableSortedSetNaturalOrderBuilder<T extends Comparable<? super T>> {
+  /** Prefer {@link ImmutableSortedSet#naturalOrder()} over more verbose alternatives. */
+  static final class ImmutableSortedSetNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedSet.Builder<T> before() {
       return ImmutableSortedSet.orderedBy(Comparator.<T>naturalOrder());
@@ -51,11 +48,8 @@ final class ImmutableSortedSetRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableSortedSet#reverseOrder()} over the alternative that requires explicitly
-   * providing the {@link Comparator}.
-   */
-  static final class ImmutableSortedSetReverseOrderBuilder<T extends Comparable<? super T>> {
+  /** Prefer {@link ImmutableSortedSet#reverseOrder()} over more verbose alternatives. */
+  static final class ImmutableSortedSetReverseOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedSet.Builder<T> before() {
       return ImmutableSortedSet.orderedBy(Comparator.<T>reverseOrder());
@@ -67,8 +61,8 @@ final class ImmutableSortedSetRules {
     }
   }
 
-  /** Prefer {@link ImmutableSortedSet#of()} over more contrived alternatives. */
-  static final class EmptyImmutableSortedSet<T extends Comparable<? super T>> {
+  /** Prefer {@link ImmutableSortedSet#of()} over less efficient or more contrived alternatives. */
+  static final class ImmutableSortedSetOf<T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedSet<T> before() {
       return Refaster.anyOf(
@@ -83,43 +77,43 @@ final class ImmutableSortedSetRules {
   }
 
   /**
-   * Prefer {@link ImmutableSortedSet#copyOf(Iterable)} and variants over more contrived
-   * alternatives.
+   * Prefer {@link ImmutableSortedSet#copyOf(Iterable)} and variants over more verbose, less
+   * efficient, or more contrived alternatives.
    */
   // XXX: There's also a variant with a custom Comparator. (And some special cases with
   // `reverseOrder`.) Worth the hassle?
-  static final class IterableToImmutableSortedSet<T extends Comparable<? super T>> {
+  static final class ImmutableSortedSetCopyOf<T extends Comparable<? super T>> {
     @BeforeTemplate
-    ImmutableSortedSet<T> before(T[] iterable) {
+    ImmutableSortedSet<T> before(T[] elements) {
       return Refaster.anyOf(
-          ImmutableSortedSet.<T>naturalOrder().add(iterable).build(),
-          Arrays.stream(iterable).collect(toImmutableSortedSet(naturalOrder())));
+          ImmutableSortedSet.<T>naturalOrder().add(elements).build(),
+          Arrays.stream(elements).collect(toImmutableSortedSet(naturalOrder())));
     }
 
     @BeforeTemplate
-    ImmutableSortedSet<T> before(Iterator<T> iterable) {
+    ImmutableSortedSet<T> before(Iterator<T> elements) {
       return Refaster.anyOf(
-          ImmutableSortedSet.copyOf(naturalOrder(), iterable),
-          ImmutableSortedSet.<T>naturalOrder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableSortedSet(naturalOrder())));
+          ImmutableSortedSet.copyOf(naturalOrder(), elements),
+          ImmutableSortedSet.<T>naturalOrder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableSortedSet(naturalOrder())));
     }
 
     @BeforeTemplate
-    ImmutableSortedSet<T> before(Iterable<T> iterable) {
+    ImmutableSortedSet<T> before(Iterable<T> elements) {
       return Refaster.anyOf(
-          ImmutableSortedSet.copyOf(naturalOrder(), iterable),
-          ImmutableSortedSet.<T>naturalOrder().addAll(iterable).build(),
-          Streams.stream(iterable).collect(toImmutableSortedSet(naturalOrder())));
+          ImmutableSortedSet.copyOf(naturalOrder(), elements),
+          ImmutableSortedSet.<T>naturalOrder().addAll(elements).build(),
+          Streams.stream(elements).collect(toImmutableSortedSet(naturalOrder())));
     }
 
     @BeforeTemplate
-    ImmutableSortedSet<T> before(Collection<T> iterable) {
-      return iterable.stream().collect(toImmutableSortedSet(naturalOrder()));
+    ImmutableSortedSet<T> before(Collection<T> elements) {
+      return elements.stream().collect(toImmutableSortedSet(naturalOrder()));
     }
 
     @AfterTemplate
-    ImmutableSortedSet<T> after(Iterable<T> iterable) {
-      return ImmutableSortedSet.copyOf(iterable);
+    ImmutableSortedSet<T> after(Iterable<T> elements) {
+      return ImmutableSortedSet.copyOf(elements);
     }
   }
 
@@ -128,9 +122,10 @@ final class ImmutableSortedSetRules {
    * alternatives.
    */
   // XXX: Also handle the variant with a custom comparator.
-  // XXX: Note that this rule rewrites fewer expressions than `StreamToImmutableSet`, because
+  // XXX: Note that this rule rewrites fewer expressions than `StreamCollectToImmutableSet`, because
   // `#compareTo` and `#equals` may be inconsistent. We should separately flag such cases.
-  static final class StreamToImmutableSortedSet<T extends Comparable<? super T>> {
+  static final class StreamCollectToImmutableSortedSetNaturalOrder<
+      T extends Comparable<? super T>> {
     @BeforeTemplate
     ImmutableSortedSet<T> before(Stream<T> stream) {
       return ImmutableSortedSet.copyOf(stream.iterator());

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableTableRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ImmutableTableRules.java
@@ -34,11 +34,8 @@ final class ImmutableTableRules {
     }
   }
 
-  /**
-   * Prefer {@link ImmutableTable.Builder#buildOrThrow()} over the less explicit {@link
-   * ImmutableTable.Builder#build()}.
-   */
-  static final class ImmutableTableBuilderBuildOrThrow<R, C, V> {
+  /** Prefer {@link ImmutableTable.Builder#buildOrThrow()} over less explicit alternatives. */
+  static final class BuilderBuildOrThrow<R, C, V> {
     @BeforeTemplate
     ImmutableTable<R, C, V> before(ImmutableTable.Builder<R, C, V> builder) {
       return builder.build();
@@ -50,10 +47,14 @@ final class ImmutableTableRules {
     }
   }
 
-  /** Prefer {@link ImmutableTable#of(Object, Object, Object)} over more contrived alternatives. */
-  static final class CellToImmutableTable<R, C, V> {
+  /**
+   * Prefer {@link ImmutableTable#of(Object, Object, Object)} over less efficient or more contrived
+   * alternatives.
+   */
+  static final class ImmutableTableOfCellGetRowKeyCellGetColumnKeyCellGetValue<
+      R, C, V, R2 extends R, C2 extends C, V2 extends V> {
     @BeforeTemplate
-    ImmutableTable<R, C, V> before(Table.Cell<? extends R, ? extends C, ? extends V> cell) {
+    ImmutableTable<R, C, V> before(Table.Cell<R2, C2, V2> cell) {
       return Refaster.anyOf(
           ImmutableTable.<R, C, V>builder().put(cell).buildOrThrow(),
           Stream.of(cell)
@@ -63,16 +64,13 @@ final class ImmutableTableRules {
     }
 
     @AfterTemplate
-    ImmutableTable<R, C, V> after(Table.Cell<? extends R, ? extends C, ? extends V> cell) {
+    ImmutableTable<R, C, V> after(Table.Cell<R2, C2, V2> cell) {
       return ImmutableTable.of(cell.getRowKey(), cell.getColumnKey(), cell.getValue());
     }
   }
 
-  /**
-   * Don't map a stream's elements to table cells, only to subsequently collect them into an {@link
-   * ImmutableTable}. The collection can be performed directly.
-   */
-  abstract static class StreamOfCellsToImmutableTable<E, R, C, V> {
+  /** Prefer {@code stream.collect(toImmutableTable(...))} over more contrived alternatives. */
+  abstract static class StreamCollectToImmutableTable<E, R, C, V> {
     @Placeholder(allowsIdentity = true)
     abstract R rowFunction(@MayOptionallyUse E element);
 
@@ -99,7 +97,7 @@ final class ImmutableTableRules {
     }
   }
 
-  /** Prefer {@link ImmutableTable#of()} over more contrived alternatives . */
+  /** Prefer {@link ImmutableTable#of()} over less efficient alternatives. */
   static final class ImmutableTableOf<R, C, V> {
     @BeforeTemplate
     ImmutableTable<R, C, V> before() {
@@ -116,7 +114,7 @@ final class ImmutableTableRules {
    * Prefer {@link ImmutableTable.Builder#put(Object, Object, Object)} over more contrived
    * alternatives.
    */
-  static final class ImmutableTableBuilderPut<R, C, V> {
+  static final class BuilderPut<R, C, V> {
     @BeforeTemplate
     ImmutableTable.Builder<R, C, V> before(
         ImmutableTable.Builder<R, C, V> builder, R rowKey, C columnKey, V value) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/InputStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/InputStreamRules.java
@@ -13,18 +13,20 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class InputStreamRules {
   private InputStreamRules() {}
 
+  /** Prefer {@link InputStream#transferTo(OutputStream)} over non-JDK alternatives. */
   static final class InputStreamTransferTo {
     @BeforeTemplate
-    long before(InputStream in, OutputStream out) throws IOException {
-      return ByteStreams.copy(in, out);
+    long before(InputStream from, OutputStream out) throws IOException {
+      return ByteStreams.copy(from, out);
     }
 
     @AfterTemplate
-    long after(InputStream in, OutputStream out) throws IOException {
-      return in.transferTo(out);
+    long after(InputStream from, OutputStream out) throws IOException {
+      return from.transferTo(out);
     }
   }
 
+  /** Prefer {@link InputStream#readAllBytes()} over non-JDK alternatives. */
   static final class InputStreamReadAllBytes {
     @BeforeTemplate
     byte[] before(InputStream in) throws IOException {
@@ -37,18 +39,20 @@ final class InputStreamRules {
     }
   }
 
+  /** Prefer {@link InputStream#readNBytes(int)} over non-JDK alternatives. */
   static final class InputStreamReadNBytes {
     @BeforeTemplate
-    byte[] before(InputStream in, int n) throws IOException {
-      return ByteStreams.limit(in, n).readAllBytes();
+    byte[] before(InputStream in, int len) throws IOException {
+      return ByteStreams.limit(in, len).readAllBytes();
     }
 
     @AfterTemplate
-    byte[] after(InputStream in, int n) throws IOException {
-      return in.readNBytes(n);
+    byte[] after(InputStream in, int len) throws IOException {
+      return in.readNBytes(len);
     }
   }
 
+  /** Prefer {@link InputStream#skipNBytes(long)} over non-JDK alternatives. */
   static final class InputStreamSkipNBytes {
     @BeforeTemplate
     void before(InputStream in, long n) throws IOException {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/IntStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/IntStreamRules.java
@@ -20,21 +20,21 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class IntStreamRules {
   private IntStreamRules() {}
 
-  /** Prefer {@link IntStream#range(int, int)} over the more contrived alternative. */
-  static final class IntStreamClosedOpenRange {
+  /** Prefer {@link IntStream#range(int, int)} over more verbose alternatives. */
+  static final class IntStreamRange {
     @BeforeTemplate
-    IntStream before(int from, int to) {
-      return IntStream.rangeClosed(from, to - 1);
+    IntStream before(int startInclusive, int endExclusive) {
+      return IntStream.rangeClosed(startInclusive, endExclusive - 1);
     }
 
     @AfterTemplate
-    IntStream after(int from, int to) {
-      return IntStream.range(from, to);
+    IntStream after(int startInclusive, int endExclusive) {
+      return IntStream.range(startInclusive, endExclusive);
     }
   }
 
-  /** Don't unnecessarily call {@link Streams#concat(IntStream...)}. */
-  static final class ConcatOneIntStream {
+  /** Prefer using {@link IntStream}s as-is over more contrived alternatives. */
+  static final class IntStreamIdentity {
     @BeforeTemplate
     IntStream before(IntStream stream) {
       return Streams.concat(stream);
@@ -47,21 +47,21 @@ final class IntStreamRules {
     }
   }
 
-  /** Prefer {@link IntStream#concat(IntStream, IntStream)} over the Guava alternative. */
-  static final class ConcatTwoIntStreams {
+  /** Prefer {@link IntStream#concat(IntStream, IntStream)} over non-JDK alternatives. */
+  static final class IntStreamConcat {
     @BeforeTemplate
-    IntStream before(IntStream s1, IntStream s2) {
-      return Streams.concat(s1, s2);
+    IntStream before(IntStream a, IntStream b) {
+      return Streams.concat(a, b);
     }
 
     @AfterTemplate
-    IntStream after(IntStream s1, IntStream s2) {
-      return IntStream.concat(s1, s2);
+    IntStream after(IntStream a, IntStream b) {
+      return IntStream.concat(a, b);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link IntStream#filter(IntPredicate)} operations. */
-  abstract static class FilterOuterIntStreamAfterFlatMap {
+  /** Prefer {@link IntStream#filter(IntPredicate)} over more contrived alternatives. */
+  abstract static class IntStreamFlatMapFilter {
     @Placeholder
     abstract IntStream toIntStreamFunction(@MayOptionallyUse int element);
 
@@ -76,8 +76,8 @@ final class IntStreamRules {
     }
   }
 
-  /** Avoid unnecessary nesting of {@link IntStream#filter(IntPredicate)} operations. */
-  abstract static class FilterOuterStreamAfterFlatMapToInt<T> {
+  /** Prefer {@link IntStream#filter(IntPredicate)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToIntFilter<T> {
     @Placeholder(allowsIdentity = true)
     abstract IntStream toIntStreamFunction(@MayOptionallyUse T element);
 
@@ -92,73 +92,73 @@ final class IntStreamRules {
     }
   }
 
-  /** Avoid unnecessary nesting of {@link IntStream#map(IntUnaryOperator)} operations. */
-  abstract static class MapOuterIntStreamAfterFlatMap {
+  /** Prefer {@link IntStream#map(IntUnaryOperator)} over more contrived alternatives. */
+  abstract static class IntStreamFlatMapMap {
     @Placeholder
     abstract IntStream toIntStreamFunction(@MayOptionallyUse int element);
 
     @BeforeTemplate
-    IntStream before(IntStream stream, IntUnaryOperator function) {
-      return stream.flatMap(v -> toIntStreamFunction(v).map(function));
+    IntStream before(IntStream stream, IntUnaryOperator unaryOperator) {
+      return stream.flatMap(v -> toIntStreamFunction(v).map(unaryOperator));
     }
 
     @AfterTemplate
-    IntStream after(IntStream stream, IntUnaryOperator function) {
-      return stream.flatMap(v -> toIntStreamFunction(v)).map(function);
+    IntStream after(IntStream stream, IntUnaryOperator unaryOperator) {
+      return stream.flatMap(v -> toIntStreamFunction(v)).map(unaryOperator);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link IntStream#map(IntUnaryOperator)} operations. */
-  abstract static class MapOuterStreamAfterFlatMapToInt<T> {
+  /** Prefer {@link IntStream#map(IntUnaryOperator)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToIntMap<T> {
     @Placeholder(allowsIdentity = true)
     abstract IntStream toIntStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    IntStream before(Stream<T> stream, IntUnaryOperator function) {
-      return stream.flatMapToInt(v -> toIntStreamFunction(v).map(function));
+    IntStream before(Stream<T> stream, IntUnaryOperator unaryOperator) {
+      return stream.flatMapToInt(v -> toIntStreamFunction(v).map(unaryOperator));
     }
 
     @AfterTemplate
-    IntStream after(Stream<T> stream, IntUnaryOperator function) {
-      return stream.flatMapToInt(v -> toIntStreamFunction(v)).map(function);
+    IntStream after(Stream<T> stream, IntUnaryOperator unaryOperator) {
+      return stream.flatMapToInt(v -> toIntStreamFunction(v)).map(unaryOperator);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link IntStream#flatMap(IntFunction)} operations. */
-  abstract static class FlatMapOuterIntStreamAfterFlatMap {
+  /** Prefer {@link IntStream#flatMap(IntFunction)} over more contrived alternatives. */
+  abstract static class IntStreamFlatMapFlatMap<S extends IntStream> {
     @Placeholder
     abstract IntStream toIntStreamFunction(@MayOptionallyUse int element);
 
     @BeforeTemplate
-    IntStream before(IntStream stream, IntFunction<? extends IntStream> function) {
+    IntStream before(IntStream stream, IntFunction<S> function) {
       return stream.flatMap(v -> toIntStreamFunction(v).flatMap(function));
     }
 
     @AfterTemplate
-    IntStream after(IntStream stream, IntFunction<? extends IntStream> function) {
+    IntStream after(IntStream stream, IntFunction<S> function) {
       return stream.flatMap(v -> toIntStreamFunction(v)).flatMap(function);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link IntStream#flatMap(IntFunction)} operations. */
-  abstract static class FlatMapOuterStreamAfterFlatMapToInt<T> {
+  /** Prefer {@link IntStream#flatMap(IntFunction)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToIntFlatMap<T, S extends IntStream> {
     @Placeholder(allowsIdentity = true)
     abstract IntStream toIntStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    IntStream before(Stream<T> stream, IntFunction<? extends IntStream> function) {
+    IntStream before(Stream<T> stream, IntFunction<S> function) {
       return stream.flatMapToInt(v -> toIntStreamFunction(v).flatMap(function));
     }
 
     @AfterTemplate
-    IntStream after(Stream<T> stream, IntFunction<? extends IntStream> function) {
+    IntStream after(Stream<T> stream, IntFunction<S> function) {
       return stream.flatMapToInt(v -> toIntStreamFunction(v)).flatMap(function);
     }
   }
 
   /**
-   * Apply {@link IntStream#filter(IntPredicate)} before {@link IntStream#sorted()} to reduce the
-   * number of elements to sort.
+   * Prefer {@link IntStream#filter(IntPredicate)} before {@link IntStream#sorted()} over less
+   * efficient alternatives.
    */
   static final class IntStreamFilterSorted {
     @BeforeTemplate
@@ -172,8 +172,8 @@ final class IntStreamRules {
     }
   }
 
-  /** In order to test whether a stream has any element, simply try to find one. */
-  static final class IntStreamIsEmpty {
+  /** Prefer {@link IntStream#findAny()} over less efficient alternatives. */
+  static final class IntStreamFindAnyIsEmpty {
     @BeforeTemplate
     boolean before(IntStream stream) {
       return Refaster.anyOf(
@@ -189,8 +189,8 @@ final class IntStreamRules {
     }
   }
 
-  /** In order to test whether a stream has any element, simply try to find one. */
-  static final class IntStreamIsNotEmpty {
+  /** Prefer {@link IntStream#findAny()} over less efficient alternatives. */
+  static final class IntStreamFindAnyIsPresent {
     @BeforeTemplate
     boolean before(IntStream stream) {
       return Refaster.anyOf(
@@ -206,6 +206,7 @@ final class IntStreamRules {
     }
   }
 
+  /** Prefer {@link IntStream#min()} over less efficient alternatives. */
   static final class IntStreamMin {
     @BeforeTemplate
     OptionalInt before(IntStream stream) {
@@ -219,7 +220,7 @@ final class IntStreamRules {
   }
 
   /** Prefer {@link IntStream#noneMatch(IntPredicate)} over more contrived alternatives. */
-  static final class IntStreamNoneMatch {
+  static final class IntStreamNoneMatchWithIntPredicate {
     @BeforeTemplate
     boolean before(IntStream stream, IntPredicate predicate) {
       return Refaster.anyOf(
@@ -234,7 +235,8 @@ final class IntStreamRules {
     }
   }
 
-  abstract static class IntStreamNoneMatch2 {
+  /** Prefer {@link IntStream#noneMatch(IntPredicate)} over less explicit alternatives. */
+  abstract static class IntStreamNoneMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse int element);
 
@@ -264,7 +266,8 @@ final class IntStreamRules {
     }
   }
 
-  static final class IntStreamAllMatch {
+  /** Prefer {@link IntStream#allMatch(IntPredicate)} over more contrived alternatives. */
+  static final class IntStreamAllMatchWithIntPredicate {
     @BeforeTemplate
     boolean before(IntStream stream, IntPredicate predicate) {
       return stream.noneMatch(predicate.negate());
@@ -276,7 +279,8 @@ final class IntStreamRules {
     }
   }
 
-  abstract static class IntStreamAllMatch2 {
+  /** Prefer {@link IntStream#allMatch(IntPredicate)} over less explicit alternatives. */
+  abstract static class IntStreamAllMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse int element);
 
@@ -291,6 +295,7 @@ final class IntStreamRules {
     }
   }
 
+  /** Prefer {@link IntStream#takeWhile(IntPredicate)} over more verbose alternatives. */
   static final class IntStreamTakeWhile {
     @BeforeTemplate
     IntStream before(IntStream stream, IntPredicate predicate) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/IntStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/IntStreamRules.java
@@ -20,7 +20,13 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class IntStreamRules {
   private IntStreamRules() {}
 
-  /** Prefer {@link IntStream#range(int, int)} over more verbose alternatives. */
+  /**
+   * Prefer {@link IntStream#range(int, int)} over more verbose alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior when {@code endExclusive} equals
+   * {@link Integer#MIN_VALUE}: the subtraction {@code endExclusive - 1} overflows to {@link
+   * Integer#MAX_VALUE}, producing a semantically different stream.
+   */
   static final class IntStreamRange {
     @BeforeTemplate
     IntStream before(int startInclusive, int endExclusive) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitRules.java
@@ -15,17 +15,17 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class JUnitRules {
   private JUnitRules() {}
 
-  /** Prefer statically imported {@link Arguments#arguments} over {@link Arguments#of} calls. */
+  /** Prefer {@link Arguments#arguments} over less idiomatic alternatives. */
   static final class ArgumentsEnumeration<T> {
     @BeforeTemplate
-    Arguments before(@Repeated T objects) {
-      return Arguments.of(objects);
+    Arguments before(@Repeated T arguments) {
+      return Arguments.of(arguments);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Arguments after(@Repeated T objects) {
-      return arguments(objects);
+    Arguments after(@Repeated T arguments) {
+      return arguments(arguments);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitRules.java
@@ -15,7 +15,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class JUnitRules {
   private JUnitRules() {}
 
-  /** Prefer {@link Arguments#arguments} over less idiomatic alternatives. */
+  /** Prefer {@link Arguments#arguments(Object...)} over less idiomatic alternatives. */
   static final class ArgumentsEnumeration<T> {
     @BeforeTemplate
     Arguments before(@Repeated T arguments) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -43,6 +43,12 @@ import tech.picnic.errorprone.refaster.matchers.IsLambdaExpressionOrMethodRefere
  */
 // XXX: The `AssertThat*Array*ContainsExactly*` rules assume that `expected` and `actual` are not
 // both `null`.
+// XXX: The `ThrowingSupplier`-typed before-templates below should additionally require that the
+// matched expression is void-compatible (i.e., also satisfies the `ThrowingCallable` functional
+// interface). Without this constraint, a lambda like `() -> "constant"` can match the
+// `ThrowingSupplier<?>` before-template, yet fail to compile as `ThrowingCallable` in the
+// after-template. The `@Matches(IsLambdaExpressionOrMethodReference.class)` annotation added to
+// these templates does not address this; a dedicated matcher is still needed.
 @OnlineDocumentation
 @TypeMigration(
     of = Assertions.class,

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/JUnitToAssertJRules.java
@@ -21,8 +21,11 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import com.google.errorprone.annotations.DoNotCall;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Matches;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.function.Supplier;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractBooleanAssert;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
 import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Assertions;
@@ -30,20 +33,16 @@ import org.junit.jupiter.api.function.Executable;
 import org.junit.jupiter.api.function.ThrowingSupplier;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.annotation.TypeMigration;
+import tech.picnic.errorprone.refaster.matchers.IsLambdaExpressionOrMethodReference;
 
 /**
- * Refaster rules to replace JUnit assertions with AssertJ equivalents.
+ * Refaster rules that replace JUnit APIs with AssertJ equivalents.
  *
- * <p>Note that, while both libraries throw an {@link AssertionError} in case of an assertion
- * failure, the exact subtype used generally differs.
+ * <p><strong>Warning:</strong> while both libraries throw an {@link AssertionError} in case of an
+ * assertion failure, the exact subtype used generally differs.
  */
 // XXX: The `AssertThat*Array*ContainsExactly*` rules assume that `expected` and `actual` are not
 // both `null`.
-// XXX: Introduce a `@Matcher` on `Executable` and `ThrowingSupplier` expressions, such that they
-// are only matched if they are also compatible with the `ThrowingCallable` functional interface.
-// When implementing such a matcher, note that expressions with a non-void return type such as
-// `() -> toString()` match both `ThrowingSupplier` and `ThrowingCallable`, but `() -> "constant"`
-// is only compatible with the former.
 @OnlineDocumentation
 @TypeMigration(
     of = Assertions.class,
@@ -272,7 +271,8 @@ import tech.picnic.errorprone.refaster.annotation.TypeMigration;
 final class JUnitToAssertJRules {
   private JUnitToAssertJRules() {}
 
-  static final class AssertThatBooleanArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyBoolean {
     @BeforeTemplate
     void before(boolean[] actual, boolean[] expected) {
       assertArrayEquals(expected, actual);
@@ -285,35 +285,38 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatBooleanArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyBooleanString {
     @BeforeTemplate
-    void before(boolean[] actual, String message, boolean[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(boolean[] actual, String newErrorMessage, boolean[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean[] actual, String message, boolean[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(boolean[] actual, String newErrorMessage, boolean[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatBooleanArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyBooleanSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(boolean[] actual, Supplier<@Nullable String> message, boolean[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(boolean[] actual, Supplier<@Nullable String> supplier, boolean[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean[] actual, Supplier<@Nullable String> message, boolean[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(boolean[] actual, Supplier<@Nullable String> supplier, boolean[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatByteArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyByte {
     @BeforeTemplate
     void before(byte[] actual, byte[] expected) {
       assertArrayEquals(expected, actual);
@@ -326,35 +329,38 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatByteArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyByteString {
     @BeforeTemplate
-    void before(byte[] actual, String message, byte[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(byte[] actual, String newErrorMessage, byte[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(byte[] actual, String message, byte[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(byte[] actual, String newErrorMessage, byte[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatByteArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyByteSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(byte[] actual, Supplier<@Nullable String> message, byte[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(byte[] actual, Supplier<@Nullable String> supplier, byte[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(byte[] actual, Supplier<@Nullable String> message, byte[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(byte[] actual, Supplier<@Nullable String> supplier, byte[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatCharArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyChar {
     @BeforeTemplate
     void before(char[] actual, char[] expected) {
       assertArrayEquals(expected, actual);
@@ -367,35 +373,38 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatCharArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyCharString {
     @BeforeTemplate
-    void before(char[] actual, String message, char[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(char[] actual, String newErrorMessage, char[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(char[] actual, String message, char[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(char[] actual, String newErrorMessage, char[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatCharArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyCharSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(char[] actual, Supplier<@Nullable String> message, char[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(char[] actual, Supplier<@Nullable String> supplier, char[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(char[] actual, Supplier<@Nullable String> message, char[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(char[] actual, Supplier<@Nullable String> supplier, char[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatShortArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyShort {
     @BeforeTemplate
     void before(short[] actual, short[] expected) {
       assertArrayEquals(expected, actual);
@@ -408,35 +417,38 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatShortArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyShortString {
     @BeforeTemplate
-    void before(short[] actual, String message, short[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(short[] actual, String newErrorMessage, short[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(short[] actual, String message, short[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(short[] actual, String newErrorMessage, short[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatShortArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyShortSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(short[] actual, Supplier<@Nullable String> message, short[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(short[] actual, Supplier<@Nullable String> supplier, short[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(short[] actual, Supplier<@Nullable String> message, short[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(short[] actual, Supplier<@Nullable String> supplier, short[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatIntArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyInt {
     @BeforeTemplate
     void before(int[] actual, int[] expected) {
       assertArrayEquals(expected, actual);
@@ -449,35 +461,38 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatIntArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyIntString {
     @BeforeTemplate
-    void before(int[] actual, String message, int[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(int[] actual, String newErrorMessage, int[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(int[] actual, String message, int[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(int[] actual, String newErrorMessage, int[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatIntArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyIntSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(int[] actual, Supplier<@Nullable String> message, int[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(int[] actual, Supplier<@Nullable String> supplier, int[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(int[] actual, Supplier<@Nullable String> message, int[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(int[] actual, Supplier<@Nullable String> supplier, int[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatLongArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyLong {
     @BeforeTemplate
     void before(long[] actual, long[] expected) {
       assertArrayEquals(expected, actual);
@@ -490,35 +505,38 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatLongArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyLongString {
     @BeforeTemplate
-    void before(long[] actual, String message, long[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(long[] actual, String newErrorMessage, long[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(long[] actual, String message, long[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(long[] actual, String newErrorMessage, long[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatLongArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyLongSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(long[] actual, Supplier<@Nullable String> message, long[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(long[] actual, Supplier<@Nullable String> supplier, long[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(long[] actual, Supplier<@Nullable String> message, long[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(long[] actual, Supplier<@Nullable String> supplier, long[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatFloatArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyFloat {
     @BeforeTemplate
     void before(float[] actual, float[] expected) {
       assertArrayEquals(expected, actual);
@@ -531,76 +549,88 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatFloatArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyFloatString {
     @BeforeTemplate
-    void before(float[] actual, String message, float[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(float[] actual, String newErrorMessage, float[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float[] actual, String message, float[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(float[] actual, String newErrorMessage, float[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatFloatArrayWithFailMessageSupplierContainsExactly {
-    @BeforeTemplate
-    // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(float[] actual, Supplier<@Nullable String> message, float[] expected) {
-      assertArrayEquals(expected, actual, message);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float[] actual, Supplier<@Nullable String> message, float[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
-    }
-  }
-
-  static final class AssertThatFloatArrayContainsExactlyWithOffset {
-    @BeforeTemplate
-    void before(float[] actual, float[] expected, float delta) {
-      assertArrayEquals(expected, actual, delta);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float[] actual, float[] expected, float delta) {
-      assertThat(actual).containsExactly(expected, offset(delta));
-    }
-  }
-
-  static final class AssertThatFloatArrayWithFailMessageContainsExactlyWithOffset {
-    @BeforeTemplate
-    void before(float[] actual, String message, float[] expected, float delta) {
-      assertArrayEquals(expected, actual, delta, message);
-    }
-
-    @AfterTemplate
-    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float[] actual, String message, float[] expected, float delta) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
-    }
-  }
-
-  static final class AssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffset {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyFloatSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(float[] actual, Supplier<@Nullable String> message, float[] expected, float delta) {
-      assertArrayEquals(expected, actual, delta, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(float[] actual, Supplier<@Nullable String> supplier, float[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float[] actual, Supplier<@Nullable String> message, float[] expected, float delta) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    void after(float[] actual, Supplier<@Nullable String> supplier, float[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatDoubleArrayContainsExactly {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatContainsExactlyOffsetFloat {
+    @BeforeTemplate
+    void before(float[] actual, float[] values, float value) {
+      assertArrayEquals(values, actual, value);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, float[] values, float value) {
+      assertThat(actual).containsExactly(values, offset(value));
+    }
+  }
+
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageContainsExactlyOffsetFloatString {
+    @BeforeTemplate
+    void before(float[] actual, String newErrorMessage, float[] values, float value) {
+      assertArrayEquals(values, actual, value, newErrorMessage);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, String newErrorMessage, float[] values, float value) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(values, offset(value));
+    }
+  }
+
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageContainsExactlyOffsetFloatSupplier {
+    @BeforeTemplate
+    // XXX: Drop this suppression once the SonarCloud false positive is resolved.
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(float[] actual, Supplier<@Nullable String> supplier, float[] values, float value) {
+      assertArrayEquals(values, actual, value, supplier);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    void after(float[] actual, Supplier<@Nullable String> supplier, float[] values, float value) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(values, offset(value));
+    }
+  }
+
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyDouble {
     @BeforeTemplate
     void before(double[] actual, double[] expected) {
       assertArrayEquals(expected, actual);
@@ -613,85 +643,90 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatDoubleArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyDoubleString {
     @BeforeTemplate
-    void before(double[] actual, String message, double[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(double[] actual, String newErrorMessage, double[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double[] actual, String message, double[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(double[] actual, String newErrorMessage, double[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatDoubleArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyDoubleSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(double[] actual, Supplier<@Nullable String> message, double[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(double[] actual, Supplier<@Nullable String> supplier, double[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double[] actual, Supplier<@Nullable String> message, double[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(double[] actual, Supplier<@Nullable String> supplier, double[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
-  static final class AssertThatDoubleArrayContainsExactlyWithOffset {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatContainsExactlyOffsetDouble {
     @BeforeTemplate
-    void before(double[] actual, double[] expected, double delta) {
-      assertArrayEquals(expected, actual, delta);
+    void before(double[] actual, double[] values, double value) {
+      assertArrayEquals(values, actual, value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double[] actual, double[] expected, double delta) {
-      assertThat(actual).containsExactly(expected, offset(delta));
+    void after(double[] actual, double[] values, double value) {
+      assertThat(actual).containsExactly(values, offset(value));
     }
   }
 
-  static final class AssertThatDoubleArrayWithFailMessageContainsExactlyWithOffset {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageContainsExactlyOffsetDoubleString {
     @BeforeTemplate
-    void before(double[] actual, String message, double[] expected, double delta) {
-      assertArrayEquals(expected, actual, delta, message);
+    void before(double[] actual, String newErrorMessage, double[] values, double value) {
+      assertArrayEquals(values, actual, value, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double[] actual, String message, double[] expected, double delta) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    void after(double[] actual, String newErrorMessage, double[] values, double value) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(values, offset(value));
     }
   }
 
-  static final class AssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffset {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageContainsExactlyOffsetDoubleSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings(
-        "java:S4449" /* SonarCloud thinks that `messageSupplier` itself is `@Nullable`. */)
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
     void before(
-        double[] actual,
-        Supplier<@Nullable String> messageSupplier,
-        double[] expected,
-        double delta) {
-      assertArrayEquals(expected, actual, delta, messageSupplier);
+        double[] actual, Supplier<@Nullable String> supplier, double[] values, double value) {
+      assertArrayEquals(values, actual, value, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(
-        double[] actual,
-        Supplier<@Nullable String> messageSupplier,
-        double[] expected,
-        double delta) {
-      assertThat(actual).withFailMessage(messageSupplier).containsExactly(expected, offset(delta));
+        double[] actual, Supplier<@Nullable String> supplier, double[] values, double value) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(values, offset(value));
     }
   }
 
-  static final class AssertThatObjectArrayContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactlyObject {
     @BeforeTemplate
     void before(Object[] actual, Object[] expected) {
       assertArrayEquals(expected, actual);
@@ -704,34 +739,37 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatObjectArrayWithFailMessageContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyObjectString {
     @BeforeTemplate
-    void before(Object[] actual, String message, Object[] expected) {
-      assertArrayEquals(expected, actual, message);
+    void before(Object[] actual, String newErrorMessage, Object[] expected) {
+      assertArrayEquals(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object[] actual, String message, Object[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(Object[] actual, String newErrorMessage, Object[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertThatObjectArrayWithFailMessageSupplierContainsExactly {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactlyObjectSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
-    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `message` itself is `@Nullable`. */)
-    void before(Object[] actual, Supplier<@Nullable String> message, Object[] expected) {
-      assertArrayEquals(expected, actual, message);
+    @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
+    void before(Object[] actual, Supplier<@Nullable String> supplier, Object[] expected) {
+      assertArrayEquals(expected, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object[] actual, Supplier<@Nullable String> message, Object[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(Object[] actual, Supplier<@Nullable String> supplier, Object[] expected) {
+      assertThat(actual).withFailMessage(supplier).containsExactly(expected);
     }
   }
 
+  /** Prefer {@link org.assertj.core.api.Assertions#fail()} over non-AssertJ alternatives. */
   static final class Fail<T> {
     @BeforeTemplate
     T before() {
@@ -751,46 +789,55 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class FailWithMessage<T> {
+  /** Prefer {@link org.assertj.core.api.Assertions#fail(String)} over non-AssertJ alternatives. */
+  static final class FailWithString<T> {
     @BeforeTemplate
-    T before(String message) {
-      return Assertions.fail(message);
+    T before(String failureMessage) {
+      return Assertions.fail(failureMessage);
     }
 
     // XXX: Add `@UseImportPolicy(STATIC_IMPORT_ALWAYS)`. See `Fail` comment.
     @AfterTemplate
-    T after(String message) {
-      return fail(message);
+    T after(String failureMessage) {
+      return fail(failureMessage);
     }
   }
 
-  static final class FailWithMessageAndThrowable<T> {
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#fail(String, Throwable)} over non-AssertJ
+   * alternatives.
+   */
+  static final class FailWithStringAndThrowable<T> {
     @BeforeTemplate
-    T before(String message, Throwable throwable) {
-      return Assertions.fail(message, throwable);
+    T before(String failureMessage, Throwable realCause) {
+      return Assertions.fail(failureMessage, realCause);
     }
 
     // XXX: Add `@UseImportPolicy(STATIC_IMPORT_ALWAYS)`. See `Fail` comment.
     @AfterTemplate
-    T after(String message, Throwable throwable) {
-      return fail(message, throwable);
+    T after(String failureMessage, Throwable realCause) {
+      return fail(failureMessage, realCause);
     }
   }
 
+  /**
+   * Prefer {@link org.assertj.core.api.Assertions#fail(Throwable)} over non-AssertJ alternatives.
+   */
   static final class FailWithThrowable<T> {
     @BeforeTemplate
-    T before(Throwable throwable) {
-      return Assertions.fail(throwable);
+    T before(Throwable realCause) {
+      return Assertions.fail(realCause);
     }
 
     // XXX: Add `@UseImportPolicy(STATIC_IMPORT_ALWAYS)`. See `Fail` comment.
     @AfterTemplate
     @DoNotCall
-    T after(Throwable throwable) {
-      return fail(throwable);
+    T after(Throwable realCause) {
+      return fail(realCause);
     }
   }
 
+  /** Prefer {@link AbstractBooleanAssert#isTrue()} over non-AssertJ alternatives. */
   static final class AssertThatIsTrue {
     @BeforeTemplate
     void before(boolean actual) {
@@ -804,20 +851,22 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatWithFailMessageStringIsTrue {
+  /** Prefer {@link AbstractBooleanAssert#isTrue()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsTrueString {
     @BeforeTemplate
-    void before(boolean actual, String message) {
-      assertTrue(actual, message);
+    void before(boolean actual, String newErrorMessage) {
+      assertTrue(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean actual, String message) {
-      assertThat(actual).withFailMessage(message).isTrue();
+    void after(boolean actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isTrue();
     }
   }
 
-  static final class AssertThatWithFailMessageSupplierIsTrue {
+  /** Prefer {@link AbstractBooleanAssert#isTrue()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsTrueSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
@@ -832,6 +881,7 @@ final class JUnitToAssertJRules {
     }
   }
 
+  /** Prefer {@link AbstractBooleanAssert#isFalse()} over non-AssertJ alternatives. */
   static final class AssertThatIsFalse {
     @BeforeTemplate
     void before(boolean actual) {
@@ -845,20 +895,22 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatWithFailMessageStringIsFalse {
+  /** Prefer {@link AbstractBooleanAssert#isFalse()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsFalseString {
     @BeforeTemplate
-    void before(boolean actual, String message) {
-      assertFalse(actual, message);
+    void before(boolean actual, String newErrorMessage) {
+      assertFalse(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean actual, String message) {
-      assertThat(actual).withFailMessage(message).isFalse();
+    void after(boolean actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isFalse();
     }
   }
 
-  static final class AssertThatWithFailMessageSupplierIsFalse {
+  /** Prefer {@link AbstractBooleanAssert#isFalse()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsFalseSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
@@ -873,6 +925,7 @@ final class JUnitToAssertJRules {
     }
   }
 
+  /** Prefer {@link AbstractAssert#isNull()} over non-AssertJ alternatives. */
   static final class AssertThatIsNull {
     @BeforeTemplate
     void before(Object actual) {
@@ -886,20 +939,22 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatWithFailMessageStringIsNull {
+  /** Prefer {@link AbstractAssert#isNull()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNullString {
     @BeforeTemplate
-    void before(Object actual, String message) {
-      assertNull(actual, message);
+    void before(Object actual, String newErrorMessage) {
+      assertNull(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message) {
-      assertThat(actual).withFailMessage(message).isNull();
+    void after(Object actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNull();
     }
   }
 
-  static final class AssertThatWithFailMessageSupplierIsNull {
+  /** Prefer {@link AbstractAssert#isNull()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNullSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
@@ -914,6 +969,7 @@ final class JUnitToAssertJRules {
     }
   }
 
+  /** Prefer {@link AbstractAssert#isNotNull()} over non-AssertJ alternatives. */
   static final class AssertThatIsNotNull {
     @BeforeTemplate
     void before(Object actual) {
@@ -927,20 +983,22 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatWithFailMessageStringIsNotNull {
+  /** Prefer {@link AbstractAssert#isNotNull()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNotNullString {
     @BeforeTemplate
-    void before(Object actual, String message) {
-      assertNotNull(actual, message);
+    void before(Object actual, String newErrorMessage) {
+      assertNotNull(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message) {
-      assertThat(actual).withFailMessage(message).isNotNull();
+    void after(Object actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNotNull();
     }
   }
 
-  static final class AssertThatWithFailMessageSupplierIsNotNull {
+  /** Prefer {@link AbstractAssert#isNotNull()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNotNullSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
@@ -955,6 +1013,7 @@ final class JUnitToAssertJRules {
     }
   }
 
+  /** Prefer {@link AbstractAssert#isSameAs(Object)} over non-AssertJ alternatives. */
   static final class AssertThatIsSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected) {
@@ -968,20 +1027,22 @@ final class JUnitToAssertJRules {
     }
   }
 
-  static final class AssertThatWithFailMessageStringIsSameAs {
+  /** Prefer {@link AbstractAssert#isSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsSameAsString {
     @BeforeTemplate
-    void before(Object actual, String message, Object expected) {
-      assertSame(expected, actual, message);
+    void before(Object actual, String newErrorMessage, Object expected) {
+      assertSame(expected, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message, Object expected) {
-      assertThat(actual).withFailMessage(message).isSameAs(expected);
+    void after(Object actual, String newErrorMessage, Object expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).isSameAs(expected);
     }
   }
 
-  static final class AssertThatWithFailMessageSupplierIsSameAs {
+  /** Prefer {@link AbstractAssert#isSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsSameAsSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
@@ -996,229 +1057,291 @@ final class JUnitToAssertJRules {
     }
   }
 
+  /** Prefer {@link AbstractAssert#isNotSameAs(Object)} over non-AssertJ alternatives. */
   static final class AssertThatIsNotSameAs {
     @BeforeTemplate
-    void before(Object actual, Object expected) {
-      assertNotSame(expected, actual);
+    void before(Object actual, Object other) {
+      assertNotSame(other, actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Object expected) {
-      assertThat(actual).isNotSameAs(expected);
+    void after(Object actual, Object other) {
+      assertThat(actual).isNotSameAs(other);
     }
   }
 
-  static final class AssertThatWithFailMessageStringIsNotSameAs {
+  /** Prefer {@link AbstractAssert#isNotSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNotSameAsString {
     @BeforeTemplate
-    void before(Object actual, String message, Object expected) {
-      assertNotSame(expected, actual, message);
+    void before(Object actual, String newErrorMessage, Object other) {
+      assertNotSame(other, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message, Object expected) {
-      assertThat(actual).withFailMessage(message).isNotSameAs(expected);
+    void after(Object actual, String newErrorMessage, Object other) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNotSameAs(other);
     }
   }
 
-  static final class AssertThatWithFailMessageSupplierIsNotSameAs {
+  /** Prefer {@link AbstractAssert#isNotSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNotSameAsSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
-    void before(Object actual, Supplier<@Nullable String> supplier, Object expected) {
-      assertNotSame(expected, actual, supplier);
+    void before(Object actual, Supplier<@Nullable String> supplier, Object other) {
+      assertNotSame(other, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Supplier<@Nullable String> supplier, Object expected) {
-      assertThat(actual).withFailMessage(supplier).isNotSameAs(expected);
+    void after(Object actual, Supplier<@Nullable String> supplier, Object other) {
+      assertThat(actual).withFailMessage(supplier).isNotSameAs(other);
     }
   }
 
+  /**
+   * Prefer {@code assertThatThrownBy(...).isExactlyInstanceOf(...)} over non-AssertJ alternatives.
+   */
   static final class AssertThatThrownByIsExactlyInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable throwingCallable, Class<T> clazz) {
-      assertThrowsExactly(clazz, throwingCallable);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseThrowable,
+        Class<T> type) {
+      assertThrowsExactly(type, shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable, Class<T> clazz) {
-      assertThatThrownBy(throwingCallable).isExactlyInstanceOf(clazz);
+    void after(ThrowingCallable shouldRaiseThrowable, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable).isExactlyInstanceOf(type);
     }
   }
 
-  static final class AssertThatThrownByWithFailMessageStringIsExactlyInstanceOf<
+  /**
+   * Prefer {@code assertThatThrownBy(...).isExactlyInstanceOf(...)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatThrownByWithFailMessageIsExactlyInstanceOfString<
       T extends Throwable> {
     @BeforeTemplate
-    void before(Executable throwingCallable, String message, Class<T> clazz) {
-      assertThrowsExactly(clazz, throwingCallable, message);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseThrowable,
+        String newErrorMessage,
+        Class<T> type) {
+      assertThrowsExactly(type, shouldRaiseThrowable, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable, String message, Class<T> clazz) {
-      assertThatThrownBy(throwingCallable).withFailMessage(message).isExactlyInstanceOf(clazz);
+    void after(ThrowingCallable shouldRaiseThrowable, String newErrorMessage, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable)
+          .withFailMessage(newErrorMessage)
+          .isExactlyInstanceOf(type);
     }
   }
 
-  static final class AssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf<
+  /**
+   * Prefer {@code assertThatThrownBy(...).isExactlyInstanceOf(...)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatThrownByWithFailMessageIsExactlyInstanceOfSupplier<
       T extends Throwable> {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
-    void before(Executable throwingCallable, Supplier<@Nullable String> supplier, Class<T> clazz) {
-      assertThrowsExactly(clazz, throwingCallable, supplier);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseThrowable,
+        Supplier<@Nullable String> supplier,
+        Class<T> type) {
+      assertThrowsExactly(type, shouldRaiseThrowable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(
-        ThrowingCallable throwingCallable, Supplier<@Nullable String> supplier, Class<T> clazz) {
-      assertThatThrownBy(throwingCallable).withFailMessage(supplier).isExactlyInstanceOf(clazz);
+        ThrowingCallable shouldRaiseThrowable, Supplier<@Nullable String> supplier, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable).withFailMessage(supplier).isExactlyInstanceOf(type);
     }
   }
 
+  /** Prefer {@code assertThatThrownBy(...).isInstanceOf(...)} over non-AssertJ alternatives. */
   static final class AssertThatThrownByIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable throwingCallable, Class<T> clazz) {
-      assertThrows(clazz, throwingCallable);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseThrowable,
+        Class<T> type) {
+      assertThrows(type, shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable, Class<T> clazz) {
-      assertThatThrownBy(throwingCallable).isInstanceOf(clazz);
+    void after(ThrowingCallable shouldRaiseThrowable, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(type);
     }
   }
 
-  static final class AssertThatThrownByWithFailMessageStringIsInstanceOf<T extends Throwable> {
+  /** Prefer {@code assertThatThrownBy(...).isInstanceOf(...)} over non-AssertJ alternatives. */
+  static final class AssertThatThrownByWithFailMessageIsInstanceOfString<T extends Throwable> {
     @BeforeTemplate
-    void before(Executable throwingCallable, String message, Class<T> clazz) {
-      assertThrows(clazz, throwingCallable, message);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseThrowable,
+        String newErrorMessage,
+        Class<T> type) {
+      assertThrows(type, shouldRaiseThrowable, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable, String message, Class<T> clazz) {
-      assertThatThrownBy(throwingCallable).withFailMessage(message).isInstanceOf(clazz);
+    void after(ThrowingCallable shouldRaiseThrowable, String newErrorMessage, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable).withFailMessage(newErrorMessage).isInstanceOf(type);
     }
   }
 
-  static final class AssertThatThrownByWithFailMessageSupplierIsInstanceOf<T extends Throwable> {
+  /** Prefer {@code assertThatThrownBy(...).isInstanceOf(...)} over non-AssertJ alternatives. */
+  static final class AssertThatThrownByWithFailMessageIsInstanceOfSupplier<T extends Throwable> {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
-    void before(Executable throwingCallable, Supplier<@Nullable String> supplier, Class<T> clazz) {
-      assertThrows(clazz, throwingCallable, supplier);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseThrowable,
+        Supplier<@Nullable String> supplier,
+        Class<T> type) {
+      assertThrows(type, shouldRaiseThrowable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
     void after(
-        ThrowingCallable throwingCallable, Supplier<@Nullable String> supplier, Class<T> clazz) {
-      assertThatThrownBy(throwingCallable).withFailMessage(supplier).isInstanceOf(clazz);
+        ThrowingCallable shouldRaiseThrowable, Supplier<@Nullable String> supplier, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable).withFailMessage(supplier).isInstanceOf(type);
     }
   }
 
+  /**
+   * Prefer {@code assertThatCode(...).doesNotThrowAnyException()} over non-AssertJ alternatives.
+   */
   static final class AssertThatCodeDoesNotThrowAnyException {
     @BeforeTemplate
-    void before(Executable throwingCallable) {
-      assertDoesNotThrow(throwingCallable);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseOrNotThrowable) {
+      assertDoesNotThrow(shouldRaiseOrNotThrowable);
     }
 
     @BeforeTemplate
-    void before(ThrowingSupplier<?> throwingCallable) {
-      assertDoesNotThrow(throwingCallable);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class)
+            ThrowingSupplier<?> shouldRaiseOrNotThrowable) {
+      assertDoesNotThrow(shouldRaiseOrNotThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable) {
-      assertThatCode(throwingCallable).doesNotThrowAnyException();
+    void after(ThrowingCallable shouldRaiseOrNotThrowable) {
+      assertThatCode(shouldRaiseOrNotThrowable).doesNotThrowAnyException();
     }
   }
 
-  static final class AssertThatCodeWithFailMessageStringDoesNotThrowAnyException {
+  /**
+   * Prefer {@code assertThatCode(...).doesNotThrowAnyException()} over non-AssertJ alternatives.
+   */
+  static final class AssertThatCodeWithFailMessageDoesNotThrowAnyExceptionString {
     @BeforeTemplate
-    void before(Executable throwingCallable, String message) {
-      assertDoesNotThrow(throwingCallable, message);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseOrNotThrowable,
+        String newErrorMessage) {
+      assertDoesNotThrow(shouldRaiseOrNotThrowable, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(ThrowingSupplier<?> throwingCallable, String message) {
-      assertDoesNotThrow(throwingCallable, message);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class)
+            ThrowingSupplier<?> shouldRaiseOrNotThrowable,
+        String newErrorMessage) {
+      assertDoesNotThrow(shouldRaiseOrNotThrowable, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable, String message) {
-      assertThatCode(throwingCallable).withFailMessage(message).doesNotThrowAnyException();
+    void after(ThrowingCallable shouldRaiseOrNotThrowable, String newErrorMessage) {
+      assertThatCode(shouldRaiseOrNotThrowable)
+          .withFailMessage(newErrorMessage)
+          .doesNotThrowAnyException();
     }
   }
 
-  static final class AssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException {
+  /**
+   * Prefer {@code assertThatCode(...).doesNotThrowAnyException()} over non-AssertJ alternatives.
+   */
+  static final class AssertThatCodeWithFailMessageDoesNotThrowAnyExceptionSupplier {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
-    void before(Executable throwingCallable, Supplier<@Nullable String> supplier) {
-      assertDoesNotThrow(throwingCallable, supplier);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) Executable shouldRaiseOrNotThrowable,
+        Supplier<@Nullable String> supplier) {
+      assertDoesNotThrow(shouldRaiseOrNotThrowable, supplier);
     }
 
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
-    void before(ThrowingSupplier<?> throwingCallable, Supplier<@Nullable String> supplier) {
-      assertDoesNotThrow(throwingCallable, supplier);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class)
+            ThrowingSupplier<?> shouldRaiseOrNotThrowable,
+        Supplier<@Nullable String> supplier) {
+      assertDoesNotThrow(shouldRaiseOrNotThrowable, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable throwingCallable, Supplier<@Nullable String> supplier) {
-      assertThatCode(throwingCallable).withFailMessage(supplier).doesNotThrowAnyException();
+    void after(ThrowingCallable shouldRaiseOrNotThrowable, Supplier<@Nullable String> supplier) {
+      assertThatCode(shouldRaiseOrNotThrowable)
+          .withFailMessage(supplier)
+          .doesNotThrowAnyException();
     }
   }
 
+  /** Prefer {@link AbstractAssert#isInstanceOf(Class)} over non-AssertJ alternatives. */
   static final class AssertThatIsInstanceOf<T> {
     @BeforeTemplate
-    void before(Object actual, Class<T> clazz) {
-      assertInstanceOf(clazz, actual);
+    void before(Object actual, Class<T> type) {
+      assertInstanceOf(type, actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Class<T> clazz) {
-      assertThat(actual).isInstanceOf(clazz);
+    void after(Object actual, Class<T> type) {
+      assertThat(actual).isInstanceOf(type);
     }
   }
 
-  static final class AssertThatWithFailMessageStringIsInstanceOf<T> {
+  /** Prefer {@link AbstractAssert#isInstanceOf(Class)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsInstanceOfString<T> {
     @BeforeTemplate
-    void before(Object actual, String message, Class<T> clazz) {
-      assertInstanceOf(clazz, actual, message);
+    void before(Object actual, String newErrorMessage, Class<T> type) {
+      assertInstanceOf(type, actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message, Class<T> clazz) {
-      assertThat(actual).withFailMessage(message).isInstanceOf(clazz);
+    void after(Object actual, String newErrorMessage, Class<T> type) {
+      assertThat(actual).withFailMessage(newErrorMessage).isInstanceOf(type);
     }
   }
 
-  static final class AssertThatWithFailMessageSupplierIsInstanceOf<T> {
+  /** Prefer {@link AbstractAssert#isInstanceOf(Class)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsInstanceOfSupplier<T> {
     @BeforeTemplate
     // XXX: Drop this suppression once the SonarCloud false positive is resolved.
     @SuppressWarnings("java:S4449" /* SonarCloud thinks that `supplier` itself is `@Nullable`. */)
-    void before(Object actual, Supplier<@Nullable String> supplier, Class<T> clazz) {
-      assertInstanceOf(clazz, actual, supplier);
+    void before(Object actual, Supplier<@Nullable String> supplier, Class<T> type) {
+      assertInstanceOf(type, actual, supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Supplier<@Nullable String> supplier, Class<T> clazz) {
-      assertThat(actual).withFailMessage(supplier).isInstanceOf(clazz);
+    void after(Object actual, Supplier<@Nullable String> supplier, Class<T> type) {
+      assertThat(actual).withFailMessage(supplier).isInstanceOf(type);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/Jackson2Rules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/Jackson2Rules.java
@@ -19,107 +19,100 @@ final class Jackson2Rules {
   /** Prefer {@link JsonNode#optional(int)} over more contrived alternatives. */
   static final class JsonNodeOptionalInt {
     @BeforeTemplate
-    Optional<JsonNode> before(JsonNode node, int index) {
+    Optional<JsonNode> before(JsonNode jsonNode, int index) {
       return Refaster.anyOf(
-          node.get(index).asOptional(),
-          node.path(index).asOptional(),
-          Optional.of(node.get(index)),
-          Optional.ofNullable(node.get(index)));
+          jsonNode.get(index).asOptional(),
+          jsonNode.path(index).asOptional(),
+          Optional.of(jsonNode.get(index)),
+          Optional.ofNullable(jsonNode.get(index)));
     }
 
     @AfterTemplate
-    Optional<JsonNode> after(JsonNode node, int index) {
-      return node.optional(index);
+    Optional<JsonNode> after(JsonNode jsonNode, int index) {
+      return jsonNode.optional(index);
     }
   }
 
   /** Prefer {@link JsonNode#optional(String)} over more contrived alternatives. */
   static final class JsonNodeOptionalString {
     @BeforeTemplate
-    Optional<JsonNode> before(JsonNode node, String fieldName) {
+    Optional<JsonNode> before(JsonNode jsonNode, String propertyName) {
       return Refaster.anyOf(
-          node.get(fieldName).asOptional(),
-          node.path(fieldName).asOptional(),
-          Optional.of(node.get(fieldName)),
-          Optional.ofNullable(node.get(fieldName)));
+          jsonNode.get(propertyName).asOptional(),
+          jsonNode.path(propertyName).asOptional(),
+          Optional.of(jsonNode.get(propertyName)),
+          Optional.ofNullable(jsonNode.get(propertyName)));
     }
 
     @AfterTemplate
-    Optional<JsonNode> after(JsonNode node, String fieldName) {
-      return node.optional(fieldName);
+    Optional<JsonNode> after(JsonNode jsonNode, String propertyName) {
+      return jsonNode.optional(propertyName);
     }
   }
 
-  /**
-   * Prefer {@link ObjectMapper#valueToTree(Object)} over more contrived and less efficient
-   * alternatives.
-   */
+  /** Prefer {@link ObjectMapper#valueToTree(Object)} over less efficient alternatives. */
   static final class ObjectMapperValueToTree {
     @BeforeTemplate
-    JsonNode before(ObjectMapper objectMapper, Object object) throws IOException {
+    JsonNode before(ObjectMapper objectMapper, Object fromValue) throws IOException {
       return Refaster.anyOf(
-          objectMapper.readTree(objectMapper.writeValueAsBytes(object)),
-          objectMapper.readTree(objectMapper.writeValueAsString(object)));
+          objectMapper.readTree(objectMapper.writeValueAsBytes(fromValue)),
+          objectMapper.readTree(objectMapper.writeValueAsString(fromValue)));
     }
 
     @AfterTemplate
-    JsonNode after(ObjectMapper objectMapper, Object object) {
-      return objectMapper.valueToTree(object);
+    JsonNode after(ObjectMapper objectMapper, Object fromValue) {
+      return objectMapper.valueToTree(fromValue);
+    }
+  }
+
+  /** Prefer {@link ObjectMapper#convertValue(Object, Class)} over less efficient alternatives. */
+  static final class ObjectMapperConvertValueClass<T> {
+    @BeforeTemplate
+    T before(ObjectMapper objectMapper, Object fromValue, Class<T> toValueType) throws IOException {
+      return Refaster.anyOf(
+          objectMapper.readValue(objectMapper.writeValueAsBytes(fromValue), toValueType),
+          objectMapper.readValue(objectMapper.writeValueAsString(fromValue), toValueType));
+    }
+
+    @AfterTemplate
+    T after(ObjectMapper objectMapper, Object fromValue, Class<T> toValueType) {
+      return objectMapper.convertValue(fromValue, toValueType);
     }
   }
 
   /**
-   * Prefer {@link ObjectMapper#convertValue(Object, Class)} over more contrived and less efficient
+   * Prefer {@link ObjectMapper#convertValue(Object, JavaType)} over less efficient alternatives.
+   */
+  static final class ObjectMapperConvertValueJavaType<T> {
+    @BeforeTemplate
+    T before(ObjectMapper objectMapper, Object fromValue, JavaType toValueType) throws IOException {
+      return Refaster.anyOf(
+          objectMapper.readValue(objectMapper.writeValueAsBytes(fromValue), toValueType),
+          objectMapper.readValue(objectMapper.writeValueAsString(fromValue), toValueType));
+    }
+
+    @AfterTemplate
+    T after(ObjectMapper objectMapper, Object fromValue, JavaType toValueType) {
+      return objectMapper.convertValue(fromValue, toValueType);
+    }
+  }
+
+  /**
+   * Prefer {@link ObjectMapper#convertValue(Object, TypeReference)} over less efficient
    * alternatives.
    */
-  static final class ObjectMapperConvertValueWithClass<T> {
+  static final class ObjectMapperConvertValueTypeReference<T> {
     @BeforeTemplate
-    T before(ObjectMapper objectMapper, Object object, Class<T> valueType) throws IOException {
-      return Refaster.anyOf(
-          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueType),
-          objectMapper.readValue(objectMapper.writeValueAsString(object), valueType));
-    }
-
-    @AfterTemplate
-    T after(ObjectMapper objectMapper, Object object, Class<T> valueType) {
-      return objectMapper.convertValue(object, valueType);
-    }
-  }
-
-  /**
-   * Prefer {@link ObjectMapper#convertValue(Object, JavaType)} over more contrived and less
-   * efficient alternatives.
-   */
-  static final class ObjectMapperConvertValueWithJavaType<T> {
-    @BeforeTemplate
-    T before(ObjectMapper objectMapper, Object object, JavaType valueType) throws IOException {
-      return Refaster.anyOf(
-          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueType),
-          objectMapper.readValue(objectMapper.writeValueAsString(object), valueType));
-    }
-
-    @AfterTemplate
-    T after(ObjectMapper objectMapper, Object object, JavaType valueType) {
-      return objectMapper.convertValue(object, valueType);
-    }
-  }
-
-  /**
-   * Prefer {@link ObjectMapper#convertValue(Object, TypeReference)} over more contrived and less
-   * efficient alternatives.
-   */
-  static final class ObjectMapperConvertValueWithTypeReference<T> {
-    @BeforeTemplate
-    T before(ObjectMapper objectMapper, Object object, TypeReference<T> valueTypeRef)
+    T before(ObjectMapper objectMapper, Object fromValue, TypeReference<T> toValueTypeRef)
         throws IOException {
       return Refaster.anyOf(
-          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueTypeRef),
-          objectMapper.readValue(objectMapper.writeValueAsString(object), valueTypeRef));
+          objectMapper.readValue(objectMapper.writeValueAsBytes(fromValue), toValueTypeRef),
+          objectMapper.readValue(objectMapper.writeValueAsString(fromValue), toValueTypeRef));
     }
 
     @AfterTemplate
-    T after(ObjectMapper objectMapper, Object object, TypeReference<T> valueTypeRef) {
-      return objectMapper.convertValue(object, valueTypeRef);
+    T after(ObjectMapper objectMapper, Object fromValue, TypeReference<T> toValueTypeRef) {
+      return objectMapper.convertValue(fromValue, toValueTypeRef);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/Jackson3Rules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/Jackson3Rules.java
@@ -18,106 +18,99 @@ final class Jackson3Rules {
   /** Prefer {@link JsonNode#optional(int)} over more contrived alternatives. */
   static final class JsonNodeOptionalInt {
     @BeforeTemplate
-    Optional<JsonNode> before(JsonNode node, int index) {
+    Optional<JsonNode> before(JsonNode jsonNode, int index) {
       return Refaster.anyOf(
-          node.get(index).asOptional(),
-          node.path(index).asOptional(),
-          Optional.of(node.get(index)),
-          Optional.ofNullable(node.get(index)));
+          jsonNode.get(index).asOptional(),
+          jsonNode.path(index).asOptional(),
+          Optional.of(jsonNode.get(index)),
+          Optional.ofNullable(jsonNode.get(index)));
     }
 
     @AfterTemplate
-    Optional<JsonNode> after(JsonNode node, int index) {
-      return node.optional(index);
+    Optional<JsonNode> after(JsonNode jsonNode, int index) {
+      return jsonNode.optional(index);
     }
   }
 
   /** Prefer {@link JsonNode#optional(String)} over more contrived alternatives. */
   static final class JsonNodeOptionalString {
     @BeforeTemplate
-    Optional<JsonNode> before(JsonNode node, String fieldName) {
+    Optional<JsonNode> before(JsonNode jsonNode, String propertyName) {
       return Refaster.anyOf(
-          node.get(fieldName).asOptional(),
-          node.path(fieldName).asOptional(),
-          Optional.of(node.get(fieldName)),
-          Optional.ofNullable(node.get(fieldName)));
+          jsonNode.get(propertyName).asOptional(),
+          jsonNode.path(propertyName).asOptional(),
+          Optional.of(jsonNode.get(propertyName)),
+          Optional.ofNullable(jsonNode.get(propertyName)));
     }
 
     @AfterTemplate
-    Optional<JsonNode> after(JsonNode node, String fieldName) {
-      return node.optional(fieldName);
+    Optional<JsonNode> after(JsonNode jsonNode, String propertyName) {
+      return jsonNode.optional(propertyName);
     }
   }
 
-  /**
-   * Prefer {@link ObjectMapper#valueToTree(Object)} over more contrived and less efficient
-   * alternatives.
-   */
+  /** Prefer {@link ObjectMapper#valueToTree(Object)} over less efficient alternatives. */
   static final class ObjectMapperValueToTree {
     @BeforeTemplate
-    JsonNode before(ObjectMapper objectMapper, Object object) {
+    JsonNode before(ObjectMapper objectMapper, Object fromValue) {
       return Refaster.anyOf(
-          objectMapper.readTree(objectMapper.writeValueAsBytes(object)),
-          objectMapper.readTree(objectMapper.writeValueAsString(object)));
+          objectMapper.readTree(objectMapper.writeValueAsBytes(fromValue)),
+          objectMapper.readTree(objectMapper.writeValueAsString(fromValue)));
     }
 
     @AfterTemplate
-    JsonNode after(ObjectMapper objectMapper, Object object) {
-      return objectMapper.valueToTree(object);
+    JsonNode after(ObjectMapper objectMapper, Object fromValue) {
+      return objectMapper.valueToTree(fromValue);
+    }
+  }
+
+  /** Prefer {@link ObjectMapper#convertValue(Object, Class)} over less efficient alternatives. */
+  static final class ObjectMapperConvertValueClass<T> {
+    @BeforeTemplate
+    T before(ObjectMapper objectMapper, Object fromValue, Class<T> toValueType) {
+      return Refaster.anyOf(
+          objectMapper.readValue(objectMapper.writeValueAsBytes(fromValue), toValueType),
+          objectMapper.readValue(objectMapper.writeValueAsString(fromValue), toValueType));
+    }
+
+    @AfterTemplate
+    T after(ObjectMapper objectMapper, Object fromValue, Class<T> toValueType) {
+      return objectMapper.convertValue(fromValue, toValueType);
     }
   }
 
   /**
-   * Prefer {@link ObjectMapper#convertValue(Object, Class)} over more contrived and less efficient
+   * Prefer {@link ObjectMapper#convertValue(Object, JavaType)} over less efficient alternatives.
+   */
+  static final class ObjectMapperConvertValueJavaType<T> {
+    @BeforeTemplate
+    T before(ObjectMapper objectMapper, Object fromValue, JavaType toValueType) {
+      return Refaster.anyOf(
+          objectMapper.readValue(objectMapper.writeValueAsBytes(fromValue), toValueType),
+          objectMapper.readValue(objectMapper.writeValueAsString(fromValue), toValueType));
+    }
+
+    @AfterTemplate
+    T after(ObjectMapper objectMapper, Object fromValue, JavaType toValueType) {
+      return objectMapper.convertValue(fromValue, toValueType);
+    }
+  }
+
+  /**
+   * Prefer {@link ObjectMapper#convertValue(Object, TypeReference)} over less efficient
    * alternatives.
    */
-  static final class ObjectMapperConvertValueWithClass<T> {
+  static final class ObjectMapperConvertValueTypeReference<T> {
     @BeforeTemplate
-    T before(ObjectMapper objectMapper, Object object, Class<T> valueType) {
+    T before(ObjectMapper objectMapper, Object fromValue, TypeReference<T> toValueTypeRef) {
       return Refaster.anyOf(
-          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueType),
-          objectMapper.readValue(objectMapper.writeValueAsString(object), valueType));
+          objectMapper.readValue(objectMapper.writeValueAsBytes(fromValue), toValueTypeRef),
+          objectMapper.readValue(objectMapper.writeValueAsString(fromValue), toValueTypeRef));
     }
 
     @AfterTemplate
-    T after(ObjectMapper objectMapper, Object object, Class<T> valueType) {
-      return objectMapper.convertValue(object, valueType);
-    }
-  }
-
-  /**
-   * Prefer {@link ObjectMapper#convertValue(Object, JavaType)} over more contrived and less
-   * efficient alternatives.
-   */
-  static final class ObjectMapperConvertValueWithJavaType<T> {
-    @BeforeTemplate
-    T before(ObjectMapper objectMapper, Object object, JavaType valueType) {
-      return Refaster.anyOf(
-          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueType),
-          objectMapper.readValue(objectMapper.writeValueAsString(object), valueType));
-    }
-
-    @AfterTemplate
-    T after(ObjectMapper objectMapper, Object object, JavaType valueType) {
-      return objectMapper.convertValue(object, valueType);
-    }
-  }
-
-  /**
-   * Prefer {@link ObjectMapper#convertValue(Object, TypeReference)} over more contrived and less
-   * efficient alternatives.
-   */
-  static final class ObjectMapperConvertValueWithTypeReference<T> {
-    @BeforeTemplate
-    T before(ObjectMapper objectMapper, Object object, TypeReference<T> valueTypeRef) {
-      return Refaster.anyOf(
-          objectMapper.readValue(objectMapper.writeValueAsBytes(object), valueTypeRef),
-          objectMapper.readValue(objectMapper.writeValueAsString(object), valueTypeRef));
-    }
-
-    @AfterTemplate
-    T after(ObjectMapper objectMapper, Object object, TypeReference<T> valueTypeRef) {
-      return objectMapper.convertValue(object, valueTypeRef);
+    T after(ObjectMapper objectMapper, Object fromValue, TypeReference<T> toValueTypeRef) {
+      return objectMapper.convertValue(fromValue, toValueTypeRef);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java
@@ -20,21 +20,21 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class LongStreamRules {
   private LongStreamRules() {}
 
-  /** Prefer {@link LongStream#range(long, long)} over the more contrived alternative. */
-  static final class LongStreamClosedOpenRange {
+  /** Prefer {@link LongStream#range(long, long)} over more verbose alternatives. */
+  static final class LongStreamRange {
     @BeforeTemplate
-    LongStream before(long from, long to) {
-      return LongStream.rangeClosed(from, to - 1);
+    LongStream before(long startInclusive, long endExclusive) {
+      return LongStream.rangeClosed(startInclusive, endExclusive - 1);
     }
 
     @AfterTemplate
-    LongStream after(long from, long to) {
-      return LongStream.range(from, to);
+    LongStream after(long startInclusive, long endExclusive) {
+      return LongStream.range(startInclusive, endExclusive);
     }
   }
 
-  /** Don't unnecessarily call {@link Streams#concat(LongStream...)}. */
-  static final class ConcatOneLongStream {
+  /** Prefer the {@link LongStream} as-is over more contrived alternatives. */
+  static final class LongStreamIdentity {
     @BeforeTemplate
     LongStream before(LongStream stream) {
       return Streams.concat(stream);
@@ -47,21 +47,21 @@ final class LongStreamRules {
     }
   }
 
-  /** Prefer {@link LongStream#concat(LongStream, LongStream)} over the Guava alternative. */
-  static final class ConcatTwoLongStreams {
+  /** Prefer {@link LongStream#concat(LongStream, LongStream)} over non-JDK alternatives. */
+  static final class LongStreamConcat {
     @BeforeTemplate
-    LongStream before(LongStream s1, LongStream s2) {
-      return Streams.concat(s1, s2);
+    LongStream before(LongStream a, LongStream b) {
+      return Streams.concat(a, b);
     }
 
     @AfterTemplate
-    LongStream after(LongStream s1, LongStream s2) {
-      return LongStream.concat(s1, s2);
+    LongStream after(LongStream a, LongStream b) {
+      return LongStream.concat(a, b);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link LongStream#filter(LongPredicate)} operations. */
-  abstract static class FilterOuterLongStreamAfterFlatMap {
+  /** Prefer {@link LongStream#filter(LongPredicate)} over more contrived alternatives. */
+  abstract static class LongStreamFlatMapFilter {
     @Placeholder
     abstract LongStream toLongStreamFunction(@MayOptionallyUse long element);
 
@@ -76,8 +76,8 @@ final class LongStreamRules {
     }
   }
 
-  /** Avoid unnecessary nesting of {@link LongStream#filter(LongPredicate)} operations. */
-  abstract static class FilterOuterStreamAfterFlatMapToLong<T> {
+  /** Prefer {@link LongStream#filter(LongPredicate)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToLongFilter<T> {
     @Placeholder(allowsIdentity = true)
     abstract LongStream toLongStreamFunction(@MayOptionallyUse T element);
 
@@ -92,73 +92,73 @@ final class LongStreamRules {
     }
   }
 
-  /** Avoid unnecessary nesting of {@link LongStream#map(LongUnaryOperator)} operations. */
-  abstract static class MapOuterLongStreamAfterFlatMap {
+  /** Prefer {@link LongStream#map(LongUnaryOperator)} over more contrived alternatives. */
+  abstract static class LongStreamFlatMapMap {
     @Placeholder
     abstract LongStream toLongStreamFunction(@MayOptionallyUse long element);
 
     @BeforeTemplate
-    LongStream before(LongStream stream, LongUnaryOperator function) {
-      return stream.flatMap(v -> toLongStreamFunction(v).map(function));
+    LongStream before(LongStream stream, LongUnaryOperator unaryOperator) {
+      return stream.flatMap(v -> toLongStreamFunction(v).map(unaryOperator));
     }
 
     @AfterTemplate
-    LongStream after(LongStream stream, LongUnaryOperator function) {
-      return stream.flatMap(v -> toLongStreamFunction(v)).map(function);
+    LongStream after(LongStream stream, LongUnaryOperator unaryOperator) {
+      return stream.flatMap(v -> toLongStreamFunction(v)).map(unaryOperator);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link LongStream#map(LongUnaryOperator)} operations. */
-  abstract static class MapOuterStreamAfterFlatMapToLong<T> {
+  /** Prefer {@link LongStream#map(LongUnaryOperator)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToLongMap<T> {
     @Placeholder(allowsIdentity = true)
     abstract LongStream toLongStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    LongStream before(Stream<T> stream, LongUnaryOperator function) {
-      return stream.flatMapToLong(v -> toLongStreamFunction(v).map(function));
+    LongStream before(Stream<T> stream, LongUnaryOperator unaryOperator) {
+      return stream.flatMapToLong(v -> toLongStreamFunction(v).map(unaryOperator));
     }
 
     @AfterTemplate
-    LongStream after(Stream<T> stream, LongUnaryOperator function) {
-      return stream.flatMapToLong(v -> toLongStreamFunction(v)).map(function);
+    LongStream after(Stream<T> stream, LongUnaryOperator unaryOperator) {
+      return stream.flatMapToLong(v -> toLongStreamFunction(v)).map(unaryOperator);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link LongStream#flatMap(LongFunction)} operations. */
-  abstract static class FlatMapOuterLongStreamAfterFlatMap {
+  /** Prefer {@link LongStream#flatMap(LongFunction)} over more contrived alternatives. */
+  abstract static class LongStreamFlatMapFlatMap<S extends LongStream> {
     @Placeholder
     abstract LongStream toLongStreamFunction(@MayOptionallyUse long element);
 
     @BeforeTemplate
-    LongStream before(LongStream stream, LongFunction<? extends LongStream> function) {
+    LongStream before(LongStream stream, LongFunction<S> function) {
       return stream.flatMap(v -> toLongStreamFunction(v).flatMap(function));
     }
 
     @AfterTemplate
-    LongStream after(LongStream stream, LongFunction<? extends LongStream> function) {
+    LongStream after(LongStream stream, LongFunction<S> function) {
       return stream.flatMap(v -> toLongStreamFunction(v)).flatMap(function);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link LongStream#flatMap(LongFunction)} operations. */
-  abstract static class FlatMapOuterStreamAfterFlatMapToLong<T> {
+  /** Prefer {@link LongStream#flatMap(LongFunction)} over more contrived alternatives. */
+  abstract static class StreamFlatMapToLongFlatMap<T, S extends LongStream> {
     @Placeholder(allowsIdentity = true)
     abstract LongStream toLongStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    LongStream before(Stream<T> stream, LongFunction<? extends LongStream> function) {
+    LongStream before(Stream<T> stream, LongFunction<S> function) {
       return stream.flatMapToLong(v -> toLongStreamFunction(v).flatMap(function));
     }
 
     @AfterTemplate
-    LongStream after(Stream<T> stream, LongFunction<? extends LongStream> function) {
+    LongStream after(Stream<T> stream, LongFunction<S> function) {
       return stream.flatMapToLong(v -> toLongStreamFunction(v)).flatMap(function);
     }
   }
 
   /**
-   * Apply {@link LongStream#filter(LongPredicate)} before {@link LongStream#sorted()} to reduce the
-   * number of elements to sort.
+   * Prefer {@link LongStream#filter(LongPredicate)} before {@link LongStream#sorted()} over less
+   * efficient alternatives.
    */
   static final class LongStreamFilterSorted {
     @BeforeTemplate
@@ -172,8 +172,8 @@ final class LongStreamRules {
     }
   }
 
-  /** In order to test whether a stream has any element, simply try to find one. */
-  static final class LongStreamIsEmpty {
+  /** Prefer {@link LongStream#findAny()} over less efficient alternatives. */
+  static final class LongStreamFindAnyIsEmpty {
     @BeforeTemplate
     boolean before(LongStream stream) {
       return Refaster.anyOf(
@@ -189,8 +189,8 @@ final class LongStreamRules {
     }
   }
 
-  /** In order to test whether a stream has any element, simply try to find one. */
-  static final class LongStreamIsNotEmpty {
+  /** Prefer {@link LongStream#findAny()} over less efficient alternatives. */
+  static final class LongStreamFindAnyIsPresent {
     @BeforeTemplate
     boolean before(LongStream stream) {
       return Refaster.anyOf(
@@ -206,6 +206,7 @@ final class LongStreamRules {
     }
   }
 
+  /** Prefer {@link LongStream#min()} over less efficient alternatives. */
   static final class LongStreamMin {
     @BeforeTemplate
     OptionalLong before(LongStream stream) {
@@ -219,7 +220,7 @@ final class LongStreamRules {
   }
 
   /** Prefer {@link LongStream#noneMatch(LongPredicate)} over more contrived alternatives. */
-  static final class LongStreamNoneMatch {
+  static final class LongStreamNoneMatchWithLongPredicate {
     @BeforeTemplate
     boolean before(LongStream stream, LongPredicate predicate) {
       return Refaster.anyOf(
@@ -234,7 +235,8 @@ final class LongStreamRules {
     }
   }
 
-  abstract static class LongStreamNoneMatch2 {
+  /** Prefer {@link LongStream#noneMatch(LongPredicate)} over less explicit alternatives. */
+  abstract static class LongStreamNoneMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse long element);
 
@@ -264,7 +266,8 @@ final class LongStreamRules {
     }
   }
 
-  static final class LongStreamAllMatch {
+  /** Prefer {@link LongStream#allMatch(LongPredicate)} over more contrived alternatives. */
+  static final class LongStreamAllMatchWithLongPredicate {
     @BeforeTemplate
     boolean before(LongStream stream, LongPredicate predicate) {
       return stream.noneMatch(predicate.negate());
@@ -276,7 +279,8 @@ final class LongStreamRules {
     }
   }
 
-  abstract static class LongStreamAllMatch2 {
+  /** Prefer {@link LongStream#allMatch(LongPredicate)} over less explicit alternatives. */
+  abstract static class LongStreamAllMatch {
     @Placeholder
     abstract boolean test(@MayOptionallyUse long element);
 
@@ -291,6 +295,7 @@ final class LongStreamRules {
     }
   }
 
+  /** Prefer {@link LongStream#takeWhile(LongPredicate)} over more verbose alternatives. */
   static final class LongStreamTakeWhile {
     @BeforeTemplate
     LongStream before(LongStream stream, LongPredicate predicate) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/LongStreamRules.java
@@ -20,7 +20,13 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class LongStreamRules {
   private LongStreamRules() {}
 
-  /** Prefer {@link LongStream#range(long, long)} over more verbose alternatives. */
+  /**
+   * Prefer {@link LongStream#range(long, long)} over more verbose alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior when {@code endExclusive} equals
+   * {@link Long#MIN_VALUE}: the subtraction {@code endExclusive - 1} overflows to {@link
+   * Long#MAX_VALUE}, producing a semantically different stream.
+   */
   static final class LongStreamRange {
     @BeforeTemplate
     LongStream before(long startInclusive, long endExclusive) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapEntryRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapEntryRules.java
@@ -28,7 +28,7 @@ final class MapEntryRules {
    * <p><strong>Warning:</strong> while both {@link Maps#immutableEntry(Object, Object)} and {@link
    * AbstractMap.SimpleImmutableEntry} allow {@code null} keys and values, the preferred {@link
    * Map#entry(Object, Object)} variant does not. Moreover, the {@link Map.Entry} instances produced
-   * by the former approaches is {@link java.io.Serializable}, while this does not hold for the
+   * by the former approaches are {@link java.io.Serializable}, while this does not hold for the
    * object returned by the preferred approach.
    */
   static final class MapEntry<K, V> {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapEntryRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapEntryRules.java
@@ -22,31 +22,31 @@ final class MapEntryRules {
   private MapEntryRules() {}
 
   /**
-   * Prefer {@link Map#entry(Object, Object)} over alternative ways to create an immutable map
-   * entry.
+   * Prefer {@link Map#entry(Object, Object)} over non-JDK alternatives or the associated
+   * constructor.
    *
    * <p><strong>Warning:</strong> while both {@link Maps#immutableEntry(Object, Object)} and {@link
-   * AbstractMap.SimpleImmutableEntry} allow {@code null} keys and values, the preferred @link
+   * AbstractMap.SimpleImmutableEntry} allow {@code null} keys and values, the preferred {@link
    * Map#entry(Object, Object)} variant does not. Moreover, the {@link Map.Entry} instances produced
    * by the former approaches is {@link java.io.Serializable}, while this does not hold for the
    * object returned by the preferred approach.
    */
   static final class MapEntry<K, V> {
     @BeforeTemplate
-    Map.Entry<K, V> before(K key, V value) {
+    Map.Entry<K, V> before(K k, V v) {
       return Refaster.anyOf(
-          Maps.immutableEntry(key, value), new AbstractMap.SimpleImmutableEntry<>(key, value));
+          Maps.immutableEntry(k, v), new AbstractMap.SimpleImmutableEntry<>(k, v));
     }
 
     @AfterTemplate
-    Map.Entry<K, V> after(K key, V value) {
-      return Map.entry(key, value);
+    Map.Entry<K, V> after(K k, V v) {
+      return Map.entry(k, v);
     }
   }
 
   /** Prefer {@link Map.Entry#comparingByKey()} over more verbose alternatives. */
   // XXX: Also rewrite `Comparator.comparing{Double,Int,Long}(Map.Entry::getKey)`.
-  static final class MapEntryComparingByKey<K extends Comparable<? super K>, V> {
+  static final class ComparingByKey<K extends Comparable<? super K>, V> {
     @BeforeTemplate
     Comparator<Map.Entry<K, V>> before() {
       return Refaster.anyOf(comparing(Map.Entry::getKey), comparingByKey(naturalOrder()));
@@ -60,22 +60,22 @@ final class MapEntryRules {
   }
 
   /** Prefer {@link Map.Entry#comparingByKey(Comparator)} over more verbose alternatives. */
-  static final class MapEntryComparingByKeyWithCustomComparator<K, V> {
+  static final class ComparingByKeyWithComparator<K extends C, V, C> {
     @BeforeTemplate
-    Comparator<Map.Entry<K, V>> before(Comparator<? super K> cmp) {
+    Comparator<Map.Entry<K, V>> before(Comparator<C> cmp) {
       return comparing(Map.Entry::getKey, cmp);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Comparator<Map.Entry<K, V>> after(Comparator<? super K> cmp) {
+    Comparator<Map.Entry<K, V>> after(Comparator<C> cmp) {
       return comparingByKey(cmp);
     }
   }
 
   /** Prefer {@link Map.Entry#comparingByValue()} over more verbose alternatives. */
   // XXX: Also rewrite `Comparator.comparing{Double,Int,Long}(Map.Entry::getValue)`.
-  static final class MapEntryComparingByValue<K, V extends Comparable<? super V>> {
+  static final class ComparingByValue<K, V extends Comparable<? super V>> {
     @BeforeTemplate
     Comparator<Map.Entry<K, V>> before() {
       return Refaster.anyOf(comparing(Map.Entry::getValue), comparingByValue(naturalOrder()));
@@ -89,15 +89,15 @@ final class MapEntryRules {
   }
 
   /** Prefer {@link Map.Entry#comparingByValue(Comparator)} over more verbose alternatives. */
-  static final class MapEntryComparingByValueWithCustomComparator<K, V> {
+  static final class ComparingByValueWithComparator<K, V extends C, C> {
     @BeforeTemplate
-    Comparator<Map.Entry<K, V>> before(Comparator<? super V> cmp) {
+    Comparator<Map.Entry<K, V>> before(Comparator<C> cmp) {
       return comparing(Map.Entry::getValue, cmp);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Comparator<Map.Entry<K, V>> after(Comparator<? super V> cmp) {
+    Comparator<Map.Entry<K, V>> after(Comparator<C> cmp) {
       return comparingByValue(cmp);
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -17,7 +17,13 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class MapRules {
   private MapRules() {}
 
-  /** Prefer {@link EnumMap} over less efficient alternatives. */
+  /**
+   * Prefer {@link EnumMap} over less efficient alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if null keys are used: {@link
+   * HashMap} permits them, while {@link EnumMap} throws a {@link NullPointerException}.
+   * Additionally, {@link EnumMap} iterates in enum-declaration order rather than insertion order.
+   */
   // XXX: We could add a rule for `new EnumMap(Map<K, ? extends V> m)`, but that constructor does
   // not allow an empty non-EnumMap to be provided.
   @SuppressWarnings("NonApiType" /* Refaster templates declare the most specific return type. */)
@@ -117,7 +123,7 @@ final class MapRules {
     }
   }
 
-  /** Prefer {@link Map#keySet()} over more contrived alternatives. */
+  /** Prefer {@code map.keySet().stream()} over more contrived alternatives. */
   static final class MapKeySetStream<K, V> {
     @BeforeTemplate
     Stream<K> before(Map<K, V> map) {
@@ -130,7 +136,7 @@ final class MapRules {
     }
   }
 
-  /** Prefer {@link Map#values()} over more contrived alternatives. */
+  /** Prefer {@code map.values().stream()} over more contrived alternatives. */
   static final class MapValuesStream<K, V> {
     @BeforeTemplate
     Stream<V> before(Map<K, V> map) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MapRules.java
@@ -17,21 +17,24 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class MapRules {
   private MapRules() {}
 
+  /** Prefer {@link EnumMap} over less efficient alternatives. */
   // XXX: We could add a rule for `new EnumMap(Map<K, ? extends V> m)`, but that constructor does
   // not allow an empty non-EnumMap to be provided.
-  static final class CreateEnumMap<K extends Enum<K>, V> {
+  @SuppressWarnings("NonApiType" /* Refaster templates declare the most specific return type. */)
+  static final class NewEnumMapClass<K extends Enum<K>, V> {
     @BeforeTemplate
-    Map<K, V> before() {
+    HashMap<K, V> before() {
       return new HashMap<>();
     }
 
     @AfterTemplate
-    Map<K, V> after() {
+    EnumMap<K, V> after() {
       return new EnumMap<>(Refaster.<K>clazz());
     }
   }
 
-  static final class MapGetOrNull<K, V, T> {
+  /** Prefer {@link Map#get(Object)} over more verbose alternatives. */
+  static final class MapGet<K, V, T> {
     @BeforeTemplate
     @Nullable V before(Map<K, V> map, T key) {
       return map.getOrDefault(key, null);
@@ -43,9 +46,13 @@ final class MapRules {
     }
   }
 
-  /** Prefer {@link Map#getOrDefault(Object, Object)} over more contrived alternatives. */
-  // XXX: Note that `requireNonNullElse` throws an NPE if the second argument is `null`, while the
-  // alternative does not.
+  /**
+   * Prefer {@link Map#getOrDefault(Object, Object)} over more contrived alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if {@code defaultValue} is {@code
+   * null}: {@link java.util.Objects#requireNonNullElse} throws a {@link NullPointerException} in
+   * that case, while {@link Map#getOrDefault(Object, Object)} does not.
+   */
   static final class MapGetOrDefault<K, V, T> {
     @BeforeTemplate
     V before(Map<K, V> map, T key, V defaultValue) {
@@ -110,8 +117,8 @@ final class MapRules {
     }
   }
 
-  /** Don't unnecessarily use {@link Map#entrySet()}. */
-  static final class MapKeyStream<K, V> {
+  /** Prefer {@link Map#keySet()} over more contrived alternatives. */
+  static final class MapKeySetStream<K, V> {
     @BeforeTemplate
     Stream<K> before(Map<K, V> map) {
       return map.entrySet().stream().map(Map.Entry::getKey);
@@ -123,11 +130,12 @@ final class MapRules {
     }
   }
 
-  /** Don't unnecessarily use {@link Map#entrySet()}. */
-  static final class MapValueStream<K, V> {
+  /** Prefer {@link Map#values()} over more contrived alternatives. */
+  static final class MapValuesStream<K, V> {
     @BeforeTemplate
     Stream<V> before(Map<K, V> map) {
-      return map.entrySet().stream().map(Map.Entry::getValue);
+      return Refaster.anyOf(
+          map.keySet().stream().map(map::get), map.entrySet().stream().map(Map.Entry::getValue));
     }
 
     @AfterTemplate

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MicrometerRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MicrometerRules.java
@@ -11,78 +11,76 @@ import io.micrometer.core.instrument.Tags;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to expressions dealing with Micrometer. */
-// XXX: Consider replacing the `TagsOf[N]` rules with a bug checker, so that various other
-// expressions (e.g. those creating other collection types, those passing in tags some other way, or
-// those passing in more tags) can be replaced as wel.
+// XXX: Consider replacing the `TagsOfN` rules with a bug checker, so that various other expressions
+// (e.g. those creating other collection types, those passing in tags some other way, or those
+// passing in more tags) can be replaced as well.
 @OnlineDocumentation
 final class MicrometerRules {
   private MicrometerRules() {}
 
-  /** Prefer using {@link Tags} over other immutable collections. */
+  /** Prefer {@link Tags#of(Tag...)} over less idiomatic alternatives. */
   static final class TagsOf1 {
     @BeforeTemplate
-    ImmutableCollection<Tag> before(Tag tag) {
-      return Refaster.anyOf(ImmutableSet.of(tag), ImmutableList.of(tag));
+    ImmutableCollection<Tag> before(Tag e1) {
+      return Refaster.anyOf(ImmutableSet.of(e1), ImmutableList.of(e1));
     }
 
     @AfterTemplate
-    Iterable<Tag> after(Tag tag) {
-      return Tags.of(tag);
+    Tags after(Tag e1) {
+      return Tags.of(e1);
     }
   }
 
-  /** Prefer using {@link Tags} over other immutable collections. */
+  /** Prefer {@link Tags#of(Tag...)} over less idiomatic alternatives. */
   static final class TagsOf2 {
     @BeforeTemplate
-    ImmutableCollection<Tag> before(Tag tag1, Tag tag2) {
-      return Refaster.anyOf(ImmutableSet.of(tag1, tag2), ImmutableList.of(tag1, tag2));
+    ImmutableCollection<Tag> before(Tag e1, Tag e2) {
+      return Refaster.anyOf(ImmutableSet.of(e1, e2), ImmutableList.of(e1, e2));
     }
 
     @AfterTemplate
-    Iterable<Tag> after(Tag tag1, Tag tag2) {
-      return Tags.of(tag1, tag2);
+    Tags after(Tag e1, Tag e2) {
+      return Tags.of(e1, e2);
     }
   }
 
-  /** Prefer using {@link Tags} over other immutable collections. */
+  /** Prefer {@link Tags#of(Tag...)} over less idiomatic alternatives. */
   static final class TagsOf3 {
     @BeforeTemplate
-    ImmutableCollection<Tag> before(Tag tag1, Tag tag2, Tag tag3) {
-      return Refaster.anyOf(ImmutableSet.of(tag1, tag2, tag3), ImmutableList.of(tag1, tag2, tag3));
+    ImmutableCollection<Tag> before(Tag e1, Tag e2, Tag e3) {
+      return Refaster.anyOf(ImmutableSet.of(e1, e2, e3), ImmutableList.of(e1, e2, e3));
     }
 
     @AfterTemplate
-    Iterable<Tag> after(Tag tag1, Tag tag2, Tag tag3) {
-      return Tags.of(tag1, tag2, tag3);
+    Tags after(Tag e1, Tag e2, Tag e3) {
+      return Tags.of(e1, e2, e3);
     }
   }
 
-  /** Prefer using {@link Tags} over other immutable collections. */
+  /** Prefer {@link Tags#of(Tag...)} over less idiomatic alternatives. */
   static final class TagsOf4 {
     @BeforeTemplate
-    ImmutableCollection<Tag> before(Tag tag1, Tag tag2, Tag tag3, Tag tag4) {
-      return Refaster.anyOf(
-          ImmutableSet.of(tag1, tag2, tag3, tag4), ImmutableList.of(tag1, tag2, tag3, tag4));
+    ImmutableCollection<Tag> before(Tag e1, Tag e2, Tag e3, Tag e4) {
+      return Refaster.anyOf(ImmutableSet.of(e1, e2, e3, e4), ImmutableList.of(e1, e2, e3, e4));
     }
 
     @AfterTemplate
-    Iterable<Tag> after(Tag tag1, Tag tag2, Tag tag3, Tag tag4) {
-      return Tags.of(tag1, tag2, tag3, tag4);
+    Tags after(Tag e1, Tag e2, Tag e3, Tag e4) {
+      return Tags.of(e1, e2, e3, e4);
     }
   }
 
-  /** Prefer using {@link Tags} over other immutable collections. */
+  /** Prefer {@link Tags#of(Tag...)} over less idiomatic alternatives. */
   static final class TagsOf5 {
     @BeforeTemplate
-    ImmutableCollection<Tag> before(Tag tag1, Tag tag2, Tag tag3, Tag tag4, Tag tag5) {
+    ImmutableCollection<Tag> before(Tag e1, Tag e2, Tag e3, Tag e4, Tag e5) {
       return Refaster.anyOf(
-          ImmutableSet.of(tag1, tag2, tag3, tag4, tag5),
-          ImmutableList.of(tag1, tag2, tag3, tag4, tag5));
+          ImmutableSet.of(e1, e2, e3, e4, e5), ImmutableList.of(e1, e2, e3, e4, e5));
     }
 
     @AfterTemplate
-    Iterable<Tag> after(Tag tag1, Tag tag2, Tag tag3, Tag tag4, Tag tag5) {
-      return Tags.of(tag1, tag2, tag3, tag4, tag5);
+    Tags after(Tag e1, Tag e2, Tag e3, Tag e4, Tag e5) {
+      return Tags.of(e1, e2, e3, e4, e5);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MockitoRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MockitoRules.java
@@ -19,10 +19,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class MockitoRules {
   private MockitoRules() {}
 
-  /**
-   * Prefer {@link Mockito#never()}} over explicitly specifying that the associated invocation must
-   * happen precisely zero times.
-   */
+  /** Prefer {@link Mockito#never()} over less explicit alternatives. */
   static final class Never {
     @BeforeTemplate
     VerificationMode before() {
@@ -36,11 +33,8 @@ final class MockitoRules {
     }
   }
 
-  /**
-   * Prefer {@link Mockito#verify(Object)} over explicitly specifying that the associated invocation
-   * must happen precisely once; this is the default behavior.
-   */
-  static final class VerifyOnce<T> {
+  /** Prefer {@link Mockito#verify(Object)} over more verbose alternatives. */
+  static final class Verify<T> {
     @BeforeTemplate
     T before(T mock) {
       return verify(mock, times(1));
@@ -53,7 +47,8 @@ final class MockitoRules {
     }
   }
 
-  static final class InvocationOnMockGetArguments {
+  /** Prefer {@link InvocationOnMock#getArgument(int)} over more verbose alternatives. */
+  static final class InvocationOnMockGetArgument {
     @BeforeTemplate
     Object before(InvocationOnMock invocation, int i) {
       return invocation.getArguments()[i];
@@ -65,7 +60,8 @@ final class MockitoRules {
     }
   }
 
-  static final class InvocationOnMockGetArgumentsWithTypeParameter<T> {
+  /** Prefer {@code invocation.<T>getArgument(int)} over less explicit alternatives. */
+  static final class InvocationOnMockGetArgumentObject<T> {
     @BeforeTemplate
     @SuppressWarnings("unchecked" /* Cast is presumed safe in matched context. */)
     T before(InvocationOnMock invocation, int i) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MultimapRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/MultimapRules.java
@@ -103,7 +103,7 @@ final class MultimapRules {
     }
   }
 
-  /** Don't unnecessarily use {@link Multimap#entries()}. */
+  /** Prefer {@code multimap.keys().stream()} over more contrived alternatives. */
   static final class MultimapKeysStream<K, V> {
     @BeforeTemplate
     Stream<K> before(Multimap<K, V> multimap) {
@@ -116,7 +116,7 @@ final class MultimapRules {
     }
   }
 
-  /** Don't unnecessarily use {@link Multimap#entries()}. */
+  /** Prefer {@code multimap.values().stream()} over more contrived alternatives. */
   static final class MultimapValuesStream<K, V> {
     @BeforeTemplate
     Stream<V> before(Multimap<K, V> multimap) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/NullRules.java
@@ -22,35 +22,29 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class NullRules {
   private NullRules() {}
 
-  /**
-   * Prefer the {@code ==} operator (with {@code null} as the second operand) over {@link
-   * Objects#isNull(Object)}.
-   */
-  static final class IsNull {
+  /** Prefer {@code == null} over less idiomatic alternatives. */
+  static final class EqualToNull {
     @BeforeTemplate
-    boolean before(@Nullable Object object) {
-      return Refaster.anyOf(null == object, Objects.isNull(object));
+    boolean before(@Nullable Object obj) {
+      return Refaster.anyOf(null == obj, Objects.isNull(obj));
     }
 
     @AfterTemplate
-    boolean after(@Nullable Object object) {
-      return object == null;
+    boolean after(@Nullable Object obj) {
+      return obj == null;
     }
   }
 
-  /**
-   * Prefer the {@code !=} operator (with {@code null} as the second operand) over {@link
-   * Objects#nonNull(Object)}.
-   */
-  static final class IsNotNull {
+  /** Prefer {@code != null} over less idiomatic alternatives. */
+  static final class NotEqualToNull {
     @BeforeTemplate
-    boolean before(@Nullable Object object) {
-      return Refaster.anyOf(null != object, Objects.nonNull(object));
+    boolean before(@Nullable Object obj) {
+      return Refaster.anyOf(null != obj, Objects.nonNull(obj));
     }
 
     @AfterTemplate
-    boolean after(@Nullable Object object) {
-      return object != null;
+    boolean after(@Nullable Object obj) {
+      return obj != null;
     }
   }
 
@@ -63,15 +57,15 @@ final class NullRules {
   // an NPE.
   static final class RequireNonNullElse<T> {
     @BeforeTemplate
-    T before(T first, T second) {
+    T before(T obj, T defaultObj) {
       return Refaster.anyOf(
-          MoreObjects.firstNonNull(first, second), Optional.ofNullable(first).orElse(second));
+          MoreObjects.firstNonNull(obj, defaultObj), Optional.ofNullable(obj).orElse(defaultObj));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    T after(T first, T second) {
-      return requireNonNullElse(first, second);
+    T after(T obj, T defaultObj) {
+      return requireNonNullElse(obj, defaultObj);
     }
   }
 
@@ -84,22 +78,19 @@ final class NullRules {
   // an NPE.
   static final class RequireNonNullElseGet<T, S extends T> {
     @BeforeTemplate
-    T before(T object, Supplier<S> supplier) {
-      return Optional.ofNullable(object).orElseGet(supplier);
+    T before(T obj, Supplier<S> supplier) {
+      return Optional.ofNullable(obj).orElseGet(supplier);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    T after(T object, Supplier<S> supplier) {
-      return requireNonNullElseGet(object, supplier);
+    T after(T obj, Supplier<S> supplier) {
+      return requireNonNullElseGet(obj, supplier);
     }
   }
 
-  /**
-   * Prefer {@link Objects#isNull(Object)} over the equivalent lambda function or more contrived
-   * alternatives.
-   */
-  static final class IsNullFunction<T> {
+  /** Prefer {@link Objects#isNull(Object)} over less idiomatic or more contrived alternatives. */
+  static final class ObjectsIsNull<T> {
     @BeforeTemplate
     Predicate<T> before() {
       return Refaster.anyOf(o -> o == null, not(Objects::nonNull));
@@ -111,11 +102,8 @@ final class NullRules {
     }
   }
 
-  /**
-   * Prefer {@link Objects#nonNull(Object)} over the equivalent lambda function or more contrived
-   * alternatives.
-   */
-  static final class NonNullFunction<T> {
+  /** Prefer {@link Objects#nonNull(Object)} over less idiomatic or more contrived alternatives. */
+  static final class ObjectsNonNull<T> {
     @BeforeTemplate
     Predicate<T> before() {
       return Refaster.anyOf(o -> o != null, not(Objects::isNull));

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -27,7 +27,7 @@ import tech.picnic.errorprone.refaster.matchers.RequiresComputation;
 final class OptionalRules {
   private OptionalRules() {}
 
-  /** Prefer {@link Optional#empty()} over the more contrived alternative. */
+  /** Prefer {@link Optional#empty()} over more contrived alternatives. */
   static final class OptionalEmpty<T> {
     @BeforeTemplate
     Optional<T> before() {
@@ -40,22 +40,23 @@ final class OptionalRules {
     }
   }
 
+  /** Prefer {@link Optional#ofNullable(Object)} over more contrived alternatives. */
   static final class OptionalOfNullable<T> {
     // XXX: Refaster should be smart enough to also rewrite occurrences in which there are
     // parentheses around the null check, but that's currently not the case. Try to fix that.
     @BeforeTemplate
-    @SuppressWarnings("TernaryOperatorOptionalNegativeFiltering" /* Special case. */)
-    Optional<T> before(@Nullable T object) {
-      return object == null ? Optional.empty() : Optional.of(object);
+    @SuppressWarnings("RefasterEmitCommentBeforeOptionalOfFilterNot" /* Special case. */)
+    Optional<T> before(@Nullable T value) {
+      return value == null ? Optional.empty() : Optional.of(value);
     }
 
     @AfterTemplate
-    Optional<T> after(T object) {
-      return Optional.ofNullable(object);
+    Optional<T> after(T value) {
+      return Optional.ofNullable(value);
     }
   }
 
-  /** Prefer {@link Optional#isEmpty()} over the more verbose alternative. */
+  /** Prefer {@link Optional#isEmpty()} over more verbose alternatives. */
   static final class OptionalIsEmpty<T> {
     @BeforeTemplate
     boolean before(Optional<T> optional) {
@@ -68,7 +69,7 @@ final class OptionalRules {
     }
   }
 
-  /** Prefer {@link Optional#isPresent()} over the inverted alternative. */
+  /** Prefer {@link Optional#isPresent()} over more verbose alternatives. */
   static final class OptionalIsPresent<T> {
     @BeforeTemplate
     boolean before(Optional<T> optional) {
@@ -82,7 +83,7 @@ final class OptionalRules {
   }
 
   /** Prefer {@link Optional#orElseThrow()} over the less explicit {@link Optional#get()}. */
-  static final class OptionalOrElseThrow<T> {
+  static final class OptionalOrElseThrowWithOptional<T> {
     @BeforeTemplate
     @SuppressWarnings({
       "java:S3655" /* Matched expressions are in practice embedded in a larger context. */,
@@ -100,9 +101,9 @@ final class OptionalRules {
   }
 
   /** Prefer {@link Optional#orElseThrow()} over the less explicit {@link Optional#get()}. */
-  // XXX: This rule is analogous to `OptionalOrElseThrow` above. Arguably this is its
+  // XXX: This rule is analogous to `OptionalOrElseThrowWithOptional` above. Arguably this is its
   // generalization. If/when Refaster is extended to understand this, delete the rule above.
-  static final class OptionalOrElseThrowMethodReference<T> {
+  static final class OptionalOrElseThrow<T> {
     @BeforeTemplate
     Function<Optional<T>, T> before() {
       return Optional::get;
@@ -115,7 +116,7 @@ final class OptionalRules {
   }
 
   /** Prefer {@link Optional#equals(Object)} over more contrived alternatives. */
-  static final class OptionalEqualsOptional<T, S> {
+  static final class OptionalEqualsOptionalOf<T, S> {
     @BeforeTemplate
     boolean before(Optional<T> optional, S value) {
       return Refaster.anyOf(
@@ -128,20 +129,17 @@ final class OptionalRules {
     }
   }
 
-  /**
-   * Don't use the ternary operator to extract the first element of a possibly-empty {@link
-   * Iterator} as an {@link Optional}.
-   */
-  static final class OptionalFirstIteratorElement<T> {
+  /** Prefer {@code Streams.stream(iterator).findFirst()} over more contrived alternatives. */
+  static final class StreamsStreamFindFirst<T> {
     @BeforeTemplate
-    Optional<T> before(Iterator<T> it) {
-      return it.hasNext() ? Optional.of(it.next()) : Optional.empty();
+    Optional<T> before(Iterator<T> iterator) {
+      return iterator.hasNext() ? Optional.of(iterator.next()) : Optional.empty();
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Optional<T> after(Iterator<T> it) {
-      return Streams.stream(it).findFirst();
+    Optional<T> after(Iterator<T> iterator) {
+      return Streams.stream(iterator).findFirst();
     }
   }
 
@@ -149,19 +147,19 @@ final class OptionalRules {
   // XXX: This rule may introduce a compilation error: the `test` expression may reference a
   // non-effectively final variable, which is not allowed in the replacement lambda expression.
   // Review whether a `@Matcher` can be used to avoid this.
-  abstract static class TernaryOperatorOptionalPositiveFiltering<T> {
+  abstract static class RefasterEmitCommentBeforeOptionalOfFilter<T> {
     @Placeholder
     abstract boolean test(T value);
 
     @BeforeTemplate
-    Optional<T> before(T input) {
-      return test(input) ? Optional.of(input) : Optional.empty();
+    Optional<T> before(T value) {
+      return test(value) ? Optional.of(value) : Optional.empty();
     }
 
     @AfterTemplate
-    Optional<T> after(T input) {
+    Optional<T> after(T value) {
       return Refaster.emitCommentBefore(
-          "Or Optional.ofNullable (can't auto-infer).", Optional.of(input).filter(v -> test(v)));
+          "Or Optional.ofNullable (can't auto-infer).", Optional.of(value).filter(v -> test(v)));
     }
   }
 
@@ -169,44 +167,37 @@ final class OptionalRules {
   // XXX: This rule may introduce a compilation error: the `test` expression may reference a
   // non-effectively final variable, which is not allowed in the replacement lambda expression.
   // Review whether a `@Matcher` can be used to avoid this.
-  abstract static class TernaryOperatorOptionalNegativeFiltering<T> {
+  abstract static class RefasterEmitCommentBeforeOptionalOfFilterNot<T> {
     @Placeholder
     abstract boolean test(T value);
 
     @BeforeTemplate
-    Optional<T> before(T input) {
-      return test(input) ? Optional.empty() : Optional.of(input);
+    Optional<T> before(T value) {
+      return test(value) ? Optional.empty() : Optional.of(value);
     }
 
     @AfterTemplate
-    Optional<T> after(T input) {
+    Optional<T> after(T value) {
       return Refaster.emitCommentBefore(
-          "Or Optional.ofNullable (can't auto-infer).", Optional.of(input).filter(v -> !test(v)));
+          "Or Optional.ofNullable (can't auto-infer).", Optional.of(value).filter(v -> !test(v)));
     }
   }
 
-  /**
-   * Prefer {@link Optional#filter(Predicate)} over {@link Optional#map(Function)} when converting
-   * an {@link Optional} to a boolean.
-   */
-  static final class MapOptionalToBoolean<T> {
+  /** Prefer {@link Optional#filter(Predicate)} over more contrived alternatives. */
+  static final class OptionalFilterIsPresent<S, T extends S> {
     @BeforeTemplate
-    boolean before(Optional<T> optional, Function<? super T, Boolean> predicate) {
+    Boolean before(Optional<T> optional, Function<S, Boolean> predicate) {
       return optional.map(predicate).orElse(false);
     }
 
     @AfterTemplate
-    boolean after(Optional<T> optional, Predicate<? super T> predicate) {
+    boolean after(Optional<T> optional, Predicate<S> predicate) {
       return optional.filter(predicate).isPresent();
     }
   }
 
-  /**
-   * Prefer {@link Optional#map} over a {@link Optional#flatMap} that wraps the result of a
-   * transformation in an {@link Optional}; the former operation transforms {@code null} to {@link
-   * Optional#empty()}.
-   */
-  abstract static class MapToNullable<T, S> {
+  /** Prefer {@link Optional#map(Function)} over more contrived alternatives. */
+  abstract static class OptionalMap<T, S> {
     @Placeholder
     abstract S toNullableFunction(@MayOptionallyUse T element);
 
@@ -224,7 +215,8 @@ final class OptionalRules {
     }
   }
 
-  abstract static class FlatMapToOptional<T, S> {
+  /** Prefer {@link Optional#flatMap(Function)} over more contrived alternatives. */
+  abstract static class OptionalFlatMap<T, S> {
     @Placeholder
     abstract Optional<S> toOptionalFunction(@MayOptionallyUse T element);
 
@@ -239,41 +231,39 @@ final class OptionalRules {
     }
   }
 
-  static final class OrOrElseThrow<T> {
+  /**
+   * Prefer {@link Optional#or(Supplier)} combined with {@link Optional#orElseThrow()} over more
+   * contrived alternatives.
+   */
+  static final class OptionalOrOrElseThrow<T> {
     @BeforeTemplate
-    T before(Optional<T> o1, Optional<T> o2) {
-      return o1.orElseGet(() -> o2.orElseThrow());
+    T before(Optional<T> optional1, Optional<T> optional2) {
+      return optional1.orElseGet(() -> optional2.orElseThrow());
     }
 
     @AfterTemplate
-    T after(Optional<T> o1, Optional<T> o2) {
-      return o1.or(() -> o2).orElseThrow();
+    T after(Optional<T> optional1, Optional<T> optional2) {
+      return optional1.or(() -> optional2).orElseThrow();
     }
   }
 
-  /**
-   * Prefer {@link Optional#orElse(Object)} over {@link Optional#orElseGet(Supplier)} if the
-   * fallback value does not require non-trivial computation.
-   */
+  /** Prefer {@link Optional#orElse(Object)} over more contrived alternatives. */
   // XXX: This rule is the counterpart to the `OptionalOrElseGet` bug checker. Once the
   // `MethodReferenceUsage` bug checker is "production ready", that bug checker may similarly be
   // replaced with a Refaster rule.
   static final class OptionalOrElse<T> {
     @BeforeTemplate
-    T before(Optional<T> optional, @NotMatches(RequiresComputation.class) T value) {
-      return optional.orElseGet(() -> value);
+    T before(Optional<T> optional, @NotMatches(RequiresComputation.class) T other) {
+      return optional.orElseGet(() -> other);
     }
 
     @AfterTemplate
-    T after(Optional<T> optional, T value) {
-      return optional.orElse(value);
+    T after(Optional<T> optional, T other) {
+      return optional.orElse(other);
     }
   }
 
-  /**
-   * Flatten a stream of {@link Optional}s using {@link Optional#stream()}, rather than using one of
-   * the more verbose alternatives.
-   */
+  /** Prefer {@link Optional#stream()} over more verbose or non-JDK alternatives. */
   // XXX: Do we need the `.filter(Optional::isPresent)`? If it's absent the caller probably assumed
   // that the values are present. (If we drop it, we should rewrite vacuous filter steps.)
   // XXX: The rewritten `filter`/`map` expression may be more performant than its replacement. See
@@ -281,7 +271,7 @@ final class OptionalRules {
   // with JMH benchmarks; this would be a great use case.)
   // XXX: Perhaps `stream.mapMulti(Optional::ifPresent)` is what we should use. See
   // https://github.com/palantir/gradle-baseline/pull/2996.
-  static final class StreamFlatMapOptional<T> {
+  static final class StreamFlatMapOptionalStream<T> {
     @BeforeTemplate
     Stream<T> before(Stream<Optional<T>> stream) {
       return Refaster.anyOf(
@@ -296,8 +286,8 @@ final class OptionalRules {
   }
 
   /**
-   * Within a stream's map operation unconditional {@link Optional#orElseThrow()} calls can be
-   * avoided.
+   * Prefer {@link Optional#stream()} within {@link Stream#flatMap(Function)} over more contrived
+   * alternatives.
    *
    * <p><strong>Warning:</strong> this rewrite rule is not completely behavior preserving. The
    * original code throws an exception if the mapping operation does not produce a value, while the
@@ -305,7 +295,7 @@ final class OptionalRules {
    */
   // XXX: An alternative approach is to use `.flatMap(Optional::stream)`. That may be a bit longer,
   // but yields nicer code. Think about it.
-  abstract static class StreamMapToOptionalGet<T, S> {
+  abstract static class StreamFlatMapStream<T, S> {
     @Placeholder
     abstract Optional<S> toOptionalFunction(@MayOptionallyUse T element);
 
@@ -320,56 +310,62 @@ final class OptionalRules {
     }
   }
 
-  /** Avoid unnecessary nesting of {@link Optional#filter(Predicate)} operations. */
-  abstract static class FilterOuterOptionalAfterFlatMap<T, S> {
+  /**
+   * Prefer {@link Optional#filter(Predicate)} outside of {@link Optional#flatMap(Function)} over
+   * more contrived alternatives.
+   */
+  abstract static class OptionalFlatMapFilter<T, W, S extends W> {
     @Placeholder
     abstract Optional<S> toOptionalFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    Optional<S> before(Optional<T> optional, Predicate<? super S> predicate) {
+    Optional<S> before(Optional<T> optional, Predicate<W> predicate) {
       return optional.flatMap(v -> toOptionalFunction(v).filter(predicate));
     }
 
     @AfterTemplate
-    Optional<S> after(Optional<T> optional, Predicate<? super S> predicate) {
+    Optional<S> after(Optional<T> optional, Predicate<W> predicate) {
       return optional.flatMap(v -> toOptionalFunction(v)).filter(predicate);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link Optional#map(Function)} operations. */
-  abstract static class MapOuterOptionalAfterFlatMap<T, S, R> {
+  /**
+   * Prefer {@link Optional#map(Function)} outside of {@link Optional#flatMap(Function)} over more
+   * contrived alternatives.
+   */
+  abstract static class OptionalFlatMapMap<T, U, S extends U, R, V extends R> {
     @Placeholder
     abstract Optional<S> toOptionalFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    Optional<R> before(Optional<T> optional, Function<? super S, ? extends R> function) {
-      return optional.flatMap(v -> toOptionalFunction(v).map(function));
+    Optional<V> before(Optional<T> optional, Function<U, V> mapper) {
+      return optional.flatMap(v -> toOptionalFunction(v).map(mapper));
     }
 
     @AfterTemplate
-    Optional<R> after(Optional<T> optional, Function<? super S, ? extends R> function) {
-      return optional.flatMap(v -> toOptionalFunction(v)).map(function);
+    Optional<V> after(Optional<T> optional, Function<U, V> mapper) {
+      return optional.flatMap(v -> toOptionalFunction(v)).map(mapper);
     }
   }
 
   /** Avoid unnecessary nesting of {@link Optional#flatMap(Function)} operations. */
-  abstract static class FlatMapOuterOptionalAfterFlatMap<T, S, R> {
+  abstract static class OptionalFlatMapFlatMap<T, S, R> {
     @Placeholder
     abstract Optional<S> toOptionalFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    Optional<R> before(Optional<T> optional, Function<? super S, Optional<? extends R>> function) {
-      return optional.flatMap(v -> toOptionalFunction(v).flatMap(function));
+    Optional<R> before(Optional<T> optional, Function<? super S, Optional<? extends R>> mapper) {
+      return optional.flatMap(v -> toOptionalFunction(v).flatMap(mapper));
     }
 
     @AfterTemplate
-    Optional<R> after(Optional<T> optional, Function<? super S, Optional<? extends R>> function) {
-      return optional.flatMap(v -> toOptionalFunction(v)).flatMap(function);
+    Optional<R> after(Optional<T> optional, Function<? super S, Optional<? extends R>> mapper) {
+      return optional.flatMap(v -> toOptionalFunction(v)).flatMap(mapper);
     }
   }
 
   /** Prefer {@link Optional#or(Supplier)} over more verbose alternatives. */
-  static final class OptionalOrOtherOptional<T> {
+  static final class OptionalOr<T> {
     @BeforeTemplate
     @SuppressWarnings({
       "LexicographicalAnnotationAttributeListing" /* `key-*` entry must remain last. */,
@@ -377,30 +373,30 @@ final class OptionalRules {
       "OptionalOrElse" /* Parameters represent expressions that may require computation. */,
       "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
     })
-    Optional<T> before(Optional<T> optional1, Optional<T> optional2) {
+    Optional<T> before(Optional<T> optional, Optional<T> other) {
       // XXX: Note that rewriting the first and third variant will change the code's behavior if
       // `optional2` has side-effects.
       // XXX: Note that rewriting the first, third and fourth variant will introduce a compilation
       // error if `optional2` is not effectively final. Review whether a `@Matcher` can be used to
       // avoid this.
       return Refaster.anyOf(
-          optional1.map(Optional::of).orElse(optional2),
-          optional1.map(Optional::of).orElseGet(() -> optional2),
-          Stream.of(optional1, optional2).flatMap(Optional::stream).findFirst(),
-          optional1.isPresent() ? optional1 : optional2);
+          optional.map(Optional::of).orElse(other),
+          optional.map(Optional::of).orElseGet(() -> other),
+          Stream.of(optional, other).flatMap(Optional::stream).findFirst(),
+          optional.isPresent() ? optional : other);
     }
 
     @AfterTemplate
-    Optional<T> after(Optional<T> optional1, Optional<T> optional2) {
-      return optional1.or(() -> optional2);
+    Optional<T> after(Optional<T> optional, Optional<T> other) {
+      return optional.or(() -> other);
     }
   }
 
-  /** Don't unnecessarily transform an {@link Optional} to an equivalent instance. */
-  static final class OptionalIdentity<T> {
+  /** Prefer using {@link Optional}s as-is over more contrived alternatives. */
+  static final class OptionalIdentity<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("NestedOptionals")
-    Optional<T> before(Optional<T> optional, Comparator<? super T> comparator) {
+    Optional<T> before(Optional<T> optional, Comparator<S> cmp) {
       return Refaster.anyOf(
           optional.or(Refaster.anyOf(() -> Optional.empty(), Optional::empty)),
           optional
@@ -408,8 +404,8 @@ final class OptionalRules {
               .orElseGet(Refaster.anyOf(() -> Optional.empty(), Optional::empty)),
           optional.stream().findFirst(),
           optional.stream().findAny(),
-          optional.stream().min(comparator),
-          optional.stream().max(comparator));
+          optional.stream().min(cmp),
+          optional.stream().max(cmp));
     }
 
     @AfterTemplate
@@ -419,39 +415,33 @@ final class OptionalRules {
     }
   }
 
-  /**
-   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when filtering a value of the
-   * former type.
-   */
-  static final class OptionalFilter<T> {
+  /** Prefer {@link Optional#filter(Predicate)} over more contrived alternatives. */
+  static final class OptionalFilter<S, T extends S> {
     @BeforeTemplate
-    Optional<T> before(Optional<T> optional, Predicate<? super T> predicate) {
+    Optional<T> before(Optional<T> optional, Predicate<S> predicate) {
       return Refaster.anyOf(
           optional.stream().filter(predicate).findFirst(),
           optional.stream().filter(predicate).findAny());
     }
 
     @AfterTemplate
-    Optional<T> after(Optional<T> optional, Predicate<? super T> predicate) {
+    Optional<T> after(Optional<T> optional, Predicate<S> predicate) {
       return optional.filter(predicate);
     }
   }
 
-  /**
-   * Avoid unnecessary {@link Optional} to {@link Stream} conversion when mapping a value of the
-   * former type.
-   */
-  // XXX: If `StreamMapFirst` also simplifies `.findAny()` expressions, then this rule can be
+  /** Prefer {@link Optional#map(Function)} over more contrived alternatives. */
+  // XXX: If `StreamFindFirstMap` also simplifies `.findAny()` expressions, then this rule can be
   // dropped in favour of `StreamMapFirst` and `OptionalIdentity`.
-  static final class OptionalMap<S, T> {
+  static final class OptionalMapWithFunction<W, S extends W, T, V extends T> {
     @BeforeTemplate
-    Optional<? extends T> before(Optional<S> optional, Function<? super S, ? extends T> function) {
-      return optional.stream().map(function).findAny();
+    Optional<V> before(Optional<S> optional, Function<W, V> mapper) {
+      return optional.stream().map(mapper).findAny();
     }
 
     @AfterTemplate
-    Optional<? extends T> after(Optional<S> optional, Function<? super S, ? extends T> function) {
-      return optional.map(function);
+    Optional<V> after(Optional<S> optional, Function<W, V> mapper) {
+      return optional.map(mapper);
     }
   }
 

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PatternRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PatternRules.java
@@ -9,7 +9,7 @@ import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/** Refaster rules related to code dealing with regular expressions. */
+/** Refaster rules related to expressions dealing with {@link Pattern}s. */
 @OnlineDocumentation
 final class PatternRules {
   private PatternRules() {}
@@ -21,7 +21,7 @@ final class PatternRules {
   // `pattern.asMatchPredicate()`.
   static final class PatternAsPredicate {
     @BeforeTemplate
-    Predicate<CharSequence> before(Pattern pattern) {
+    com.google.common.base.Predicate<CharSequence> before(Pattern pattern) {
       return Predicates.contains(pattern);
     }
 
@@ -34,13 +34,13 @@ final class PatternRules {
   /** Prefer {@link Pattern#asPredicate()} over non-JDK alternatives. */
   static final class PatternCompileAsPredicate {
     @BeforeTemplate
-    Predicate<CharSequence> before(String pattern) {
-      return containsPattern(pattern);
+    com.google.common.base.Predicate<CharSequence> before(String regex) {
+      return containsPattern(regex);
     }
 
     @AfterTemplate
-    Predicate<String> after(String pattern) {
-      return Pattern.compile(pattern).asPredicate();
+    Predicate<String> after(String regex) {
+      return Pattern.compile(regex).asPredicate();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PreconditionsRules.java
@@ -16,81 +16,81 @@ import java.util.Objects;
 import org.jspecify.annotations.Nullable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
-/** Refaster templates related to statements dealing with {@link Preconditions}. */
+/** Refaster rules related to expressions dealing with {@link Preconditions}. */
 @OnlineDocumentation
 final class PreconditionsRules {
   private PreconditionsRules() {}
 
   /** Prefer {@link Preconditions#checkArgument(boolean)} over more verbose alternatives. */
-  static final class CheckArgument {
+  static final class CheckArgumentNot {
     @BeforeTemplate
-    void before(boolean condition) {
-      if (condition) {
+    void before(boolean expression) {
+      if (expression) {
         throw new IllegalArgumentException();
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition) {
-      checkArgument(!condition);
+    void after(boolean expression) {
+      checkArgument(!expression);
     }
   }
 
   /** Prefer {@link Preconditions#checkArgument(boolean, Object)} over more verbose alternatives. */
-  static final class CheckArgumentWithMessage {
+  static final class CheckArgumentNotWithString {
     @BeforeTemplate
-    void before(boolean condition, String message) {
-      if (condition) {
-        throw new IllegalArgumentException(message);
+    void before(boolean expression, String errorMessage) {
+      if (expression) {
+        throw new IllegalArgumentException(errorMessage);
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, String message) {
-      checkArgument(!condition, message);
+    void after(boolean expression, String errorMessage) {
+      checkArgument(!expression, errorMessage);
     }
   }
 
   /**
-   * Prefer {@link Preconditions#checkElementIndex(int, int, String)} over less descriptive or more
+   * Prefer {@link Preconditions#checkElementIndex(int, int, String)} over less explicit or more
    * verbose alternatives.
    *
    * <p>Note that the two-argument {@link Preconditions#checkElementIndex(int, int)} is better
    * replaced with {@link java.util.Objects#checkIndex(int, int)}.
    */
-  static final class CheckElementIndexWithMessage {
+  static final class CheckElementIndex {
     @BeforeTemplate
-    void before(int index, int size, String message) {
+    void before(int index, int size, String desc) {
       if (index < 0 || index >= size) {
-        throw new IndexOutOfBoundsException(message);
+        throw new IndexOutOfBoundsException(desc);
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(int index, int size, String message) {
-      checkElementIndex(index, size, message);
+    void after(int index, int size, String desc) {
+      checkElementIndex(index, size, desc);
     }
   }
 
   /** Prefer {@link Objects#requireNonNull(Object)} over non-JDK alternatives. */
-  static final class RequireNonNull<T> {
+  static final class RequireNonNullExpression<T> {
     @BeforeTemplate
-    T before(T object) {
-      return checkNotNull(object);
+    T before(T obj) {
+      return checkNotNull(obj);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    T after(T object) {
-      return requireNonNull(object);
+    T after(T obj) {
+      return requireNonNull(obj);
     }
   }
 
   /** Prefer {@link Objects#requireNonNull(Object)} over more verbose alternatives. */
-  static final class RequireNonNullStatement<T extends @Nullable Object> {
+  static final class RequireNonNullBlock<T extends @Nullable Object> {
     // XXX: Drop the `java:S2583` violation suppression once SonarCloud better supports JSpecify
     // annotations.
     @BeforeTemplate
@@ -99,35 +99,35 @@ final class PreconditionsRules {
       "java:S2583" /* SonarCloud incorrectly believes that `object` is not `@Nullable`. */,
       "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
     })
-    void before(T object) {
-      if (object == null) {
+    void before(T obj) {
+      if (obj == null) {
         throw new NullPointerException();
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(T object) {
-      requireNonNull(object);
+    void after(T obj) {
+      requireNonNull(obj);
     }
   }
 
   /** Prefer {@link Objects#requireNonNull(Object, String)} over non-JDK alternatives. */
-  static final class RequireNonNullWithMessage<T> {
+  static final class RequireNonNullWithStringExpression<T> {
     @BeforeTemplate
-    T before(T object, String message) {
-      return checkNotNull(object, message);
+    T before(T obj, String message) {
+      return checkNotNull(obj, message);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    T after(T object, String message) {
-      return requireNonNull(object, message);
+    T after(T obj, String message) {
+      return requireNonNull(obj, message);
     }
   }
 
   /** Prefer {@link Objects#requireNonNull(Object, String)} over more verbose alternatives. */
-  static final class RequireNonNullWithMessageStatement<T extends @Nullable Object> {
+  static final class RequireNonNullWithStringBlock<T extends @Nullable Object> {
     // XXX: Drop the `java:S2583` violation suppression once SonarCloud better supports JSpecify
     // annotations.
     @BeforeTemplate
@@ -136,21 +136,21 @@ final class PreconditionsRules {
       "java:S2583" /* SonarCloud incorrectly believes that `object` is not `@Nullable`. */,
       "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
     })
-    void before(T object, String message) {
-      if (object == null) {
+    void before(T obj, String message) {
+      if (obj == null) {
         throw new NullPointerException(message);
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(T object, String message) {
-      requireNonNull(object, message);
+    void after(T obj, String message) {
+      requireNonNull(obj, message);
     }
   }
 
   /**
-   * Prefer {@link Preconditions#checkPositionIndex(int, int)} over less descriptive or more verbose
+   * Prefer {@link Preconditions#checkPositionIndex(int, int)} over less explicit or more verbose
    * alternatives.
    */
   static final class CheckPositionIndex {
@@ -169,53 +169,53 @@ final class PreconditionsRules {
   }
 
   /**
-   * Prefer {@link Preconditions#checkPositionIndex(int, int, String)} over less descriptive or more
+   * Prefer {@link Preconditions#checkPositionIndex(int, int, String)} over less explicit or more
    * verbose alternatives.
    */
-  static final class CheckPositionIndexWithMessage {
+  static final class CheckPositionIndexWithString {
     @BeforeTemplate
-    void before(int index, int size, String message) {
+    void before(int index, int size, String desc) {
       if (index < 0 || index > size) {
-        throw new IndexOutOfBoundsException(message);
+        throw new IndexOutOfBoundsException(desc);
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(int index, int size, String message) {
-      checkPositionIndex(index, size, message);
+    void after(int index, int size, String desc) {
+      checkPositionIndex(index, size, desc);
     }
   }
 
   /** Prefer {@link Preconditions#checkState(boolean)} over more verbose alternatives. */
-  static final class CheckState {
+  static final class CheckStateNot {
     @BeforeTemplate
-    void before(boolean condition) {
-      if (condition) {
+    void before(boolean expression) {
+      if (expression) {
         throw new IllegalStateException();
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition) {
-      checkState(!condition);
+    void after(boolean expression) {
+      checkState(!expression);
     }
   }
 
   /** Prefer {@link Preconditions#checkState(boolean, Object)} over more verbose alternatives. */
-  static final class CheckStateWithMessage {
+  static final class CheckStateNotWithString {
     @BeforeTemplate
-    void before(boolean condition, String message) {
-      if (condition) {
-        throw new IllegalStateException(message);
+    void before(boolean expression, String errorMessage) {
+      if (expression) {
+        throw new IllegalStateException(errorMessage);
       }
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, String message) {
-      checkState(!condition, message);
+    void after(boolean expression, String errorMessage) {
+      checkState(!expression, errorMessage);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PrimitiveRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/PrimitiveRules.java
@@ -22,63 +22,63 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class PrimitiveRules {
   private PrimitiveRules() {}
 
-  /** Avoid contrived ways of expressing the "less than" relationship. */
+  /** Prefer {@code a < b} over less explicit alternatives. */
   static final class LessThan {
     @BeforeTemplate
     @SuppressWarnings("java:S1940" /* This violation will be rewritten. */)
-    boolean before(double a, double b) {
-      return !(a >= b);
+    boolean before(double d1, double d2) {
+      return !(d1 >= d2);
     }
 
     @AfterTemplate
-    boolean after(double a, double b) {
-      return a < b;
+    boolean after(double d1, double d2) {
+      return d1 < d2;
     }
   }
 
-  /** Avoid contrived ways of expressing the "less than or equal to" relationship. */
+  /** Prefer {@code a <= b} over less explicit alternatives. */
   static final class LessThanOrEqualTo {
     @BeforeTemplate
     @SuppressWarnings("java:S1940" /* This violation will be rewritten. */)
-    boolean before(double a, double b) {
-      return !(a > b);
+    boolean before(double d1, double d2) {
+      return !(d1 > d2);
     }
 
     @AfterTemplate
-    boolean after(double a, double b) {
-      return a <= b;
+    boolean after(double d1, double d2) {
+      return d1 <= d2;
     }
   }
 
-  /** Avoid contrived ways of expressing the "greater than" relationship. */
+  /** Prefer {@code a > b} over less explicit alternatives. */
   static final class GreaterThan {
     @BeforeTemplate
     @SuppressWarnings("java:S1940" /* This violation will be rewritten. */)
-    boolean before(double a, double b) {
-      return !(a <= b);
+    boolean before(double d1, double d2) {
+      return !(d1 <= d2);
     }
 
     @AfterTemplate
-    boolean after(double a, double b) {
-      return a > b;
+    boolean after(double d1, double d2) {
+      return d1 > d2;
     }
   }
 
-  /** Avoid contrived ways of expressing the "greater than or equal to" relationship. */
+  /** Prefer {@code a >= b} over less explicit alternatives. */
   static final class GreaterThanOrEqualTo {
     @BeforeTemplate
     @SuppressWarnings("java:S1940" /* This violation will be rewritten. */)
-    boolean before(double a, double b) {
-      return !(a < b);
+    boolean before(double d1, double d2) {
+      return !(d1 < d2);
     }
 
     @AfterTemplate
-    boolean after(double a, double b) {
-      return a >= b;
+    boolean after(double d1, double d2) {
+      return d1 >= d2;
     }
   }
 
-  /** Prefer {@link Math#clamp(long, int, int)} over more verbose alternatives. */
+  /** Prefer {@link Math#clamp(long, int, int)} over non-JDK or more verbose alternatives. */
   static final class MathClampInt {
     // XXX: The `Math.min`/`Math.max` patterns do not throw an `IllegalArgumentException` if `min >
     // max`, while the `Math.clamp` pattern does. This is considered an acceptable behavioral
@@ -100,7 +100,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Math#clamp(long, long, long)} over more verbose alternatives. */
+  /** Prefer {@link Math#clamp(long, long, long)} over non-JDK or more verbose alternatives. */
   static final class MathClampLong {
     // XXX: The `Math.min`/`Math.max` patterns do not throw an `IllegalArgumentException` if `min >
     // max`, while the `Math.clamp` pattern does. This is considered an acceptable behavioral
@@ -122,7 +122,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Math#clamp(float, float, float)} over more verbose alternatives. */
+  /** Prefer {@link Math#clamp(float, float, float)} over non-JDK or more verbose alternatives. */
   static final class MathClampFloat {
     // XXX: The `Math.min`/`Math.max` patterns do not throw an `IllegalArgumentException` if `min >
     // max`, while the `Math.clamp` pattern does. This is considered an acceptable behavioral
@@ -144,7 +144,9 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Math#clamp(double, double, double)} over more verbose alternatives. */
+  /**
+   * Prefer {@link Math#clamp(double, double, double)} over non-JDK or more verbose alternatives.
+   */
   static final class MathClampDouble {
     // XXX: The `Math.min`/`Math.max` patterns do not throw an `IllegalArgumentException` if `min >
     // max`, while the `Math.clamp` pattern does. This is considered an acceptable behavioral
@@ -166,22 +168,22 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Math#toIntExact(long)} over the Guava alternative. */
+  /** Prefer {@link Math#toIntExact(long)} over non-JDK alternatives. */
   // XXX: This rule changes the exception possibly thrown from `IllegalArgumentException` to
   // `ArithmeticException`.
-  static final class LongToIntExact {
+  static final class MathToIntExact {
     @BeforeTemplate
-    int before(long l) {
-      return Ints.checkedCast(l);
+    int before(long value) {
+      return Ints.checkedCast(value);
     }
 
     @AfterTemplate
-    int after(long l) {
-      return Math.toIntExact(l);
+    int after(long value) {
+      return Math.toIntExact(value);
     }
   }
 
-  /** Prefer {@link Character#BYTES} over the Guava alternative. */
+  /** Prefer {@link Character#BYTES} over non-JDK alternatives. */
   static final class CharacterBytes {
     @BeforeTemplate
     int before() {
@@ -194,7 +196,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Short#BYTES} over the Guava alternative. */
+  /** Prefer {@link Short#BYTES} over non-JDK alternatives. */
   static final class ShortBytes {
     @BeforeTemplate
     int before() {
@@ -207,7 +209,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Integer#BYTES} over the Guava alternative. */
+  /** Prefer {@link Integer#BYTES} over non-JDK alternatives. */
   static final class IntegerBytes {
     @BeforeTemplate
     int before() {
@@ -220,7 +222,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Long#BYTES} over the Guava alternative. */
+  /** Prefer {@link Long#BYTES} over non-JDK alternatives. */
   static final class LongBytes {
     @BeforeTemplate
     int before() {
@@ -233,7 +235,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Float#BYTES} over the Guava alternative. */
+  /** Prefer {@link Float#BYTES} over non-JDK alternatives. */
   static final class FloatBytes {
     @BeforeTemplate
     int before() {
@@ -246,7 +248,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer {@link Double#BYTES} over the Guava alternative. */
+  /** Prefer {@link Double#BYTES} over non-JDK alternatives. */
   static final class DoubleBytes {
     @BeforeTemplate
     int before() {
@@ -259,7 +261,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer an {@link Integer#signum(int)} comparison to 0 over less idiomatic alternatives. */
+  /** Prefer {@code Integer.signum(i) > 0} over less idiomatic alternatives. */
   static final class IntegerSignumIsPositive {
     @BeforeTemplate
     boolean before(int i) {
@@ -273,7 +275,7 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer an {@link Integer#signum(int)} comparison to 0 over less idiomatic alternatives. */
+  /** Prefer {@code Integer.signum(i) < 0} over less idiomatic alternatives. */
   static final class IntegerSignumIsNegative {
     @BeforeTemplate
     boolean before(int i) {
@@ -287,35 +289,35 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer an {@link Long#signum(long)} comparison to 0 over less idiomatic alternatives. */
+  /** Prefer {@code Long.signum(i) > 0} over less idiomatic alternatives. */
   static final class LongSignumIsPositive {
     @BeforeTemplate
-    boolean before(long l) {
-      return Refaster.anyOf(Long.signum(l) == 1, Long.signum(l) >= 1);
+    boolean before(long i) {
+      return Refaster.anyOf(Long.signum(i) == 1, Long.signum(i) >= 1);
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(long l) {
-      return Long.signum(l) > 0;
+    boolean after(long i) {
+      return Long.signum(i) > 0;
     }
   }
 
-  /** Prefer an {@link Long#signum(long)} comparison to 0 over less idiomatic alternatives. */
+  /** Prefer {@code Long.signum(i) < 0} over less idiomatic alternatives. */
   static final class LongSignumIsNegative {
     @BeforeTemplate
-    boolean before(long l) {
-      return Refaster.anyOf(Long.signum(l) == -1, Long.signum(l) <= -1);
+    boolean before(long i) {
+      return Refaster.anyOf(Long.signum(i) == -1, Long.signum(i) <= -1);
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(long l) {
-      return Long.signum(l) < 0;
+    boolean after(long i) {
+      return Long.signum(i) < 0;
     }
   }
 
-  /** Prefer JDK's {@link Integer#compareUnsigned(int, int)} over third-party alternatives. */
+  /** Prefer {@link Integer#compareUnsigned(int, int)} over non-JDK alternatives. */
   static final class IntegerCompareUnsigned {
     @BeforeTemplate
     int before(int x, int y) {
@@ -328,135 +330,124 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer JDK's {@link Long#compareUnsigned(long, long)} over third-party alternatives. */
+  /** Prefer {@link Long#compareUnsigned(long, long)} over non-JDK alternatives. */
   static final class LongCompareUnsigned {
     @BeforeTemplate
-    long before(long x, long y) {
+    int before(long x, long y) {
       return UnsignedLongs.compare(x, y);
     }
 
     @AfterTemplate
-    long after(long x, long y) {
+    int after(long x, long y) {
       return Long.compareUnsigned(x, y);
     }
   }
 
-  /** Prefer JDK's {@link Integer#divideUnsigned(int, int)} over third-party alternatives. */
+  /** Prefer {@link Integer#divideUnsigned(int, int)} over non-JDK alternatives. */
   static final class IntegerDivideUnsigned {
     @BeforeTemplate
-    int before(int x, int y) {
-      return UnsignedInts.divide(x, y);
+    int before(int dividend, int divisor) {
+      return UnsignedInts.divide(dividend, divisor);
     }
 
     @AfterTemplate
-    int after(int x, int y) {
-      return Integer.divideUnsigned(x, y);
+    int after(int dividend, int divisor) {
+      return Integer.divideUnsigned(dividend, divisor);
     }
   }
 
-  /** Prefer JDK's {@link Long#divideUnsigned(long, long)} over third-party alternatives. */
+  /** Prefer {@link Long#divideUnsigned(long, long)} over non-JDK alternatives. */
   static final class LongDivideUnsigned {
     @BeforeTemplate
-    long before(long x, long y) {
-      return UnsignedLongs.divide(x, y);
+    long before(long dividend, long divisor) {
+      return UnsignedLongs.divide(dividend, divisor);
     }
 
     @AfterTemplate
-    long after(long x, long y) {
-      return Long.divideUnsigned(x, y);
+    long after(long dividend, long divisor) {
+      return Long.divideUnsigned(dividend, divisor);
     }
   }
 
-  /** Prefer JDK's {@link Integer#remainderUnsigned(int, int)} over third-party alternatives. */
+  /** Prefer {@link Integer#remainderUnsigned(int, int)} over non-JDK alternatives. */
   static final class IntegerRemainderUnsigned {
     @BeforeTemplate
-    int before(int x, int y) {
-      return UnsignedInts.remainder(x, y);
+    int before(int dividend, int divisor) {
+      return UnsignedInts.remainder(dividend, divisor);
     }
 
     @AfterTemplate
-    int after(int x, int y) {
-      return Integer.remainderUnsigned(x, y);
+    int after(int dividend, int divisor) {
+      return Integer.remainderUnsigned(dividend, divisor);
     }
   }
 
-  /** Prefer JDK's {@link Long#remainderUnsigned(long, long)} over third-party alternatives. */
+  /** Prefer {@link Long#remainderUnsigned(long, long)} over non-JDK alternatives. */
   static final class LongRemainderUnsigned {
     @BeforeTemplate
-    long before(long x, long y) {
-      return UnsignedLongs.remainder(x, y);
+    long before(long dividend, long divisor) {
+      return UnsignedLongs.remainder(dividend, divisor);
     }
 
     @AfterTemplate
-    long after(long x, long y) {
-      return Long.remainderUnsigned(x, y);
+    long after(long dividend, long divisor) {
+      return Long.remainderUnsigned(dividend, divisor);
     }
   }
 
-  /**
-   * Prefer JDK's {@link Integer#parseUnsignedInt(String)} over third-party or more verbose
-   * alternatives.
-   */
+  /** Prefer {@link Integer#parseUnsignedInt(String)} over non-JDK or more verbose alternatives. */
   static final class IntegerParseUnsignedInt {
     @BeforeTemplate
-    int before(String string) {
-      return Refaster.anyOf(
-          UnsignedInts.parseUnsignedInt(string), Integer.parseUnsignedInt(string, 10));
+    int before(String s) {
+      return Refaster.anyOf(UnsignedInts.parseUnsignedInt(s), Integer.parseUnsignedInt(s, 10));
     }
 
     @AfterTemplate
-    int after(String string) {
-      return Integer.parseUnsignedInt(string);
+    int after(String s) {
+      return Integer.parseUnsignedInt(s);
     }
   }
 
-  /**
-   * Prefer JDK's {@link Long#parseUnsignedLong(String)} over third-party or more verbose
-   * alternatives.
-   */
+  /** Prefer {@link Long#parseUnsignedLong(String)} over non-JDK or more verbose alternatives. */
   static final class LongParseUnsignedLong {
     @BeforeTemplate
-    long before(String string) {
-      return Refaster.anyOf(
-          UnsignedLongs.parseUnsignedLong(string), Long.parseUnsignedLong(string, 10));
+    long before(String s) {
+      return Refaster.anyOf(UnsignedLongs.parseUnsignedLong(s), Long.parseUnsignedLong(s, 10));
     }
 
     @AfterTemplate
-    long after(String string) {
-      return Long.parseUnsignedLong(string);
+    long after(String s) {
+      return Long.parseUnsignedLong(s);
     }
   }
 
-  /** Prefer JDK's {@link Integer#parseUnsignedInt(String, int)} over third-party alternatives. */
-  static final class IntegerParseUnsignedIntWithRadix {
+  /** Prefer {@link Integer#parseUnsignedInt(String, int)} over non-JDK alternatives. */
+  static final class IntegerParseUnsignedIntWithInt {
     @BeforeTemplate
-    int before(String string, int radix) {
-      return UnsignedInts.parseUnsignedInt(string, radix);
+    int before(String s, int radix) {
+      return UnsignedInts.parseUnsignedInt(s, radix);
     }
 
     @AfterTemplate
-    int after(String string, int radix) {
-      return Integer.parseUnsignedInt(string, radix);
+    int after(String s, int radix) {
+      return Integer.parseUnsignedInt(s, radix);
     }
   }
 
-  /** Prefer JDK's {@link Long#parseUnsignedLong(String, int)} over third-party alternatives. */
-  static final class LongParseUnsignedLongWithRadix {
+  /** Prefer {@link Long#parseUnsignedLong(String, int)} over non-JDK alternatives. */
+  static final class LongParseUnsignedLongWithInt {
     @BeforeTemplate
-    long before(String string, int radix) {
-      return UnsignedLongs.parseUnsignedLong(string, radix);
+    long before(String s, int radix) {
+      return UnsignedLongs.parseUnsignedLong(s, radix);
     }
 
     @AfterTemplate
-    long after(String string, int radix) {
-      return Long.parseUnsignedLong(string, radix);
+    long after(String s, int radix) {
+      return Long.parseUnsignedLong(s, radix);
     }
   }
 
-  /**
-   * Prefer JDK's {@link Integer#toUnsignedString(int)} over third-party or more verbose
-   * alternatives.
-   */
+  /** Prefer {@link Integer#toUnsignedString(int)} over non-JDK or more verbose alternatives. */
   static final class IntegerToUnsignedString {
     @BeforeTemplate
     String before(int i) {
@@ -469,9 +460,7 @@ final class PrimitiveRules {
     }
   }
 
-  /**
-   * Prefer JDK's {@link Long#toUnsignedString(long)} over third-party or more verbose alternatives.
-   */
+  /** Prefer {@link Long#toUnsignedString(long)} over non-JDK or more verbose alternatives. */
   static final class LongToUnsignedString {
     @BeforeTemplate
     String before(long i) {
@@ -484,8 +473,8 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer JDK's {@link Integer#toUnsignedString(int,int)} over third-party alternatives. */
-  static final class IntegerToUnsignedStringWithRadix {
+  /** Prefer {@link Integer#toUnsignedString(int, int)} over non-JDK alternatives. */
+  static final class IntegerToUnsignedStringWithInt {
     @BeforeTemplate
     String before(int i, int radix) {
       return UnsignedInts.toString(i, radix);
@@ -497,8 +486,8 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer JDK's {@link Long#toUnsignedString(long,int)} over third-party alternatives. */
-  static final class LongToUnsignedStringWithRadix {
+  /** Prefer {@link Long#toUnsignedString(long, int)} over non-JDK alternatives. */
+  static final class LongToUnsignedStringWithInt {
     @BeforeTemplate
     String before(long i, int radix) {
       return UnsignedLongs.toString(i, radix);
@@ -510,10 +499,10 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer JDK's {@link Arrays#compareUnsigned(byte[], byte[])} over third-party alternatives. */
+  /** Prefer {@link Arrays#compareUnsigned(byte[], byte[])} over non-JDK alternatives. */
   // XXX: This rule will yield non-compilable code if the result of the replaced expression is
   // dereferenced. Investigate how to make this safe.
-  static final class ArraysCompareUnsignedBytes {
+  static final class ArraysCompareUnsignedByte {
     @BeforeTemplate
     Comparator<byte[]> before() {
       return UnsignedBytes.lexicographicalComparator();
@@ -525,10 +514,10 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer JDK's {@link Arrays#compareUnsigned(int[], int[])} over third-party alternatives. */
+  /** Prefer {@link Arrays#compareUnsigned(int[], int[])} over non-JDK alternatives. */
   // XXX: This rule will yield non-compilable code if the result of the replaced expression is
   // dereferenced. Investigate how to make this safe.
-  static final class ArraysCompareUnsignedInts {
+  static final class ArraysCompareUnsignedInt {
     @BeforeTemplate
     Comparator<int[]> before() {
       return UnsignedInts.lexicographicalComparator();
@@ -540,10 +529,10 @@ final class PrimitiveRules {
     }
   }
 
-  /** Prefer JDK's {@link Arrays#compareUnsigned(long[], long[])} over third-party alternatives. */
+  /** Prefer {@link Arrays#compareUnsigned(long[], long[])} over non-JDK alternatives. */
   // XXX: This rule will yield non-compilable code if the result of the replaced expression is
   // dereferenced. Investigate how to make this safe.
-  static final class ArraysCompareUnsignedLongs {
+  static final class ArraysCompareUnsignedLong {
     @BeforeTemplate
     Comparator<long[]> before() {
       return UnsignedLongs.lexicographicalComparator();

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/RandomGeneratorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/RandomGeneratorRules.java
@@ -16,37 +16,44 @@ final class RandomGeneratorRules {
   private RandomGeneratorRules() {}
 
   /**
-   * Prefer {@link RandomGenerator#nextDouble(double)} over alternatives that yield a smaller domain
-   * of values and may result in {@link Double#isInfinite() inifinity}.
+   * Prefer {@link RandomGenerator#nextDouble(double)} over more fragile alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite may change the domain of generated values; in
+   * particular, the before-template can yield values outside {@code [0, bound)} or even {@link
+   * Double#isInfinite() infinity}.
    */
   static final class RandomGeneratorNextDouble {
     @BeforeTemplate
-    double before(RandomGenerator random, double bound) {
-      return Refaster.anyOf(random.nextDouble() * bound, bound * random.nextDouble());
+    double before(RandomGenerator randomGenerator, double bound) {
+      return Refaster.anyOf(
+          randomGenerator.nextDouble() * bound, bound * randomGenerator.nextDouble());
     }
 
     @AfterTemplate
-    double after(RandomGenerator random, double bound) {
-      return random.nextDouble(bound);
+    double after(RandomGenerator randomGenerator, double bound) {
+      return randomGenerator.nextDouble(bound);
     }
   }
 
   /**
-   * Prefer {@link RandomGenerator#nextDouble(double origin, double bound)} over alternatives that
-   * may silently yield an ununiform domain of values.
+   * Prefer {@link RandomGenerator#nextDouble(double origin, double bound)} over more fragile
+   * alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite may change the distribution of generated values; the
+   * before-template can silently yield a non-uniform domain.
    */
   // XXX: This rule assumes that `a` is not an expensive or side-effectful expression.
   // XXX: The replacement code throws an `IllegalArgumentException` in more cases than the original
   // code, but only in situations that are likely unintended.
-  static final class RandomGeneratorNextDoubleWithOrigin {
+  static final class RandomGeneratorNextDoublePlus {
     @BeforeTemplate
-    double before(RandomGenerator random, double a, double b) {
-      return a + random.nextDouble(b);
+    double before(RandomGenerator randomGenerator, double origin, double bound) {
+      return origin + randomGenerator.nextDouble(bound);
     }
 
     @AfterTemplate
-    double after(RandomGenerator random, double a, double b) {
-      return random.nextDouble(a, a + b);
+    double after(RandomGenerator randomGenerator, double origin, double bound) {
+      return randomGenerator.nextDouble(origin, origin + bound);
     }
   }
 
@@ -54,41 +61,44 @@ final class RandomGeneratorRules {
   static final class RandomGeneratorNextInt {
     @BeforeTemplate
     @SuppressWarnings("RandomGeneratorNextLong" /* This is a more specific template. */)
-    int before(RandomGenerator random, int bound) {
+    int before(RandomGenerator randomGenerator, int bound) {
       return Refaster.anyOf(
-          (int) random.nextDouble(bound), (int) Math.round(random.nextDouble(bound)));
+          (int) randomGenerator.nextDouble(bound),
+          (int) Math.round(randomGenerator.nextDouble(bound)));
     }
 
     @AfterTemplate
-    int after(RandomGenerator random, int bound) {
-      return random.nextInt(bound);
+    int after(RandomGenerator randomGenerator, int bound) {
+      return randomGenerator.nextInt(bound);
     }
   }
 
   /**
-   * Prefer {@link RandomGenerator#nextInt(int origin, int bound)} over alternatives that may
-   * silently yield values outside the intended domain.
+   * Prefer {@link RandomGenerator#nextInt(int origin, int bound)} over more fragile alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite may change the set of generated values; the
+   * before-template can silently yield values outside the intended domain.
    */
   // XXX: This rule assumes that `a` is not an expensive or side-effectful expression.
   // XXX: The replacement code throws an `IllegalArgumentException` in more cases than the original
   // code, but only in situations that are likely unintended.
-  static final class RandomGeneratorNextIntWithOrigin {
+  static final class RandomGeneratorNextIntPlus {
     @BeforeTemplate
-    int before(RandomGenerator random, int a, int b) {
-      return a + random.nextInt(b);
+    int before(RandomGenerator randomGenerator, int origin, int bound) {
+      return origin + randomGenerator.nextInt(bound);
     }
 
     @AfterTemplate
-    int after(RandomGenerator random, int a, int b) {
-      return random.nextInt(a, a + b);
+    int after(RandomGenerator randomGenerator, int origin, int bound) {
+      return randomGenerator.nextInt(origin, origin + bound);
     }
   }
 
   /**
    * Prefer {@link RandomGenerator#nextLong(long)} over more contrived alternatives.
    *
-   * <p>Additionally, for large bounds, the unnecessary floating point arithmetic prevents some
-   * {@code long} values from being generated.
+   * <p><strong>Warning:</strong> for large bounds, the before-template's floating point arithmetic
+   * prevents some {@code long} values from being generated.
    */
   static final class RandomGeneratorNextLong {
     // XXX: By including expressions with and without a cast from `long` to `double`, we cater both
@@ -100,36 +110,39 @@ final class RandomGeneratorRules {
       "LongDoubleConversion" /* This violation will be rewritten. */,
       "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
     })
-    long before(RandomGenerator random, long bound) {
+    long before(RandomGenerator randomGenerator, long bound) {
       return Refaster.anyOf(
-          (long) random.nextDouble((double) bound),
-          Math.round(random.nextDouble((double) bound)),
-          (long) random.nextDouble(bound),
-          Math.round(random.nextDouble(bound)));
+          (long) randomGenerator.nextDouble((double) bound),
+          Math.round(randomGenerator.nextDouble((double) bound)),
+          (long) randomGenerator.nextDouble(bound),
+          Math.round(randomGenerator.nextDouble(bound)));
     }
 
     @AfterTemplate
-    long after(RandomGenerator random, long bound) {
-      return random.nextLong(bound);
+    long after(RandomGenerator randomGenerator, long bound) {
+      return randomGenerator.nextLong(bound);
     }
   }
 
   /**
-   * Prefer {@link RandomGenerator#nextLong(long origin, long bound)} over more contrived
+   * Prefer {@link RandomGenerator#nextLong(long origin, long bound)} over more fragile
    * alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite may change the set of generated values; the
+   * before-template can silently yield values outside the intended domain.
    */
   // XXX: This rule assumes that `a` is not an expensive or side-effectful expression.
   // XXX: The replacement code throws an `IllegalArgumentException` in more cases than the original
   // code, but only in situations that are likely unintended.
-  static final class RandomGeneratorNextLongWithOrigin {
+  static final class RandomGeneratorNextLongPlus {
     @BeforeTemplate
-    long before(RandomGenerator random, long a, long b) {
-      return a + random.nextLong(b);
+    long before(RandomGenerator randomGenerator, long origin, long bound) {
+      return origin + randomGenerator.nextLong(bound);
     }
 
     @AfterTemplate
-    long after(RandomGenerator random, long a, long b) {
-      return random.nextLong(a, a + b);
+    long after(RandomGenerator randomGenerator, long origin, long bound) {
+      return randomGenerator.nextLong(origin, origin + bound);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -102,6 +102,10 @@ final class ReactorRules {
 
   /**
    * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less efficient alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if the source can emit or propagate
+   * a {@link TimeoutException}: the original code suppresses any such signal, while the replacement
+   * only handles the one emitted by the {@code timeout} operator itself.
    */
   static final class MonoTimeoutMonoEmptyDuration<T> {
     @BeforeTemplate
@@ -117,6 +121,10 @@ final class ReactorRules {
 
   /**
    * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less efficient alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if the source can emit or propagate
+   * a {@link TimeoutException}: the original code suppresses any such signal, while the replacement
+   * only handles the one emitted by the {@code timeout} operator itself.
    */
   static final class MonoTimeoutMonoJustDuration<T> {
     @BeforeTemplate
@@ -132,6 +140,10 @@ final class ReactorRules {
 
   /**
    * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less efficient alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if the source can emit or propagate
+   * a {@link TimeoutException}: the original code suppresses any such signal, while the replacement
+   * only handles the one emitted by the {@code timeout} operator itself.
    */
   static final class MonoTimeoutDuration<T> {
     @BeforeTemplate
@@ -148,6 +160,10 @@ final class ReactorRules {
   /**
    * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less efficient
    * alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if the source can emit or propagate
+   * a {@link TimeoutException}: the original code suppresses any such signal, while the replacement
+   * only handles the one emitted by the {@code timeout} operator itself.
    */
   static final class MonoTimeoutMonoEmptyPublisher<T, S> {
     @BeforeTemplate
@@ -164,6 +180,10 @@ final class ReactorRules {
   /**
    * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less efficient
    * alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if the source can emit or propagate
+   * a {@link TimeoutException}: the original code suppresses any such signal, while the replacement
+   * only handles the one emitted by the {@code timeout} operator itself.
    */
   static final class MonoTimeoutMonoJustPublisher<T, S> {
     @BeforeTemplate
@@ -180,6 +200,10 @@ final class ReactorRules {
   /**
    * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less efficient
    * alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes behavior if the source can emit or propagate
+   * a {@link TimeoutException}: the original code suppresses any such signal, while the replacement
+   * only handles the one emitted by the {@code timeout} operator itself.
    */
   static final class MonoTimeoutPublisher<T, S> {
     @BeforeTemplate
@@ -635,7 +659,7 @@ final class ReactorRules {
 
     @AfterTemplate
     Flux<T> after(@Repeated T data) {
-      return Flux.just(data);
+      return Flux.just(Refaster.asVarargs(data));
     }
   }
 
@@ -2088,8 +2112,7 @@ final class ReactorRules {
    * Prefer {@link MathFlux#min(Publisher, Comparator)} over less efficient or more verbose
    * alternatives.
    */
-  static final class FluxTransformMathFluxMinSingleOrEmptyWithComparator<
-      T extends Comparable<? super T>> {
+  static final class FluxTransformMathFluxMinSingleOrEmptyWithComparator<T> {
     @BeforeTemplate
     Mono<T> before(Flux<T> flux, Comparator<? super T> comparator) {
       return Refaster.anyOf(
@@ -2119,8 +2142,7 @@ final class ReactorRules {
    * Prefer {@link MathFlux#max(Publisher, Comparator)} over less efficient or more verbose
    * alternatives.
    */
-  static final class FluxTransformMathFluxMaxSingleOrEmptyWithComparator<
-      T extends Comparable<? super T>> {
+  static final class FluxTransformMathFluxMaxSingleOrEmptyWithComparator<T> {
     @BeforeTemplate
     Mono<T> before(Flux<T> flux, Comparator<? super T> comparator) {
       return Refaster.anyOf(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ReactorRules.java
@@ -54,6 +54,7 @@ import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 import reactor.math.MathFlux;
 import reactor.test.StepVerifier;
+import reactor.test.StepVerifier.FirstStep;
 import reactor.test.publisher.PublisherProbe;
 import reactor.util.context.Context;
 import reactor.util.function.Tuple2;
@@ -100,137 +101,134 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
-   * alternatives.
+   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less efficient alternatives.
    */
-  static final class MonoTimeoutDurationMonoEmpty<T> {
+  static final class MonoTimeoutMonoEmptyDuration<T> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Duration duration) {
-      return mono.timeout(duration).onErrorComplete(TimeoutException.class);
+    Mono<T> before(Mono<T> mono, Duration timeout) {
+      return mono.timeout(timeout).onErrorComplete(TimeoutException.class);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Duration duration) {
-      return mono.timeout(duration, Mono.empty());
+    Mono<T> after(Mono<T> mono, Duration timeout) {
+      return mono.timeout(timeout, Mono.empty());
     }
   }
 
   /**
-   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
-   * alternatives.
+   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less efficient alternatives.
    */
-  static final class MonoTimeoutDurationMonoJust<T> {
+  static final class MonoTimeoutMonoJustDuration<T> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Duration duration, T fallbackValue) {
-      return mono.timeout(duration).onErrorReturn(TimeoutException.class, fallbackValue);
+    Mono<T> before(Mono<T> mono, Duration timeout, T data) {
+      return mono.timeout(timeout).onErrorReturn(TimeoutException.class, data);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Duration duration, T fallbackValue) {
-      return mono.timeout(duration, Mono.just(fallbackValue));
+    Mono<T> after(Mono<T> mono, Duration timeout, T data) {
+      return mono.timeout(timeout, Mono.just(data));
     }
   }
 
   /**
-   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less performant
-   * alternatives.
+   * Prefer {@link Mono#timeout(Duration, Mono)} over more contrived or less efficient alternatives.
    */
   static final class MonoTimeoutDuration<T> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Duration duration, Mono<T> fallback) {
-      return mono.timeout(duration).onErrorResume(TimeoutException.class, e -> fallback);
+    Mono<T> before(Mono<T> mono, Duration timeout, Mono<T> fallback) {
+      return mono.timeout(timeout).onErrorResume(TimeoutException.class, e -> fallback);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Duration duration, Mono<T> fallback) {
-      return mono.timeout(duration, fallback);
+    Mono<T> after(Mono<T> mono, Duration timeout, Mono<T> fallback) {
+      return mono.timeout(timeout, fallback);
     }
   }
 
   /**
-   * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less performant
+   * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less efficient
    * alternatives.
    */
-  static final class MonoTimeoutPublisherMonoEmpty<T, S> {
+  static final class MonoTimeoutMonoEmptyPublisher<T, S> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Publisher<S> other) {
-      return mono.timeout(other).onErrorComplete(TimeoutException.class);
+    Mono<T> before(Mono<T> mono, Publisher<S> firstTimeout) {
+      return mono.timeout(firstTimeout).onErrorComplete(TimeoutException.class);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Publisher<S> other) {
-      return mono.timeout(other, Mono.empty());
+    Mono<T> after(Mono<T> mono, Publisher<S> firstTimeout) {
+      return mono.timeout(firstTimeout, Mono.empty());
     }
   }
 
   /**
-   * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less performant
+   * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less efficient
    * alternatives.
    */
-  static final class MonoTimeoutPublisherMonoJust<T, S> {
+  static final class MonoTimeoutMonoJustPublisher<T, S> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Publisher<S> other, T fallbackValue) {
-      return mono.timeout(other).onErrorReturn(TimeoutException.class, fallbackValue);
+    Mono<T> before(Mono<T> mono, Publisher<S> firstTimeout, T data) {
+      return mono.timeout(firstTimeout).onErrorReturn(TimeoutException.class, data);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Publisher<S> other, T fallbackValue) {
-      return mono.timeout(other, Mono.just(fallbackValue));
+    Mono<T> after(Mono<T> mono, Publisher<S> firstTimeout, T data) {
+      return mono.timeout(firstTimeout, Mono.just(data));
     }
   }
 
   /**
-   * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less performant
+   * Prefer {@link Mono#timeout(Publisher, Mono)} over more contrived or less efficient
    * alternatives.
    */
   static final class MonoTimeoutPublisher<T, S> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Publisher<S> other, Mono<T> fallback) {
-      return mono.timeout(other).onErrorResume(TimeoutException.class, e -> fallback);
+    Mono<T> before(Mono<T> mono, Publisher<S> firstTimeout, Mono<T> fallback) {
+      return mono.timeout(firstTimeout).onErrorResume(TimeoutException.class, e -> fallback);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Publisher<S> other, Mono<T> fallback) {
-      return mono.timeout(other, fallback);
+    Mono<T> after(Mono<T> mono, Publisher<S> firstTimeout, Mono<T> fallback) {
+      return mono.timeout(firstTimeout, fallback);
     }
   }
 
   /** Prefer {@link Mono#just(Object)} over more contrived alternatives. */
   static final class MonoJust<T> {
     @BeforeTemplate
-    Mono<T> before(T value) {
-      return Refaster.anyOf(Mono.justOrEmpty(Optional.of(value)), Flux.just(value).next());
+    Mono<T> before(T data) {
+      return Refaster.anyOf(Mono.justOrEmpty(Optional.of(data)), Flux.just(data).next());
     }
 
     @AfterTemplate
-    Mono<T> after(T value) {
-      return Mono.just(value);
+    Mono<T> after(T data) {
+      return Mono.just(data);
     }
   }
 
   /** Prefer {@link Mono#justOrEmpty(Object)} over more contrived alternatives. */
   static final class MonoJustOrEmptyObject<T extends @Nullable Object> {
     @BeforeTemplate
-    Mono<T> before(T value) {
-      return Mono.justOrEmpty(Optional.ofNullable(value));
+    Mono<T> before(T data) {
+      return Mono.justOrEmpty(Optional.ofNullable(data));
     }
 
     @AfterTemplate
-    Mono<T> after(T value) {
-      return Mono.justOrEmpty(value);
+    Mono<T> after(T data) {
+      return Mono.justOrEmpty(data);
     }
   }
 
   /** Prefer {@link Mono#justOrEmpty(Optional)} over more verbose alternatives. */
   static final class MonoJustOrEmptyOptional<T> {
     @BeforeTemplate
-    Mono<T> before(Optional<T> optional) {
-      return Mono.just(optional).filter(Optional::isPresent).map(Optional::orElseThrow);
+    Mono<T> before(Optional<T> data) {
+      return Mono.just(data).filter(Optional::isPresent).map(Optional::orElseThrow);
     }
 
     @AfterTemplate
-    Mono<T> after(Optional<T> optional) {
-      return Mono.justOrEmpty(optional);
+    Mono<T> after(Optional<T> data) {
+      return Mono.justOrEmpty(data);
     }
   }
 
@@ -244,15 +242,14 @@ final class ReactorRules {
     @BeforeTemplate
     @SuppressWarnings(
         "MonoFromSupplier" /* `optional` may match a checked exception-throwing expression. */)
-    Mono<T> before(Optional<T> optional) {
+    Mono<T> before(Optional<T> data) {
       return Refaster.anyOf(
-          Mono.fromCallable(() -> optional.orElse(null)),
-          Mono.fromSupplier(() -> optional.orElse(null)));
+          Mono.fromCallable(() -> data.orElse(null)), Mono.fromSupplier(() -> data.orElse(null)));
     }
 
     @AfterTemplate
-    Mono<T> after(Optional<T> optional) {
-      return Mono.defer(() -> Mono.justOrEmpty(optional));
+    Mono<T> after(Optional<T> data) {
+      return Mono.defer(() -> Mono.justOrEmpty(data));
     }
   }
 
@@ -278,15 +275,15 @@ final class ReactorRules {
    *
    * <p>In particular, avoid mixing of the {@link Optional} and {@link Mono} APIs.
    */
-  static final class MonoFromOptionalSwitchIfEmpty<T> {
+  static final class MonoJustOrEmptySwitchIfEmpty<T> {
     @BeforeTemplate
-    Mono<T> before(Optional<T> optional, Mono<T> mono) {
-      return optional.map(Mono::just).orElse(mono);
+    Mono<T> before(Optional<T> data, Mono<T> alternate) {
+      return data.map(Mono::just).orElse(alternate);
     }
 
     @AfterTemplate
-    Mono<T> after(Optional<T> optional, Mono<T> mono) {
-      return Mono.justOrEmpty(optional).switchIfEmpty(mono);
+    Mono<T> after(Optional<T> data, Mono<T> alternate) {
+      return Mono.justOrEmpty(data).switchIfEmpty(alternate);
     }
   }
 
@@ -297,13 +294,13 @@ final class ReactorRules {
    */
   static final class MonoZip<T, S> {
     @BeforeTemplate
-    Mono<Tuple2<T, S>> before(Mono<T> mono, Mono<S> other) {
-      return mono.zipWith(other);
+    Mono<Tuple2<T, S>> before(Mono<T> p1, Mono<S> p2) {
+      return p1.zipWith(p2);
     }
 
     @AfterTemplate
-    Mono<Tuple2<T, S>> after(Mono<T> mono, Mono<S> other) {
-      return Mono.zip(mono, other);
+    Mono<Tuple2<T, S>> after(Mono<T> p1, Mono<S> p2) {
+      return Mono.zip(p1, p2);
     }
   }
 
@@ -312,15 +309,15 @@ final class ReactorRules {
    * Mono#zipWith(Mono, BiFunction)}, as the former better conveys that the {@link Mono}s may be
    * subscribed to concurrently, and generalizes to combining three or more reactive streams.
    */
-  static final class MonoZipWithCombinator<T, S, R> {
+  static final class MonoZipMapFunction<T, S, R> {
     @BeforeTemplate
-    Mono<R> before(Mono<T> mono, Mono<S> other, BiFunction<T, S, R> combinator) {
-      return mono.zipWith(other, combinator);
+    Mono<R> before(Mono<T> p1, Mono<S> p2, BiFunction<T, S, R> function) {
+      return p1.zipWith(p2, function);
     }
 
     @AfterTemplate
-    Mono<R> after(Mono<T> mono, Mono<S> other, BiFunction<T, S, R> combinator) {
-      return Mono.zip(mono, other).map(function(combinator));
+    Mono<R> after(Mono<T> p1, Mono<S> p2, BiFunction<T, S, R> function) {
+      return Mono.zip(p1, p2).map(function(function));
     }
   }
 
@@ -331,13 +328,13 @@ final class ReactorRules {
    */
   static final class FluxZip<T, S> {
     @BeforeTemplate
-    Flux<Tuple2<T, S>> before(Flux<T> flux, Publisher<S> other) {
-      return flux.zipWith(other);
+    Flux<Tuple2<T, S>> before(Flux<T> source1, Publisher<S> source2) {
+      return source1.zipWith(source2);
     }
 
     @AfterTemplate
-    Flux<Tuple2<T, S>> after(Flux<T> flux, Publisher<S> other) {
-      return Flux.zip(flux, other);
+    Flux<Tuple2<T, S>> after(Flux<T> source1, Publisher<S> source2) {
+      return Flux.zip(source1, source2);
     }
   }
 
@@ -346,47 +343,43 @@ final class ReactorRules {
    * Flux#zipWith(Publisher, BiFunction)}, as the former better conveys that the {@link Publisher}s
    * may be subscribed to concurrently, and generalizes to combining three or more reactive streams.
    */
-  static final class FluxZipWithCombinator<T, S, R> {
+  static final class FluxZipMapFunction<T, S, R> {
     @BeforeTemplate
-    Flux<R> before(Flux<T> flux, Publisher<S> other, BiFunction<T, S, R> combinator) {
-      return flux.zipWith(other, combinator);
+    Flux<R> before(Flux<T> source1, Publisher<S> source2, BiFunction<T, S, R> function) {
+      return source1.zipWith(source2, function);
     }
 
     @AfterTemplate
-    Flux<R> after(Flux<T> flux, Publisher<S> other, BiFunction<T, S, R> combinator) {
-      return Flux.zip(flux, other).map(function(combinator));
+    Flux<R> after(Flux<T> source1, Publisher<S> source2, BiFunction<T, S, R> function) {
+      return Flux.zip(source1, source2).map(function(function));
     }
   }
 
   /** Prefer {@link Flux#zipWithIterable(Iterable)} over more contrived alternatives. */
   static final class FluxZipWithIterable<T, S> {
     @BeforeTemplate
-    Flux<Tuple2<T, S>> before(Flux<T> flux, Iterable<S> iterable) {
-      return Flux.zip(flux, Flux.fromIterable(iterable));
+    Flux<Tuple2<T, S>> before(Flux<T> source1, Iterable<S> iterable) {
+      return Flux.zip(source1, Flux.fromIterable(iterable));
     }
 
     @AfterTemplate
-    Flux<Tuple2<T, S>> after(Flux<T> flux, Iterable<S> iterable) {
-      return flux.zipWithIterable(iterable);
+    Flux<Tuple2<T, S>> after(Flux<T> source1, Iterable<S> iterable) {
+      return source1.zipWithIterable(iterable);
     }
   }
 
   /** Prefer {@link Flux#zipWithIterable(Iterable, BiFunction)} over more contrived alternatives. */
-  static final class FluxZipWithIterableBiFunction<T, S, R> {
+  static final class FluxZipWithIterableWithBiFunction<T, S, R> {
     @BeforeTemplate
     Flux<R> before(
-        Flux<T> flux,
-        Iterable<S> iterable,
-        BiFunction<? super T, ? super S, ? extends R> function) {
-      return flux.zipWith(Flux.fromIterable(iterable), function);
+        Flux<T> flux, Iterable<S> iterable, BiFunction<? super T, ? super S, ? extends R> zipper) {
+      return flux.zipWith(Flux.fromIterable(iterable), zipper);
     }
 
     @AfterTemplate
     Flux<R> after(
-        Flux<T> flux,
-        Iterable<S> iterable,
-        BiFunction<? super T, ? super S, ? extends R> function) {
-      return flux.zipWithIterable(iterable, function);
+        Flux<T> flux, Iterable<S> iterable, BiFunction<? super T, ? super S, ? extends R> zipper) {
+      return flux.zipWithIterable(iterable, zipper);
     }
   }
 
@@ -396,90 +389,96 @@ final class ReactorRules {
    */
   static final class FluxZipWithIterableMapFunction<T, S, R> {
     @BeforeTemplate
-    Flux<R> before(Flux<T> flux, Iterable<S> iterable, BiFunction<T, S, R> combinator) {
-      return flux.zipWithIterable(iterable, combinator);
+    Flux<R> before(Flux<T> flux, Iterable<S> iterable, BiFunction<T, S, R> function) {
+      return flux.zipWithIterable(iterable, function);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Flux<R> after(Flux<T> flux, Iterable<S> iterable, BiFunction<T, S, R> combinator) {
-      return flux.zipWithIterable(iterable).map(function(combinator));
-    }
-  }
-
-  /** Don't unnecessarily defer {@link Mono#error(Throwable)}. */
-  static final class MonoDeferredError<T> {
-    @BeforeTemplate
-    Mono<T> before(Throwable throwable) {
-      return Mono.defer(() -> Mono.error(throwable));
-    }
-
-    @AfterTemplate
-    Mono<T> after(Throwable throwable) {
-      return Mono.error(() -> throwable);
-    }
-  }
-
-  /** Don't unnecessarily defer {@link Flux#error(Throwable)}. */
-  static final class FluxDeferredError<T> {
-    @BeforeTemplate
-    Flux<T> before(Throwable throwable) {
-      return Flux.defer(() -> Flux.error(throwable));
-    }
-
-    @AfterTemplate
-    Flux<T> after(Throwable throwable) {
-      return Flux.error(() -> throwable);
+    Flux<R> after(Flux<T> flux, Iterable<S> iterable, BiFunction<T, S, R> function) {
+      return flux.zipWithIterable(iterable).map(function(function));
     }
   }
 
   /**
-   * Don't unnecessarily pass {@link Mono#error(Supplier)} a method reference or lambda expression.
+   * Prefer {@link Mono#error(Supplier)} over unnecessarily deferring {@link Mono#error(Throwable)}.
+   */
+  static final class MonoErrorThrowable<T> {
+    @BeforeTemplate
+    Mono<T> before(Throwable error) {
+      return Mono.defer(() -> Mono.error(error));
+    }
+
+    @AfterTemplate
+    Mono<T> after(Throwable error) {
+      return Mono.error(() -> error);
+    }
+  }
+
+  /**
+   * Prefer {@link Flux#error(Supplier)} over unnecessarily deferring {@link Flux#error(Throwable)}.
+   */
+  static final class FluxErrorThrowable<T> {
+    @BeforeTemplate
+    Flux<T> before(Throwable error) {
+      return Flux.defer(() -> Flux.error(error));
+    }
+
+    @AfterTemplate
+    Flux<T> after(Throwable error) {
+      return Flux.error(() -> error);
+    }
+  }
+
+  /**
+   * Prefer passing {@link Mono#error(Supplier)} a direct supplier reference over a lambda or method
+   * reference that invokes another supplier.
    */
   // XXX: Drop this rule once the more general rule `AssortedRules#SupplierAsSupplier` works
   // reliably.
   static final class MonoErrorSupplier<T, E extends Throwable> {
     @BeforeTemplate
-    Mono<T> before(Supplier<E> supplier) {
-      return Mono.error(() -> supplier.get());
+    Mono<T> before(Supplier<E> errorSupplier) {
+      return Mono.error(() -> errorSupplier.get());
     }
 
     @AfterTemplate
-    Mono<T> after(Supplier<E> supplier) {
-      return Mono.error(supplier);
+    Mono<T> after(Supplier<E> errorSupplier) {
+      return Mono.error(errorSupplier);
     }
   }
 
   /**
-   * Don't unnecessarily pass {@link Flux#error(Supplier)} a method reference or lambda expression.
+   * Prefer passing {@link Flux#error(Supplier)} a direct supplier reference over a lambda or method
+   * reference that invokes another supplier.
    */
   // XXX: Drop this rule once the more general rule `AssortedRules#SupplierAsSupplier` works
   // reliably.
   static final class FluxErrorSupplier<T, E extends Throwable> {
     @BeforeTemplate
-    Flux<T> before(Supplier<E> supplier) {
-      return Flux.error(() -> supplier.get());
+    Flux<T> before(Supplier<E> errorSupplier) {
+      return Flux.error(() -> errorSupplier.get());
     }
 
     @AfterTemplate
-    Flux<T> after(Supplier<E> supplier) {
-      return Flux.error(supplier);
+    Flux<T> after(Supplier<E> errorSupplier) {
+      return Flux.error(errorSupplier);
     }
   }
 
   /** Prefer {@link Mono#thenReturn(Object)} over more verbose alternatives. */
   static final class MonoThenReturn<T, S> {
     @BeforeTemplate
-    Mono<S> before(Mono<T> mono, S object) {
+    Mono<S> before(Mono<T> mono, S value) {
       return Refaster.anyOf(
-          mono.ignoreElement().thenReturn(object),
-          mono.then().thenReturn(object),
-          mono.then(Mono.just(object)));
+          mono.ignoreElement().thenReturn(value),
+          mono.then().thenReturn(value),
+          mono.then(Mono.just(value)));
     }
 
     @AfterTemplate
-    Mono<S> after(Mono<T> mono, S object) {
-      return mono.thenReturn(object);
+    Mono<S> after(Mono<T> mono, S value) {
+      return mono.thenReturn(value);
     }
   }
 
@@ -507,26 +506,26 @@ final class ReactorRules {
   /** Prefer {@link Mono#defaultIfEmpty(Object)} over more contrived alternatives. */
   static final class MonoDefaultIfEmpty<T> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, T object) {
-      return mono.switchIfEmpty(Mono.just(object));
+    Mono<T> before(Mono<T> mono, T defaultV) {
+      return mono.switchIfEmpty(Mono.just(defaultV));
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, T object) {
-      return mono.defaultIfEmpty(object);
+    Mono<T> after(Mono<T> mono, T defaultV) {
+      return mono.defaultIfEmpty(defaultV);
     }
   }
 
   /** Prefer {@link Flux#defaultIfEmpty(Object)} over more contrived alternatives. */
   static final class FluxDefaultIfEmpty<T> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, T object) {
-      return flux.switchIfEmpty(Refaster.anyOf(Mono.just(object), Flux.just(object)));
+    Flux<T> before(Flux<T> flux, T defaultV) {
+      return flux.switchIfEmpty(Refaster.anyOf(Mono.just(defaultV), Flux.just(defaultV)));
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, T object) {
-      return flux.defaultIfEmpty(object);
+    Flux<T> after(Flux<T> flux, T defaultV) {
+      return flux.defaultIfEmpty(defaultV);
     }
   }
 
@@ -542,7 +541,7 @@ final class ReactorRules {
         int prefetch,
         Comparator<? super T> comparator,
         @Matches(IsEmpty.class) T[] emptyArray,
-        @Matches(IsEmpty.class) Iterable<T> emptyIterable,
+        @Matches(IsEmpty.class) Iterable<T> emptyIt,
         @Matches(IsEmpty.class) Stream<T> emptyStream) {
       return Refaster.anyOf(
           Flux.zip(combinator),
@@ -564,7 +563,7 @@ final class ReactorRules {
           Flux.mergeSequential(prefetch),
           Flux.mergeSequentialDelayError(prefetch),
           Flux.fromArray(emptyArray),
-          Flux.fromIterable(emptyIterable),
+          Flux.fromIterable(emptyIt),
           Flux.fromStream(() -> emptyStream));
     }
 
@@ -591,56 +590,56 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link Flux#timeout(Duration, Publisher)} over more contrived or less performant
+   * Prefer {@link Flux#timeout(Duration, Publisher)} over more contrived or less efficient
    * alternatives.
    */
   static final class FluxTimeoutFluxEmpty<T> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, Duration duration) {
-      return flux.timeout(duration).onErrorComplete(TimeoutException.class);
+    Flux<T> before(Flux<T> flux, Duration timeout) {
+      return flux.timeout(timeout).onErrorComplete(TimeoutException.class);
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, Duration duration) {
-      return flux.timeout(duration, Flux.empty());
+    Flux<T> after(Flux<T> flux, Duration timeout) {
+      return flux.timeout(timeout, Flux.empty());
     }
   }
 
   /** Prefer {@link Flux#just(Object)} over more contrived alternatives. */
   static final class FluxJust<T> {
     @BeforeTemplate
-    Flux<Integer> before(int value) {
-      return Flux.range(value, 1);
+    Flux<Integer> before(int data) {
+      return Flux.range(data, 1);
     }
 
     @BeforeTemplate
-    Flux<T> before(T value) {
+    Flux<T> before(T data) {
       return Refaster.anyOf(
-          Mono.just(value).flux(),
-          Flux.fromStream(() -> Stream.of(value)),
-          Mono.just(value).repeat().take(1));
+          Mono.just(data).flux(),
+          Flux.fromStream(() -> Stream.of(data)),
+          Mono.just(data).repeat().take(1));
     }
 
     @AfterTemplate
-    Flux<T> after(T value) {
-      return Flux.just(value);
+    Flux<T> after(T data) {
+      return Flux.just(data);
     }
   }
 
   /** Prefer {@link Flux#just(Object[])} over more contrived alternatives. */
-  static final class FluxJustArray<T> {
+  static final class FluxJustVarargs<T> {
     @BeforeTemplate
-    Flux<T> before(@Repeated T values) {
-      return Flux.fromStream(() -> Stream.of(Refaster.asVarargs(values)));
+    Flux<T> before(@Repeated T data) {
+      return Flux.fromStream(() -> Stream.of(Refaster.asVarargs(data)));
     }
 
     @AfterTemplate
-    Flux<T> after(@Repeated T values) {
-      return Flux.just(values);
+    Flux<T> after(@Repeated T data) {
+      return Flux.just(data);
     }
   }
 
-  /** Prefer {@link Flux#fromArray(Object[])}} over more ambiguous or contrived alternatives. */
+  /** Prefer {@link Flux#fromArray(Object[])} over more ambiguous or contrived alternatives. */
   static final class FluxFromArray<T> {
     @BeforeTemplate
     Flux<T> before(@NotMatches(IsRefasterAsVarargs.class) T[] array) {
@@ -653,7 +652,9 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily transform a {@link Mono} to an equivalent instance. */
+  /**
+   * Prefer using {@link Mono}s as-is over less efficient transformations to equivalent instances.
+   */
   static final class MonoIdentity<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono) {
@@ -682,7 +683,10 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily transform a {@link Mono} to a {@link Flux} to expect exactly one item. */
+  /**
+   * Prefer using {@link Mono#single()} or {@link Mono#singleOptional()} over unnecessarily
+   * transforming a {@link Mono} to a {@link Flux}.
+   */
   static final class MonoSingle<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono) {
@@ -720,7 +724,7 @@ final class ReactorRules {
   /** Prefer {@link Mono#using(Callable, Function, boolean)} over more contrived alternatives. */
   // XXX: The `.single()` variant emits a `NoSuchElementException` if the source is empty, while the
   // replacement does not.
-  static final class MonoUsingEagerBoolean<D extends AutoCloseable, T> {
+  static final class MonoUsingWithBoolean<D extends AutoCloseable, T> {
     @BeforeTemplate
     Mono<T> before(
         Callable<? extends D> resourceSupplier,
@@ -744,7 +748,7 @@ final class ReactorRules {
   /** Prefer {@link Mono#using(Callable, Function, Consumer)} over more contrived alternatives. */
   // XXX: The `.single()` variant emits a `NoSuchElementException` if the source is empty, while the
   // replacement does not.
-  static final class MonoUsingResourceCleanup<D, T> {
+  static final class MonoUsingWithConsumer<D, T> {
     @BeforeTemplate
     Mono<T> before(
         Callable<? extends D> resourceSupplier,
@@ -771,7 +775,7 @@ final class ReactorRules {
    */
   // XXX: The `.single()` variant emits a `NoSuchElementException` if the source is empty, while the
   // replacement does not.
-  static final class MonoUsingConsumerEagerBoolean<D, T> {
+  static final class MonoUsingWithConsumerAndBoolean<D, T> {
     @BeforeTemplate
     Mono<T> before(
         Callable<? extends D> resourceSupplier,
@@ -799,7 +803,7 @@ final class ReactorRules {
    */
   // XXX: The `.single()` variant emits a `NoSuchElementException` if the source is empty, while the
   // replacement does not.
-  static final class MonoUsingWhenAsyncCleanup<D, T> {
+  static final class MonoUsingWhen<D, T> {
     @BeforeTemplate
     Mono<T> before(
         Publisher<? extends D> resourceSupplier,
@@ -826,7 +830,7 @@ final class ReactorRules {
    */
   // XXX: The `.single()` variant emits a `NoSuchElementException` if the source is empty, while the
   // replacement does not.
-  static final class MonoUsingWhenAsync<D, T> {
+  static final class MonoUsingWhenWithBiFunctionAndFunction<D, T> {
     @BeforeTemplate
     Mono<T> before(
         Publisher<? extends D> resourceSupplier,
@@ -854,8 +858,11 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily pass an empty publisher to {@link Flux#switchIfEmpty(Publisher)}. */
-  static final class FluxSwitchIfEmptyOfEmptyPublisher<T> {
+  /**
+   * Prefer using {@link Flux}s as-is over unnecessarily passing an empty publisher to {@link
+   * Flux#switchIfEmpty(Publisher)}.
+   */
+  static final class FluxIdentity<T> {
     @BeforeTemplate
     Flux<T> before(Flux<T> flux) {
       return flux.switchIfEmpty(Refaster.anyOf(Mono.empty(), Flux.empty()));
@@ -874,65 +881,64 @@ final class ReactorRules {
     @SuppressWarnings("NestedPublishers")
     Flux<S> before(
         Flux<T> flux,
-        Function<? super T, ? extends P> function,
+        Function<? super T, ? extends P> mapper,
         @Matches(IsIdentityOperation.class)
-            Function<? super P, ? extends Publisher<? extends S>> identityOperation) {
+            Function<? super P, ? extends Publisher<? extends S>> identityMapper) {
       return Refaster.anyOf(
-          flux.concatMap(function, 0),
-          flux.flatMap(function, 1),
-          flux.flatMapSequential(function, 1),
-          flux.map(function).concatMap(identityOperation));
+          flux.concatMap(mapper, 0),
+          flux.flatMap(mapper, 1),
+          flux.flatMapSequential(mapper, 1),
+          flux.map(mapper).concatMap(identityMapper));
     }
 
     @AfterTemplate
-    Flux<S> after(Flux<T> flux, Function<? super T, ? extends P> function) {
-      return flux.concatMap(function);
+    Flux<S> after(Flux<T> flux, Function<? super T, ? extends P> mapper) {
+      return flux.concatMap(mapper);
     }
   }
 
   /** Prefer {@link Flux#concatMap(Function, int)} over more contrived alternatives. */
-  static final class FluxConcatMapWithPrefetch<T, S, P extends Publisher<? extends S>> {
+  static final class FluxConcatMapWithInt<T, S, P extends Publisher<? extends S>> {
     @BeforeTemplate
     @SuppressWarnings("NestedPublishers")
     Flux<S> before(
         Flux<T> flux,
-        Function<? super T, ? extends P> function,
+        Function<? super T, ? extends P> mapper,
         int prefetch,
         @Matches(IsIdentityOperation.class)
-            Function<? super P, ? extends Publisher<? extends S>> identityOperation) {
+            Function<? super P, ? extends Publisher<? extends S>> identityMapper) {
       return Refaster.anyOf(
-          flux.flatMap(function, 1, prefetch),
-          flux.flatMapSequential(function, 1, prefetch),
-          flux.map(function).concatMap(identityOperation, prefetch));
+          flux.flatMap(mapper, 1, prefetch),
+          flux.flatMapSequential(mapper, 1, prefetch),
+          flux.map(mapper).concatMap(identityMapper, prefetch));
     }
 
     @AfterTemplate
-    Flux<S> after(Flux<T> flux, Function<? super T, ? extends P> function, int prefetch) {
-      return flux.concatMap(function, prefetch);
+    Flux<S> after(Flux<T> flux, Function<? super T, ? extends P> mapper, int prefetch) {
+      return flux.concatMap(mapper, prefetch);
     }
   }
 
-  /** Avoid contrived alternatives to {@link Mono#flatMapIterable(Function)}. */
+  /** Prefer {@link Mono#flatMapIterable(Function)} over more contrived alternatives. */
   static final class MonoFlatMapIterable<T, S, I extends Iterable<? extends S>> {
     @BeforeTemplate
-    Flux<S> before(Mono<T> mono, Function<? super T, I> function) {
-      return mono.map(function).flatMapMany(Flux::fromIterable);
+    Flux<S> before(Mono<T> mono, Function<? super T, I> mapper) {
+      return mono.map(mapper).flatMapMany(Flux::fromIterable);
     }
 
     @BeforeTemplate
     Flux<S> before(
         Mono<T> mono,
-        Function<? super T, I> function,
+        Function<? super T, I> mapper,
         @Matches(IsIdentityOperation.class)
-            Function<? super I, ? extends Iterable<? extends S>> identityOperation) {
+            Function<? super I, ? extends Iterable<? extends S>> identityMapper) {
       return Refaster.anyOf(
-          mono.map(function).flatMapIterable(identityOperation),
-          mono.flux().concatMapIterable(function));
+          mono.map(mapper).flatMapIterable(identityMapper), mono.flux().concatMapIterable(mapper));
     }
 
     @AfterTemplate
-    Flux<S> after(Mono<T> mono, Function<? super T, I> function) {
-      return mono.flatMapIterable(function);
+    Flux<S> after(Mono<T> mono, Function<? super T, I> mapper) {
+      return mono.flatMapIterable(mapper);
     }
   }
 
@@ -954,55 +960,55 @@ final class ReactorRules {
   }
 
   /**
-   * Prefer {@link Flux#concatMapIterable(Function)} over alternatives with less clear syntax or
+   * Prefer {@link Flux#concatMapIterable(Function)} over alternatives with less explicit syntax or
    * semantics.
    */
   static final class FluxConcatMapIterable<T, S, I extends Iterable<? extends S>> {
     @BeforeTemplate
     Flux<S> before(
         Flux<T> flux,
-        Function<? super T, I> function,
+        Function<? super T, I> mapper,
         @Matches(IsIdentityOperation.class)
-            Function<? super I, ? extends Iterable<? extends S>> identityOperation) {
+            Function<? super I, ? extends Iterable<? extends S>> identityMapper) {
       return Refaster.anyOf(
-          flux.flatMapIterable(function), flux.map(function).concatMapIterable(identityOperation));
+          flux.flatMapIterable(mapper), flux.map(mapper).concatMapIterable(identityMapper));
     }
 
     @AfterTemplate
-    Flux<S> after(Flux<T> flux, Function<? super T, ? extends Iterable<? extends S>> function) {
-      return flux.concatMapIterable(function);
+    Flux<S> after(Flux<T> flux, Function<? super T, ? extends Iterable<? extends S>> mapper) {
+      return flux.concatMapIterable(mapper);
     }
   }
 
   /**
-   * Prefer {@link Flux#concatMapIterable(Function, int)} over alternatives with less clear syntax
-   * or semantics.
+   * Prefer {@link Flux#concatMapIterable(Function, int)} over alternatives with less explicit
+   * syntax or semantics.
    */
-  static final class FluxConcatMapIterableWithPrefetch<T, S, I extends Iterable<? extends S>> {
+  static final class FluxConcatMapIterableWithInt<T, S, I extends Iterable<? extends S>> {
     @BeforeTemplate
     Flux<S> before(
         Flux<T> flux,
-        Function<? super T, I> function,
+        Function<? super T, I> mapper,
         int prefetch,
         @Matches(IsIdentityOperation.class)
-            Function<? super I, ? extends Iterable<? extends S>> identityOperation) {
+            Function<? super I, ? extends Iterable<? extends S>> identityMapper) {
       return Refaster.anyOf(
-          flux.flatMapIterable(function, prefetch),
-          flux.map(function).concatMapIterable(identityOperation, prefetch));
+          flux.flatMapIterable(mapper, prefetch),
+          flux.map(mapper).concatMapIterable(identityMapper, prefetch));
     }
 
     @AfterTemplate
     Flux<S> after(
-        Flux<T> flux, Function<? super T, ? extends Iterable<? extends S>> function, int prefetch) {
-      return flux.concatMapIterable(function, prefetch);
+        Flux<T> flux, Function<? super T, ? extends Iterable<? extends S>> mapper, int prefetch) {
+      return flux.concatMapIterable(mapper, prefetch);
     }
   }
 
   /**
-   * Don't use {@link Mono#flatMapMany(Function)} to implicitly convert a {@link Mono} to a {@link
-   * Flux}.
+   * Prefer using {@link Mono#flatMap(Function)} followed by {@code .flux()} over {@link
+   * Mono#flatMapMany(Function)} for explicit type conversion.
    */
-  abstract static class MonoFlatMapToFlux<T, S> {
+  abstract static class MonoFlatMapFlux<T, S> {
     // XXX: It would be more expressive if this `@Placeholder` were replaced with a `Function<?
     // super T, ? extends Mono<? extends S>>` parameter, so that compatible non-lambda expression
     // arguments to `flatMapMany` are also matched. However, the type inferred for lambda and method
@@ -1050,7 +1056,7 @@ final class ReactorRules {
     abstract S transformation(@MayOptionallyUse T value);
 
     @BeforeTemplate
-    Flux<S> before(Flux<T> flux, int prefetch, boolean delayUntilEnd, int maxConcurrency) {
+    Flux<S> before(Flux<T> flux, int prefetch, boolean delayUntilEnd, int concurrency) {
       return Refaster.anyOf(
           flux.concatMap(x -> Mono.just(transformation(x))),
           flux.concatMap(x -> Flux.just(transformation(x))),
@@ -1062,20 +1068,20 @@ final class ReactorRules {
           flux.concatMapDelayError(x -> Flux.just(transformation(x)), prefetch),
           flux.concatMapDelayError(x -> Mono.just(transformation(x)), delayUntilEnd, prefetch),
           flux.concatMapDelayError(x -> Flux.just(transformation(x)), delayUntilEnd, prefetch),
-          flux.flatMap(x -> Mono.just(transformation(x)), maxConcurrency),
-          flux.flatMap(x -> Flux.just(transformation(x)), maxConcurrency),
-          flux.flatMap(x -> Mono.just(transformation(x)), maxConcurrency, prefetch),
-          flux.flatMap(x -> Flux.just(transformation(x)), maxConcurrency, prefetch),
-          flux.flatMapDelayError(x -> Mono.just(transformation(x)), maxConcurrency, prefetch),
-          flux.flatMapDelayError(x -> Flux.just(transformation(x)), maxConcurrency, prefetch),
-          flux.flatMapSequential(x -> Mono.just(transformation(x)), maxConcurrency),
-          flux.flatMapSequential(x -> Flux.just(transformation(x)), maxConcurrency),
-          flux.flatMapSequential(x -> Mono.just(transformation(x)), maxConcurrency, prefetch),
-          flux.flatMapSequential(x -> Flux.just(transformation(x)), maxConcurrency, prefetch),
+          flux.flatMap(x -> Mono.just(transformation(x)), concurrency),
+          flux.flatMap(x -> Flux.just(transformation(x)), concurrency),
+          flux.flatMap(x -> Mono.just(transformation(x)), concurrency, prefetch),
+          flux.flatMap(x -> Flux.just(transformation(x)), concurrency, prefetch),
+          flux.flatMapDelayError(x -> Mono.just(transformation(x)), concurrency, prefetch),
+          flux.flatMapDelayError(x -> Flux.just(transformation(x)), concurrency, prefetch),
+          flux.flatMapSequential(x -> Mono.just(transformation(x)), concurrency),
+          flux.flatMapSequential(x -> Flux.just(transformation(x)), concurrency),
+          flux.flatMapSequential(x -> Mono.just(transformation(x)), concurrency, prefetch),
+          flux.flatMapSequential(x -> Flux.just(transformation(x)), concurrency, prefetch),
           flux.flatMapSequentialDelayError(
-              x -> Mono.just(transformation(x)), maxConcurrency, prefetch),
+              x -> Mono.just(transformation(x)), concurrency, prefetch),
           flux.flatMapSequentialDelayError(
-              x -> Flux.just(transformation(x)), maxConcurrency, prefetch),
+              x -> Flux.just(transformation(x)), concurrency, prefetch),
           flux.switchMap(x -> Mono.just(transformation(x))),
           flux.switchMap(x -> Flux.just(transformation(x))));
     }
@@ -1118,7 +1124,7 @@ final class ReactorRules {
 
     @BeforeTemplate
     @SuppressWarnings("java:S138" /* Method is long, but not complex. */)
-    Publisher<S> before(Flux<T> flux, int prefetch, boolean delayUntilEnd, int maxConcurrency) {
+    Flux<S> before(Flux<T> flux, int prefetch, boolean delayUntilEnd, int concurrency) {
       return Refaster.anyOf(
           flux.concatMap(
               x ->
@@ -1154,40 +1160,40 @@ final class ReactorRules {
                   Refaster.anyOf(
                       Mono.justOrEmpty(transformation(x)),
                       Mono.fromSupplier(() -> transformation(x))),
-              maxConcurrency),
+              concurrency),
           flux.flatMap(
               x ->
                   Refaster.anyOf(
                       Mono.justOrEmpty(transformation(x)),
                       Mono.fromSupplier(() -> transformation(x))),
-              maxConcurrency,
+              concurrency,
               prefetch),
           flux.flatMapDelayError(
               x ->
                   Refaster.anyOf(
                       Mono.justOrEmpty(transformation(x)),
                       Mono.fromSupplier(() -> transformation(x))),
-              maxConcurrency,
+              concurrency,
               prefetch),
           flux.flatMapSequential(
               x ->
                   Refaster.anyOf(
                       Mono.justOrEmpty(transformation(x)),
                       Mono.fromSupplier(() -> transformation(x))),
-              maxConcurrency),
+              concurrency),
           flux.flatMapSequential(
               x ->
                   Refaster.anyOf(
                       Mono.justOrEmpty(transformation(x)),
                       Mono.fromSupplier(() -> transformation(x))),
-              maxConcurrency,
+              concurrency,
               prefetch),
           flux.flatMapSequentialDelayError(
               x ->
                   Refaster.anyOf(
                       Mono.justOrEmpty(transformation(x)),
                       Mono.fromSupplier(() -> transformation(x))),
-              maxConcurrency,
+              concurrency,
               prefetch),
           flux.switchMap(
               x ->
@@ -1206,7 +1212,7 @@ final class ReactorRules {
    * Prefer immediately unwrapping {@link Optional} transformation results inside {@link
    * Flux#mapNotNull(Function)} over more contrived alternatives.
    */
-  abstract static class FluxMapNotNullTransformationOrElse<T, S> {
+  abstract static class FluxMapNotNullOrElseNull<T, S> {
     @Placeholder(allowsIdentity = true)
     abstract Optional<S> transformation(@MayOptionallyUse T value);
 
@@ -1228,7 +1234,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Flux#mapNotNull(Function)} over more contrived alternatives. */
-  static final class FluxMapNotNullOrElse<T> {
+  static final class FluxMapNotNullOptionalOrElseNull<T> {
     @BeforeTemplate
     Flux<T> before(Flux<Optional<T>> flux) {
       return flux.filter(Optional::isPresent).map(Optional::orElseThrow);
@@ -1243,7 +1249,7 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Mono#flux()}} over more contrived alternatives. */
+  /** Prefer {@link Mono#flux()} over more contrived alternatives. */
   static final class MonoFlux<T> {
     @BeforeTemplate
     Flux<T> before(Mono<T> mono) {
@@ -1257,7 +1263,7 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer direct invocation of {@link Mono#then()}} over more contrived alternatives. */
+  /** Prefer direct invocation of {@link Mono#then()} over more contrived alternatives. */
   static final class MonoThen<T> {
     @BeforeTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
@@ -1276,7 +1282,7 @@ final class ReactorRules {
     }
   }
 
-  /** Avoid vacuous invocations of {@link Flux#ignoreElements()}. */
+  /** Prefer {@link Flux#then()} over vacuously invoking {@link Flux#ignoreElements()}. */
   static final class FluxThen<T> {
     @BeforeTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
@@ -1297,47 +1303,50 @@ final class ReactorRules {
     }
   }
 
-  /** Avoid vacuous invocations of {@link Mono#ignoreElement()}. */
+  /**
+   * Prefer {@link Mono#thenEmpty(Publisher)} over vacuously invoking {@link Mono#ignoreElement()}.
+   */
   static final class MonoThenEmpty<T> {
     @BeforeTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
-    Mono<Void> before(Mono<T> mono, Publisher<Void> publisher) {
-      return mono.ignoreElement().thenEmpty(publisher);
+    Mono<Void> before(Mono<T> mono, Publisher<Void> other) {
+      return mono.ignoreElement().thenEmpty(other);
     }
 
     @AfterTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
-    Mono<Void> after(Mono<T> mono, Publisher<Void> publisher) {
-      return mono.thenEmpty(publisher);
+    Mono<Void> after(Mono<T> mono, Publisher<Void> other) {
+      return mono.thenEmpty(other);
     }
   }
 
-  /** Avoid vacuous invocations of {@link Flux#ignoreElements()}. */
+  /**
+   * Prefer {@link Flux#thenEmpty(Publisher)} over vacuously invoking {@link Flux#ignoreElements()}.
+   */
   static final class FluxThenEmpty<T> {
     @BeforeTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
-    Mono<Void> before(Flux<T> flux, Publisher<Void> publisher) {
-      return flux.ignoreElements().thenEmpty(publisher);
+    Mono<Void> before(Flux<T> flux, Publisher<Void> other) {
+      return flux.ignoreElements().thenEmpty(other);
     }
 
     @AfterTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
-    Mono<Void> after(Flux<T> flux, Publisher<Void> publisher) {
-      return flux.thenEmpty(publisher);
+    Mono<Void> after(Flux<T> flux, Publisher<Void> other) {
+      return flux.thenEmpty(other);
     }
   }
 
-  /** Avoid vacuous operations prior to invocation of {@link Mono#thenMany(Publisher)}. */
+  /** Prefer {@link Mono#thenMany(Publisher)} over applying vacuous operations first. */
   static final class MonoThenMany<T, S> {
     @BeforeTemplate
-    Flux<S> before(Mono<T> mono, Publisher<S> publisher) {
-      return Refaster.anyOf(
-          mono.ignoreElement().thenMany(publisher), mono.flux().thenMany(publisher));
+    Flux<S> before(Mono<T> mono, Publisher<S> other) {
+      return Refaster.anyOf(mono.ignoreElement().thenMany(other), mono.flux().thenMany(other));
     }
 
     @AfterTemplate
-    Flux<S> after(Mono<T> mono, Publisher<S> publisher) {
-      return mono.thenMany(publisher);
+    Flux<S> after(Mono<T> mono, Publisher<S> other) {
+      return mono.thenMany(other);
     }
   }
 
@@ -1345,66 +1354,68 @@ final class ReactorRules {
    * Prefer explicit invocation of {@link Mono#flux()} over implicit conversions from {@link Mono}
    * to {@link Flux}.
    */
-  static final class MonoThenMonoFlux<T, S> {
+  static final class MonoThenFlux<T, S> {
     @BeforeTemplate
-    Flux<S> before(Mono<T> mono1, Mono<S> mono2) {
-      return mono1.thenMany(mono2);
+    Flux<S> before(Mono<T> mono, Mono<S> other) {
+      return mono.thenMany(other);
     }
 
     @AfterTemplate
-    Flux<S> after(Mono<T> mono1, Mono<S> mono2) {
-      return mono1.then(mono2).flux();
+    Flux<S> after(Mono<T> mono, Mono<S> other) {
+      return mono.then(other).flux();
     }
   }
 
-  /** Avoid vacuous invocations of {@link Flux#ignoreElements()}. */
+  /**
+   * Prefer {@link Flux#thenMany(Publisher)} over vacuously invoking {@link Flux#ignoreElements()}.
+   */
   static final class FluxThenMany<T, S> {
     @BeforeTemplate
-    Flux<S> before(Flux<T> flux, Publisher<S> publisher) {
-      return flux.ignoreElements().thenMany(publisher);
+    Flux<S> before(Flux<T> flux, Publisher<S> other) {
+      return flux.ignoreElements().thenMany(other);
     }
 
     @AfterTemplate
-    Flux<S> after(Flux<T> flux, Publisher<S> publisher) {
-      return flux.thenMany(publisher);
+    Flux<S> after(Flux<T> flux, Publisher<S> other) {
+      return flux.thenMany(other);
     }
   }
 
-  /** Avoid vacuous operations prior to invocation of {@link Mono#then(Mono)}. */
-  static final class MonoThenMono<T, S> {
+  /** Prefer {@link Mono#then(Mono)} over applying vacuous operations first. */
+  static final class MonoThenWithMono<T, S> {
     @BeforeTemplate
-    Mono<S> before(Mono<T> mono1, Mono<S> mono2) {
-      return Refaster.anyOf(mono1.ignoreElement().then(mono2), mono1.flux().then(mono2));
+    Mono<S> before(Mono<T> mono, Mono<S> other) {
+      return Refaster.anyOf(mono.ignoreElement().then(other), mono.flux().then(other));
     }
 
     @BeforeTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
-    Mono<Void> before2(Mono<T> mono1, Mono<Void> mono2) {
-      return mono1.thenEmpty(mono2);
+    Mono<Void> before2(Mono<T> mono, Mono<Void> other) {
+      return mono.thenEmpty(other);
     }
 
     @AfterTemplate
-    Mono<S> after(Mono<T> mono1, Mono<S> mono2) {
-      return mono1.then(mono2);
+    Mono<S> after(Mono<T> mono, Mono<S> other) {
+      return mono.then(other);
     }
   }
 
-  /** Avoid vacuous invocations of {@link Flux#ignoreElements()}. */
-  static final class FluxThenMono<T, S> {
+  /** Prefer {@link Flux#then(Mono)} over vacuously invoking {@link Flux#ignoreElements()}. */
+  static final class FluxThenWithMono<T, S> {
     @BeforeTemplate
-    Mono<S> before(Flux<T> flux, Mono<S> mono) {
-      return flux.ignoreElements().then(mono);
+    Mono<S> before(Flux<T> flux, Mono<S> other) {
+      return flux.ignoreElements().then(other);
     }
 
     @BeforeTemplate
     @SuppressWarnings("VoidMissingNullable" /* Suggestion is incompatible with Reactor API. */)
-    Mono<Void> before2(Flux<T> flux, Mono<Void> mono) {
-      return flux.thenEmpty(mono);
+    Mono<Void> before2(Flux<T> flux, Mono<Void> other) {
+      return flux.thenEmpty(other);
     }
 
     @AfterTemplate
-    Mono<S> after(Flux<T> flux, Mono<S> mono) {
-      return flux.then(mono);
+    Mono<S> after(Flux<T> flux, Mono<S> other) {
+      return flux.then(other);
     }
   }
 
@@ -1415,11 +1426,11 @@ final class ReactorRules {
   // rule. Consider introducing an Error Prone check for this.
   static final class MonoSingleOptional<T> {
     @BeforeTemplate
-    Mono<Optional<T>> before(Mono<T> mono, Optional<T> optional, Mono<Optional<T>> alternate) {
+    Mono<Optional<T>> before(Mono<T> mono, Optional<T> defaultV, Mono<Optional<T>> alternate) {
       return Refaster.anyOf(
           mono.flux().collect(toOptional()),
           mono.map(Optional::of).defaultIfEmpty(Optional.empty()),
-          mono.singleOptional().defaultIfEmpty(optional),
+          mono.singleOptional().defaultIfEmpty(defaultV),
           mono.singleOptional().switchIfEmpty(alternate),
           mono.transform(Mono::singleOptional));
     }
@@ -1432,7 +1443,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Mono#cast(Class)} over {@link Mono#map(Function)} with a cast. */
-  static final class MonoCast<T, S> {
+  static final class MonoCastClass<T, S> {
     @BeforeTemplate
     Mono<S> before(Mono<T> mono) {
       return mono.map(Refaster.<S>clazz()::cast);
@@ -1445,7 +1456,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Flux#cast(Class)} over {@link Flux#map(Function)} with a cast. */
-  static final class FluxCast<T, S> {
+  static final class FluxCastClass<T, S> {
     @BeforeTemplate
     Flux<S> before(Flux<T> flux) {
       return flux.map(Refaster.<S>clazz()::cast);
@@ -1489,15 +1500,15 @@ final class ReactorRules {
     @SuppressWarnings("NestedPublishers")
     Mono<T> before(
         Mono<S> mono,
-        Function<? super S, ? extends P> function,
+        Function<? super S, ? extends P> transformer,
         @Matches(IsIdentityOperation.class)
-            Function<? super P, ? extends Mono<? extends T>> identityOperation) {
-      return mono.map(function).flatMap(identityOperation);
+            Function<? super P, ? extends Mono<? extends T>> identityTransformer) {
+      return mono.map(transformer).flatMap(identityTransformer);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<S> mono, Function<? super S, ? extends P> function) {
-      return mono.flatMap(function);
+    Mono<T> after(Mono<S> mono, Function<? super S, ? extends P> transformer) {
+      return mono.flatMap(transformer);
     }
   }
 
@@ -1507,35 +1518,35 @@ final class ReactorRules {
     @SuppressWarnings("NestedPublishers")
     Flux<T> before(
         Mono<S> mono,
-        Function<? super S, P> function,
+        Function<? super S, P> mapper,
         @Matches(IsIdentityOperation.class)
-            Function<? super P, ? extends Publisher<? extends T>> identityOperation,
+            Function<? super P, ? extends Publisher<? extends T>> identityMapper,
         int prefetch,
         boolean delayUntilEnd,
-        int maxConcurrency) {
+        int concurrency) {
       return Refaster.anyOf(
-          mono.map(function).flatMapMany(identityOperation),
-          mono.flux().concatMap(function),
-          mono.flux().concatMap(function, prefetch),
-          mono.flux().concatMapDelayError(function),
-          mono.flux().concatMapDelayError(function, prefetch),
-          mono.flux().concatMapDelayError(function, delayUntilEnd, prefetch),
-          mono.flux().flatMap(function, maxConcurrency),
-          mono.flux().flatMap(function, maxConcurrency, prefetch),
-          mono.flux().flatMapDelayError(function, maxConcurrency, prefetch),
-          mono.flux().flatMapSequential(function, maxConcurrency),
-          mono.flux().flatMapSequential(function, maxConcurrency, prefetch),
-          mono.flux().flatMapSequentialDelayError(function, maxConcurrency, prefetch));
+          mono.map(mapper).flatMapMany(identityMapper),
+          mono.flux().concatMap(mapper),
+          mono.flux().concatMap(mapper, prefetch),
+          mono.flux().concatMapDelayError(mapper),
+          mono.flux().concatMapDelayError(mapper, prefetch),
+          mono.flux().concatMapDelayError(mapper, delayUntilEnd, prefetch),
+          mono.flux().flatMap(mapper, concurrency),
+          mono.flux().flatMap(mapper, concurrency, prefetch),
+          mono.flux().flatMapDelayError(mapper, concurrency, prefetch),
+          mono.flux().flatMapSequential(mapper, concurrency),
+          mono.flux().flatMapSequential(mapper, concurrency, prefetch),
+          mono.flux().flatMapSequentialDelayError(mapper, concurrency, prefetch));
     }
 
     @BeforeTemplate
-    Flux<T> before(Mono<S> mono, Function<? super S, Publisher<? extends T>> function) {
-      return mono.flux().switchMap(function);
+    Flux<T> before(Mono<S> mono, Function<? super S, Publisher<? extends T>> mapper) {
+      return mono.flux().switchMap(mapper);
     }
 
     @AfterTemplate
-    Flux<T> after(Mono<S> mono, Function<? super S, ? extends P> function) {
-      return mono.flatMapMany(function);
+    Flux<T> after(Mono<S> mono, Function<? super S, ? extends P> mapper) {
+      return mono.flatMapMany(mapper);
     }
   }
 
@@ -1543,7 +1554,7 @@ final class ReactorRules {
    * Prefer {@link Flux#concatMapIterable(Function)} over alternatives that require an additional
    * subscription.
    */
-  static final class ConcatMapIterableIdentity<T> {
+  static final class FluxConcatMapIterableIdentity<T> {
     @BeforeTemplate
     Flux<T> before(Flux<? extends Iterable<T>> flux) {
       return Refaster.anyOf(
@@ -1561,7 +1572,7 @@ final class ReactorRules {
    * Prefer {@link Flux#concatMapIterable(Function, int)} over alternatives that require an
    * additional subscription.
    */
-  static final class ConcatMapIterableIdentityWithPrefetch<T> {
+  static final class FluxConcatMapIterableIdentityWithInt<T> {
     @BeforeTemplate
     Flux<T> before(Flux<? extends Iterable<T>> flux, int prefetch) {
       return Refaster.anyOf(
@@ -1577,22 +1588,21 @@ final class ReactorRules {
   }
 
   /** Prefer {@link Flux#fromIterable(Iterable)} over less efficient alternatives. */
-  // XXX: Once the `FluxFromStreamSupplier` rule is constrained using
+  // XXX: Once the `FluxFromStream` rule is constrained using
   // `@NotMatches(IsIdentityOperation.class)`, this rule should also cover
   // `Flux.fromStream(collection.stream())`.
   static final class FluxFromIterable<T> {
     // XXX: Once the `MethodReferenceUsage` check is generally enabled, drop the second
     // `Refaster.anyOf` variant.
     @BeforeTemplate
-    Flux<T> before(Collection<T> collection) {
+    Flux<T> before(Collection<T> it) {
       return Flux.fromStream(
-          Refaster.<Supplier<Stream<? extends T>>>anyOf(
-              collection::stream, () -> collection.stream()));
+          Refaster.<Supplier<Stream<? extends T>>>anyOf(it::stream, () -> it.stream()));
     }
 
     @AfterTemplate
-    Flux<T> after(Collection<T> collection) {
-      return Flux.fromIterable(collection);
+    Flux<T> after(Collection<T> it) {
+      return Flux.fromIterable(it);
     }
   }
 
@@ -1628,14 +1638,18 @@ final class ReactorRules {
   static final class MonoDoOnError<T> {
     @BeforeTemplate
     Mono<T> before(
-        Mono<T> mono, Class<? extends Throwable> clazz, Consumer<? super Throwable> onError) {
-      return mono.doOnError(clazz::isInstance, onError);
+        Mono<T> mono,
+        Class<? extends Throwable> exceptionType,
+        Consumer<? super Throwable> onError) {
+      return mono.doOnError(exceptionType::isInstance, onError);
     }
 
     @AfterTemplate
     Mono<T> after(
-        Mono<T> mono, Class<? extends Throwable> clazz, Consumer<? super Throwable> onError) {
-      return mono.doOnError(clazz, onError);
+        Mono<T> mono,
+        Class<? extends Throwable> exceptionType,
+        Consumer<? super Throwable> onError) {
+      return mono.doOnError(exceptionType, onError);
     }
   }
 
@@ -1646,14 +1660,18 @@ final class ReactorRules {
   static final class FluxDoOnError<T> {
     @BeforeTemplate
     Flux<T> before(
-        Flux<T> flux, Class<? extends Throwable> clazz, Consumer<? super Throwable> onError) {
-      return flux.doOnError(clazz::isInstance, onError);
+        Flux<T> flux,
+        Class<? extends Throwable> exceptionType,
+        Consumer<? super Throwable> onError) {
+      return flux.doOnError(exceptionType::isInstance, onError);
     }
 
     @AfterTemplate
     Flux<T> after(
-        Flux<T> flux, Class<? extends Throwable> clazz, Consumer<? super Throwable> onError) {
-      return flux.doOnError(clazz, onError);
+        Flux<T> flux,
+        Class<? extends Throwable> exceptionType,
+        Consumer<? super Throwable> onError) {
+      return flux.doOnError(exceptionType, onError);
     }
   }
 
@@ -1665,15 +1683,15 @@ final class ReactorRules {
     @BeforeTemplate
     Mono<T> before(
         Mono<T> mono,
-        Consumer<? super Throwable> onThrowable,
-        Class<E> clazz,
-        Consumer<? super E> onError,
+        Consumer<? super Throwable> onError1,
+        Class<E> exceptionType,
+        Consumer<? super E> onError2,
         Predicate<? super Throwable> predicate) {
       return Refaster.anyOf(
           mono.onErrorResume(e -> Mono.empty()),
-          mono.onErrorComplete().doOnError(onThrowable),
-          mono.onErrorComplete().doOnError(clazz, onError),
-          mono.onErrorComplete().doOnError(predicate, onThrowable));
+          mono.onErrorComplete().doOnError(onError1),
+          mono.onErrorComplete().doOnError(exceptionType, onError2),
+          mono.onErrorComplete().doOnError(predicate, onError1));
     }
 
     @AfterTemplate
@@ -1690,15 +1708,15 @@ final class ReactorRules {
     @BeforeTemplate
     Flux<T> before(
         Flux<T> flux,
-        Consumer<? super Throwable> onThrowable,
-        Class<E> clazz,
-        Consumer<? super E> onError,
+        Consumer<? super Throwable> onError1,
+        Class<E> exceptionType,
+        Consumer<? super E> onError2,
         Predicate<? super Throwable> predicate) {
       return Refaster.anyOf(
           flux.onErrorResume(e -> Refaster.anyOf(Mono.empty(), Flux.empty())),
-          flux.onErrorComplete().doOnError(onThrowable),
-          flux.onErrorComplete().doOnError(clazz, onError),
-          flux.onErrorComplete().doOnError(predicate, onThrowable));
+          flux.onErrorComplete().doOnError(onError1),
+          flux.onErrorComplete().doOnError(exceptionType, onError2),
+          flux.onErrorComplete().doOnError(predicate, onError1));
     }
 
     @AfterTemplate
@@ -1707,37 +1725,37 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Mono#onErrorComplete(Class)}} over more contrived alternatives. */
-  static final class MonoOnErrorCompleteClass<T> {
+  /** Prefer {@link Mono#onErrorComplete(Class)} over more contrived alternatives. */
+  static final class MonoOnErrorCompleteWithClass<T> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Class<? extends Throwable> clazz) {
+    Mono<T> before(Mono<T> mono, Class<? extends Throwable> type) {
       return Refaster.anyOf(
-          mono.onErrorComplete(clazz::isInstance), mono.onErrorResume(clazz, e -> Mono.empty()));
+          mono.onErrorComplete(type::isInstance), mono.onErrorResume(type, e -> Mono.empty()));
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Class<? extends Throwable> clazz) {
-      return mono.onErrorComplete(clazz);
+    Mono<T> after(Mono<T> mono, Class<? extends Throwable> type) {
+      return mono.onErrorComplete(type);
     }
   }
 
-  /** Prefer {@link Flux#onErrorComplete(Class)}} over more contrived alternatives. */
-  static final class FluxOnErrorCompleteClass<T> {
+  /** Prefer {@link Flux#onErrorComplete(Class)} over more contrived alternatives. */
+  static final class FluxOnErrorCompleteWithClass<T> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, Class<? extends Throwable> clazz) {
+    Flux<T> before(Flux<T> flux, Class<? extends Throwable> type) {
       return Refaster.anyOf(
-          flux.onErrorComplete(clazz::isInstance),
-          flux.onErrorResume(clazz, e -> Refaster.anyOf(Mono.empty(), Flux.empty())));
+          flux.onErrorComplete(type::isInstance),
+          flux.onErrorResume(type, e -> Refaster.anyOf(Mono.empty(), Flux.empty())));
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, Class<? extends Throwable> clazz) {
-      return flux.onErrorComplete(clazz);
+    Flux<T> after(Flux<T> flux, Class<? extends Throwable> type) {
+      return flux.onErrorComplete(type);
     }
   }
 
-  /** Prefer {@link Mono#onErrorComplete(Predicate)}} over more contrived alternatives. */
-  static final class MonoOnErrorCompletePredicate<T> {
+  /** Prefer {@link Mono#onErrorComplete(Predicate)} over more contrived alternatives. */
+  static final class MonoOnErrorCompleteWithPredicate<T> {
     @BeforeTemplate
     Mono<T> before(Mono<T> mono, Predicate<? super Throwable> predicate) {
       return mono.onErrorResume(predicate, e -> Mono.empty());
@@ -1749,8 +1767,8 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link Flux#onErrorComplete(Predicate)}} over more contrived alternatives. */
-  static final class FluxOnErrorCompletePredicate<T> {
+  /** Prefer {@link Flux#onErrorComplete(Predicate)} over more contrived alternatives. */
+  static final class FluxOnErrorCompleteWithPredicate<T> {
     @BeforeTemplate
     Flux<T> before(Flux<T> flux, Predicate<? super Throwable> predicate) {
       return flux.onErrorResume(predicate, e -> Refaster.anyOf(Mono.empty(), Flux.empty()));
@@ -1770,17 +1788,17 @@ final class ReactorRules {
     @BeforeTemplate
     Mono<T> before(
         Mono<T> mono,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         BiConsumer<Throwable, Object> errorConsumer) {
-      return mono.onErrorContinue(clazz::isInstance, errorConsumer);
+      return mono.onErrorContinue(type::isInstance, errorConsumer);
     }
 
     @AfterTemplate
     Mono<T> after(
         Mono<T> mono,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         BiConsumer<Throwable, Object> errorConsumer) {
-      return mono.onErrorContinue(clazz, errorConsumer);
+      return mono.onErrorContinue(type, errorConsumer);
     }
   }
 
@@ -1792,17 +1810,17 @@ final class ReactorRules {
     @BeforeTemplate
     Flux<T> before(
         Flux<T> flux,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         BiConsumer<Throwable, Object> errorConsumer) {
-      return flux.onErrorContinue(clazz::isInstance, errorConsumer);
+      return flux.onErrorContinue(type::isInstance, errorConsumer);
     }
 
     @AfterTemplate
     Flux<T> after(
         Flux<T> flux,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         BiConsumer<Throwable, Object> errorConsumer) {
-      return flux.onErrorContinue(clazz, errorConsumer);
+      return flux.onErrorContinue(type, errorConsumer);
     }
   }
 
@@ -1814,17 +1832,17 @@ final class ReactorRules {
     @BeforeTemplate
     Mono<T> before(
         Mono<T> mono,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Throwable> mapper) {
-      return mono.onErrorMap(clazz::isInstance, mapper);
+      return mono.onErrorMap(type::isInstance, mapper);
     }
 
     @AfterTemplate
     Mono<T> after(
         Mono<T> mono,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Throwable> mapper) {
-      return mono.onErrorMap(clazz, mapper);
+      return mono.onErrorMap(type, mapper);
     }
   }
 
@@ -1836,17 +1854,17 @@ final class ReactorRules {
     @BeforeTemplate
     Flux<T> before(
         Flux<T> flux,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Throwable> mapper) {
-      return flux.onErrorMap(clazz::isInstance, mapper);
+      return flux.onErrorMap(type::isInstance, mapper);
     }
 
     @AfterTemplate
     Flux<T> after(
         Flux<T> flux,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Throwable> mapper) {
-      return flux.onErrorMap(clazz, mapper);
+      return flux.onErrorMap(type, mapper);
     }
   }
 
@@ -1858,17 +1876,17 @@ final class ReactorRules {
     @BeforeTemplate
     Mono<T> before(
         Mono<T> mono,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Mono<? extends T>> fallback) {
-      return mono.onErrorResume(clazz::isInstance, fallback);
+      return mono.onErrorResume(type::isInstance, fallback);
     }
 
     @AfterTemplate
     Mono<T> after(
         Mono<T> mono,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Mono<? extends T>> fallback) {
-      return mono.onErrorResume(clazz, fallback);
+      return mono.onErrorResume(type, fallback);
     }
   }
 
@@ -1880,17 +1898,17 @@ final class ReactorRules {
     @BeforeTemplate
     Flux<T> before(
         Flux<T> flux,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Publisher<? extends T>> fallback) {
-      return flux.onErrorResume(clazz::isInstance, fallback);
+      return flux.onErrorResume(type::isInstance, fallback);
     }
 
     @AfterTemplate
     Flux<T> after(
         Flux<T> flux,
-        Class<? extends Throwable> clazz,
+        Class<? extends Throwable> type,
         Function<? super Throwable, ? extends Publisher<? extends T>> fallback) {
-      return flux.onErrorResume(clazz, fallback);
+      return flux.onErrorResume(type, fallback);
     }
   }
 
@@ -1900,13 +1918,13 @@ final class ReactorRules {
    */
   static final class MonoOnErrorReturn<T> {
     @BeforeTemplate
-    Mono<T> before(Mono<T> mono, Class<? extends Throwable> clazz, T fallbackValue) {
-      return mono.onErrorReturn(clazz::isInstance, fallbackValue);
+    Mono<T> before(Mono<T> mono, Class<? extends Throwable> type, T fallbackValue) {
+      return mono.onErrorReturn(type::isInstance, fallbackValue);
     }
 
     @AfterTemplate
-    Mono<T> after(Mono<T> mono, Class<? extends Throwable> clazz, T fallbackValue) {
-      return mono.onErrorReturn(clazz, fallbackValue);
+    Mono<T> after(Mono<T> mono, Class<? extends Throwable> type, T fallbackValue) {
+      return mono.onErrorReturn(type, fallbackValue);
     }
   }
 
@@ -1916,13 +1934,13 @@ final class ReactorRules {
    */
   static final class FluxOnErrorReturn<T> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, Class<? extends Throwable> clazz, T fallbackValue) {
-      return flux.onErrorReturn(clazz::isInstance, fallbackValue);
+    Flux<T> before(Flux<T> flux, Class<? extends Throwable> type, T fallbackValue) {
+      return flux.onErrorReturn(type::isInstance, fallbackValue);
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, Class<? extends Throwable> clazz, T fallbackValue) {
-      return flux.onErrorReturn(clazz, fallbackValue);
+    Flux<T> after(Flux<T> flux, Class<? extends Throwable> type, T fallbackValue) {
+      return flux.onErrorReturn(type, fallbackValue);
     }
   }
 
@@ -1932,13 +1950,13 @@ final class ReactorRules {
    */
   static final class FluxFilterSort<T> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, Predicate<? super T> predicate) {
-      return flux.sort().filter(predicate);
+    Flux<T> before(Flux<T> flux, Predicate<? super T> p) {
+      return flux.sort().filter(p);
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, Predicate<? super T> predicate) {
-      return flux.filter(predicate).sort();
+    Flux<T> after(Flux<T> flux, Predicate<? super T> p) {
+      return flux.filter(p).sort();
     }
   }
 
@@ -1948,13 +1966,13 @@ final class ReactorRules {
    */
   static final class FluxFilterSortWithComparator<T> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, Predicate<? super T> predicate, Comparator<? super T> comparator) {
-      return flux.sort(comparator).filter(predicate);
+    Flux<T> before(Flux<T> flux, Predicate<? super T> p, Comparator<? super T> sortFunction) {
+      return flux.sort(sortFunction).filter(p);
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, Predicate<? super T> predicate, Comparator<? super T> comparator) {
-      return flux.filter(predicate).sort(comparator);
+    Flux<T> after(Flux<T> flux, Predicate<? super T> p, Comparator<? super T> sortFunction) {
+      return flux.filter(p).sort(sortFunction);
     }
   }
 
@@ -1980,13 +1998,13 @@ final class ReactorRules {
    */
   static final class FluxDistinctSortWithComparator<S, T extends S> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, Comparator<S> comparator) {
-      return flux.sort(comparator).distinct();
+    Flux<T> before(Flux<T> flux, Comparator<S> sortFunction) {
+      return flux.sort(sortFunction).distinct();
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, Comparator<S> comparator) {
-      return flux.distinct().sort(comparator);
+    Flux<T> after(Flux<T> flux, Comparator<S> sortFunction) {
+      return flux.distinct().sort(sortFunction);
     }
   }
 
@@ -1996,13 +2014,13 @@ final class ReactorRules {
    */
   static final class FluxTakeWhile<T> {
     @BeforeTemplate
-    Flux<T> before(Flux<T> flux, Predicate<? super T> predicate) {
-      return flux.takeWhile(predicate).filter(predicate);
+    Flux<T> before(Flux<T> flux, Predicate<? super T> continuePredicate) {
+      return flux.takeWhile(continuePredicate).filter(continuePredicate);
     }
 
     @AfterTemplate
-    Flux<T> after(Flux<T> flux, Predicate<? super T> predicate) {
-      return flux.takeWhile(predicate);
+    Flux<T> after(Flux<T> flux, Predicate<? super T> continuePredicate) {
+      return flux.takeWhile(continuePredicate);
     }
   }
 
@@ -2054,7 +2072,7 @@ final class ReactorRules {
   }
 
   /** Prefer {@link MathFlux#min(Publisher)} over less efficient alternatives. */
-  static final class FluxTransformMin<T extends Comparable<? super T>> {
+  static final class FluxTransformMathFluxMinSingleOrEmpty<T extends Comparable<? super T>> {
     @BeforeTemplate
     Mono<T> before(Flux<T> flux) {
       return flux.sort().next();
@@ -2070,21 +2088,22 @@ final class ReactorRules {
    * Prefer {@link MathFlux#min(Publisher, Comparator)} over less efficient or more verbose
    * alternatives.
    */
-  static final class FluxTransformMinWithComparator<T extends Comparable<? super T>> {
+  static final class FluxTransformMathFluxMinSingleOrEmptyWithComparator<
+      T extends Comparable<? super T>> {
     @BeforeTemplate
-    Mono<T> before(Flux<T> flux, Comparator<? super T> cmp) {
+    Mono<T> before(Flux<T> flux, Comparator<? super T> comparator) {
       return Refaster.anyOf(
-          flux.sort(cmp).next(), flux.collect(minBy(cmp)).flatMap(Mono::justOrEmpty));
+          flux.sort(comparator).next(), flux.collect(minBy(comparator)).flatMap(Mono::justOrEmpty));
     }
 
     @AfterTemplate
-    Mono<T> after(Flux<T> flux, Comparator<? super T> cmp) {
-      return flux.transform(f -> MathFlux.min(f, cmp)).singleOrEmpty();
+    Mono<T> after(Flux<T> flux, Comparator<? super T> comparator) {
+      return flux.transform(f -> MathFlux.min(f, comparator)).singleOrEmpty();
     }
   }
 
   /** Prefer {@link MathFlux#max(Publisher)} over less efficient alternatives. */
-  static final class FluxTransformMax<T extends Comparable<? super T>> {
+  static final class FluxTransformMathFluxMaxSingleOrEmpty<T extends Comparable<? super T>> {
     @BeforeTemplate
     Mono<T> before(Flux<T> flux) {
       return flux.sort().last();
@@ -2100,54 +2119,55 @@ final class ReactorRules {
    * Prefer {@link MathFlux#max(Publisher, Comparator)} over less efficient or more verbose
    * alternatives.
    */
-  static final class FluxTransformMaxWithComparator<T extends Comparable<? super T>> {
+  static final class FluxTransformMathFluxMaxSingleOrEmptyWithComparator<
+      T extends Comparable<? super T>> {
     @BeforeTemplate
-    Mono<T> before(Flux<T> flux, Comparator<? super T> cmp) {
+    Mono<T> before(Flux<T> flux, Comparator<? super T> comparator) {
       return Refaster.anyOf(
-          flux.sort(cmp).last(), flux.collect(maxBy(cmp)).flatMap(Mono::justOrEmpty));
+          flux.sort(comparator).last(), flux.collect(maxBy(comparator)).flatMap(Mono::justOrEmpty));
     }
 
     @AfterTemplate
-    Mono<T> after(Flux<T> flux, Comparator<? super T> cmp) {
-      return flux.transform(f -> MathFlux.max(f, cmp)).singleOrEmpty();
+    Mono<T> after(Flux<T> flux, Comparator<? super T> comparator) {
+      return flux.transform(f -> MathFlux.max(f, comparator)).singleOrEmpty();
     }
   }
 
   /** Prefer {@link MathFlux#min(Publisher)} over more contrived alternatives. */
   static final class MathFluxMin<T extends Comparable<? super T>> {
     @BeforeTemplate
-    Mono<T> before(Publisher<T> publisher) {
+    Mono<T> before(Publisher<T> source) {
       return Refaster.anyOf(
-          MathFlux.min(publisher, naturalOrder()), MathFlux.max(publisher, reverseOrder()));
+          MathFlux.min(source, naturalOrder()), MathFlux.max(source, reverseOrder()));
     }
 
     @AfterTemplate
-    Mono<T> after(Publisher<T> publisher) {
-      return MathFlux.min(publisher);
+    Mono<T> after(Publisher<T> source) {
+      return MathFlux.min(source);
     }
   }
 
   /** Prefer {@link MathFlux#max(Publisher)} over more contrived alternatives. */
   static final class MathFluxMax<T extends Comparable<? super T>> {
     @BeforeTemplate
-    Mono<T> before(Publisher<T> publisher) {
+    Mono<T> before(Publisher<T> source) {
       return Refaster.anyOf(
-          MathFlux.min(publisher, reverseOrder()), MathFlux.max(publisher, naturalOrder()));
+          MathFlux.min(source, reverseOrder()), MathFlux.max(source, naturalOrder()));
     }
 
     @AfterTemplate
-    Mono<T> after(Publisher<T> publisher) {
-      return MathFlux.max(publisher);
+    Mono<T> after(Publisher<T> source) {
+      return MathFlux.max(source);
     }
   }
 
-  /** Prefer {@link reactor.util.context.Context#empty()}} over more verbose alternatives. */
+  /** Prefer {@link reactor.util.context.Context#empty()} over more verbose alternatives. */
   // XXX: Introduce Refaster rules or a `BugChecker` that maps `(Immutable)Map.of(k, v)` to
   // `Context.of(k, v)` and likewise for multi-pair overloads.
   static final class ContextEmpty {
     @BeforeTemplate
-    Context before(@Matches(IsEmpty.class) Map<?, ?> map) {
-      return Context.of(map);
+    Context before(@Matches(IsEmpty.class) Map<?, ?> emptyMap) {
+      return Context.of(emptyMap);
     }
 
     @AfterTemplate
@@ -2156,7 +2176,7 @@ final class ReactorRules {
     }
   }
 
-  /** Prefer {@link PublisherProbe#empty()}} over more verbose alternatives. */
+  /** Prefer {@link PublisherProbe#empty()} over more verbose alternatives. */
   static final class PublisherProbeEmpty<T> {
     @BeforeTemplate
     PublisherProbe<T> before() {
@@ -2258,11 +2278,11 @@ final class ReactorRules {
    * Prefer {@link Assertions#assertThat(boolean)} to check whether a {@link PublisherProbe} was
    * {@link PublisherProbe#wasSubscribed() subscribed to}, over more verbose alternatives.
    */
-  static final class AssertThatPublisherProbeWasSubscribed<T> {
+  static final class AssertThatPublisherProbeWasSubscribedIsEqualTo<T> {
     @AlsoNegation
     @BeforeTemplate
-    void before(PublisherProbe<T> probe, boolean wasSubscribed) {
-      if (wasSubscribed) {
+    void before(PublisherProbe<T> probe, boolean expected) {
+      if (expected) {
         probe.assertWasSubscribed();
       } else {
         probe.assertWasNotSubscribed();
@@ -2270,8 +2290,8 @@ final class ReactorRules {
     }
 
     @AfterTemplate
-    void after(PublisherProbe<T> probe, boolean wasSubscribed) {
-      assertThat(probe.wasSubscribed()).isEqualTo(wasSubscribed);
+    void after(PublisherProbe<T> probe, boolean expected) {
+      assertThat(probe.wasSubscribed()).isEqualTo(expected);
     }
   }
 
@@ -2279,11 +2299,11 @@ final class ReactorRules {
    * Prefer {@link Assertions#assertThat(boolean)} to check whether a {@link PublisherProbe} was
    * {@link PublisherProbe#wasCancelled() cancelled}, over more verbose alternatives.
    */
-  static final class AssertThatPublisherProbeWasCancelled<T> {
+  static final class AssertThatPublisherProbeWasCancelledIsEqualTo<T> {
     @AlsoNegation
     @BeforeTemplate
-    void before(PublisherProbe<T> probe, boolean wasCancelled) {
-      if (wasCancelled) {
+    void before(PublisherProbe<T> probe, boolean expected) {
+      if (expected) {
         probe.assertWasCancelled();
       } else {
         probe.assertWasNotCancelled();
@@ -2291,8 +2311,8 @@ final class ReactorRules {
     }
 
     @AfterTemplate
-    void after(PublisherProbe<T> probe, boolean wasCancelled) {
-      assertThat(probe.wasCancelled()).isEqualTo(wasCancelled);
+    void after(PublisherProbe<T> probe, boolean expected) {
+      assertThat(probe.wasCancelled()).isEqualTo(expected);
     }
   }
 
@@ -2300,11 +2320,11 @@ final class ReactorRules {
    * Prefer {@link Assertions#assertThat(boolean)} to check whether a {@link PublisherProbe} was
    * {@link PublisherProbe#wasRequested() requested}, over more verbose alternatives.
    */
-  static final class AssertThatPublisherProbeWasRequested<T> {
+  static final class AssertThatPublisherProbeWasRequestedIsEqualTo<T> {
     @AlsoNegation
     @BeforeTemplate
-    void before(PublisherProbe<T> probe, boolean wasRequested) {
-      if (wasRequested) {
+    void before(PublisherProbe<T> probe, boolean expected) {
+      if (expected) {
         probe.assertWasRequested();
       } else {
         probe.assertWasNotRequested();
@@ -2312,34 +2332,35 @@ final class ReactorRules {
     }
 
     @AfterTemplate
-    void after(PublisherProbe<T> probe, boolean wasRequested) {
-      assertThat(probe.wasRequested()).isEqualTo(wasRequested);
+    void after(PublisherProbe<T> probe, boolean expected) {
+      assertThat(probe.wasRequested()).isEqualTo(expected);
     }
   }
 
   /** Prefer {@link Mono#as(Function)} when creating a {@link StepVerifier}. */
-  static final class StepVerifierFromMono<T> {
+  static final class MonoAsStepVerifierCreate<T> {
     @BeforeTemplate
-    StepVerifier.FirstStep<? extends T> before(Mono<T> mono) {
-      return Refaster.anyOf(StepVerifier.create(mono), mono.flux().as(StepVerifier::create));
+    FirstStep<T> before(Mono<T> publisher) {
+      return Refaster.anyOf(
+          StepVerifier.create(publisher), publisher.flux().as(StepVerifier::create));
     }
 
     @AfterTemplate
-    StepVerifier.FirstStep<? extends T> after(Mono<T> mono) {
-      return mono.as(StepVerifier::create);
+    FirstStep<T> after(Mono<T> publisher) {
+      return publisher.as(StepVerifier::create);
     }
   }
 
   /** Prefer {@link Flux#as(Function)} when creating a {@link StepVerifier}. */
-  static final class StepVerifierFromFlux<T> {
+  static final class FluxAsStepVerifierCreate<T> {
     @BeforeTemplate
-    StepVerifier.FirstStep<? extends T> before(Flux<T> flux) {
-      return StepVerifier.create(flux);
+    FirstStep<T> before(Flux<T> publisher) {
+      return StepVerifier.create(publisher);
     }
 
     @AfterTemplate
-    StepVerifier.FirstStep<? extends T> after(Flux<T> flux) {
-      return flux.as(StepVerifier::create);
+    FirstStep<T> after(Flux<T> publisher) {
+      return publisher.as(StepVerifier::create);
     }
   }
 
@@ -2372,7 +2393,7 @@ final class ReactorRules {
    * Prefer {@link StepVerifier#verify(Duration)} over a dangling {@link
    * StepVerifier#verifyThenAssertThat(Duration)}.
    */
-  static final class StepVerifierVerifyDuration {
+  static final class StepVerifierVerifyWithDuration {
     @BeforeTemplate
     StepVerifier.Assertions before(StepVerifier stepVerifier, Duration duration) {
       return stepVerifier.verifyThenAssertThat(duration);
@@ -2384,7 +2405,7 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily invoke {@link StepVerifier#verifyLater()} multiple times. */
+  /** Prefer invoking {@link StepVerifier#verifyLater()} once over multiple invocations. */
   static final class StepVerifierVerifyLater {
     @BeforeTemplate
     StepVerifier before(StepVerifier stepVerifier) {
@@ -2397,14 +2418,14 @@ final class ReactorRules {
     }
   }
 
-  /** Don't unnecessarily have {@link StepVerifier.Step} expect no elements. */
-  static final class StepVerifierStepIdentity<T> {
+  /** Prefer using {@link StepVerifier.Step}s as-is over unnecessarily expecting no elements. */
+  static final class StepIdentity<T> {
     @BeforeTemplate
     @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
     StepVerifier.Step<T> before(
-        StepVerifier.Step<T> step, @Matches(IsEmpty.class) Iterable<? extends T> iterable) {
+        StepVerifier.Step<T> step, @Matches(IsEmpty.class) Iterable<? extends T> emptyIterable) {
       return Refaster.anyOf(
-          step.expectNext(), step.expectNextCount(0), step.expectNextSequence(iterable));
+          step.expectNext(), step.expectNextCount(0), step.expectNextSequence(emptyIterable));
     }
 
     @AfterTemplate
@@ -2415,26 +2436,29 @@ final class ReactorRules {
   }
 
   /** Prefer {@link StepVerifier.Step#expectNext(Object)} over more verbose alternatives. */
-  static final class StepVerifierStepExpectNext<T> {
+  static final class StepExpectNext<T> {
     @BeforeTemplate
-    StepVerifier.Step<T> before(StepVerifier.Step<T> step, T object) {
+    StepVerifier.Step<T> before(StepVerifier.Step<T> step, T obj) {
       return Refaster.anyOf(
-          step.expectNextMatches(e -> e.equals(object)), step.expectNextMatches(object::equals));
+          step.expectNextMatches(e -> e.equals(obj)), step.expectNextMatches(obj::equals));
     }
 
     @AfterTemplate
-    StepVerifier.Step<T> after(StepVerifier.Step<T> step, T object) {
-      return step.expectNext(object);
+    StepVerifier.Step<T> after(StepVerifier.Step<T> step, T obj) {
+      return step.expectNext(obj);
     }
   }
 
-  /** Avoid list collection when verifying that a {@link Flux} emits exactly one value. */
+  /**
+   * Prefer using {@link FirstStep#expectNext(Object)} over collecting a single-element {@link Flux}
+   * into a list.
+   */
   // XXX: This rule assumes that the matched collector does not drop elements. Consider introducing
   // a `@Matches(DoesNotDropElements.class)` or `@NotMatches(MayDropElements.class)` guard.
-  static final class FluxAsStepVerifierExpectNext<T, L extends List<T>> {
+  static final class FluxAsStepVerifierCreateExpectNext<T, L extends List<T>> {
     @BeforeTemplate
-    StepVerifier.Step<L> before(Flux<T> flux, T object, Collector<? super T, ?, L> listCollector) {
-      return flux.collect(listCollector)
+    StepVerifier.Step<L> before(Flux<T> flux, T object, Collector<? super T, ?, L> collector) {
+      return flux.collect(collector)
           .as(StepVerifier::create)
           .assertNext(list -> assertThat(list).containsExactly(object));
     }
@@ -2446,44 +2470,44 @@ final class ReactorRules {
   }
 
   /** Prefer {@link StepVerifier.LastStep#verifyComplete()} over more verbose alternatives. */
-  static final class StepVerifierLastStepVerifyComplete {
+  static final class LastStepVerifyComplete {
     @BeforeTemplate
-    Duration before(StepVerifier.LastStep step) {
-      return step.expectComplete().verify();
+    Duration before(StepVerifier.LastStep lastStep) {
+      return lastStep.expectComplete().verify();
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step) {
-      return step.verifyComplete();
+    Duration after(StepVerifier.LastStep lastStep) {
+      return lastStep.verifyComplete();
     }
   }
 
   /** Prefer {@link StepVerifier.LastStep#verifyError()} over more verbose alternatives. */
-  static final class StepVerifierLastStepVerifyError {
+  static final class LastStepVerifyError {
     @BeforeTemplate
-    Duration before(StepVerifier.LastStep step) {
-      return step.expectError().verify();
+    Duration before(StepVerifier.LastStep lastStep) {
+      return lastStep.expectError().verify();
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step) {
-      return step.verifyError();
+    Duration after(StepVerifier.LastStep lastStep) {
+      return lastStep.verifyError();
     }
   }
 
   /** Prefer {@link StepVerifier.LastStep#verifyError(Class)} over more verbose alternatives. */
-  static final class StepVerifierLastStepVerifyErrorClass<T extends Throwable> {
+  static final class LastStepVerifyErrorWithClass<T extends Throwable> {
     @BeforeTemplate
-    Duration before(StepVerifier.LastStep step, Class<T> clazz) {
+    Duration before(StepVerifier.LastStep lastStep, Class<T> type) {
       return Refaster.anyOf(
-          step.expectError(clazz).verify(),
-          step.verifyErrorMatches(clazz::isInstance),
-          step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz)));
+          lastStep.expectError(type).verify(),
+          lastStep.verifyErrorMatches(type::isInstance),
+          lastStep.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(type)));
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step, Class<T> clazz) {
-      return step.verifyError(clazz);
+    Duration after(StepVerifier.LastStep lastStep, Class<T> type) {
+      return lastStep.verifyError(type);
     }
   }
 
@@ -2491,21 +2515,22 @@ final class ReactorRules {
    * Prefer {@link StepVerifier.LastStep#verifyErrorMatches(Predicate)} over more verbose
    * alternatives.
    */
-  static final class StepVerifierLastStepVerifyErrorMatches {
+  static final class LastStepVerifyErrorMatches {
     @BeforeTemplate
-    Duration before(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
-      return step.expectErrorMatches(predicate).verify();
+    Duration before(StepVerifier.LastStep lastStep, Predicate<Throwable> predicate) {
+      return lastStep.expectErrorMatches(predicate).verify();
     }
 
     @BeforeTemplate
     @SuppressWarnings("StepVerifierVerify" /* This is a more specific template. */)
-    StepVerifier.Assertions before2(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
-      return step.expectError().verifyThenAssertThat().hasOperatorErrorMatching(predicate);
+    StepVerifier.Assertions before2(
+        StepVerifier.LastStep lastStep, Predicate<Throwable> predicate) {
+      return lastStep.expectError().verifyThenAssertThat().hasOperatorErrorMatching(predicate);
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step, Predicate<Throwable> predicate) {
-      return step.verifyErrorMatches(predicate);
+    Duration after(StepVerifier.LastStep lastStep, Predicate<Throwable> predicate) {
+      return lastStep.verifyErrorMatches(predicate);
     }
   }
 
@@ -2513,15 +2538,15 @@ final class ReactorRules {
    * Prefer {@link StepVerifier.LastStep#verifyErrorSatisfies(Consumer)} over more verbose
    * alternatives.
    */
-  static final class StepVerifierLastStepVerifyErrorSatisfies {
+  static final class LastStepVerifyErrorSatisfies {
     @BeforeTemplate
-    Duration before(StepVerifier.LastStep step, Consumer<Throwable> consumer) {
-      return step.expectErrorSatisfies(consumer).verify();
+    Duration before(StepVerifier.LastStep lastStep, Consumer<Throwable> consumer) {
+      return lastStep.expectErrorSatisfies(consumer).verify();
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step, Consumer<Throwable> consumer) {
-      return step.verifyErrorSatisfies(consumer);
+    Duration after(StepVerifier.LastStep lastStep, Consumer<Throwable> consumer) {
+      return lastStep.verifyErrorSatisfies(consumer);
     }
   }
 
@@ -2529,53 +2554,56 @@ final class ReactorRules {
    * Prefer {@link StepVerifier.LastStep#verifyErrorSatisfies(Consumer)} with AssertJ over more
    * contrived alternatives.
    */
-  static final class StepVerifierLastStepVerifyErrorSatisfiesAssertJ<T extends Throwable> {
+  static final class LastStepVerifyErrorSatisfiesAssertThatIsInstanceOfHasMessage<
+      T extends Throwable> {
     @BeforeTemplate
     @SuppressWarnings("StepVerifierVerify" /* This is a more specific template. */)
-    StepVerifier.Assertions before(StepVerifier.LastStep step, Class<T> clazz, String message) {
+    StepVerifier.Assertions before(StepVerifier.LastStep lastStep, Class<T> type, String message) {
       return Refaster.anyOf(
-          step.expectError()
+          lastStep
+              .expectError()
               .verifyThenAssertThat()
-              .hasOperatorErrorOfType(clazz)
+              .hasOperatorErrorOfType(type)
               .hasOperatorErrorWithMessage(message),
-          step.expectError(clazz).verifyThenAssertThat().hasOperatorErrorWithMessage(message),
-          step.expectErrorMessage(message).verifyThenAssertThat().hasOperatorErrorOfType(clazz));
+          lastStep.expectError(type).verifyThenAssertThat().hasOperatorErrorWithMessage(message),
+          lastStep.expectErrorMessage(message).verifyThenAssertThat().hasOperatorErrorOfType(type));
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Duration after(StepVerifier.LastStep step, Class<T> clazz, String message) {
-      return step.verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(clazz).hasMessage(message));
+    Duration after(StepVerifier.LastStep lastStep, Class<T> type, String message) {
+      return lastStep.verifyErrorSatisfies(
+          t -> assertThat(t).isInstanceOf(type).hasMessage(message));
     }
   }
 
   /**
    * Prefer {@link StepVerifier.LastStep#verifyErrorMessage(String)} over more verbose alternatives.
    */
-  static final class StepVerifierLastStepVerifyErrorMessage {
+  static final class LastStepVerifyErrorMessage {
     @BeforeTemplate
-    Duration before(StepVerifier.LastStep step, String message) {
-      return step.expectErrorMessage(message).verify();
+    Duration before(StepVerifier.LastStep lastStep, String str) {
+      return lastStep.expectErrorMessage(str).verify();
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step, String message) {
-      return step.verifyErrorMessage(message);
+    Duration after(StepVerifier.LastStep lastStep, String str) {
+      return lastStep.verifyErrorMessage(str);
     }
   }
 
   /**
    * Prefer {@link StepVerifier.LastStep#verifyTimeout(Duration)} over more verbose alternatives.
    */
-  static final class StepVerifierLastStepVerifyTimeout {
+  static final class LastStepVerifyTimeout {
     @BeforeTemplate
-    Duration before(StepVerifier.LastStep step, Duration duration) {
-      return step.expectTimeout(duration).verify();
+    Duration before(StepVerifier.LastStep lastStep, Duration duration) {
+      return lastStep.expectTimeout(duration).verify();
     }
 
     @AfterTemplate
-    Duration after(StepVerifier.LastStep step, Duration duration) {
-      return step.verifyTimeout(duration);
+    Duration after(StepVerifier.LastStep lastStep, Duration duration) {
+      return lastStep.verifyTimeout(duration);
     }
   }
 
@@ -2583,9 +2611,8 @@ final class ReactorRules {
    * Prefer {@link Mono#fromFuture(Supplier)} over {@link Mono#fromFuture(CompletableFuture)}, as
    * the former may defer initiation of the asynchronous computation until subscription.
    */
-  static final class MonoFromFutureSupplier<T> {
-    // XXX: Constrain the `future` parameter using `@NotMatches(IsIdentityOperation.class)` once
-    // `IsIdentityOperation` no longer matches nullary method invocations.
+  static final class MonoFromFuture<T> {
+    // XXX: Constrain the `future` parameter using `@Matches(RequiresComputation.class)`.
     @BeforeTemplate
     Mono<T> before(CompletableFuture<T> future) {
       return Mono.fromFuture(future);
@@ -2602,9 +2629,8 @@ final class ReactorRules {
    * Mono#fromFuture(CompletableFuture, boolean)}, as the former may defer initiation of the
    * asynchronous computation until subscription.
    */
-  static final class MonoFromFutureSupplierBoolean<T> {
-    // XXX: Constrain the `future` parameter using `@NotMatches(IsIdentityOperation.class)` once
-    // `IsIdentityOperation` no longer matches nullary method invocations.
+  static final class MonoFromFutureWithBoolean<T> {
+    // XXX: Constrain the `future` parameter using `@Matches(RequiresComputation.class)`.
     @BeforeTemplate
     Mono<T> before(CompletableFuture<T> future, boolean suppressCancel) {
       return Mono.fromFuture(future, suppressCancel);
@@ -2617,10 +2643,13 @@ final class ReactorRules {
   }
 
   /**
-   * Don't propagate {@link Mono} cancellations to an upstream cache value computation, as
-   * completion of such computations may benefit concurrent or subsequent cache usages.
+   * Prefer suppressing {@link Mono} cancellations to upstream cache value computations over
+   * propagating them, as completion of such computations may benefit concurrent or subsequent cache
+   * usages.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes cancellation propagation behavior.
    */
-  static final class MonoFromFutureAsyncLoadingCacheGet<K, V> {
+  static final class MonoFromFutureAsyncLoadingCacheGetTrue<K, V> {
     @BeforeTemplate
     Mono<V> before(AsyncLoadingCache<K, V> cache, K key) {
       return Mono.fromFuture(() -> cache.get(key));
@@ -2633,10 +2662,13 @@ final class ReactorRules {
   }
 
   /**
-   * Don't propagate {@link Mono} cancellations to upstream cache value computations, as completion
-   * of such computations may benefit concurrent or subsequent cache usages.
+   * Prefer suppressing {@link Mono} cancellations to upstream cache value computations over
+   * propagating them, as completion of such computations may benefit concurrent or subsequent cache
+   * usages.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes cancellation propagation behavior.
    */
-  static final class MonoFromFutureAsyncLoadingCacheGetAll<K1, K2 extends K1, V> {
+  static final class MonoFromFutureAsyncLoadingCacheGetAllTrue<K1, K2 extends K1, V> {
     @BeforeTemplate
     Mono<Map<K1, V>> before(AsyncLoadingCache<K1, V> cache, Iterable<K2> keys) {
       return Mono.fromFuture(() -> cache.getAll(keys));
@@ -2653,30 +2685,29 @@ final class ReactorRules {
    * yields a {@link Flux} that is more likely to behave as expected when subscribed to more than
    * once.
    */
-  static final class FluxFromStreamSupplier<T> {
-    // XXX: Constrain the `stream` parameter using `@NotMatches(IsIdentityOperation.class)` once
-    // `IsIdentityOperation` no longer matches nullary method invocations.
+  static final class FluxFromStream<T> {
+    // XXX: Constrain the `future` parameter using `@Matches(RequiresComputation.class)`.
     @BeforeTemplate
-    Flux<T> before(Stream<T> stream) {
-      return Flux.fromStream(stream);
+    Flux<T> before(Stream<T> s) {
+      return Flux.fromStream(s);
     }
 
     @AfterTemplate
-    Flux<T> after(Stream<T> stream) {
-      return Flux.fromStream(() -> stream);
+    Flux<T> after(Stream<T> s) {
+      return Flux.fromStream(() -> s);
     }
   }
 
   /** Prefer fluent {@link Flux#next()} over less explicit alternatives. */
   static final class FluxNext<T> {
     @BeforeTemplate
-    Mono<T> before(Flux<T> flux) {
-      return Mono.from(flux);
+    Mono<T> before(Flux<T> source) {
+      return Mono.from(source);
     }
 
     @AfterTemplate
-    Mono<T> after(Flux<T> flux) {
-      return flux.next();
+    Mono<T> after(Flux<T> source) {
+      return source.next();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/RxJava2AdapterRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/RxJava2AdapterRules.java
@@ -20,193 +20,177 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class RxJava2AdapterRules {
   private RxJava2AdapterRules() {}
 
-  /** Use the fluent API style when using {@link RxJava2Adapter#completableToMono}. */
-  static final class CompletableToMono {
+  /** Prefer {@link RxJava2Adapter#completableToMono} over less idiomatic alternatives. */
+  static final class CompletableAsRxJava2AdapterCompletableToMono {
     @BeforeTemplate
     @SuppressWarnings("java:S4968" /* Result may be `Mono<Void>`. */)
-    Mono<? extends @Nullable Void> before(Completable completable) {
+    Mono<? extends @Nullable Void> before(Completable source) {
       return Refaster.anyOf(
-          RxJava2Adapter.completableToMono(completable),
-          completable.to(RxJava2Adapter::completableToMono));
+          RxJava2Adapter.completableToMono(source), source.to(RxJava2Adapter::completableToMono));
     }
 
     @AfterTemplate
     @SuppressWarnings("java:S4968" /* Result may be `Mono<Void>`. */)
-    Mono<? extends @Nullable Void> after(Completable completable) {
-      return completable.as(RxJava2Adapter::completableToMono);
+    Mono<? extends @Nullable Void> after(Completable source) {
+      return source.as(RxJava2Adapter::completableToMono);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#flowableToFlux} over less idiomatic alternatives. */
+  static final class FlowableAsRxJava2AdapterFlowableToFlux<T> {
+    @BeforeTemplate
+    Flux<T> before(Flowable<T> source) {
+      return Refaster.anyOf(
+          Flux.from(source),
+          source.to(Flux::from),
+          source.as(Flux::from),
+          RxJava2Adapter.flowableToFlux(source),
+          source.to(RxJava2Adapter::flowableToFlux));
+    }
+
+    @AfterTemplate
+    Flux<T> after(Flowable<T> source) {
+      return source.as(RxJava2Adapter::flowableToFlux);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#fluxToFlowable} over less idiomatic alternatives. */
+  static final class FluxAsRxJava2AdapterFluxToFlowable<T> {
+    @BeforeTemplate
+    Flowable<T> before(Flux<T> source) {
+      return Refaster.anyOf(
+          Flowable.fromPublisher(source),
+          source.as(Flowable::fromPublisher),
+          RxJava2Adapter.fluxToFlowable(source));
+    }
+
+    @AfterTemplate
+    Flowable<T> after(Flux<T> source) {
+      return source.as(RxJava2Adapter::fluxToFlowable);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#fluxToObservable} over less idiomatic alternatives. */
+  static final class FluxAsRxJava2AdapterFluxToObservable<T> {
+    @BeforeTemplate
+    Observable<T> before(Flux<T> publisher) {
+      return Refaster.anyOf(
+          Observable.fromPublisher(publisher),
+          publisher.as(Observable::fromPublisher),
+          RxJava2Adapter.fluxToObservable(publisher));
+    }
+
+    @AfterTemplate
+    Observable<T> after(Flux<T> publisher) {
+      return publisher.as(RxJava2Adapter::fluxToObservable);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#maybeToMono} over less idiomatic alternatives. */
+  static final class MaybeAsRxJava2AdapterMaybeToMono<T> {
+    @BeforeTemplate
+    Mono<T> before(Maybe<T> source) {
+      return Refaster.anyOf(
+          RxJava2Adapter.maybeToMono(source), source.to(RxJava2Adapter::maybeToMono));
+    }
+
+    @AfterTemplate
+    Mono<T> after(Maybe<T> source) {
+      return source.as(RxJava2Adapter::maybeToMono);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#monoToCompletable} over less idiomatic alternatives. */
+  static final class MonoAsRxJava2AdapterMonoToCompletable<T> {
+    @BeforeTemplate
+    Completable before(Mono<T> publisher) {
+      return Refaster.anyOf(
+          Completable.fromPublisher(publisher),
+          publisher.as(Completable::fromPublisher),
+          RxJava2Adapter.monoToCompletable(publisher));
+    }
+
+    @AfterTemplate
+    Completable after(Mono<T> publisher) {
+      return publisher.as(RxJava2Adapter::monoToCompletable);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#monoToFlowable} over less idiomatic alternatives. */
+  static final class MonoAsRxJava2AdapterMonoToFlowable<T> {
+    @BeforeTemplate
+    Flowable<T> before(Mono<T> source) {
+      return Refaster.anyOf(
+          Flowable.fromPublisher(source),
+          source.as(Flowable::fromPublisher),
+          RxJava2Adapter.monoToFlowable(source));
+    }
+
+    @AfterTemplate
+    Flowable<T> after(Mono<T> source) {
+      return source.as(RxJava2Adapter::monoToFlowable);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#monoToMaybe} over less idiomatic alternatives. */
+  static final class MonoAsRxJava2AdapterMonoToMaybe<T> {
+    @BeforeTemplate
+    Maybe<T> before(Mono<T> source) {
+      return RxJava2Adapter.monoToMaybe(source);
+    }
+
+    @AfterTemplate
+    Maybe<T> after(Mono<T> source) {
+      return source.as(RxJava2Adapter::monoToMaybe);
+    }
+  }
+
+  /** Prefer {@link RxJava2Adapter#monoToSingle} over less idiomatic alternatives. */
+  static final class MonoAsRxJava2AdapterMonoToSingle<T> {
+    @BeforeTemplate
+    Single<T> before(Mono<T> publisher) {
+      return Refaster.anyOf(
+          Single.fromPublisher(publisher),
+          publisher.as(Single::fromPublisher),
+          RxJava2Adapter.monoToSingle(publisher));
+    }
+
+    @AfterTemplate
+    Single<T> after(Mono<T> publisher) {
+      return publisher.as(RxJava2Adapter::monoToSingle);
     }
   }
 
   /**
-   * Use {@link RxJava2Adapter#flowableToFlux} to convert a {@link Flowable} to a {@link Flux}, and
-   * do so using the fluent API style.
+   * Prefer chaining {@link Observable#toFlowable(BackpressureStrategy)} with {@link
+   * RxJava2Adapter#flowableToFlux} over less idiomatic alternatives.
    */
-  static final class FlowableToFlux<T> {
+  static final class ObservableToFlowableAsRxJava2AdapterFlowableToFlux<T> {
     @BeforeTemplate
-    Flux<T> before(Flowable<T> flowable) {
+    Flux<T> before(Observable<T> source, BackpressureStrategy strategy) {
       return Refaster.anyOf(
-          Flux.from(flowable),
-          flowable.to(Flux::from),
-          flowable.as(Flux::from),
-          RxJava2Adapter.flowableToFlux(flowable),
-          flowable.to(RxJava2Adapter::flowableToFlux));
+          RxJava2Adapter.observableToFlux(source, strategy),
+          source.as(obs -> RxJava2Adapter.observableToFlux(obs, strategy)),
+          source.to(obs -> RxJava2Adapter.observableToFlux(obs, strategy)));
     }
 
     @AfterTemplate
-    Flux<T> after(Flowable<T> flowable) {
-      return flowable.as(RxJava2Adapter::flowableToFlux);
+    Flux<T> after(Observable<T> source, BackpressureStrategy strategy) {
+      return source.toFlowable(strategy).as(RxJava2Adapter::flowableToFlux);
     }
   }
 
-  /**
-   * Use {@link RxJava2Adapter#fluxToFlowable} to convert a {@link Flux} to a {@link Flowable}, and
-   * do so using the fluent API style.
-   */
-  static final class FluxToFlowable<T> {
+  /** Prefer {@link RxJava2Adapter#singleToMono} over less idiomatic alternatives. */
+  static final class SingleAsRxJava2AdapterSingleToMono<T> {
     @BeforeTemplate
-    Flowable<T> before(Flux<T> flux) {
+    Mono<T> before(Single<T> source) {
       return Refaster.anyOf(
-          Flowable.fromPublisher(flux),
-          flux.as(Flowable::fromPublisher),
-          RxJava2Adapter.fluxToFlowable(flux));
+          RxJava2Adapter.singleToMono(source), source.to(RxJava2Adapter::singleToMono));
     }
 
     @AfterTemplate
-    Flowable<T> after(Flux<T> flux) {
-      return flux.as(RxJava2Adapter::fluxToFlowable);
-    }
-  }
-
-  /**
-   * Use {@link RxJava2Adapter#fluxToObservable} to convert a {@link Flux} to a {@link Observable},
-   * and do so using the fluent API style.
-   */
-  static final class FluxToObservable<T> {
-    @BeforeTemplate
-    Observable<T> before(Flux<T> flux) {
-      return Refaster.anyOf(
-          Observable.fromPublisher(flux),
-          flux.as(Observable::fromPublisher),
-          RxJava2Adapter.fluxToObservable(flux));
-    }
-
-    @AfterTemplate
-    Observable<T> after(Flux<T> flux) {
-      return flux.as(RxJava2Adapter::fluxToObservable);
-    }
-  }
-
-  /** Use the fluent API style when using {@link RxJava2Adapter#maybeToMono}. */
-  static final class MaybeToMono<T> {
-    @BeforeTemplate
-    Mono<T> before(Maybe<T> maybe) {
-      return Refaster.anyOf(
-          RxJava2Adapter.maybeToMono(maybe), maybe.to(RxJava2Adapter::maybeToMono));
-    }
-
-    @AfterTemplate
-    Mono<T> after(Maybe<T> maybe) {
-      return maybe.as(RxJava2Adapter::maybeToMono);
-    }
-  }
-
-  /**
-   * Use {@link RxJava2Adapter#monoToCompletable} to convert a {@link Mono} to a {@link
-   * Completable}, and do so using the fluent API style.
-   */
-  static final class MonoToCompletable<T> {
-    @BeforeTemplate
-    Completable before(Mono<T> mono) {
-      return Refaster.anyOf(
-          Completable.fromPublisher(mono),
-          mono.as(Completable::fromPublisher),
-          RxJava2Adapter.monoToCompletable(mono));
-    }
-
-    @AfterTemplate
-    Completable after(Mono<T> mono) {
-      return mono.as(RxJava2Adapter::monoToCompletable);
-    }
-  }
-
-  /**
-   * Use {@link RxJava2Adapter#monoToFlowable} to convert a {@link Mono} to a {@link Flowable}, and
-   * do so using the fluent API style.
-   */
-  static final class MonoToFlowable<T> {
-    @BeforeTemplate
-    Flowable<T> before(Mono<T> mono) {
-      return Refaster.anyOf(
-          Flowable.fromPublisher(mono),
-          mono.as(Flowable::fromPublisher),
-          RxJava2Adapter.monoToFlowable(mono));
-    }
-
-    @AfterTemplate
-    Flowable<T> after(Mono<T> mono) {
-      return mono.as(RxJava2Adapter::monoToFlowable);
-    }
-  }
-
-  /** Use the fluent API style when using {@link RxJava2Adapter#monoToMaybe}. */
-  static final class MonoToMaybe<T> {
-    @BeforeTemplate
-    Maybe<T> before(Mono<T> mono) {
-      return RxJava2Adapter.monoToMaybe(mono);
-    }
-
-    @AfterTemplate
-    Maybe<T> after(Mono<T> mono) {
-      return mono.as(RxJava2Adapter::monoToMaybe);
-    }
-  }
-
-  /**
-   * Use {@link RxJava2Adapter#monoToSingle} to convert a {@link Mono} to a {@link Single}, and do
-   * so using the fluent API style.
-   */
-  static final class MonoToSingle<T> {
-    @BeforeTemplate
-    Single<T> before(Mono<T> mono) {
-      return Refaster.anyOf(
-          Single.fromPublisher(mono),
-          mono.as(Single::fromPublisher),
-          RxJava2Adapter.monoToSingle(mono));
-    }
-
-    @AfterTemplate
-    Single<T> after(Mono<T> mono) {
-      return mono.as(RxJava2Adapter::monoToSingle);
-    }
-  }
-
-  /** Use the fluent API style when using {@link RxJava2Adapter#observableToFlux}. */
-  static final class ObservableToFlux<T> {
-    @BeforeTemplate
-    Flux<T> before(Observable<T> observable, BackpressureStrategy strategy) {
-      return Refaster.anyOf(
-          RxJava2Adapter.observableToFlux(observable, strategy),
-          observable.as(obs -> RxJava2Adapter.observableToFlux(obs, strategy)),
-          observable.to(obs -> RxJava2Adapter.observableToFlux(obs, strategy)));
-    }
-
-    @AfterTemplate
-    Flux<T> after(Observable<T> observable, BackpressureStrategy strategy) {
-      return observable.toFlowable(strategy).as(RxJava2Adapter::flowableToFlux);
-    }
-  }
-
-  /** Use the fluent API style when using {@link RxJava2Adapter#singleToMono}. */
-  static final class SingleToMono<T> {
-    @BeforeTemplate
-    Mono<T> before(Single<T> single) {
-      return Refaster.anyOf(
-          RxJava2Adapter.singleToMono(single), single.to(RxJava2Adapter::singleToMono));
-    }
-
-    @AfterTemplate
-    Mono<T> after(Single<T> single) {
-      return single.as(RxJava2Adapter::singleToMono);
+    Mono<T> after(Single<T> source) {
+      return source.as(RxJava2Adapter::singleToMono);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/RxJava2AdapterRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/RxJava2AdapterRules.java
@@ -20,7 +20,9 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class RxJava2AdapterRules {
   private RxJava2AdapterRules() {}
 
-  /** Prefer {@link RxJava2Adapter#completableToMono} over less idiomatic alternatives. */
+  /**
+   * Prefer {@link RxJava2Adapter#completableToMono(Completable)} over less idiomatic alternatives.
+   */
   static final class CompletableAsRxJava2AdapterCompletableToMono {
     @BeforeTemplate
     @SuppressWarnings("java:S4968" /* Result may be `Mono<Void>`. */)
@@ -36,7 +38,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#flowableToFlux} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#flowableToFlux(Flowable)} over less idiomatic alternatives. */
   static final class FlowableAsRxJava2AdapterFlowableToFlux<T> {
     @BeforeTemplate
     Flux<T> before(Flowable<T> source) {
@@ -54,7 +56,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#fluxToFlowable} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#fluxToFlowable(Flux)} over less idiomatic alternatives. */
   static final class FluxAsRxJava2AdapterFluxToFlowable<T> {
     @BeforeTemplate
     Flowable<T> before(Flux<T> source) {
@@ -70,7 +72,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#fluxToObservable} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#fluxToObservable(Flux)} over less idiomatic alternatives. */
   static final class FluxAsRxJava2AdapterFluxToObservable<T> {
     @BeforeTemplate
     Observable<T> before(Flux<T> publisher) {
@@ -86,7 +88,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#maybeToMono} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#maybeToMono(Maybe)} over less idiomatic alternatives. */
   static final class MaybeAsRxJava2AdapterMaybeToMono<T> {
     @BeforeTemplate
     Mono<T> before(Maybe<T> source) {
@@ -100,7 +102,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#monoToCompletable} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#monoToCompletable(Mono)} over less idiomatic alternatives. */
   static final class MonoAsRxJava2AdapterMonoToCompletable<T> {
     @BeforeTemplate
     Completable before(Mono<T> publisher) {
@@ -116,7 +118,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#monoToFlowable} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#monoToFlowable(Mono)} over less idiomatic alternatives. */
   static final class MonoAsRxJava2AdapterMonoToFlowable<T> {
     @BeforeTemplate
     Flowable<T> before(Mono<T> source) {
@@ -132,7 +134,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#monoToMaybe} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#monoToMaybe(Mono)} over less idiomatic alternatives. */
   static final class MonoAsRxJava2AdapterMonoToMaybe<T> {
     @BeforeTemplate
     Maybe<T> before(Mono<T> source) {
@@ -145,7 +147,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#monoToSingle} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#monoToSingle(Mono)} over less idiomatic alternatives. */
   static final class MonoAsRxJava2AdapterMonoToSingle<T> {
     @BeforeTemplate
     Single<T> before(Mono<T> publisher) {
@@ -163,7 +165,7 @@ final class RxJava2AdapterRules {
 
   /**
    * Prefer chaining {@link Observable#toFlowable(BackpressureStrategy)} with {@link
-   * RxJava2Adapter#flowableToFlux} over less idiomatic alternatives.
+   * RxJava2Adapter#flowableToFlux(Flowable)} over less idiomatic alternatives.
    */
   static final class ObservableToFlowableAsRxJava2AdapterFlowableToFlux<T> {
     @BeforeTemplate
@@ -180,7 +182,7 @@ final class RxJava2AdapterRules {
     }
   }
 
-  /** Prefer {@link RxJava2Adapter#singleToMono} over less idiomatic alternatives. */
+  /** Prefer {@link RxJava2Adapter#singleToMono(Single)} over less idiomatic alternatives. */
   static final class SingleAsRxJava2AdapterSingleToMono<T> {
     @BeforeTemplate
     Mono<T> before(Single<T> source) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/SpringTestRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/SpringTestRules.java
@@ -13,35 +13,38 @@ final class SpringTestRules {
   private SpringTestRules() {}
 
   /**
-   * Prefer {@link BodyContentSpec#json(String, JsonCompareMode)} over alternatives that implicitly
-   * perform a {@link JsonCompareMode#LENIENT lenient} comparison or are deprecated.
+   * Prefer {@link BodyContentSpec#json(String, JsonCompareMode)} with lenient mode over deprecated
+   * alternatives.
    */
-  static final class BodyContentSpecJsonLenient {
+  static final class BodyContentSpecJsonJsonCompareModeLenient {
     @BeforeTemplate
-    @SuppressWarnings("deprecation" /* This deprecated method invocation will be rewritten. */)
-    BodyContentSpec before(BodyContentSpec spec, String expectedJson) {
-      return Refaster.anyOf(spec.json(expectedJson), spec.json(expectedJson, /* strict= */ false));
+    @SuppressWarnings("deprecation" /* This deprecated API usage will be rewritten. */)
+    BodyContentSpec before(BodyContentSpec bodyContentSpec, String expectedJson) {
+      return Refaster.anyOf(
+          bodyContentSpec.json(expectedJson),
+          bodyContentSpec.json(expectedJson, /* strict= */ false));
     }
 
     @AfterTemplate
-    BodyContentSpec after(BodyContentSpec spec, String expectedJson) {
-      return spec.json(expectedJson, JsonCompareMode.LENIENT);
+    BodyContentSpec after(BodyContentSpec bodyContentSpec, String expectedJson) {
+      return bodyContentSpec.json(expectedJson, JsonCompareMode.LENIENT);
     }
   }
 
   /**
-   * Prefer {@link BodyContentSpec#json(String, JsonCompareMode)} over the deprecated alternative.
+   * Prefer {@link BodyContentSpec#json(String, JsonCompareMode)} with strict mode over deprecated
+   * alternatives.
    */
-  static final class BodyContentSpecJsonStrict {
+  static final class BodyContentSpecJsonJsonCompareModeStrict {
     @BeforeTemplate
-    @SuppressWarnings("deprecation" /* This deprecated method invocation will be rewritten. */)
-    BodyContentSpec before(BodyContentSpec spec, String expectedJson) {
-      return spec.json(expectedJson, /* strict= */ true);
+    @SuppressWarnings("deprecation" /* This deprecated API usage will be rewritten. */)
+    BodyContentSpec before(BodyContentSpec bodyContentSpec, String expectedJson) {
+      return bodyContentSpec.json(expectedJson, /* strict= */ true);
     }
 
     @AfterTemplate
-    BodyContentSpec after(BodyContentSpec spec, String expectedJson) {
-      return spec.json(expectedJson, JsonCompareMode.STRICT);
+    BodyContentSpec after(BodyContentSpec bodyContentSpec, String expectedJson) {
+      return bodyContentSpec.json(expectedJson, JsonCompareMode.STRICT);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -27,7 +27,6 @@ import com.google.common.collect.Streams;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
-import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Matches;
 import com.google.errorprone.refaster.annotation.MayOptionallyUse;
@@ -70,10 +69,7 @@ import tech.picnic.errorprone.refaster.matchers.RequiresComputation;
 final class StreamRules {
   private StreamRules() {}
 
-  /**
-   * Prefer {@link Collectors#joining()} over {@link Collectors#joining(CharSequence)} with an empty
-   * delimiter string.
-   */
+  /** Prefer {@link Collectors#joining()} over more verbose alternatives. */
   static final class Joining {
     @BeforeTemplate
     Collector<CharSequence, ?, String> before() {
@@ -87,24 +83,24 @@ final class StreamRules {
     }
   }
 
-  /** Prefer {@link Stream#empty()} over less clear alternatives. */
+  /** Prefer {@link Stream#empty()} over less explicit alternatives. */
   // XXX: We can additionally introduce a rule that maps `OptionalInt.empty().stream()` to
   // `IntStream.empty()`, and likewise for `OptionalLong` and `OptionalDouble`, but those
   // expressions are highly unlikely to be seen in the wild.
-  static final class EmptyStream<T> {
+  static final class StreamEmpty<T> {
     @BeforeTemplate
     Stream<T> before(
-        @Matches(IsEmpty.class) Collection<T> collection,
-        @Matches(IsEmpty.class) Iterable<T> iterable,
-        @Matches(IsEmpty.class) Iterator<T> iterator,
-        @Matches(IsEmpty.class) T[] array) {
+        @Matches(IsEmpty.class) Collection<T> emptyCollection,
+        @Matches(IsEmpty.class) Iterable<T> emptyIterable,
+        @Matches(IsEmpty.class) Iterator<T> emptyIterator,
+        @Matches(IsEmpty.class) T[] emptyArray) {
       return Refaster.anyOf(
           Stream.of(),
           Optional.<T>empty().stream(),
-          collection.stream(),
-          Streams.stream(iterable),
-          Streams.stream(iterator),
-          Arrays.stream(array));
+          emptyCollection.stream(),
+          Streams.stream(emptyIterable),
+          Streams.stream(emptyIterator),
+          Arrays.stream(emptyArray));
     }
 
     @AfterTemplate
@@ -120,25 +116,22 @@ final class StreamRules {
     @BeforeTemplate
     @SuppressWarnings(
         "java:S2583" /* SonarCloud incorrectly believes that `object` is not `@Nullable`. */)
-    Stream<T> before(T object) {
+    Stream<T> before(T t) {
       return Refaster.anyOf(
-          Stream.of(object).filter(Objects::nonNull),
-          Optional.ofNullable(object).stream(),
-          object != null ? Stream.of(object) : Stream.empty(),
-          object == null ? Stream.empty() : Stream.of(object));
+          Stream.of(t).filter(Objects::nonNull),
+          Optional.ofNullable(t).stream(),
+          t != null ? Stream.of(t) : Stream.empty(),
+          t == null ? Stream.empty() : Stream.of(t));
     }
 
     @AfterTemplate
-    Stream<T> after(T object) {
-      return Stream.ofNullable(object);
+    Stream<T> after(T t) {
+      return Stream.ofNullable(t);
     }
   }
 
-  /**
-   * Prefer {@link Arrays#stream(Object[])} over {@link Stream#of(Object[])}, as the former is
-   * clearer.
-   */
-  static final class StreamOfArray<T> {
+  /** Prefer {@link Arrays#stream(Object[])} over less explicit alternatives. */
+  static final class ArraysStream<T> {
     @BeforeTemplate
     Stream<T> before(@NotMatches(IsRefasterAsVarargs.class) T[] array) {
       return Stream.of(array);
@@ -150,8 +143,8 @@ final class StreamRules {
     }
   }
 
-  /** Don't unnecessarily call {@link Streams#concat(Stream...)}. */
-  static final class ConcatOneStream<T> {
+  /** Prefer the {@link Stream} as-is over more contrived alternatives. */
+  static final class StreamIdentity<T> {
     @BeforeTemplate
     Stream<T> before(Stream<T> stream) {
       return Streams.concat(stream);
@@ -164,69 +157,68 @@ final class StreamRules {
     }
   }
 
-  /** Prefer {@link Stream#concat(Stream, Stream)} over the Guava alternative. */
-  static final class ConcatTwoStreams<T> {
+  /** Prefer {@link Stream#concat(Stream, Stream)} over non-JDK alternatives. */
+  static final class StreamConcat<T> {
     @BeforeTemplate
-    Stream<T> before(Stream<T> s1, Stream<T> s2) {
-      return Streams.concat(s1, s2);
+    Stream<T> before(Stream<T> a, Stream<T> b) {
+      return Streams.concat(a, b);
     }
 
     @AfterTemplate
-    Stream<T> after(Stream<T> s1, Stream<T> s2) {
-      return Stream.concat(s1, s2);
+    Stream<T> after(Stream<T> a, Stream<T> b) {
+      return Stream.concat(a, b);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link Stream#filter(Predicate)} operations. */
-  abstract static class FilterOuterStreamAfterFlatMap<T, S> {
+  /** Prefer {@link Stream#filter(Predicate)} over more contrived alternatives. */
+  abstract static class StreamFlatMapFilter<T, S2, S extends S2> {
     @Placeholder
     abstract Stream<S> toStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    Stream<S> before(Stream<T> stream, Predicate<? super S> predicate) {
+    Stream<S> before(Stream<T> stream, Predicate<S2> predicate) {
       return stream.flatMap(v -> toStreamFunction(v).filter(predicate));
     }
 
     @AfterTemplate
-    Stream<S> after(Stream<T> stream, Predicate<? super S> predicate) {
+    Stream<S> after(Stream<T> stream, Predicate<S2> predicate) {
       return stream.flatMap(v -> toStreamFunction(v)).filter(predicate);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link Stream#map(Function)} operations. */
-  abstract static class MapOuterStreamAfterFlatMap<T, S, R> {
+  /** Prefer {@link Stream#map(Function)} over more contrived alternatives. */
+  abstract static class StreamFlatMapMap<T, S2, S extends S2, R> {
     @Placeholder
     abstract Stream<S> toStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    Stream<R> before(Stream<T> stream, Function<? super S, ? extends R> function) {
+    Stream<R> before(Stream<T> stream, Function<S2, R> function) {
       return stream.flatMap(v -> toStreamFunction(v).map(function));
     }
 
     @AfterTemplate
-    Stream<R> after(Stream<T> stream, Function<? super S, ? extends R> function) {
+    Stream<R> after(Stream<T> stream, Function<S2, R> function) {
       return stream.flatMap(v -> toStreamFunction(v)).map(function);
     }
   }
 
-  /** Avoid unnecessary nesting of {@link Stream#flatMap(Function)} operations. */
-  abstract static class FlatMapOuterStreamAfterFlatMap<T, S, R> {
+  /** Prefer {@link Stream#flatMap(Function)} over more contrived alternatives. */
+  abstract static class StreamFlatMapFlatMap<T, S2, S extends S2, R> {
     @Placeholder
     abstract Stream<S> toStreamFunction(@MayOptionallyUse T element);
 
     @BeforeTemplate
-    Stream<R> before(
-        Stream<T> stream, Function<? super S, ? extends Stream<? extends R>> function) {
+    Stream<R> before(Stream<T> stream, Function<S2, ? extends Stream<? extends R>> function) {
       return stream.flatMap(v -> toStreamFunction(v).flatMap(function));
     }
 
     @AfterTemplate
-    Stream<R> after(Stream<T> stream, Function<? super S, ? extends Stream<? extends R>> function) {
+    Stream<R> after(Stream<T> stream, Function<S2, ? extends Stream<? extends R>> function) {
       return stream.flatMap(v -> toStreamFunction(v)).flatMap(function);
     }
   }
 
-  /** Prefer {@link Stream#sorted()} over more contrived alternatives. */
+  /** Prefer {@link Stream#sorted()} over more verbose alternatives. */
   static final class StreamSorted<T extends Comparable<? super T>> {
     @BeforeTemplate
     Stream<T> before(Stream<T> stream) {
@@ -240,42 +232,40 @@ final class StreamRules {
   }
 
   /**
-   * Apply {@link Stream#filter(Predicate)} before {@link Stream#sorted()} to reduce the number of
-   * elements to sort.
+   * Prefer {@link Stream#filter(Predicate)} before {@link Stream#sorted()} over less efficient
+   * alternatives.
    */
-  static final class StreamFilterSorted<T> {
+  static final class StreamFilterSorted<S, T extends S> {
     @BeforeTemplate
-    Stream<T> before(Stream<T> stream, Predicate<? super T> predicate) {
+    Stream<T> before(Stream<T> stream, Predicate<S> predicate) {
       return stream.sorted().filter(predicate);
     }
 
     @AfterTemplate
-    Stream<T> after(Stream<T> stream, Predicate<? super T> predicate) {
+    Stream<T> after(Stream<T> stream, Predicate<S> predicate) {
       return stream.filter(predicate).sorted();
     }
   }
 
   /**
-   * Apply {@link Stream#filter(Predicate)} before {@link Stream#sorted(Comparator)} to reduce the
-   * number of elements to sort.
+   * Prefer {@link Stream#filter(Predicate)} before {@link Stream#sorted(Comparator)} over less
+   * efficient alternatives.
    */
-  static final class StreamFilterSortedWithComparator<T> {
+  static final class StreamFilterSortedWithComparator<S, T extends S> {
     @BeforeTemplate
-    Stream<T> before(
-        Stream<T> stream, Predicate<? super T> predicate, Comparator<? super T> comparator) {
-      return stream.sorted(comparator).filter(predicate);
+    Stream<T> before(Stream<T> stream, Predicate<S> predicate, Comparator<S> cmp) {
+      return stream.sorted(cmp).filter(predicate);
     }
 
     @AfterTemplate
-    Stream<T> after(
-        Stream<T> stream, Predicate<? super T> predicate, Comparator<? super T> comparator) {
-      return stream.filter(predicate).sorted(comparator);
+    Stream<T> after(Stream<T> stream, Predicate<S> predicate, Comparator<S> cmp) {
+      return stream.filter(predicate).sorted(cmp);
     }
   }
 
   /**
-   * Apply {@link Stream#distinct()} before {@link Stream#sorted()} to reduce the number of elements
-   * to sort.
+   * Prefer {@link Stream#distinct()} before {@link Stream#sorted()} over less efficient
+   * alternatives.
    */
   static final class StreamDistinctSorted<T> {
     @BeforeTemplate
@@ -290,118 +280,107 @@ final class StreamRules {
   }
 
   /**
-   * Apply {@link Stream#distinct()} before {@link Stream#sorted(Comparator)} to reduce the number
-   * of elements to sort.
+   * Prefer {@link Stream#distinct()} before {@link Stream#sorted(Comparator)} over less efficient
+   * alternatives.
    */
   static final class StreamDistinctSortedWithComparator<S, T extends S> {
     @BeforeTemplate
-    Stream<T> before(Stream<T> stream, Comparator<S> comparator) {
-      return stream.sorted(comparator).distinct();
+    Stream<T> before(Stream<T> stream, Comparator<S> cmp) {
+      return stream.sorted(cmp).distinct();
     }
 
     @AfterTemplate
-    Stream<T> after(Stream<T> stream, Comparator<S> comparator) {
-      return stream.distinct().sorted(comparator);
+    Stream<T> after(Stream<T> stream, Comparator<S> cmp) {
+      return stream.distinct().sorted(cmp);
     }
   }
 
-  /**
-   * Prefer {@link Comparators#least(int, Comparator)} over alternatives that require space
-   * proportional to the size of the input stream, rather than space proportional to the result
-   * stream.
-   */
+  /** Prefer {@link Comparators#least(int, Comparator)} over less efficient alternatives. */
   // XXX: For ordered streams the replacement code is not equivalent to the original code, as the
   // latter uses a stable sort operation, while the former breaks ties arbitrarily.
   static final class StreamCollectLeastStream<S, T extends S> {
     @BeforeTemplate
-    Stream<T> before(Stream<T> stream, int n, Comparator<S> comparator) {
-      return stream.sorted(comparator).limit(n);
+    Stream<T> before(Stream<T> stream, int k, Comparator<S> comparator) {
+      return stream.sorted(comparator).limit(k);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Stream<T> after(Stream<T> stream, int n, Comparator<S> comparator) {
-      return stream.collect(least(n, comparator)).stream();
+    Stream<T> after(Stream<T> stream, int k, Comparator<S> comparator) {
+      return stream.collect(least(k, comparator)).stream();
     }
   }
 
-  /**
-   * Prefer {@link Comparators#least(int, Comparator)} over alternatives that require space
-   * proportional to the size of the input stream, rather than space proportional to the result
-   * stream.
-   */
+  /** Prefer {@link Comparators#least(int, Comparator)} over less efficient alternatives. */
   // XXX: For ordered streams the replacement code is not equivalent to the original code, as the
   // latter uses a stable sort operation, while the former breaks ties arbitrarily.
   static final class StreamCollectLeastNaturalOrderStream<T extends Comparable<? super T>> {
     @BeforeTemplate
-    Stream<T> before(Stream<T> stream, int n) {
-      return stream.sorted().limit(n);
+    Stream<T> before(Stream<T> stream, int k) {
+      return stream.sorted().limit(k);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    Stream<T> after(Stream<T> stream, int n) {
-      return stream.collect(least(n, naturalOrder())).stream();
+    Stream<T> after(Stream<T> stream, int k) {
+      return stream.collect(least(k, naturalOrder())).stream();
     }
   }
 
-  /**
-   * Where possible, clarify that a mapping operation will be applied only to a single stream
-   * element.
-   */
+  /** Prefer {@code stream.findFirst().map(function)} over less efficient alternatives. */
   // XXX: Implement a similar rule for `.findAny()`. For parallel streams this wouldn't be quite the
   // same, so such a rule requires a `Matcher` that heuristically identifies `Stream` expressions
   // with deterministic order.
   // XXX: This change is not equivalent for `null`-returning functions, as the original code throws
   // an NPE if the first element is `null`, while the latter yields an empty `Optional`.
-  static final class StreamMapFirst<T, S> {
+  static final class StreamFindFirstMap<T2, T extends T2, S> {
     @BeforeTemplate
-    Optional<S> before(Stream<T> stream, Function<? super T, S> function) {
-      return stream.map(function).findFirst();
+    Optional<S> before(Stream<T> stream, Function<T2, S> mapper) {
+      return stream.map(mapper).findFirst();
     }
 
     @AfterTemplate
-    Optional<S> after(Stream<T> stream, Function<? super T, S> function) {
-      return stream.findFirst().map(function);
+    Optional<S> after(Stream<T> stream, Function<T2, S> mapper) {
+      return stream.findFirst().map(mapper);
     }
   }
 
-  /** In order to test whether a stream has any element, simply try to find one. */
+  /** Prefer {@link Stream#findAny()} over less efficient alternatives. */
   // XXX: This rule assumes that any matched `Collector` does not perform any filtering.
   // (Perhaps we could add a `@Matches` guard that validates that the collector expression does not
   // contain a `Collectors#filtering` call. That'd still not be 100% accurate, though.)
   static final class StreamFindAnyIsEmpty<T, K, V, C extends Collection<K>, M extends Map<K, V>> {
     @BeforeTemplate
-    boolean before(Stream<T> stream, Collector<? super T, ?, ? extends C> collector) {
+    Boolean before(Stream<T> stream, Collector<? super T, ?, ? extends C> downstream) {
       return Refaster.anyOf(
           stream.count() == 0,
           stream.count() <= 0,
           stream.count() < 1,
           stream.findFirst().isEmpty(),
-          stream.collect(collector).isEmpty(),
-          stream.collect(collectingAndThen(collector, C::isEmpty)));
+          stream.collect(downstream).isEmpty(),
+          stream.collect(collectingAndThen(downstream, C::isEmpty)));
     }
 
     @BeforeTemplate
-    boolean before2(Stream<T> stream, Collector<? super T, ?, ? extends M> collector) {
-      return stream.collect(collectingAndThen(collector, M::isEmpty));
+    Boolean before2(Stream<T> stream, Collector<? super T, ?, ? extends M> downstream) {
+      return stream.collect(collectingAndThen(downstream, M::isEmpty));
     }
 
     @AfterTemplate
-    @AlsoNegation
     boolean after(Stream<T> stream) {
       return stream.findAny().isEmpty();
     }
   }
 
-  /**
-   * Prefer {@link Stream#findAny()} over {@link Stream#findFirst()} if one only cares whether the
-   * stream is nonempty.
-   */
+  /** Prefer {@link Stream#findAny()} over less efficient alternatives. */
   static final class StreamFindAnyIsPresent<T> {
     @BeforeTemplate
     boolean before(Stream<T> stream) {
-      return stream.findFirst().isPresent();
+      return Refaster.anyOf(
+          stream.count() != 0,
+          stream.count() > 0,
+          stream.count() >= 1,
+          stream.findFirst().isPresent());
     }
 
     @AfterTemplate
@@ -415,8 +394,8 @@ final class StreamRules {
   // have side-effects.
   static final class StreamFindFirst<T> {
     @BeforeTemplate
-    Optional<T> before(Stream<T> stream, long limit) {
-      return Refaster.anyOf(stream.limit(limit).findFirst(), stream.limit(limit).findAny());
+    Optional<T> before(Stream<T> stream, long l) {
+      return Refaster.anyOf(stream.limit(l).findFirst(), stream.limit(l).findAny());
     }
 
     @AfterTemplate
@@ -426,10 +405,9 @@ final class StreamRules {
   }
 
   /**
-   * Prefer an unconditional {@link Map#get(Object)} call followed by a {@code null} check over a
-   * call to {@link Map#containsKey(Object)}, as the former avoids a second lookup operation.
+   * Prefer {@code stream.map(map::get).filter(Objects::nonNull)} over less efficient alternatives.
    */
-  static final class StreamMapFilter<T, K, V> {
+  static final class StreamMapMapGetFilterObjectsNonNull<T, K, V> {
     @BeforeTemplate
     Stream<V> before(Stream<T> stream, Map<K, V> map) {
       return stream.filter(map::containsKey).map(map::get);
@@ -441,10 +419,11 @@ final class StreamRules {
     }
   }
 
-  static final class StreamMin<T> {
+  /** Prefer {@link Stream#min(Comparator)} over less efficient alternatives. */
+  static final class StreamMin<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    Optional<T> before(Stream<T> stream, Comparator<? super T> comparator) {
+    Optional<T> before(Stream<T> stream, Comparator<S> comparator) {
       return Refaster.anyOf(
           stream.max(comparator.reversed()),
           stream.sorted(comparator).findFirst(),
@@ -452,11 +431,12 @@ final class StreamRules {
     }
 
     @AfterTemplate
-    Optional<T> after(Stream<T> stream, Comparator<? super T> comparator) {
+    Optional<T> after(Stream<T> stream, Comparator<S> comparator) {
       return stream.min(comparator);
     }
   }
 
+  /** Prefer {@link Stream#min(Comparator)} over less efficient alternatives. */
   static final class StreamMinNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
     Optional<T> before(Stream<T> stream) {
@@ -470,10 +450,11 @@ final class StreamRules {
     }
   }
 
-  static final class StreamMax<T> {
+  /** Prefer {@link Stream#max(Comparator)} over less efficient alternatives. */
+  static final class StreamMax<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    Optional<T> before(Stream<T> stream, Comparator<? super T> comparator) {
+    Optional<T> before(Stream<T> stream, Comparator<S> comparator) {
       return Refaster.anyOf(
           stream.min(comparator.reversed()),
           Streams.findLast(stream.sorted(comparator)),
@@ -481,11 +462,12 @@ final class StreamRules {
     }
 
     @AfterTemplate
-    Optional<T> after(Stream<T> stream, Comparator<? super T> comparator) {
+    Optional<T> after(Stream<T> stream, Comparator<S> comparator) {
       return stream.max(comparator);
     }
   }
 
+  /** Prefer {@link Stream#max(Comparator)} over less efficient alternatives. */
   static final class StreamMaxNaturalOrder<T extends Comparable<? super T>> {
     @BeforeTemplate
     Optional<T> before(Stream<T> stream) {
@@ -500,14 +482,14 @@ final class StreamRules {
   }
 
   /** Prefer {@link Stream#noneMatch(Predicate)} over more contrived alternatives. */
-  static final class StreamNoneMatch<T> {
+  static final class StreamNoneMatchWithPredicate<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S4034" /* This violation will be rewritten. */)
-    boolean before(Stream<T> stream, Predicate<? super T> predicate) {
+    boolean before(Stream<T> stream, Predicate<S> target) {
       return Refaster.anyOf(
-          !stream.anyMatch(predicate),
-          stream.allMatch(Refaster.anyOf(not(predicate), predicate.negate())),
-          stream.filter(predicate).findAny().isEmpty());
+          !stream.anyMatch(target),
+          stream.allMatch(Refaster.anyOf(not(target), target.negate())),
+          stream.filter(target).findAny().isEmpty());
     }
 
     // XXX: Consider extending `@Matches(IsIdentityOperation.class)` such that it can replace this
@@ -515,18 +497,18 @@ final class StreamRules {
     @BeforeTemplate
     boolean before2(
         Stream<T> stream,
-        @Matches(IsLambdaExpressionOrMethodReference.class)
-            Function<? super T, Boolean> predicate) {
-      return stream.map(predicate).noneMatch(Refaster.anyOf(Boolean::booleanValue, b -> b));
+        @Matches(IsLambdaExpressionOrMethodReference.class) Function<S, Boolean> target) {
+      return stream.map(target).noneMatch(Refaster.anyOf(Boolean::booleanValue, b -> b));
     }
 
     @AfterTemplate
-    boolean after(Stream<T> stream, Predicate<? super T> predicate) {
-      return stream.noneMatch(predicate);
+    boolean after(Stream<T> stream, Predicate<S> target) {
+      return stream.noneMatch(target);
     }
   }
 
-  abstract static class StreamNoneMatch2<T> {
+  /** Prefer {@link Stream#noneMatch(Predicate)} over less explicit alternatives. */
+  abstract static class StreamNoneMatch<T> {
     @Placeholder(allowsIdentity = true)
     abstract boolean test(@MayOptionallyUse T element);
 
@@ -542,10 +524,10 @@ final class StreamRules {
   }
 
   /** Prefer {@link Stream#anyMatch(Predicate)} over more contrived alternatives. */
-  static final class StreamAnyMatch<T> {
+  static final class StreamAnyMatch<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S4034" /* This violation will be rewritten. */)
-    boolean before(Stream<T> stream, Predicate<? super T> predicate) {
+    boolean before(Stream<T> stream, Predicate<S> predicate) {
       return Refaster.anyOf(
           !stream.noneMatch(predicate), stream.filter(predicate).findAny().isPresent());
     }
@@ -555,21 +537,21 @@ final class StreamRules {
     @BeforeTemplate
     boolean before2(
         Stream<T> stream,
-        @Matches(IsLambdaExpressionOrMethodReference.class)
-            Function<? super T, Boolean> predicate) {
+        @Matches(IsLambdaExpressionOrMethodReference.class) Function<S, Boolean> predicate) {
       return stream.map(predicate).anyMatch(Refaster.anyOf(Boolean::booleanValue, b -> b));
     }
 
     @AfterTemplate
-    boolean after(Stream<T> stream, Predicate<? super T> predicate) {
+    boolean after(Stream<T> stream, Predicate<S> predicate) {
       return stream.anyMatch(predicate);
     }
   }
 
-  static final class StreamAllMatch<T> {
+  /** Prefer {@link Stream#allMatch(Predicate)} over more contrived alternatives. */
+  static final class StreamAllMatchWithPredicate<S, T extends S> {
     @BeforeTemplate
-    boolean before(Stream<T> stream, Predicate<? super T> predicate) {
-      return stream.noneMatch(Refaster.anyOf(not(predicate), predicate.negate()));
+    boolean before(Stream<T> stream, Predicate<S> target) {
+      return stream.noneMatch(Refaster.anyOf(not(target), target.negate()));
     }
 
     // XXX: Consider extending `@Matches(IsIdentityOperation.class)` such that it can replace this
@@ -577,18 +559,18 @@ final class StreamRules {
     @BeforeTemplate
     boolean before2(
         Stream<T> stream,
-        @Matches(IsLambdaExpressionOrMethodReference.class)
-            Function<? super T, Boolean> predicate) {
-      return stream.map(predicate).allMatch(Refaster.anyOf(Boolean::booleanValue, b -> b));
+        @Matches(IsLambdaExpressionOrMethodReference.class) Function<S, Boolean> target) {
+      return stream.map(target).allMatch(Refaster.anyOf(Boolean::booleanValue, b -> b));
     }
 
     @AfterTemplate
-    boolean after(Stream<T> stream, Predicate<? super T> predicate) {
-      return stream.allMatch(predicate);
+    boolean after(Stream<T> stream, Predicate<S> target) {
+      return stream.allMatch(target);
     }
   }
 
-  abstract static class StreamAllMatch2<T> {
+  /** Prefer {@link Stream#allMatch(Predicate)} over less explicit alternatives. */
+  abstract static class StreamAllMatch<T> {
     @Placeholder(allowsIdentity = true)
     abstract boolean test(@MayOptionallyUse T element);
 
@@ -603,17 +585,18 @@ final class StreamRules {
     }
   }
 
-  static final class StreamMapToIntSum<T> {
+  /** Prefer {@code stream.mapToInt(mapper).sum()} over less efficient alternatives. */
+  static final class StreamMapToIntSum<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    long before(Stream<T> stream, ToIntFunction<T> mapper) {
+    Integer before(Stream<T> stream, ToIntFunction<T> mapper) {
       return stream.collect(summingInt(mapper));
     }
 
     @BeforeTemplate
-    int before2(
+    Integer before2(
         Stream<T> stream,
-        @Matches(IsLambdaExpressionOrMethodReference.class) Function<? super T, Integer> mapper) {
+        @Matches(IsLambdaExpressionOrMethodReference.class) Function<S, Integer> mapper) {
       return stream.map(mapper).reduce(0, Integer::sum);
     }
 
@@ -623,17 +606,18 @@ final class StreamRules {
     }
   }
 
-  static final class StreamMapToDoubleSum<T> {
+  /** Prefer {@code stream.mapToDouble(mapper).sum()} over less efficient alternatives. */
+  static final class StreamMapToDoubleSum<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    double before(Stream<T> stream, ToDoubleFunction<T> mapper) {
+    Double before(Stream<T> stream, ToDoubleFunction<T> mapper) {
       return stream.collect(summingDouble(mapper));
     }
 
     @BeforeTemplate
-    double before2(
+    Double before2(
         Stream<T> stream,
-        @Matches(IsLambdaExpressionOrMethodReference.class) Function<? super T, Double> mapper) {
+        @Matches(IsLambdaExpressionOrMethodReference.class) Function<S, Double> mapper) {
       return stream.map(mapper).reduce(0.0, Double::sum);
     }
 
@@ -643,17 +627,18 @@ final class StreamRules {
     }
   }
 
-  static final class StreamMapToLongSum<T> {
+  /** Prefer {@code stream.mapToLong(mapper).sum()} over less efficient alternatives. */
+  static final class StreamMapToLongSum<S, T extends S> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    long before(Stream<T> stream, ToLongFunction<T> mapper) {
+    Long before(Stream<T> stream, ToLongFunction<T> mapper) {
       return stream.collect(summingLong(mapper));
     }
 
     @BeforeTemplate
-    long before2(
+    Long before2(
         Stream<T> stream,
-        @Matches(IsLambdaExpressionOrMethodReference.class) Function<? super T, Long> mapper) {
+        @Matches(IsLambdaExpressionOrMethodReference.class) Function<S, Long> mapper) {
       return stream.map(mapper).reduce(0L, Long::sum);
     }
 
@@ -663,6 +648,9 @@ final class StreamRules {
     }
   }
 
+  /**
+   * Prefer {@code stream.mapToInt(mapper).summaryStatistics()} over less efficient alternatives.
+   */
   static final class StreamMapToIntSummaryStatistics<T> {
     @BeforeTemplate
     IntSummaryStatistics before(Stream<T> stream, ToIntFunction<T> mapper) {
@@ -675,6 +663,9 @@ final class StreamRules {
     }
   }
 
+  /**
+   * Prefer {@code stream.mapToDouble(mapper).summaryStatistics()} over less efficient alternatives.
+   */
   static final class StreamMapToDoubleSummaryStatistics<T> {
     @BeforeTemplate
     DoubleSummaryStatistics before(Stream<T> stream, ToDoubleFunction<T> mapper) {
@@ -687,6 +678,9 @@ final class StreamRules {
     }
   }
 
+  /**
+   * Prefer {@code stream.mapToLong(mapper).summaryStatistics()} over less efficient alternatives.
+   */
   static final class StreamMapToLongSummaryStatistics<T> {
     @BeforeTemplate
     LongSummaryStatistics before(Stream<T> stream, ToLongFunction<T> mapper) {
@@ -699,10 +693,11 @@ final class StreamRules {
     }
   }
 
+  /** Prefer {@link Stream#count()} over less efficient alternatives. */
   static final class StreamCount<T> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    long before(Stream<T> stream) {
+    Long before(Stream<T> stream) {
       return stream.collect(counting());
     }
 
@@ -712,106 +707,105 @@ final class StreamRules {
     }
   }
 
+  /** Prefer {@link Stream#reduce(BinaryOperator)} over less efficient alternatives. */
   static final class StreamReduce<T> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    Optional<T> before(Stream<T> stream, BinaryOperator<T> accumulator) {
-      return stream.collect(reducing(accumulator));
+    Optional<T> before(Stream<T> stream, BinaryOperator<T> op) {
+      return stream.collect(reducing(op));
     }
 
     @AfterTemplate
-    Optional<T> after(Stream<T> stream, BinaryOperator<T> accumulator) {
-      return stream.reduce(accumulator);
+    Optional<T> after(Stream<T> stream, BinaryOperator<T> op) {
+      return stream.reduce(op);
     }
   }
 
-  static final class StreamReduceWithIdentity<T> {
+  /** Prefer {@link Stream#reduce(Object, BinaryOperator)} over less efficient alternatives. */
+  static final class StreamReduceWithObject<T> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    T before(Stream<T> stream, T identity, BinaryOperator<T> accumulator) {
-      return stream.collect(reducing(identity, accumulator));
+    T before(Stream<T> stream, T identity, BinaryOperator<T> op) {
+      return stream.collect(reducing(identity, op));
     }
 
     @AfterTemplate
-    T after(Stream<T> stream, T identity, BinaryOperator<T> accumulator) {
-      return stream.reduce(identity, accumulator);
+    T after(Stream<T> stream, T identity, BinaryOperator<T> op) {
+      return stream.reduce(identity, op);
     }
   }
 
-  static final class StreamFilterCollect<T, R> {
+  /** Prefer {@link Stream#filter(Predicate)} over more contrived alternatives. */
+  static final class StreamFilterCollect<S, T extends S, R> {
     @BeforeTemplate
-    R before(
-        Stream<T> stream, Predicate<? super T> predicate, Collector<? super T, ?, R> collector) {
-      return stream.collect(filtering(predicate, collector));
+    R before(Stream<T> stream, Predicate<S> predicate, Collector<S, ?, R> downstream) {
+      return stream.collect(filtering(predicate, downstream));
     }
 
     @AfterTemplate
-    R after(
-        Stream<T> stream, Predicate<? super T> predicate, Collector<? super T, ?, R> collector) {
-      return stream.filter(predicate).collect(collector);
+    R after(Stream<T> stream, Predicate<S> predicate, Collector<S, ?, R> downstream) {
+      return stream.filter(predicate).collect(downstream);
     }
   }
 
-  static final class StreamMapCollect<T, U, R> {
+  /** Prefer {@link Stream#map(Function)} over more contrived alternatives. */
+  static final class StreamMapCollect<S, T extends S, U, R> {
     @BeforeTemplate
     @SuppressWarnings("java:S4266" /* This violation will be rewritten. */)
-    R before(
-        Stream<T> stream,
-        Function<? super T, ? extends U> mapper,
-        Collector<? super U, ?, R> collector) {
-      return stream.collect(mapping(mapper, collector));
+    R before(Stream<T> stream, Function<S, U> mapper, Collector<U, ?, R> downstream) {
+      return stream.collect(mapping(mapper, downstream));
     }
 
     @AfterTemplate
-    R after(
-        Stream<T> stream,
-        Function<? super T, ? extends U> mapper,
-        Collector<? super U, ?, R> collector) {
-      return stream.map(mapper).collect(collector);
+    R after(Stream<T> stream, Function<S, U> mapper, Collector<U, ?, R> downstream) {
+      return stream.map(mapper).collect(downstream);
     }
   }
 
-  static final class StreamFlatMapCollect<T, U, R> {
+  /** Prefer {@link Stream#flatMap(Function)} over more contrived alternatives. */
+  static final class StreamFlatMapCollect<S, T extends S, U, R> {
     @BeforeTemplate
     R before(
         Stream<T> stream,
-        Function<? super T, ? extends Stream<? extends U>> mapper,
-        Collector<? super U, ?, R> collector) {
-      return stream.collect(flatMapping(mapper, collector));
+        Function<S, ? extends Stream<? extends U>> mapper,
+        Collector<U, ?, R> downstream) {
+      return stream.collect(flatMapping(mapper, downstream));
     }
 
     @AfterTemplate
     R after(
         Stream<T> stream,
-        Function<? super T, ? extends Stream<? extends U>> mapper,
-        Collector<? super U, ?, R> collector) {
-      return stream.flatMap(mapper).collect(collector);
+        Function<S, ? extends Stream<? extends U>> mapper,
+        Collector<U, ?, R> downstream) {
+      return stream.flatMap(mapper).collect(downstream);
     }
   }
 
+  /** Prefer {@link Streams#concat(Stream...)} over more contrived alternatives. */
   static final class StreamsConcat<T> {
     @BeforeTemplate
     Stream<T> before(
-        @Repeated Stream<T> stream,
+        @Repeated Stream<T> streams,
         @Matches(IsIdentityOperation.class)
-            Function<? super Stream<T>, ? extends Stream<? extends T>> mapper) {
-      return Stream.of(Refaster.asVarargs(stream)).flatMap(mapper);
+            Function<? super Stream<T>, ? extends Stream<? extends T>> identityFunction) {
+      return Stream.of(Refaster.asVarargs(streams)).flatMap(identityFunction);
     }
 
     @AfterTemplate
-    Stream<T> after(@Repeated Stream<T> stream) {
-      return Streams.concat(Refaster.asVarargs(stream));
+    Stream<T> after(@Repeated Stream<T> streams) {
+      return Streams.concat(Refaster.asVarargs(streams));
     }
   }
 
-  static final class StreamTakeWhile<T> {
+  /** Prefer {@link Stream#takeWhile(Predicate)} over more verbose alternatives. */
+  static final class StreamTakeWhile<S, T extends S> {
     @BeforeTemplate
-    Stream<T> before(Stream<T> stream, Predicate<? super T> predicate) {
+    Stream<T> before(Stream<T> stream, Predicate<S> predicate) {
       return stream.takeWhile(predicate).filter(predicate);
     }
 
     @AfterTemplate
-    Stream<T> after(Stream<T> stream, Predicate<? super T> predicate) {
+    Stream<T> after(Stream<T> stream, Predicate<S> predicate) {
       return stream.takeWhile(predicate);
     }
   }
@@ -820,14 +814,14 @@ final class StreamRules {
    * Prefer {@link Stream#iterate(Object, Predicate, UnaryOperator)} over more contrived
    * alternatives.
    */
-  static final class StreamIterate<T> {
+  static final class StreamIterate<S, T extends S> {
     @BeforeTemplate
-    Stream<T> before(T seed, Predicate<? super T> hasNext, UnaryOperator<T> next) {
+    Stream<T> before(T seed, Predicate<S> hasNext, UnaryOperator<T> next) {
       return Stream.iterate(seed, next).takeWhile(hasNext);
     }
 
     @AfterTemplate
-    Stream<T> after(T seed, Predicate<? super T> hasNext, UnaryOperator<T> next) {
+    Stream<T> after(T seed, Predicate<S> hasNext, UnaryOperator<T> next) {
       return Stream.iterate(seed, hasNext, next);
     }
   }
@@ -836,13 +830,13 @@ final class StreamRules {
   // XXX: Generalize this and similar rules using an Error Prone check.
   static final class StreamOf1<T> {
     @BeforeTemplate
-    Stream<T> before(T e1) {
-      return ImmutableList.of(e1).stream();
+    Stream<T> before(T t) {
+      return ImmutableList.of(t).stream();
     }
 
     @AfterTemplate
-    Stream<T> after(T e1) {
-      return Stream.of(e1);
+    Stream<T> after(T t) {
+      return Stream.of(t);
     }
   }
 
@@ -928,19 +922,16 @@ final class StreamRules {
     }
   }
 
-  /**
-   * Prefer streaming the result of {@link Collections#nCopies(int, Object)} if a stream of
-   * identical elements is required.
-   */
+  /** Prefer {@link Collections#nCopies(int, Object)} over more contrived alternatives. */
   static final class CollectionsNCopiesStream<T> {
     @BeforeTemplate
-    Stream<T> before(int n, @NotMatches(RequiresComputation.class) T element) {
-      return Stream.generate(() -> element).limit(n);
+    Stream<T> before(int n, @NotMatches(RequiresComputation.class) T o) {
+      return Stream.generate(() -> o).limit(n);
     }
 
     @AfterTemplate
-    Stream<T> after(int n, T element) {
-      return Collections.nCopies(n, element).stream();
+    Stream<T> after(int n, T o) {
+      return Collections.nCopies(n, o).stream();
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringBuilderRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringBuilderRules.java
@@ -20,13 +20,13 @@ final class StringBuilderRules {
   // possible. Here, that would enable invoking the `StringBuilder#repeat(int, int)` overload.
   static final class StringBuilderRepeat {
     @BeforeTemplate
-    StringBuilder before(StringBuilder sb, String str, int count) {
-      return sb.append(str.repeat(count));
+    StringBuilder before(StringBuilder sb, String cs, int count) {
+      return sb.append(cs.repeat(count));
     }
 
     @AfterTemplate
-    StringBuilder after(StringBuilder sb, String str, int count) {
-      return sb.repeat(str, count);
+    StringBuilder after(StringBuilder sb, String cs, int count) {
+      return sb.repeat(cs, count);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StringRules.java
@@ -31,10 +31,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class StringRules {
   private StringRules() {}
 
-  /**
-   * Avoid unnecessary creation of new empty {@link String} objects; use the empty string literal
-   * instead.
-   */
+  /** Prefer {@code ""} over less efficient or less explicit alternatives. */
   static final class EmptyString {
     @BeforeTemplate
     @SuppressWarnings("java:S2129" /* This violation will be rewritten. */)
@@ -53,7 +50,7 @@ final class StringRules {
     }
   }
 
-  /** Avoid unnecessary creation of new {@link String} objects. */
+  /** Prefer using {@link String}s as-is over less efficient alternatives. */
   // XXX: Once `IdentityConversion` supports flagging constructor invocations, use that bug pattern
   // instead of this Refaster rule.
   static final class StringIdentity {
@@ -69,13 +66,13 @@ final class StringRules {
     }
   }
 
-  /** Prefer {@link String#isEmpty()} over alternatives that consult the string's length. */
+  /** Prefer {@link String#isEmpty()} over less explicit alternatives. */
   // XXX: Drop this rule once we (and OpenRewrite) no longer support projects targeting Java 14 or
   // below. The `CharSequenceIsEmpty` rule then suffices. (This rule exists so that e.g. projects
   // that target JDK 11 can disable `CharSequenceIsEmpty` without losing a valuable rule.)
   // XXX: Look into a more general approach to supporting different Java language levels, such as
   // rule selection based on some annotation, or a separate Maven module.
-  static final class StringIsEmpty {
+  static final class StringIsEmptyWithString {
     @BeforeTemplate
     @SuppressWarnings({
       "CharSequenceIsEmpty" /* This is a more specific template. */,
@@ -93,13 +90,13 @@ final class StringRules {
     }
   }
 
-  /** Prefer a method reference to {@link String#isEmpty()} over the equivalent lambda function. */
+  /** Prefer {@link String#isEmpty()} over more verbose alternatives. */
   // XXX: Now that we build with JDK 15+, this rule can be generalized to cover all `CharSequence`
   // subtypes. However, `CharSequence::isEmpty` isn't as nice as `String::isEmpty`, so we might want
   // to introduce a rule that suggests `String::isEmpty` where possible.
   // XXX: As it stands, this rule is a special case of what `MethodReferenceUsage` tries to achieve.
   // If/when `MethodReferenceUsage` becomes production ready, we should simply drop this check.
-  static final class StringIsEmptyPredicate {
+  static final class StringIsEmpty {
     @BeforeTemplate
     Predicate<String> before() {
       return s -> s.isEmpty();
@@ -111,11 +108,11 @@ final class StringRules {
     }
   }
 
-  /** Prefer a method reference to {@link String#isEmpty()} over the equivalent lambda function. */
+  /** Prefer {@code not(String::isEmpty)} over less idiomatic alternatives. */
   // XXX: Now that we build with JDK 15+, this rule can be generalized to cover all `CharSequence`
   // subtypes. However, `CharSequence::isEmpty` isn't as nice as `String::isEmpty`, so we might want
   // to introduce a rule that suggests `String::isEmpty` where possible.
-  static final class StringIsNotEmptyPredicate {
+  static final class NotStringIsEmpty {
     @BeforeTemplate
     Predicate<String> before() {
       return s -> !s.isEmpty();
@@ -128,23 +125,27 @@ final class StringRules {
     }
   }
 
-  /** Prefer {@link Strings#isNullOrEmpty(String)} over the more verbose alternative. */
-  static final class StringIsNullOrEmpty {
+  /** Prefer {@link Strings#isNullOrEmpty(String)} over more verbose alternatives. */
+  static final class StringsIsNullOrEmpty {
     @BeforeTemplate
-    boolean before(@Nullable String str) {
-      return str == null || str.isEmpty();
+    boolean before(@Nullable String string) {
+      return string == null || string.isEmpty();
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(String str) {
-      return Strings.isNullOrEmpty(str);
+    boolean after(String string) {
+      return Strings.isNullOrEmpty(string);
     }
   }
 
-  /** Prefer {@link String#isBlank()} over less efficient alternatives. */
-  // XXX: Note that this rule changes semantics, as `isBlank()` considers whitespace characters
-  // beyond U+0020, while `trim()` does not.
+  /**
+   * Prefer {@link String#isBlank()} over less efficient alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite changes the behavior for strings containing
+   * whitespace characters beyond U+0020, as {@link String#isBlank()} considers those, while {@link
+   * String#trim()} does not.
+   */
   static final class StringIsBlank {
     @BeforeTemplate
     boolean before(String str) {
@@ -158,23 +159,27 @@ final class StringRules {
     }
   }
 
-  /** Don't use the ternary operator to create an optionally-absent string. */
-  // XXX: This is a special case of `TernaryOperatorOptionalNegativeFiltering`.
-  static final class OptionalNonEmptyString {
+  /**
+   * Prefer {@code Optional.ofNullable(str).filter(not(String::isEmpty))} over more contrived
+   * alternatives.
+   */
+  // XXX: This is a special case of `RefasterEmitCommentBeforeOptionalOfFilterNot`.
+  static final class OptionalOfNullableFilterNotStringIsEmpty {
     @BeforeTemplate
-    Optional<String> before(String str) {
-      return Strings.isNullOrEmpty(str)
+    Optional<String> before(String value) {
+      return Strings.isNullOrEmpty(value)
           ? Optional.empty()
-          : Refaster.anyOf(Optional.of(str), Optional.ofNullable(str));
+          : Refaster.anyOf(Optional.of(value), Optional.ofNullable(value));
     }
 
     @AfterTemplate
-    Optional<String> after(String str) {
-      return Optional.ofNullable(str).filter(not(String::isEmpty));
+    Optional<String> after(String value) {
+      return Optional.ofNullable(value).filter(not(String::isEmpty));
     }
   }
 
-  static final class FilterEmptyString {
+  /** Prefer {@link Optional#filter(Predicate)} over non-JDK alternatives. */
+  static final class OptionalFilterNotStringIsEmpty {
     @BeforeTemplate
     Optional<String> before(Optional<String> optional) {
       return optional.map(Strings::emptyToNull);
@@ -187,37 +192,39 @@ final class StringRules {
     }
   }
 
-  /** Prefer {@link String#join(CharSequence, Iterable)} and variants over the Guava alternative. */
+  /**
+   * Prefer {@link String#join(CharSequence, Iterable)} over non-JDK or more contrived alternatives.
+   */
   // XXX: Joiner.on(char) isn't rewritten. Add separate rule?
   // XXX: Joiner#join(@Nullable Object first, @Nullable Object second, Object... rest) isn't
   // rewritten.
-  static final class JoinStrings {
+  static final class StringJoin<T extends CharSequence> {
     @BeforeTemplate
-    String before(String delimiter, CharSequence[] elements) {
+    String before(String delimiter, T[] elements) {
       return Refaster.anyOf(
           Joiner.on(delimiter).join(elements), Arrays.stream(elements).collect(joining(delimiter)));
     }
 
     @BeforeTemplate
-    String before(String delimiter, Iterable<? extends CharSequence> elements) {
+    String before(String delimiter, Iterable<T> elements) {
       return Refaster.anyOf(
           Joiner.on(delimiter).join(elements),
           Streams.stream(elements).collect(joining(delimiter)));
     }
 
     @BeforeTemplate
-    String before(CharSequence delimiter, Collection<? extends CharSequence> elements) {
+    String before(CharSequence delimiter, Collection<T> elements) {
       return elements.stream().collect(joining(delimiter));
     }
 
     @AfterTemplate
-    String after(CharSequence delimiter, Iterable<? extends CharSequence> elements) {
+    String after(CharSequence delimiter, Iterable<T> elements) {
       return String.join(delimiter, elements);
     }
   }
 
   /** Prefer {@link String#join(CharSequence, CharSequence...)} over less efficient alternatives. */
-  static final class StringJoinDelimiterVarargs {
+  static final class StringJoinVarargs {
     @BeforeTemplate
     String before(CharSequence delimiter, @Repeated CharSequence elements) {
       return Stream.of(Refaster.asVarargs(elements)).collect(joining(delimiter));
@@ -229,27 +236,21 @@ final class StringRules {
     }
   }
 
-  /**
-   * Prefer direct invocation of {@link String#valueOf(Object)} over the indirection introduced by
-   * {@link Objects#toString(Object)}.
-   */
-  static final class StringValueOf {
+  /** Prefer {@link String#valueOf(Object)} over more contrived alternatives. */
+  static final class StringValueOfWithObject {
     @BeforeTemplate
-    String before(Object object) {
-      return Objects.toString(object);
+    String before(Object obj) {
+      return Objects.toString(obj);
     }
 
     @AfterTemplate
-    String after(Object object) {
-      return String.valueOf(object);
+    String after(Object obj) {
+      return String.valueOf(obj);
     }
   }
 
-  /**
-   * Prefer direct invocation of {@link String#String(char[], int, int)} over the indirection
-   * introduced by alternatives.
-   */
-  static final class NewStringFromCharArraySubSequence {
+  /** Prefer {@link String#String(char[], int, int)} over more contrived alternatives. */
+  static final class NewString3 {
     @BeforeTemplate
     String before(char[] data, int offset, int count) {
       return Refaster.anyOf(
@@ -262,11 +263,8 @@ final class StringRules {
     }
   }
 
-  /**
-   * Prefer direct invocation of {@link String#String(char[])} over the indirection introduced by
-   * alternatives.
-   */
-  static final class NewStringFromCharArray {
+  /** Prefer {@link String#String(char[])} over more contrived alternatives. */
+  static final class NewString1 {
     @BeforeTemplate
     String before(char[] data) {
       return Refaster.anyOf(String.valueOf(data), new String(data, 0, data.length));
@@ -278,13 +276,10 @@ final class StringRules {
     }
   }
 
-  /**
-   * Prefer direct delegation to {@link String#valueOf(Object)} over the indirection introduced by
-   * {@link Objects#toString(Object)}.
-   */
+  /** Prefer {@link String#valueOf(Object)} over more contrived alternatives. */
   // XXX: This rule is analogous to `StringValueOf` above. Arguably this is its generalization.
   // If/when Refaster is extended to understand this, delete the rule above.
-  static final class StringValueOfMethodReference {
+  static final class StringValueOf {
     @BeforeTemplate
     Function<Object, String> before() {
       return Objects::toString;
@@ -296,139 +291,143 @@ final class StringRules {
     }
   }
 
-  /** Don't unnecessarily use the two-argument {@link String#substring(int, int)}. */
-  static final class SubstringRemainder {
+  /** Prefer {@link String#substring(int)} over more verbose alternatives. */
+  static final class StringSubstring {
     @BeforeTemplate
-    String before(String str, int index) {
-      return str.substring(index, str.length());
+    String before(String str, int beginIndex) {
+      return str.substring(beginIndex, str.length());
     }
 
     @AfterTemplate
-    String after(String str, int index) {
-      return str.substring(index);
+    String after(String str, int beginIndex) {
+      return str.substring(beginIndex);
     }
   }
 
   /** Prefer {@link Utf8#encodedLength(CharSequence)} over less efficient alternatives. */
   static final class Utf8EncodedLength {
     @BeforeTemplate
-    int before(String str) {
-      return str.getBytes(UTF_8).length;
+    int before(String sequence) {
+      return sequence.getBytes(UTF_8).length;
     }
 
     @AfterTemplate
-    int after(String str) {
-      return Utf8.encodedLength(str);
+    int after(String sequence) {
+      return Utf8.encodedLength(sequence);
     }
   }
 
   /** Prefer {@link String#indexOf(int, int)} over less efficient alternatives. */
-  static final class StringIndexOfCharFromIndex {
+  static final class MathMaxNegativeOneStringIndexOfMinusInt {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
-    int before(String string, int ch, int fromIndex) {
-      return string.substring(fromIndex).indexOf(ch);
+    int before(String str, int ch, int fromIndex) {
+      return str.substring(fromIndex).indexOf(ch);
     }
 
     @AfterTemplate
-    int after(String string, int ch, int fromIndex) {
-      return Math.max(-1, string.indexOf(ch, fromIndex) - fromIndex);
+    int after(String str, int ch, int fromIndex) {
+      return Math.max(-1, str.indexOf(ch, fromIndex) - fromIndex);
     }
   }
 
   /** Prefer {@link String#indexOf(int, int, int)} over less efficient alternatives. */
-  static final class StringIndexOfCharBetweenIndices {
+  static final class MathMaxNegativeOneStringIndexOfMinusIntWithInt {
     @BeforeTemplate
-    int before(String string, int ch, int beginIndex, int endIndex) {
-      return string.substring(beginIndex, endIndex).indexOf(ch);
+    int before(String str, int ch, int beginIndex, int endIndex) {
+      return str.substring(beginIndex, endIndex).indexOf(ch);
     }
 
     @AfterTemplate
-    int after(String string, int ch, int beginIndex, int endIndex) {
-      return Math.max(-1, string.indexOf(ch, beginIndex, endIndex) - beginIndex);
+    int after(String str, int ch, int beginIndex, int endIndex) {
+      return Math.max(-1, str.indexOf(ch, beginIndex, endIndex) - beginIndex);
     }
   }
 
   /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
-  static final class StringIndexOfStringFromIndex {
+  static final class MathMaxNegativeOneStringIndexOfMinusString {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
-    int before(String string, String substring, int fromIndex) {
-      return string.substring(fromIndex).indexOf(substring);
+    int before(String str1, String str2, int fromIndex) {
+      return str1.substring(fromIndex).indexOf(str2);
     }
 
     @AfterTemplate
-    int after(String string, String substring, int fromIndex) {
-      return Math.max(-1, string.indexOf(substring, fromIndex) - fromIndex);
+    int after(String str1, String str2, int fromIndex) {
+      return Math.max(-1, str1.indexOf(str2, fromIndex) - fromIndex);
     }
   }
 
   /** Prefer {@link String#indexOf(String, int)} over less efficient alternatives. */
-  static final class StringIndexOfStringBetweenIndices {
+  static final class MathMaxNegativeOneStringIndexOfMinusStringWithInt {
     @BeforeTemplate
-    int before(String string, String substring, int beginIndex, int endIndex) {
-      return string.substring(beginIndex, endIndex).indexOf(substring);
+    int before(String str1, String str2, int beginIndex, int endIndex) {
+      return str1.substring(beginIndex, endIndex).indexOf(str2);
     }
 
     @AfterTemplate
-    int after(String string, String substring, int beginIndex, int endIndex) {
-      return Math.max(-1, string.indexOf(substring, beginIndex, endIndex) - beginIndex);
+    int after(String str1, String str2, int beginIndex, int endIndex) {
+      return Math.max(-1, str1.indexOf(str2, beginIndex, endIndex) - beginIndex);
     }
   }
 
   /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
-  static final class StringLastIndexOfChar {
+  static final class MathMaxNegativeOneStringLastIndexOfMinusInt {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
-    int before(String string, int ch, int fromIndex) {
-      return string.substring(fromIndex).lastIndexOf(ch);
+    int before(String str, int ch, int beginIndex) {
+      return str.substring(beginIndex).lastIndexOf(ch);
     }
 
     @AfterTemplate
-    int after(String string, int ch, int fromIndex) {
-      return Math.max(-1, string.lastIndexOf(ch) - fromIndex);
+    int after(String str, int ch, int beginIndex) {
+      return Math.max(-1, str.lastIndexOf(ch) - beginIndex);
     }
   }
 
   /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
-  static final class StringLastIndexOfString {
+  static final class MathMaxNegativeOneStringLastIndexOfMinusString {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
-    int before(String string, String substring, int fromIndex) {
-      return string.substring(fromIndex).lastIndexOf(substring);
+    int before(String str1, String str2, int beginIndex) {
+      return str1.substring(beginIndex).lastIndexOf(str2);
     }
 
     @AfterTemplate
-    int after(String string, String substring, int fromIndex) {
-      return Math.max(-1, string.lastIndexOf(substring) - fromIndex);
+    int after(String str1, String str2, int beginIndex) {
+      return Math.max(-1, str1.lastIndexOf(str2) - beginIndex);
     }
   }
 
   /** Prefer {@link String#lastIndexOf(int, int)} over less efficient alternatives. */
-  static final class StringLastIndexOfCharWithIndex {
+  static final class StringLastIndexOfMinusOneInt {
     @BeforeTemplate
-    int before(String string, int ch, int fromIndex) {
-      return string.substring(0, fromIndex).lastIndexOf(ch);
+    int before(String str, int ch, int fromIndex) {
+      return str.substring(0, fromIndex).lastIndexOf(ch);
     }
 
     @AfterTemplate
-    int after(String string, int ch, int fromIndex) {
-      return string.lastIndexOf(ch, fromIndex - 1);
+    int after(String str, int ch, int fromIndex) {
+      return str.lastIndexOf(ch, fromIndex - 1);
     }
   }
 
-  /** Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives. */
-  // XXX: The replacement expression isn't fully equivalent: in case `substring` is empty, then
-  // the replacement yields `fromIndex - 1` rather than `fromIndex`.
-  static final class StringLastIndexOfStringWithIndex {
+  /**
+   * Prefer {@link String#lastIndexOf(String, int)} over less efficient alternatives.
+   *
+   * <p><strong>Warning:</strong> when {@code str2} is empty, this rewrite changes the result: the
+   * original expression returns {@code fromIndex}, while the replacement returns {@code fromIndex -
+   * 1}.
+   */
+  static final class StringLastIndexOfMinusOneString {
     @BeforeTemplate
-    int before(String string, String substring, int fromIndex) {
-      return string.substring(0, fromIndex).lastIndexOf(substring);
+    int before(String str1, String str2, int fromIndex) {
+      return str1.substring(0, fromIndex).lastIndexOf(str2);
     }
 
     @AfterTemplate
-    int after(String string, String substring, int fromIndex) {
-      return string.lastIndexOf(substring, fromIndex - 1);
+    int after(String str1, String str2, int fromIndex) {
+      return str1.lastIndexOf(str2, fromIndex - 1);
     }
   }
 
@@ -436,22 +435,18 @@ final class StringRules {
   static final class StringStartsWith {
     @BeforeTemplate
     @SuppressWarnings("java:S4635" /* This violation will be rewritten. */)
-    boolean before(String string, String prefix, int fromIndex) {
-      return string.substring(fromIndex).startsWith(prefix);
+    boolean before(String str, String prefix, int toffset) {
+      return str.substring(toffset).startsWith(prefix);
     }
 
     @AfterTemplate
-    boolean after(String string, String prefix, int fromIndex) {
-      return string.startsWith(prefix, fromIndex);
+    boolean after(String str, String prefix, int toffset) {
+      return str.startsWith(prefix, toffset);
     }
   }
 
-  /**
-   * Prefer {@link String#formatted(Object...)} over {@link String#format(String, Object...)}, as
-   * the former works more nicely with text blocks, while the latter does not appear advantageous in
-   * any circumstance (assuming one targets JDK 15+).
-   */
-  static final class StringFormatted {
+  /** Prefer {@link String#formatted(Object...)} over less idiomatic alternatives. */
+  static final class Formatted {
     @BeforeTemplate
     @FormatMethod
     String before(String format, @Repeated Object args) {

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/SuggestedFixRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/SuggestedFixRules.java
@@ -12,34 +12,34 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class SuggestedFixRules {
   private SuggestedFixRules() {}
 
-  /** Prefer {@link SuggestedFix#toBuilder()}} over more contrived alternatives. */
+  /** Prefer {@link SuggestedFix#toBuilder()} over more contrived alternatives. */
   static final class SuggestedFixToBuilder {
     @BeforeTemplate
-    SuggestedFix.Builder before(SuggestedFix fix) {
-      return SuggestedFix.builder().merge(fix);
+    SuggestedFix.Builder before(SuggestedFix other) {
+      return SuggestedFix.builder().merge(other);
     }
 
     @AfterTemplate
-    SuggestedFix.Builder after(SuggestedFix fix) {
-      return fix.toBuilder();
+    SuggestedFix.Builder after(SuggestedFix other) {
+      return other.toBuilder();
     }
   }
 
   /** Prefer {@link SuggestedFix#delete(Tree)} over more contrived alternatives. */
   static final class SuggestedFixDelete {
     @BeforeTemplate
-    SuggestedFix before(Tree tree) {
-      return SuggestedFix.builder().delete(tree).build();
+    SuggestedFix before(Tree node) {
+      return SuggestedFix.builder().delete(node).build();
     }
 
     @AfterTemplate
-    SuggestedFix after(Tree tree) {
-      return SuggestedFix.delete(tree);
+    SuggestedFix after(Tree node) {
+      return SuggestedFix.delete(node);
     }
   }
 
-  /** Prefer {@link SuggestedFix#replace(Tree, String)}} over more contrived alternatives. */
-  static final class SuggestedFixReplaceTree {
+  /** Prefer {@link SuggestedFix#replace(Tree, String)} over more contrived alternatives. */
+  static final class SuggestedFixReplace2 {
     @BeforeTemplate
     SuggestedFix before(Tree tree, String replaceWith) {
       return SuggestedFix.builder().replace(tree, replaceWith).build();
@@ -51,31 +51,35 @@ final class SuggestedFixRules {
     }
   }
 
-  /** Prefer {@link SuggestedFix#replace(int, int, String)}} over more contrived alternatives. */
-  static final class SuggestedFixReplaceStartEnd {
+  /** Prefer {@link SuggestedFix#replace(int, int, String)} over more contrived alternatives. */
+  static final class SuggestedFixReplace3 {
     @BeforeTemplate
-    SuggestedFix before(int start, int end, String replaceWith) {
-      return SuggestedFix.builder().replace(start, end, replaceWith).build();
+    SuggestedFix before(int startPos, int endPos, String replaceWith) {
+      return SuggestedFix.builder().replace(startPos, endPos, replaceWith).build();
     }
 
     @AfterTemplate
-    SuggestedFix after(int start, int end, String replaceWith) {
-      return SuggestedFix.replace(start, end, replaceWith);
+    SuggestedFix after(int startPos, int endPos, String replaceWith) {
+      return SuggestedFix.replace(startPos, endPos, replaceWith);
     }
   }
 
   /**
-   * Prefer {@link SuggestedFix#replace(Tree, String, int, int)}} over more contrived alternatives.
+   * Prefer {@link SuggestedFix#replace(Tree, String, int, int)} over more contrived alternatives.
    */
-  static final class SuggestedFixReplaceTreeStartEnd {
+  static final class SuggestedFixReplace4 {
     @BeforeTemplate
-    SuggestedFix before(Tree tree, String replaceWith, int start, int end) {
-      return SuggestedFix.builder().replace(tree, replaceWith, start, end).build();
+    SuggestedFix before(
+        Tree node, String replaceWith, int startPosAdjustment, int endPosAdjustment) {
+      return SuggestedFix.builder()
+          .replace(node, replaceWith, startPosAdjustment, endPosAdjustment)
+          .build();
     }
 
     @AfterTemplate
-    SuggestedFix after(Tree tree, String replaceWith, int start, int end) {
-      return SuggestedFix.replace(tree, replaceWith, start, end);
+    SuggestedFix after(
+        Tree node, String replaceWith, int startPosAdjustment, int endPosAdjustment) {
+      return SuggestedFix.replace(node, replaceWith, startPosAdjustment, endPosAdjustment);
     }
   }
 
@@ -84,39 +88,39 @@ final class SuggestedFixRules {
    */
   static final class SuggestedFixSwap {
     @BeforeTemplate
-    SuggestedFix before(Tree tree1, Tree tree2, VisitorState state) {
-      return SuggestedFix.builder().swap(tree1, tree2, state).build();
+    SuggestedFix before(Tree node1, Tree node2, VisitorState state) {
+      return SuggestedFix.builder().swap(node1, node2, state).build();
     }
 
     @AfterTemplate
-    SuggestedFix after(Tree tree1, Tree tree2, VisitorState state) {
-      return SuggestedFix.swap(tree1, tree2, state);
+    SuggestedFix after(Tree node1, Tree node2, VisitorState state) {
+      return SuggestedFix.swap(node1, node2, state);
     }
   }
 
   /** Prefer {@link SuggestedFix#prefixWith(Tree, String)} over more contrived alternatives. */
   static final class SuggestedFixPrefixWith {
     @BeforeTemplate
-    SuggestedFix before(Tree tree, String prefix) {
-      return SuggestedFix.builder().prefixWith(tree, prefix).build();
+    SuggestedFix before(Tree node, String prefix) {
+      return SuggestedFix.builder().prefixWith(node, prefix).build();
     }
 
     @AfterTemplate
-    SuggestedFix after(Tree tree, String prefix) {
-      return SuggestedFix.prefixWith(tree, prefix);
+    SuggestedFix after(Tree node, String prefix) {
+      return SuggestedFix.prefixWith(node, prefix);
     }
   }
 
-  /** Prefer {@link SuggestedFix#postfixWith(Tree, String)}} over more contrived alternatives. */
+  /** Prefer {@link SuggestedFix#postfixWith(Tree, String)} over more contrived alternatives. */
   static final class SuggestedFixPostfixWith {
     @BeforeTemplate
-    SuggestedFix before(Tree tree, String postfix) {
-      return SuggestedFix.builder().postfixWith(tree, postfix).build();
+    SuggestedFix before(Tree node, String postfix) {
+      return SuggestedFix.builder().postfixWith(node, postfix).build();
     }
 
     @AfterTemplate
-    SuggestedFix after(Tree tree, String postfix) {
-      return SuggestedFix.postfixWith(tree, postfix);
+    SuggestedFix after(Tree node, String postfix) {
+      return SuggestedFix.postfixWith(node, postfix);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TestNGToAssertJRules.java
@@ -4,7 +4,7 @@ import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.api.Assertions.offset;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertEqualsNoOrder;
 import static org.testng.Assert.assertFalse;
@@ -20,19 +20,28 @@ import com.google.common.collect.ImmutableList;
 import com.google.errorprone.annotations.DoNotCall;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
+import com.google.errorprone.refaster.annotation.Matches;
 import com.google.errorprone.refaster.annotation.UseImportPolicy;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
+import org.assertj.core.api.AbstractAssert;
+import org.assertj.core.api.AbstractBooleanAssert;
+import org.assertj.core.api.AbstractDoubleAssert;
+import org.assertj.core.api.AbstractFloatAssert;
+import org.assertj.core.api.AbstractIterableAssert;
+import org.assertj.core.api.Assertions;
 import org.assertj.core.api.ThrowableAssert.ThrowingCallable;
+import org.assertj.core.data.Offset;
 import org.testng.Assert;
 import org.testng.Assert.ThrowingRunnable;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 import tech.picnic.errorprone.refaster.annotation.TypeMigration;
+import tech.picnic.errorprone.refaster.matchers.IsLambdaExpressionOrMethodReference;
 
 /**
- * Refaster rules that replace TestNG assertions with equivalent AssertJ assertions.
+ * Refaster rules that replace TestNG APIs with AssertJ equivalents.
  *
  * <p>Some of the classes below have TestNG {@code @BeforeTemplate}s that reference wildcard type
  * bounds ({@code <?>}), while the associated AssertJ {@code @AfterTemplate}s reference stricter
@@ -49,13 +58,13 @@ import tech.picnic.errorprone.refaster.annotation.TypeMigration;
  * List<Map<String, Object>> myMaps = new ArrayList<>();
  * assertEquals(myMaps, ImmutableList.of(ImmutableMap.of()));
  * }</pre>
+ *
+ * <p><strong>Warning:</strong> while both libraries throw an {@link AssertionError} in case of an
+ * assertion failure, the exact subtype used generally differs.
  */
 // XXX: As-is these rules do not result in a complete migration:
 // - Expressions containing comments are skipped due to a limitation of Refaster.
 // - Assertions inside lambda expressions are also skipped. Unclear why.
-// XXX: Many of the test expressions for these rules use the same expression for `expected` and
-// `actual`, which makes the validation weaker than necessary; fix this. (And investigate whether we
-// can introduce validation for this.)
 @OnlineDocumentation
 @TypeMigration(
     of = Assert.class,
@@ -102,6 +111,7 @@ import tech.picnic.errorprone.refaster.annotation.TypeMigration;
 final class TestNGToAssertJRules {
   private TestNGToAssertJRules() {}
 
+  /** Prefer {@link Assertions#fail()} over non-AssertJ alternatives. */
   static final class Fail {
     @BeforeTemplate
     void before() {
@@ -116,139 +126,150 @@ final class TestNGToAssertJRules {
     }
   }
 
+  /** Prefer {@link Assertions#fail(String)} over non-AssertJ alternatives. */
   // XXX: This may cause the TestNG import not to be cleaned up, yielding a compilation failure.
-  static final class FailWithMessage {
+  static final class FailWithString {
     @BeforeTemplate
-    void before(String message) {
-      Assert.fail(message);
+    void before(String failureMessage) {
+      Assert.fail(failureMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(String message) {
-      fail(message);
+    void after(String failureMessage) {
+      fail(failureMessage);
     }
   }
 
+  /** Prefer {@link Assertions#fail(String, Throwable)} over non-AssertJ alternatives. */
   // XXX: This may cause the TestNG import not to be cleaned up, yielding a compilation failure.
-  static final class FailWithMessageAndThrowable {
+  static final class FailWithStringAndThrowable {
     @BeforeTemplate
-    void before(String message, Throwable throwable) {
-      Assert.fail(message, throwable);
+    void before(String failureMessage, Throwable realCause) {
+      Assert.fail(failureMessage, realCause);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(String message, Throwable throwable) {
-      fail(message, throwable);
+    void after(String failureMessage, Throwable realCause) {
+      fail(failureMessage, realCause);
     }
   }
 
-  static final class AssertTrue {
+  /** Prefer {@link AbstractBooleanAssert#isTrue()} over non-AssertJ alternatives. */
+  static final class AssertThatIsTrue {
     @BeforeTemplate
-    void before(boolean condition) {
-      assertTrue(condition);
+    void before(boolean actual) {
+      assertTrue(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition) {
-      assertThat(condition).isTrue();
+    void after(boolean actual) {
+      assertThat(actual).isTrue();
     }
   }
 
-  static final class AssertTrueWithMessage {
+  /** Prefer {@link AbstractBooleanAssert#isTrue()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsTrue {
     @BeforeTemplate
-    void before(boolean condition, String message) {
-      assertTrue(condition, message);
+    void before(boolean actual, String newErrorMessage) {
+      assertTrue(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, String message) {
-      assertThat(condition).withFailMessage(message).isTrue();
+    void after(boolean actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isTrue();
     }
   }
 
-  static final class AssertFalse {
+  /** Prefer {@link AbstractBooleanAssert#isFalse()} over non-AssertJ alternatives. */
+  static final class AssertThatIsFalse {
     @BeforeTemplate
-    void before(boolean condition) {
-      assertFalse(condition);
+    void before(boolean actual) {
+      assertFalse(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition) {
-      assertThat(condition).isFalse();
+    void after(boolean actual) {
+      assertThat(actual).isFalse();
     }
   }
 
-  static final class AssertFalseWithMessage {
+  /** Prefer {@link AbstractBooleanAssert#isFalse()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsFalse {
     @BeforeTemplate
-    void before(boolean condition, String message) {
-      assertFalse(condition, message);
+    void before(boolean actual, String newErrorMessage) {
+      assertFalse(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(boolean condition, String message) {
-      assertThat(condition).withFailMessage(message).isFalse();
+    void after(boolean actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isFalse();
     }
   }
 
-  static final class AssertNull {
+  /** Prefer {@link AbstractAssert#isNull()} over non-AssertJ alternatives. */
+  static final class AssertThatIsNull {
     @BeforeTemplate
-    void before(Object object) {
-      assertNull(object);
+    void before(Object actual) {
+      assertNull(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object) {
-      assertThat(object).isNull();
+    void after(Object actual) {
+      assertThat(actual).isNull();
     }
   }
 
-  static final class AssertNullWithMessage {
+  /** Prefer {@link AbstractAssert#isNull()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNull {
     @BeforeTemplate
-    void before(Object object, String message) {
-      assertNull(object, message);
+    void before(Object actual, String newErrorMessage) {
+      assertNull(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, String message) {
-      assertThat(object).withFailMessage(message).isNull();
+    void after(Object actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNull();
     }
   }
 
-  static final class AssertNotNull {
+  /** Prefer {@link AbstractAssert#isNotNull()} over non-AssertJ alternatives. */
+  static final class AssertThatIsNotNull {
     @BeforeTemplate
-    void before(Object object) {
-      assertNotNull(object);
+    void before(Object actual) {
+      assertNotNull(actual);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object) {
-      assertThat(object).isNotNull();
+    void after(Object actual) {
+      assertThat(actual).isNotNull();
     }
   }
 
-  static final class AssertNotNullWithMessage {
+  /** Prefer {@link AbstractAssert#isNotNull()} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNotNull {
     @BeforeTemplate
-    void before(Object object, String message) {
-      assertNotNull(object, message);
+    void before(Object actual, String newErrorMessage) {
+      assertNotNull(actual, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object object, String message) {
-      assertThat(object).withFailMessage(message).isNotNull();
+    void after(Object actual, String newErrorMessage) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNotNull();
     }
   }
 
-  static final class AssertSame {
+  /** Prefer {@link AbstractAssert#isSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatIsSameAs {
     @BeforeTemplate
     void before(Object actual, Object expected) {
       assertSame(actual, expected);
@@ -261,47 +282,51 @@ final class TestNGToAssertJRules {
     }
   }
 
-  static final class AssertSameWithMessage {
+  /** Prefer {@link AbstractAssert#isSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsSameAs {
     @BeforeTemplate
-    void before(Object actual, String message, Object expected) {
-      assertSame(actual, expected, message);
+    void before(Object actual, String newErrorMessage, Object expected) {
+      assertSame(actual, expected, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message, Object expected) {
-      assertThat(actual).withFailMessage(message).isSameAs(expected);
+    void after(Object actual, String newErrorMessage, Object expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).isSameAs(expected);
     }
   }
 
-  static final class AssertNotSame {
+  /** Prefer {@link AbstractAssert#isNotSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatIsNotSameAs {
     @BeforeTemplate
-    void before(Object actual, Object expected) {
-      assertNotSame(actual, expected);
+    void before(Object actual, Object other) {
+      assertNotSame(actual, other);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Object expected) {
-      assertThat(actual).isNotSameAs(expected);
+    void after(Object actual, Object other) {
+      assertThat(actual).isNotSameAs(other);
     }
   }
 
-  static final class AssertNotSameWithMessage {
+  /** Prefer {@link AbstractAssert#isNotSameAs(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNotSameAs {
     @BeforeTemplate
-    void before(Object actual, String message, Object expected) {
-      assertNotSame(actual, expected, message);
+    void before(Object actual, String newErrorMessage, Object other) {
+      assertNotSame(actual, other, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message, Object expected) {
-      assertThat(actual).withFailMessage(message).isNotSameAs(expected);
+    void after(Object actual, String newErrorMessage, Object other) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNotSameAs(other);
     }
   }
 
+  /** Prefer {@link AbstractAssert#isEqualTo(Object)} over non-AssertJ alternatives. */
   @SuppressWarnings("java:S1448" /* Each variant requires a separate `@BeforeTemplate` method. */)
-  static final class AssertEqual {
+  static final class AssertThatIsEqualTo {
     @BeforeTemplate
     void before(boolean actual, boolean expected) {
       assertEquals(actual, expected);
@@ -484,243 +509,253 @@ final class TestNGToAssertJRules {
     }
   }
 
+  /** Prefer {@link AbstractAssert#isEqualTo(Object)} over non-AssertJ alternatives. */
   @SuppressWarnings("java:S1448" /* Each variant requires a separate `@BeforeTemplate` method. */)
-  static final class AssertEqualWithMessage {
+  static final class AssertThatWithFailMessageIsEqualTo {
     @BeforeTemplate
-    void before(boolean actual, String message, boolean expected) {
-      assertEquals(actual, expected, message);
+    void before(boolean actual, String newErrorMessage, boolean expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(boolean actual, String message, Boolean expected) {
-      assertEquals(actual, expected, message);
+    void before(boolean actual, String newErrorMessage, Boolean expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Boolean actual, String message, boolean expected) {
-      assertEquals(actual, expected, message);
+    void before(Boolean actual, String newErrorMessage, boolean expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Boolean actual, String message, Boolean expected) {
-      assertEquals(actual, expected, message);
+    void before(Boolean actual, String newErrorMessage, Boolean expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(byte actual, String message, byte expected) {
-      assertEquals(actual, expected, message);
+    void before(byte actual, String newErrorMessage, byte expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(byte actual, String message, Byte expected) {
-      assertEquals(actual, expected, message);
+    void before(byte actual, String newErrorMessage, Byte expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Byte actual, String message, byte expected) {
-      assertEquals(actual, expected, message);
+    void before(Byte actual, String newErrorMessage, byte expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Byte actual, String message, Byte expected) {
-      assertEquals(actual, expected, message);
+    void before(Byte actual, String newErrorMessage, Byte expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(char actual, String message, char expected) {
-      assertEquals(actual, expected, message);
+    void before(char actual, String newErrorMessage, char expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(char actual, String message, Character expected) {
-      assertEquals(actual, expected, message);
+    void before(char actual, String newErrorMessage, Character expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Character actual, String message, char expected) {
-      assertEquals(actual, expected, message);
+    void before(Character actual, String newErrorMessage, char expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Character actual, String message, Character expected) {
-      assertEquals(actual, expected, message);
+    void before(Character actual, String newErrorMessage, Character expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(short actual, String message, short expected) {
-      assertEquals(actual, expected, message);
+    void before(short actual, String newErrorMessage, short expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(short actual, String message, Short expected) {
-      assertEquals(actual, expected, message);
+    void before(short actual, String newErrorMessage, Short expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Short actual, String message, short expected) {
-      assertEquals(actual, expected, message);
+    void before(Short actual, String newErrorMessage, short expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Short actual, String message, Short expected) {
-      assertEquals(actual, expected, message);
+    void before(Short actual, String newErrorMessage, Short expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(int actual, String message, int expected) {
-      assertEquals(actual, expected, message);
+    void before(int actual, String newErrorMessage, int expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(int actual, String message, Integer expected) {
-      assertEquals(actual, expected, message);
+    void before(int actual, String newErrorMessage, Integer expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Integer actual, String message, int expected) {
-      assertEquals(actual, expected, message);
+    void before(Integer actual, String newErrorMessage, int expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Integer actual, String message, Integer expected) {
-      assertEquals(actual, expected, message);
+    void before(Integer actual, String newErrorMessage, Integer expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(long actual, String message, long expected) {
-      assertEquals(actual, expected, message);
+    void before(long actual, String newErrorMessage, long expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(long actual, String message, Long expected) {
-      assertEquals(actual, expected, message);
+    void before(long actual, String newErrorMessage, Long expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Long actual, String message, long expected) {
-      assertEquals(actual, expected, message);
+    void before(Long actual, String newErrorMessage, long expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Long actual, String message, Long expected) {
-      assertEquals(actual, expected, message);
+    void before(Long actual, String newErrorMessage, Long expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(float actual, String message, float expected) {
-      assertEquals(actual, expected, message);
+    void before(float actual, String newErrorMessage, float expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(float actual, String message, Float expected) {
-      assertEquals(actual, expected, message);
+    void before(float actual, String newErrorMessage, Float expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Float actual, String message, float expected) {
-      assertEquals(actual, expected, message);
+    void before(Float actual, String newErrorMessage, float expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Float actual, String message, Float expected) {
-      assertEquals(actual, expected, message);
+    void before(Float actual, String newErrorMessage, Float expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(double actual, String message, double expected) {
-      assertEquals(actual, expected, message);
+    void before(double actual, String newErrorMessage, double expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(double actual, String message, Double expected) {
-      assertEquals(actual, expected, message);
+    void before(double actual, String newErrorMessage, Double expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Double actual, String message, double expected) {
-      assertEquals(actual, expected, message);
+    void before(Double actual, String newErrorMessage, double expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Double actual, String message, Double expected) {
-      assertEquals(actual, expected, message);
+    void before(Double actual, String newErrorMessage, Double expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Object actual, String message, Object expected) {
-      assertEquals(actual, expected, message);
+    void before(Object actual, String newErrorMessage, Object expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(String actual, String message, String expected) {
-      assertEquals(actual, expected, message);
+    void before(String actual, String newErrorMessage, String expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Map<?, ?> actual, String message, Map<?, ?> expected) {
-      assertEquals(actual, expected, message);
+    void before(Map<?, ?> actual, String newErrorMessage, Map<?, ?> expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message, Object expected) {
-      assertThat(actual).withFailMessage(message).isEqualTo(expected);
+    void after(Object actual, String newErrorMessage, Object expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).isEqualTo(expected);
     }
   }
 
-  static final class AssertEqualFloatsWithDelta {
+  /** Prefer {@link AbstractFloatAssert#isCloseTo(float, Offset)} over non-AssertJ alternatives. */
+  static final class AssertThatIsCloseToOffsetFloat {
     @BeforeTemplate
-    void before(float actual, float expected, float delta) {
-      assertEquals(actual, expected, delta);
+    void before(float actual, float expected, float value) {
+      assertEquals(actual, expected, value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Float actual, float expected, float delta) {
-      assertThat(actual).isCloseTo(expected, offset(delta));
+    void after(float actual, float expected, float value) {
+      assertThat(actual).isCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertEqualFloatsWithDeltaWithMessage {
+  /** Prefer {@link AbstractFloatAssert#isCloseTo(float, Offset)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsCloseToOffsetFloat {
     @BeforeTemplate
-    void before(float actual, String message, float expected, float delta) {
-      assertEquals(actual, expected, delta, message);
+    void before(float actual, String newErrorMessage, float expected, float value) {
+      assertEquals(actual, expected, value, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float actual, String message, float expected, float delta) {
-      assertThat(actual).withFailMessage(message).isCloseTo(expected, offset(delta));
+    void after(float actual, String newErrorMessage, float expected, float value) {
+      assertThat(actual).withFailMessage(newErrorMessage).isCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertEqualDoublesWithDelta {
+  /**
+   * Prefer {@link AbstractDoubleAssert#isCloseTo(double, Offset)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatIsCloseToOffsetDouble {
     @BeforeTemplate
-    void before(double actual, double expected, double delta) {
-      assertEquals(actual, expected, delta);
+    void before(double actual, double expected, double value) {
+      assertEquals(actual, expected, value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double actual, double expected, double delta) {
-      assertThat(actual).isCloseTo(expected, offset(delta));
+    void after(double actual, double expected, double value) {
+      assertThat(actual).isCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertEqualDoublesWithDeltaWithMessage {
+  /**
+   * Prefer {@link AbstractDoubleAssert#isCloseTo(double, Offset)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageIsCloseToOffsetDouble {
     @BeforeTemplate
-    void before(double actual, String message, double expected, double delta) {
-      assertEquals(actual, expected, delta, message);
+    void before(double actual, String newErrorMessage, double expected, double value) {
+      assertEquals(actual, expected, value, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double actual, String message, double expected, double delta) {
-      assertThat(actual).withFailMessage(message).isCloseTo(expected, offset(delta));
+    void after(double actual, String newErrorMessage, double expected, double value) {
+      assertThat(actual).withFailMessage(newErrorMessage).isCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertEqualArrayIterationOrder {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatContainsExactly {
     @BeforeTemplate
     void before(boolean[] actual, boolean[] expected) {
       assertEquals(actual, expected);
@@ -773,112 +808,128 @@ final class TestNGToAssertJRules {
     }
   }
 
-  static final class AssertEqualArrayIterationOrderWithMessage {
+  /** Prefer {@code assertThat(...).containsExactly(...)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageContainsExactly {
     @BeforeTemplate
-    void before(boolean[] actual, String message, boolean[] expected) {
-      assertEquals(actual, expected, message);
+    void before(boolean[] actual, String newErrorMessage, boolean[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(byte[] actual, String message, byte[] expected) {
-      assertEquals(actual, expected, message);
+    void before(byte[] actual, String newErrorMessage, byte[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(char[] actual, String message, char[] expected) {
-      assertEquals(actual, expected, message);
+    void before(char[] actual, String newErrorMessage, char[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(short[] actual, String message, short[] expected) {
-      assertEquals(actual, expected, message);
+    void before(short[] actual, String newErrorMessage, short[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(int[] actual, String message, int[] expected) {
-      assertEquals(actual, expected, message);
+    void before(int[] actual, String newErrorMessage, int[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(long[] actual, String message, long[] expected) {
-      assertEquals(actual, expected, message);
+    void before(long[] actual, String newErrorMessage, long[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(float[] actual, String message, float[] expected) {
-      assertEquals(actual, expected, message);
+    void before(float[] actual, String newErrorMessage, float[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(double[] actual, String message, double[] expected) {
-      assertEquals(actual, expected, message);
+    void before(double[] actual, String newErrorMessage, double[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Object[] actual, String message, Object[] expected) {
-      assertEquals(actual, expected, message);
+    void before(Object[] actual, String newErrorMessage, Object[] expected) {
+      assertEquals(actual, expected, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object[] actual, String message, Object[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected);
+    void after(Object[] actual, String newErrorMessage, Object[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(expected);
     }
   }
 
-  static final class AssertEqualFloatArraysWithDelta {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatContainsExactlyOffsetFloat {
     @BeforeTemplate
-    void before(float[] actual, float[] expected, float delta) {
-      assertEquals(actual, expected, delta);
+    void before(float[] actual, float[] values, float value) {
+      assertEquals(actual, values, value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float[] actual, float[] expected, float delta) {
-      assertThat(actual).containsExactly(expected, offset(delta));
+    void after(float[] actual, float[] values, float value) {
+      assertThat(actual).containsExactly(values, offset(value));
     }
   }
 
-  static final class AssertEqualFloatArraysWithDeltaWithMessage {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageContainsExactlyOffsetFloat {
     @BeforeTemplate
-    void before(float[] actual, String message, float[] expected, float delta) {
-      assertEquals(actual, expected, delta, message);
+    void before(float[] actual, String newErrorMessage, float[] values, float value) {
+      assertEquals(actual, values, value, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float[] actual, String message, float[] expected, float delta) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    void after(float[] actual, String newErrorMessage, float[] values, float value) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(values, offset(value));
     }
   }
 
-  static final class AssertEqualDoubleArraysWithDelta {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatContainsExactlyOffsetDouble {
     @BeforeTemplate
-    void before(double[] actual, double[] expected, double delta) {
-      assertEquals(actual, expected, delta);
+    void before(double[] actual, double[] values, double value) {
+      assertEquals(actual, values, value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double[] actual, double[] expected, double delta) {
-      assertThat(actual).containsExactly(expected, offset(delta));
+    void after(double[] actual, double[] values, double value) {
+      assertThat(actual).containsExactly(values, offset(value));
     }
   }
 
-  static final class AssertEqualDoubleArraysWithDeltaWithMessage {
+  /**
+   * Prefer {@code assertThat(...).containsExactly(..., offset(...))} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageContainsExactlyOffsetDouble {
     @BeforeTemplate
-    void before(double[] actual, String message, double[] expected, double delta) {
-      assertEquals(actual, expected, delta, message);
+    void before(double[] actual, String newErrorMessage, double[] values, double value) {
+      assertEquals(actual, values, value, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double[] actual, String message, double[] expected, double delta) {
-      assertThat(actual).withFailMessage(message).containsExactly(expected, offset(delta));
+    void after(double[] actual, String newErrorMessage, double[] values, double value) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactly(values, offset(value));
     }
   }
 
-  static final class AssertEqualArraysIrrespectiveOfOrder {
+  /**
+   * Prefer {@code assertThat(...).containsExactlyInAnyOrder(...)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatContainsExactlyInAnyOrder {
     @BeforeTemplate
     void before(Object[] actual, Object[] expected) {
       assertEqualsNoOrder(actual, expected);
@@ -891,341 +942,392 @@ final class TestNGToAssertJRules {
     }
   }
 
-  static final class AssertEqualArraysIrrespectiveOfOrderWithMessage {
+  /**
+   * Prefer {@code assertThat(...).containsExactlyInAnyOrder(...)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageContainsExactlyInAnyOrder {
     @BeforeTemplate
-    void before(Object[] actual, String message, Object[] expected) {
-      assertEqualsNoOrder(actual, expected, message);
+    void before(Object[] actual, String newErrorMessage, Object[] expected) {
+      assertEqualsNoOrder(actual, expected, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object[] actual, String message, Object[] expected) {
-      assertThat(actual).withFailMessage(message).containsExactlyInAnyOrder(expected);
+    void after(Object[] actual, String newErrorMessage, Object[] expected) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactlyInAnyOrder(expected);
     }
   }
 
+  /**
+   * Prefer {@code assertThat(...).toIterable().containsExactlyElementsOf(...)} over non-AssertJ
+   * alternatives.
+   */
   // XXX: TestNG's `assertEquals` accepts arbitrary `Iterator<?>` arguments. As such some
   // expressions will not be rewritten.
-  static final class AssertEqualIteratorIterationOrder<S, T extends S> {
+  static final class AssertThatToIterableContainsExactlyElementsOfImmutableListCopyOf<
+      S, T extends S> {
     @BeforeTemplate
-    void before(Iterator<S> actual, Iterator<T> expected) {
-      assertEquals(actual, expected);
+    void before(Iterator<S> actual, Iterator<T> elements) {
+      assertEquals(actual, elements);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Iterator<S> actual, Iterator<T> expected) {
+    void after(Iterator<S> actual, Iterator<T> elements) {
       // XXX: This is not `null`-safe.
       // XXX: The `ImmutableList.copyOf` should actually *not* be imported statically.
-      assertThat(actual).toIterable().containsExactlyElementsOf(ImmutableList.copyOf(expected));
+      assertThat(actual).toIterable().containsExactlyElementsOf(ImmutableList.copyOf(elements));
     }
   }
 
+  /**
+   * Prefer {@code assertThat(...).toIterable().containsExactlyElementsOf(...)} over non-AssertJ
+   * alternatives.
+   */
   // XXX: TestNG's `assertEquals` accepts arbitrary `Iterator<?>` arguments. As such some
   // expressions will not be rewritten.
-  static final class AssertEqualIteratorIterationOrderWithMessage<S, T extends S> {
+  static final
+  class AssertThatToIterableWithFailMessageContainsExactlyElementsOfImmutableListCopyOf<
+      S, T extends S> {
     @BeforeTemplate
-    void before(Iterator<S> actual, String message, Iterator<T> expected) {
-      assertEquals(actual, expected, message);
+    void before(Iterator<S> actual, String newErrorMessage, Iterator<T> elements) {
+      assertEquals(actual, elements, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Iterator<S> actual, String message, Iterator<T> expected) {
+    void after(Iterator<S> actual, String newErrorMessage, Iterator<T> elements) {
       // XXX: This is not `null`-safe.
       // XXX: The `ImmutableList.copyOf` should actually *not* be imported statically.
       assertThat(actual)
           .toIterable()
-          .withFailMessage(message)
-          .containsExactlyElementsOf(ImmutableList.copyOf(expected));
+          .withFailMessage(newErrorMessage)
+          .containsExactlyElementsOf(ImmutableList.copyOf(elements));
     }
   }
 
-  // XXX This rule fails for `java.nio.file.Path` as it is `Iterable`, but AssertJ's
+  /**
+   * Prefer {@link AbstractIterableAssert#containsExactlyElementsOf(Iterable)} over non-AssertJ
+   * alternatives.
+   */
+  // XXX: This rule fails for `java.nio.file.Path` as it is `Iterable`, but AssertJ's
   // `assertThat(Path)` does not support `.containsExactlyElementsOf`.
   // XXX: TestNG's `assertEquals` accepts arbitrary `Iterable<?>` and `Collection<?>` arguments. As
   // such some expressions will not be rewritten.
-  static final class AssertEqualIterableIterationOrder<S, T extends S> {
+  static final class AssertThatContainsExactlyElementsOf<S, T extends S> {
     @BeforeTemplate
-    void before(Iterable<S> actual, Iterable<T> expected) {
-      assertEquals(actual, expected);
+    void before(Iterable<S> actual, Iterable<T> iterable) {
+      assertEquals(actual, iterable);
     }
 
     @BeforeTemplate
-    void before(Collection<S> actual, Collection<T> expected) {
-      assertEquals(actual, expected);
+    void before(Collection<S> actual, Collection<T> iterable) {
+      assertEquals(actual, iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Iterable<S> actual, Iterable<T> expected) {
-      assertThat(actual).containsExactlyElementsOf(expected);
+    void after(Iterable<S> actual, Iterable<T> iterable) {
+      assertThat(actual).containsExactlyElementsOf(iterable);
     }
   }
 
-  // XXX This rule fails for `java.nio.file.Path` as it is `Iterable`, but AssertJ's
+  /**
+   * Prefer {@link AbstractIterableAssert#containsExactlyElementsOf(Iterable)} over non-AssertJ
+   * alternatives.
+   */
+  // XXX: This rule fails for `java.nio.file.Path` as it is `Iterable`, but AssertJ's
   // `assertThat(Path)` does not support `.containsExactlyElementsOf`.
   // XXX: TestNG's `assertEquals` accepts arbitrary `Iterable<?>` and `Collection<?>` arguments. As
   // such some expressions will not be rewritten.
-  static final class AssertEqualIterableIterationOrderWithMessage<S, T extends S> {
+  static final class AssertThatWithFailMessageContainsExactlyElementsOf<S, T extends S> {
     @BeforeTemplate
-    void before(Iterable<S> actual, String message, Iterable<T> expected) {
-      assertEquals(actual, expected, message);
+    void before(Iterable<S> actual, String newErrorMessage, Iterable<T> iterable) {
+      assertEquals(actual, iterable, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Collection<S> actual, String message, Collection<T> expected) {
-      assertEquals(actual, expected, message);
+    void before(Collection<S> actual, String newErrorMessage, Collection<T> iterable) {
+      assertEquals(actual, iterable, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Iterable<S> actual, String message, Iterable<T> expected) {
-      assertThat(actual).withFailMessage(message).containsExactlyElementsOf(expected);
+    void after(Iterable<S> actual, String newErrorMessage, Iterable<T> iterable) {
+      assertThat(actual).withFailMessage(newErrorMessage).containsExactlyElementsOf(iterable);
     }
   }
 
+  /**
+   * Prefer {@link AbstractIterableAssert#hasSameElementsAs(Iterable)} over non-AssertJ
+   * alternatives.
+   */
   // XXX: TestNG's `assertEquals` accepts arbitrary `Set<?>` arguments. As such some expressions
   // will not be rewritten.
-  static final class AssertEqualSets<S, T extends S> {
+  static final class AssertThatHasSameElementsAs<S, T extends S> {
     @BeforeTemplate
-    void before(Set<S> actual, Set<T> expected) {
-      assertEquals(actual, expected);
+    void before(Set<S> actual, Set<T> iterable) {
+      assertEquals(actual, iterable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Set<S> actual, Set<T> expected) {
-      assertThat(actual).hasSameElementsAs(expected);
+    void after(Set<S> actual, Set<T> iterable) {
+      assertThat(actual).hasSameElementsAs(iterable);
     }
   }
 
+  /**
+   * Prefer {@link AbstractIterableAssert#hasSameElementsAs(Iterable)} over non-AssertJ
+   * alternatives.
+   */
   // XXX: TestNG's `assertEquals` accepts arbitrary `Set<?>` arguments. As such some expressions
   // will not be rewritten.
-  static final class AssertEqualSetsWithMessage<S, T extends S> {
+  static final class AssertThatWithFailMessageHasSameElementsAs<S, T extends S> {
     @BeforeTemplate
-    void before(Set<S> actual, String message, Set<T> expected) {
-      assertEquals(actual, expected, message);
+    void before(Set<S> actual, String newErrorMessage, Set<T> iterable) {
+      assertEquals(actual, iterable, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Set<S> actual, String message, Set<T> expected) {
-      assertThat(actual).withFailMessage(message).hasSameElementsAs(expected);
+    void after(Set<S> actual, String newErrorMessage, Set<T> iterable) {
+      assertThat(actual).withFailMessage(newErrorMessage).hasSameElementsAs(iterable);
     }
   }
 
-  static final class AssertUnequal {
+  /** Prefer {@link AbstractAssert#isNotEqualTo(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatIsNotEqualTo {
     @BeforeTemplate
-    void before(boolean actual, boolean expected) {
-      assertNotEquals(actual, expected);
+    void before(boolean actual, boolean other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(byte actual, byte expected) {
-      assertNotEquals(actual, expected);
+    void before(byte actual, byte other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(char actual, char expected) {
-      assertNotEquals(actual, expected);
+    void before(char actual, char other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(short actual, short expected) {
-      assertNotEquals(actual, expected);
+    void before(short actual, short other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(int actual, int expected) {
-      assertNotEquals(actual, expected);
+    void before(int actual, int other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(long actual, long expected) {
-      assertNotEquals(actual, expected);
+    void before(long actual, long other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(float actual, float expected) {
-      assertNotEquals(actual, expected);
+    void before(float actual, float other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(double actual, double expected) {
-      assertNotEquals(actual, expected);
+    void before(double actual, double other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(Object actual, Object expected) {
-      assertNotEquals(actual, expected);
+    void before(Object actual, Object other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(String actual, String expected) {
-      assertNotEquals(actual, expected);
+    void before(String actual, String other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(Set<?> actual, Set<?> expected) {
-      assertNotEquals(actual, expected);
+    void before(Set<?> actual, Set<?> other) {
+      assertNotEquals(actual, other);
     }
 
     @BeforeTemplate
-    void before(Map<?, ?> actual, Map<?, ?> expected) {
-      assertNotEquals(actual, expected);
+    void before(Map<?, ?> actual, Map<?, ?> other) {
+      assertNotEquals(actual, other);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, Object expected) {
-      assertThat(actual).isNotEqualTo(expected);
+    void after(Object actual, Object other) {
+      assertThat(actual).isNotEqualTo(other);
     }
   }
 
-  static final class AssertUnequalWithMessage {
+  /** Prefer {@link AbstractAssert#isNotEqualTo(Object)} over non-AssertJ alternatives. */
+  static final class AssertThatWithFailMessageIsNotEqualTo {
     @BeforeTemplate
-    void before(boolean actual, String message, boolean expected) {
-      assertNotEquals(actual, expected, message);
+    void before(boolean actual, String newErrorMessage, boolean other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(byte actual, String message, byte expected) {
-      assertNotEquals(actual, expected, message);
+    void before(byte actual, String newErrorMessage, byte other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(char actual, String message, char expected) {
-      assertNotEquals(actual, expected, message);
+    void before(char actual, String newErrorMessage, char other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(short actual, String message, short expected) {
-      assertNotEquals(actual, expected, message);
+    void before(short actual, String newErrorMessage, short other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(int actual, String message, int expected) {
-      assertNotEquals(actual, expected, message);
+    void before(int actual, String newErrorMessage, int other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(long actual, String message, long expected) {
-      assertNotEquals(actual, expected, message);
+    void before(long actual, String newErrorMessage, long other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(float actual, String message, float expected) {
-      assertNotEquals(actual, expected, message);
+    void before(float actual, String newErrorMessage, float other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(double actual, String message, double expected) {
-      assertNotEquals(actual, expected, message);
+    void before(double actual, String newErrorMessage, double other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Object actual, String message, Object expected) {
-      assertNotEquals(actual, expected, message);
+    void before(Object actual, String newErrorMessage, Object other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(String actual, String message, String expected) {
-      assertNotEquals(actual, expected, message);
+    void before(String actual, String newErrorMessage, String other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Set<?> actual, String message, Set<?> expected) {
-      assertNotEquals(actual, expected, message);
+    void before(Set<?> actual, String newErrorMessage, Set<?> other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @BeforeTemplate
-    void before(Map<?, ?> actual, String message, Map<?, ?> expected) {
-      assertNotEquals(actual, expected, message);
+    void before(Map<?, ?> actual, String newErrorMessage, Map<?, ?> other) {
+      assertNotEquals(actual, other, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(Object actual, String message, Object expected) {
-      assertThat(actual).withFailMessage(message).isNotEqualTo(expected);
+    void after(Object actual, String newErrorMessage, Object other) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNotEqualTo(other);
     }
   }
 
-  static final class AssertUnequalFloatsWithDelta {
+  /**
+   * Prefer {@link AbstractFloatAssert#isNotCloseTo(float, Offset)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatIsNotCloseToOffsetFloat {
     @BeforeTemplate
-    void before(float actual, float expected, float delta) {
-      assertNotEquals(actual, expected, delta);
+    void before(float actual, float expected, float value) {
+      assertNotEquals(actual, expected, value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float actual, float expected, float delta) {
-      assertThat(actual).isNotCloseTo(expected, offset(delta));
+    void after(float actual, float expected, float value) {
+      assertThat(actual).isNotCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertUnequalFloatsWithDeltaWithMessage {
+  /**
+   * Prefer {@link AbstractFloatAssert#isNotCloseTo(float, Offset)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageIsNotCloseToOffsetFloat {
     @BeforeTemplate
-    void before(float actual, String message, float expected, float delta) {
-      assertNotEquals(actual, expected, delta, message);
+    void before(float actual, String newErrorMessage, float expected, float value) {
+      assertNotEquals(actual, expected, value, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(float actual, String message, float expected, float delta) {
-      assertThat(actual).withFailMessage(message).isNotCloseTo(expected, offset(delta));
+    void after(float actual, String newErrorMessage, float expected, float value) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNotCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertUnequalDoublesWithDelta {
+  /**
+   * Prefer {@link AbstractDoubleAssert#isNotCloseTo(double, Offset)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatIsNotCloseToOffsetDouble {
     @BeforeTemplate
-    void before(double actual, double expected, double delta) {
-      assertNotEquals(actual, expected, delta);
+    void before(double actual, double expected, double value) {
+      assertNotEquals(actual, expected, value);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double actual, double expected, double delta) {
-      assertThat(actual).isNotCloseTo(expected, offset(delta));
+    void after(double actual, double expected, double value) {
+      assertThat(actual).isNotCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertUnequalDoublesWithDeltaWithMessage {
+  /**
+   * Prefer {@link AbstractDoubleAssert#isNotCloseTo(double, Offset)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatWithFailMessageIsNotCloseToOffsetDouble {
     @BeforeTemplate
-    void before(double actual, String message, double expected, double delta) {
-      assertNotEquals(actual, expected, delta, message);
+    void before(double actual, String newErrorMessage, double expected, double value) {
+      assertNotEquals(actual, expected, value, newErrorMessage);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(double actual, String message, double expected, double delta) {
-      assertThat(actual).withFailMessage(message).isNotCloseTo(expected, offset(delta));
+    void after(double actual, String newErrorMessage, double expected, double value) {
+      assertThat(actual).withFailMessage(newErrorMessage).isNotCloseTo(expected, offset(value));
     }
   }
 
-  static final class AssertThrows {
+  /**
+   * Prefer {@link Assertions#assertThatThrownBy(ThrowingCallable)} over non-AssertJ alternatives.
+   */
+  static final class AssertThatThrownBy {
     @BeforeTemplate
-    void before(ThrowingRunnable runnable) {
-      assertThrows(runnable);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) ThrowingRunnable shouldRaiseThrowable) {
+      assertThrows(shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable) {
-      assertThatThrownBy(runnable);
+    void after(ThrowingCallable shouldRaiseThrowable) {
+      assertThatThrownBy(shouldRaiseThrowable);
     }
   }
 
-  static final class AssertThrowsWithType<T extends Throwable> {
+  /** Prefer {@code assertThatThrownBy(...).isInstanceOf(...)} over non-AssertJ alternatives. */
+  static final class AssertThatThrownByIsInstanceOf<T extends Throwable> {
     @BeforeTemplate
-    void before(ThrowingRunnable runnable, Class<T> clazz) {
-      assertThrows(clazz, runnable);
+    void before(
+        @Matches(IsLambdaExpressionOrMethodReference.class) ThrowingRunnable shouldRaiseThrowable,
+        Class<T> type) {
+      assertThrows(type, shouldRaiseThrowable);
     }
 
     @AfterTemplate
     @UseImportPolicy(STATIC_IMPORT_ALWAYS)
-    void after(ThrowingCallable runnable, Class<T> clazz) {
-      assertThatThrownBy(runnable).isInstanceOf(clazz);
+    void after(ThrowingCallable shouldRaiseThrowable, Class<T> type) {
+      assertThatThrownBy(shouldRaiseThrowable).isInstanceOf(type);
     }
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/TimeRules.java
@@ -30,10 +30,7 @@ import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 final class TimeRules {
   private TimeRules() {}
 
-  /**
-   * Prefer {@link Clock#instant()} over {@link Instant#now(Clock)}, as it is more concise and more
-   * "OOP-py".
-   */
+  /** Prefer {@link Clock#instant()} over more verbose alternatives. */
   static final class ClockInstant {
     @BeforeTemplate
     Instant before(Clock clock) {
@@ -46,8 +43,8 @@ final class TimeRules {
     }
   }
 
-  /** Use {@link ZoneOffset#UTC} when possible. */
-  static final class UtcConstant {
+  /** Prefer {@link ZoneOffset#UTC} over less explicit alternatives. */
+  static final class Utc {
     @BeforeTemplate
     ZoneId before() {
       // `ZoneId.of("Z")` is not listed, because Error Prone flags it out of the box.
@@ -66,94 +63,94 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link LocalDate#ofInstant(Instant, ZoneId)} over more indirect alternatives. */
+  /** Prefer {@link LocalDate#ofInstant(Instant, ZoneId)} over more contrived alternatives. */
   static final class LocalDateOfInstant {
     @BeforeTemplate
-    LocalDate before(Instant instant, ZoneId zoneId) {
+    LocalDate before(Instant instant, ZoneId zone) {
       return Refaster.anyOf(
-          instant.atZone(zoneId).toLocalDate(),
-          LocalDateTime.ofInstant(instant, zoneId).toLocalDate(),
-          OffsetDateTime.ofInstant(instant, zoneId).toLocalDate());
+          instant.atZone(zone).toLocalDate(),
+          LocalDateTime.ofInstant(instant, zone).toLocalDate(),
+          OffsetDateTime.ofInstant(instant, zone).toLocalDate());
     }
 
     @BeforeTemplate
-    LocalDate before(Instant instant, ZoneOffset zoneId) {
-      return instant.atOffset(zoneId).toLocalDate();
+    LocalDate before(Instant instant, ZoneOffset zone) {
+      return instant.atOffset(zone).toLocalDate();
     }
 
     @AfterTemplate
-    LocalDate after(Instant instant, ZoneId zoneId) {
-      return LocalDate.ofInstant(instant, zoneId);
+    LocalDate after(Instant instant, ZoneId zone) {
+      return LocalDate.ofInstant(instant, zone);
     }
   }
 
-  /** Prefer {@link LocalDateTime#ofInstant(Instant, ZoneId)} over more indirect alternatives. */
+  /** Prefer {@link LocalDateTime#ofInstant(Instant, ZoneId)} over more contrived alternatives. */
   static final class LocalDateTimeOfInstant {
     @BeforeTemplate
-    LocalDateTime before(Instant instant, ZoneId zoneId) {
+    LocalDateTime before(Instant instant, ZoneId zone) {
       return Refaster.anyOf(
-          instant.atZone(zoneId).toLocalDateTime(),
-          OffsetDateTime.ofInstant(instant, zoneId).toLocalDateTime());
+          instant.atZone(zone).toLocalDateTime(),
+          OffsetDateTime.ofInstant(instant, zone).toLocalDateTime());
     }
 
     @BeforeTemplate
-    LocalDateTime before(Instant instant, ZoneOffset zoneId) {
-      return instant.atOffset(zoneId).toLocalDateTime();
+    LocalDateTime before(Instant instant, ZoneOffset zone) {
+      return instant.atOffset(zone).toLocalDateTime();
     }
 
     @AfterTemplate
-    LocalDateTime after(Instant instant, ZoneId zoneId) {
-      return LocalDateTime.ofInstant(instant, zoneId);
+    LocalDateTime after(Instant instant, ZoneId zone) {
+      return LocalDateTime.ofInstant(instant, zone);
     }
   }
 
-  /** Prefer {@link LocalTime#ofInstant(Instant, ZoneId)} over more indirect alternatives. */
+  /** Prefer {@link LocalTime#ofInstant(Instant, ZoneId)} over more contrived alternatives. */
   static final class LocalTimeOfInstant {
     @BeforeTemplate
-    LocalTime before(Instant instant, ZoneId zoneId) {
+    LocalTime before(Instant instant, ZoneId zone) {
       return Refaster.anyOf(
-          instant.atZone(zoneId).toLocalTime(),
-          LocalDateTime.ofInstant(instant, zoneId).toLocalTime(),
-          OffsetDateTime.ofInstant(instant, zoneId).toLocalTime(),
-          OffsetTime.ofInstant(instant, zoneId).toLocalTime());
+          instant.atZone(zone).toLocalTime(),
+          LocalDateTime.ofInstant(instant, zone).toLocalTime(),
+          OffsetDateTime.ofInstant(instant, zone).toLocalTime(),
+          OffsetTime.ofInstant(instant, zone).toLocalTime());
     }
 
     @BeforeTemplate
-    LocalTime before(Instant instant, ZoneOffset zoneId) {
-      return instant.atOffset(zoneId).toLocalTime();
+    LocalTime before(Instant instant, ZoneOffset zone) {
+      return instant.atOffset(zone).toLocalTime();
     }
 
     @AfterTemplate
-    LocalTime after(Instant instant, ZoneId zoneId) {
-      return LocalTime.ofInstant(instant, zoneId);
+    LocalTime after(Instant instant, ZoneId zone) {
+      return LocalTime.ofInstant(instant, zone);
     }
   }
 
-  /** Prefer {@link OffsetDateTime#ofInstant(Instant, ZoneId)} over more indirect alternatives. */
+  /** Prefer {@link OffsetDateTime#ofInstant(Instant, ZoneId)} over more contrived alternatives. */
   static final class OffsetDateTimeOfInstant {
     @BeforeTemplate
-    OffsetDateTime before(Instant instant, ZoneId zoneId) {
-      return instant.atZone(zoneId).toOffsetDateTime();
+    OffsetDateTime before(Instant instant, ZoneId zone) {
+      return instant.atZone(zone).toOffsetDateTime();
     }
 
     @AfterTemplate
-    OffsetDateTime after(Instant instant, ZoneId zoneId) {
-      return OffsetDateTime.ofInstant(instant, zoneId);
+    OffsetDateTime after(Instant instant, ZoneId zone) {
+      return OffsetDateTime.ofInstant(instant, zone);
     }
   }
 
-  /** Don't unnecessarily transform an {@link Instant} to an equivalent instance. */
+  /** Prefer using {@link Instant}s as-is over less efficient alternatives. */
   static final class InstantIdentity {
     @BeforeTemplate
-    Instant before(Instant instant, TemporalUnit temporalUnit) {
+    Instant before(Instant instant, TemporalUnit unit) {
       return Refaster.anyOf(
           instant.plus(Duration.ZERO),
-          instant.plus(0, temporalUnit),
+          instant.plus(0, unit),
           instant.plusNanos(0),
           instant.plusMillis(0),
           instant.plusSeconds(0),
           instant.minus(Duration.ZERO),
-          instant.minus(0, temporalUnit),
+          instant.minus(0, unit),
           instant.minusNanos(0),
           instant.minusMillis(0),
           instant.minusSeconds(0),
@@ -169,12 +166,12 @@ final class TimeRules {
   }
 
   /**
-   * Prefer {@link Instant#truncatedTo(TemporalUnit)} over less obvious alternatives.
+   * Prefer {@link Instant#truncatedTo(TemporalUnit)} over less efficient alternatives.
    *
    * <p>Note that {@link Instant#toEpochMilli()} throws an {@link ArithmeticException} for dates
    * very far in the past or future, while the suggested alternative doesn't.
    */
-  static final class InstantTruncatedToMilliseconds {
+  static final class InstantTruncatedToChronoUnitMillis {
     @BeforeTemplate
     Instant before(Instant instant) {
       return Instant.ofEpochMilli(instant.toEpochMilli());
@@ -186,8 +183,8 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link Instant#truncatedTo(TemporalUnit)} over less obvious alternatives. */
-  static final class InstantTruncatedToSeconds {
+  /** Prefer {@link Instant#truncatedTo(TemporalUnit)} over less efficient alternatives. */
+  static final class InstantTruncatedToChronoUnitSeconds {
     @BeforeTemplate
     Instant before(Instant instant) {
       return Instant.ofEpochSecond(instant.getEpochSecond());
@@ -202,64 +199,64 @@ final class TimeRules {
   /** Prefer {@link Instant#atOffset(ZoneOffset)} over more verbose alternatives. */
   static final class InstantAtOffset {
     @BeforeTemplate
-    OffsetDateTime before(Instant instant, ZoneOffset zoneOffset) {
-      return OffsetDateTime.ofInstant(instant, zoneOffset);
+    OffsetDateTime before(Instant instant, ZoneOffset offset) {
+      return OffsetDateTime.ofInstant(instant, offset);
     }
 
     @AfterTemplate
-    OffsetDateTime after(Instant instant, ZoneOffset zoneOffset) {
-      return instant.atOffset(zoneOffset);
+    OffsetDateTime after(Instant instant, ZoneOffset offset) {
+      return instant.atOffset(offset);
     }
   }
 
-  /** Prefer {@link OffsetTime#ofInstant(Instant, ZoneId)} over more indirect alternatives. */
+  /** Prefer {@link OffsetTime#ofInstant(Instant, ZoneId)} over more contrived alternatives. */
   static final class OffsetTimeOfInstant {
     @BeforeTemplate
-    OffsetTime before(Instant instant, ZoneId zoneId) {
-      return OffsetDateTime.ofInstant(instant, zoneId).toOffsetTime();
+    OffsetTime before(Instant instant, ZoneId zone) {
+      return OffsetDateTime.ofInstant(instant, zone).toOffsetTime();
     }
 
     @BeforeTemplate
-    OffsetTime before(Instant instant, ZoneOffset zoneId) {
-      return instant.atOffset(zoneId).toOffsetTime();
+    OffsetTime before(Instant instant, ZoneOffset zone) {
+      return instant.atOffset(zone).toOffsetTime();
     }
 
     @AfterTemplate
-    OffsetTime after(Instant instant, ZoneId zoneId) {
-      return OffsetTime.ofInstant(instant, zoneId);
+    OffsetTime after(Instant instant, ZoneId zone) {
+      return OffsetTime.ofInstant(instant, zone);
     }
   }
 
   /** Prefer {@link Instant#atZone(ZoneId)} over more verbose alternatives. */
   static final class InstantAtZone {
     @BeforeTemplate
-    ZonedDateTime before(Instant instant, ZoneId zoneId) {
-      return ZonedDateTime.ofInstant(instant, zoneId);
+    ZonedDateTime before(Instant instant, ZoneId zone) {
+      return ZonedDateTime.ofInstant(instant, zone);
     }
 
     @AfterTemplate
-    ZonedDateTime after(Instant instant, ZoneId zoneId) {
-      return instant.atZone(zoneId);
+    ZonedDateTime after(Instant instant, ZoneId zone) {
+      return instant.atZone(zone);
     }
   }
 
-  /** Use {@link Clock#systemUTC()} when possible. */
-  static final class UtcClock {
+  /** Prefer {@link Clock#systemUTC()} over more verbose alternatives. */
+  static final class ClockSystemUTC {
     @BeforeTemplate
-    @SuppressWarnings("TimeZoneUsage")
+    @SuppressWarnings("TimeZoneUsage" /* This violation will be rewritten. */)
     Clock before() {
       return Clock.system(UTC);
     }
 
     @AfterTemplate
-    @SuppressWarnings("TimeZoneUsage")
+    @SuppressWarnings("TimeZoneUsage" /* This violation is preferred over the alternative. */)
     Clock after() {
       return Clock.systemUTC();
     }
   }
 
-  /** Prefer {@link Instant#EPOCH} over alternative representations. */
-  static final class EpochInstant {
+  /** Prefer {@link Instant#EPOCH} over less efficient alternatives. */
+  static final class InstantEpoch {
     @BeforeTemplate
     Instant before() {
       return Refaster.anyOf(
@@ -272,41 +269,35 @@ final class TimeRules {
     }
   }
 
-  /**
-   * Prefer {@link Instant#isBefore(Instant)} over explicit comparison, as it yields more readable
-   * code.
-   */
+  /** Prefer {@link Instant#isBefore(Instant)} over less explicit alternatives. */
   static final class InstantIsBefore {
     @BeforeTemplate
-    boolean before(Instant a, Instant b) {
-      return a.compareTo(b) < 0;
+    boolean before(Instant instant, Instant otherInstant) {
+      return instant.compareTo(otherInstant) < 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(Instant a, Instant b) {
-      return a.isBefore(b);
+    boolean after(Instant instant, Instant otherInstant) {
+      return instant.isBefore(otherInstant);
     }
   }
 
-  /**
-   * Prefer {@link Instant#isBefore(Instant)} over explicit comparison, as it yields more readable
-   * code.
-   */
+  /** Prefer {@link Instant#isAfter(Instant)} over less explicit alternatives. */
   static final class InstantIsAfter {
     @BeforeTemplate
-    boolean before(Instant a, Instant b) {
-      return a.compareTo(b) > 0;
+    boolean before(Instant instant, Instant otherInstant) {
+      return instant.compareTo(otherInstant) > 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(Instant a, Instant b) {
-      return a.isAfter(b);
+    boolean after(Instant instant, Instant otherInstant) {
+      return instant.isAfter(otherInstant);
     }
   }
 
-  /** Prefer the {@link LocalTime#MIN} over alternative representations. */
+  /** Prefer {@link LocalTime#MIN} over less explicit alternatives. */
   static final class LocalTimeMin {
     @BeforeTemplate
     LocalTime before() {
@@ -338,145 +329,134 @@ final class TimeRules {
     }
   }
 
-  /**
-   * Prefer {@link ChronoLocalDate#isBefore(ChronoLocalDate)} over explicit comparison, as it yields
-   * more readable code.
-   */
+  /** Prefer {@link ChronoLocalDate#isBefore(ChronoLocalDate)} over less explicit alternatives. */
   static final class ChronoLocalDateIsBefore {
     @BeforeTemplate
-    boolean before(ChronoLocalDate a, ChronoLocalDate b) {
-      return a.compareTo(b) < 0;
+    boolean before(ChronoLocalDate chronoLocalDate, ChronoLocalDate other) {
+      return chronoLocalDate.compareTo(other) < 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(ChronoLocalDate a, ChronoLocalDate b) {
-      return a.isBefore(b);
+    boolean after(ChronoLocalDate chronoLocalDate, ChronoLocalDate other) {
+      return chronoLocalDate.isBefore(other);
     }
   }
 
-  /**
-   * Prefer {@link ChronoLocalDate#isBefore(ChronoLocalDate)} over explicit comparison, as it yields
-   * more readable code.
-   */
+  /** Prefer {@link ChronoLocalDate#isAfter(ChronoLocalDate)} over less explicit alternatives. */
   static final class ChronoLocalDateIsAfter {
     @BeforeTemplate
-    boolean before(ChronoLocalDate a, ChronoLocalDate b) {
-      return a.compareTo(b) > 0;
+    boolean before(ChronoLocalDate chronoLocalDate, ChronoLocalDate other) {
+      return chronoLocalDate.compareTo(other) > 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(ChronoLocalDate a, ChronoLocalDate b) {
-      return a.isAfter(b);
+    boolean after(ChronoLocalDate chronoLocalDate, ChronoLocalDate other) {
+      return chronoLocalDate.isAfter(other);
     }
   }
 
   /**
-   * Prefer {@link ChronoLocalDateTime#isBefore(ChronoLocalDateTime)} over explicit comparison, as
-   * it yields more readable code.
+   * Prefer {@link ChronoLocalDateTime#isBefore(ChronoLocalDateTime)} over less explicit
+   * alternatives.
    */
   static final class ChronoLocalDateTimeIsBefore {
     @BeforeTemplate
-    boolean before(ChronoLocalDateTime<?> a, ChronoLocalDateTime<?> b) {
-      return a.compareTo(b) < 0;
+    boolean before(ChronoLocalDateTime<?> chronoLocalDateTime, ChronoLocalDateTime<?> other) {
+      return chronoLocalDateTime.compareTo(other) < 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(ChronoLocalDateTime<?> a, ChronoLocalDateTime<?> b) {
-      return a.isBefore(b);
+    boolean after(ChronoLocalDateTime<?> chronoLocalDateTime, ChronoLocalDateTime<?> other) {
+      return chronoLocalDateTime.isBefore(other);
     }
   }
 
   /**
-   * Prefer {@link ChronoLocalDateTime#isBefore(ChronoLocalDateTime)} over explicit comparison, as
-   * it yields more readable code.
+   * Prefer {@link ChronoLocalDateTime#isAfter(ChronoLocalDateTime)} over less explicit
+   * alternatives.
    */
   static final class ChronoLocalDateTimeIsAfter {
     @BeforeTemplate
-    boolean before(ChronoLocalDateTime<?> a, ChronoLocalDateTime<?> b) {
-      return a.compareTo(b) > 0;
+    boolean before(ChronoLocalDateTime<?> chronoLocalDateTime, ChronoLocalDateTime<?> other) {
+      return chronoLocalDateTime.compareTo(other) > 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(ChronoLocalDateTime<?> a, ChronoLocalDateTime<?> b) {
-      return a.isAfter(b);
+    boolean after(ChronoLocalDateTime<?> chronoLocalDateTime, ChronoLocalDateTime<?> other) {
+      return chronoLocalDateTime.isAfter(other);
     }
   }
 
   /**
-   * Prefer {@link ChronoZonedDateTime#isBefore(ChronoZonedDateTime)} over explicit comparison, as
-   * it yields more readable code.
+   * Prefer {@link ChronoZonedDateTime#isBefore(ChronoZonedDateTime)} over less explicit
+   * alternatives.
    */
   static final class ChronoZonedDateTimeIsBefore {
     @BeforeTemplate
-    boolean before(ChronoZonedDateTime<?> a, ChronoZonedDateTime<?> b) {
-      return a.compareTo(b) < 0;
+    boolean before(ChronoZonedDateTime<?> chronoZonedDateTime, ChronoZonedDateTime<?> other) {
+      return chronoZonedDateTime.compareTo(other) < 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(ChronoZonedDateTime<?> a, ChronoZonedDateTime<?> b) {
-      return a.isBefore(b);
+    boolean after(ChronoZonedDateTime<?> chronoZonedDateTime, ChronoZonedDateTime<?> other) {
+      return chronoZonedDateTime.isBefore(other);
     }
   }
 
   /**
-   * Prefer {@link ChronoZonedDateTime#isBefore(ChronoZonedDateTime)} over explicit comparison, as
-   * it yields more readable code.
+   * Prefer {@link ChronoZonedDateTime#isAfter(ChronoZonedDateTime)} over less explicit
+   * alternatives.
    */
   static final class ChronoZonedDateTimeIsAfter {
     @BeforeTemplate
-    boolean before(ChronoZonedDateTime<?> a, ChronoZonedDateTime<?> b) {
-      return a.compareTo(b) > 0;
+    boolean before(ChronoZonedDateTime<?> chronoZonedDateTime, ChronoZonedDateTime<?> other) {
+      return chronoZonedDateTime.compareTo(other) > 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(ChronoZonedDateTime<?> a, ChronoZonedDateTime<?> b) {
-      return a.isAfter(b);
+    boolean after(ChronoZonedDateTime<?> chronoZonedDateTime, ChronoZonedDateTime<?> other) {
+      return chronoZonedDateTime.isAfter(other);
     }
   }
 
-  /**
-   * Prefer {@link OffsetDateTime#isBefore(OffsetDateTime)} over explicit comparison, as it yields
-   * more readable code.
-   */
+  /** Prefer {@link OffsetDateTime#isBefore(OffsetDateTime)} over less explicit alternatives. */
   static final class OffsetDateTimeIsBefore {
     @BeforeTemplate
-    boolean before(OffsetDateTime a, OffsetDateTime b) {
-      return a.compareTo(b) < 0;
+    boolean before(OffsetDateTime offsetDateTime, OffsetDateTime other) {
+      return offsetDateTime.compareTo(other) < 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(OffsetDateTime a, OffsetDateTime b) {
-      return a.isBefore(b);
+    boolean after(OffsetDateTime offsetDateTime, OffsetDateTime other) {
+      return offsetDateTime.isBefore(other);
     }
   }
 
-  /**
-   * Prefer {@link OffsetDateTime#isBefore(OffsetDateTime)} over explicit comparison, as it yields
-   * more readable code.
-   */
+  /** Prefer {@link OffsetDateTime#isAfter(OffsetDateTime)} over less explicit alternatives. */
   static final class OffsetDateTimeIsAfter {
     @BeforeTemplate
-    boolean before(OffsetDateTime a, OffsetDateTime b) {
-      return a.compareTo(b) > 0;
+    boolean before(OffsetDateTime offsetDateTime, OffsetDateTime other) {
+      return offsetDateTime.compareTo(other) > 0;
     }
 
     @AfterTemplate
     @AlsoNegation
-    boolean after(OffsetDateTime a, OffsetDateTime b) {
-      return a.isAfter(b);
+    boolean after(OffsetDateTime offsetDateTime, OffsetDateTime other) {
+      return offsetDateTime.isAfter(other);
     }
   }
 
-  static final class ZeroDuration {
+  /** Prefer {@link Duration#ZERO} over less explicit alternatives. */
+  static final class DurationZero {
     @BeforeTemplate
-    Duration before(TemporalUnit temporalUnit) {
+    Duration before(TemporalUnit unit) {
       return Refaster.anyOf(
           Duration.ofNanos(0),
           Duration.ofMillis(0),
@@ -485,7 +465,7 @@ final class TimeRules {
           Duration.ofMinutes(0),
           Duration.ofHours(0),
           Duration.ofDays(0),
-          Duration.of(0, temporalUnit));
+          Duration.of(0, unit));
     }
 
     @AfterTemplate
@@ -494,136 +474,135 @@ final class TimeRules {
     }
   }
 
-  /** Prefer {@link Duration#ofDays(long)} over alternative representations. */
+  /** Prefer {@link Duration#ofDays(long)} over more contrived alternatives. */
   static final class DurationOfDays {
     @BeforeTemplate
-    Duration before(long amount) {
-      return Duration.of(amount, ChronoUnit.DAYS);
+    Duration before(long days) {
+      return Duration.of(days, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
-    Duration after(long amount) {
-      return Duration.ofDays(amount);
+    Duration after(long days) {
+      return Duration.ofDays(days);
     }
   }
 
-  /** Prefer {@link Duration#ofHours(long)} over alternative representations. */
+  /** Prefer {@link Duration#ofHours(long)} over more contrived alternatives. */
   static final class DurationOfHours {
     @BeforeTemplate
-    Duration before(long amount) {
-      return Duration.of(amount, ChronoUnit.HOURS);
+    Duration before(long hours) {
+      return Duration.of(hours, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
-    Duration after(long amount) {
-      return Duration.ofHours(amount);
+    Duration after(long hours) {
+      return Duration.ofHours(hours);
     }
   }
 
-  /** Prefer {@link Duration#ofMillis(long)} over alternative representations. */
+  /** Prefer {@link Duration#ofMillis(long)} over more contrived alternatives. */
   static final class DurationOfMillis {
     @BeforeTemplate
-    Duration before(long amount) {
-      return Duration.of(amount, ChronoUnit.MILLIS);
+    Duration before(long millis) {
+      return Duration.of(millis, ChronoUnit.MILLIS);
     }
 
     @AfterTemplate
-    Duration after(long amount) {
-      return Duration.ofMillis(amount);
+    Duration after(long millis) {
+      return Duration.ofMillis(millis);
     }
   }
 
-  /** Prefer {@link Duration#ofMinutes(long)} over alternative representations. */
+  /** Prefer {@link Duration#ofMinutes(long)} over more contrived alternatives. */
   static final class DurationOfMinutes {
     @BeforeTemplate
-    Duration before(long amount) {
-      return Duration.of(amount, ChronoUnit.MINUTES);
+    Duration before(long minutes) {
+      return Duration.of(minutes, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
-    Duration after(long amount) {
-      return Duration.ofMinutes(amount);
+    Duration after(long minutes) {
+      return Duration.ofMinutes(minutes);
     }
   }
 
-  /** Prefer {@link Duration#ofNanos(long)} over alternative representations. */
+  /** Prefer {@link Duration#ofNanos(long)} over more contrived alternatives. */
   static final class DurationOfNanos {
     @BeforeTemplate
-    Duration before(long amount) {
-      return Duration.of(amount, ChronoUnit.NANOS);
+    Duration before(long nanos) {
+      return Duration.of(nanos, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
-    Duration after(long amount) {
-      return Duration.ofNanos(amount);
+    Duration after(long nanos) {
+      return Duration.ofNanos(nanos);
     }
   }
 
-  /** Prefer {@link Duration#ofSeconds(long)} over alternative representations. */
+  /** Prefer {@link Duration#ofSeconds(long)} over more contrived alternatives. */
   static final class DurationOfSeconds {
     @BeforeTemplate
-    Duration before(long amount) {
-      return Duration.of(amount, ChronoUnit.SECONDS);
+    Duration before(long seconds) {
+      return Duration.of(seconds, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
-    Duration after(long amount) {
-      return Duration.ofSeconds(amount);
+    Duration after(long seconds) {
+      return Duration.ofSeconds(seconds);
     }
   }
 
   /**
-   * Don't unnecessarily convert to and from milliseconds. (This way nanosecond precision is
-   * retained.)
+   * Prefer {@link Duration#between} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rewrite rule increases precision!
    */
-  static final class DurationBetweenInstants {
+  static final class DurationBetweenInstant {
     @BeforeTemplate
-    Duration before(Instant a, Instant b) {
-      return Duration.ofMillis(b.toEpochMilli() - a.toEpochMilli());
+    Duration before(Instant startInclusive, Instant endExclusive) {
+      return Duration.ofMillis(endExclusive.toEpochMilli() - startInclusive.toEpochMilli());
     }
 
     @AfterTemplate
-    Duration after(Instant a, Instant b) {
-      return Duration.between(a, b);
+    Duration after(Instant startInclusive, Instant endExclusive) {
+      return Duration.between(startInclusive, endExclusive);
     }
   }
 
   /**
-   * Don't unnecessarily convert to and from milliseconds. (This way nanosecond precision is
-   * retained.)
+   * Prefer {@link Duration#between} over less efficient alternatives.
    *
    * <p><strong>Warning:</strong> this rewrite rule increases precision!
    */
-  static final class DurationBetweenOffsetDateTimes {
+  static final class DurationBetweenOffsetDateTime {
     @BeforeTemplate
-    Duration before(OffsetDateTime a, OffsetDateTime b) {
+    Duration before(OffsetDateTime startInclusive, OffsetDateTime endExclusive) {
       return Refaster.anyOf(
-          Duration.between(a.toInstant(), b.toInstant()),
-          Duration.ofSeconds(b.toEpochSecond() - a.toEpochSecond()));
+          Duration.between(startInclusive.toInstant(), endExclusive.toInstant()),
+          Duration.ofSeconds(endExclusive.toEpochSecond() - startInclusive.toEpochSecond()));
     }
 
     @AfterTemplate
-    Duration after(OffsetDateTime a, OffsetDateTime b) {
-      return Duration.between(a, b);
+    Duration after(OffsetDateTime startInclusive, OffsetDateTime endExclusive) {
+      return Duration.between(startInclusive, endExclusive);
     }
   }
 
   /** Prefer {@link Duration#isZero()} over more contrived alternatives. */
   static final class DurationIsZero {
     @BeforeTemplate
-    boolean before(Duration duration) {
-      return Refaster.anyOf(duration.equals(Duration.ZERO), Duration.ZERO.equals(duration));
+    boolean before(Duration other) {
+      return Refaster.anyOf(other.equals(Duration.ZERO), Duration.ZERO.equals(other));
     }
 
     @AfterTemplate
-    boolean after(Duration duration) {
-      return duration.isZero();
+    boolean after(Duration other) {
+      return other.isZero();
     }
   }
 
-  static final class ZeroPeriod {
+  /** Prefer {@link Period#ZERO} over less explicit alternatives. */
+  static final class PeriodZero {
     @BeforeTemplate
     Period before() {
       return Refaster.anyOf(
@@ -646,288 +625,288 @@ final class TimeRules {
   /** Prefer {@link LocalDate#plusDays(long)} over more contrived alternatives. */
   static final class LocalDatePlusDays {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int days) {
-      return localDate.plus(Period.ofDays(days));
+    LocalDate before(LocalDate localDate, int daysToAdd) {
+      return localDate.plus(Period.ofDays(daysToAdd));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long days) {
-      return localDate.plus(days, ChronoUnit.DAYS);
+    LocalDate before(LocalDate localDate, long daysToAdd) {
+      return localDate.plus(daysToAdd, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int days) {
-      return localDate.plusDays(days);
+    LocalDate after(LocalDate localDate, long daysToAdd) {
+      return localDate.plusDays(daysToAdd);
     }
   }
 
   /** Prefer {@link LocalDate#plusWeeks(long)} over more contrived alternatives. */
   static final class LocalDatePlusWeeks {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int weeks) {
-      return localDate.plus(Period.ofWeeks(weeks));
+    LocalDate before(LocalDate localDate, int weeksToAdd) {
+      return localDate.plus(Period.ofWeeks(weeksToAdd));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long weeks) {
-      return localDate.plus(weeks, ChronoUnit.WEEKS);
+    LocalDate before(LocalDate localDate, long weeksToAdd) {
+      return localDate.plus(weeksToAdd, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int weeks) {
-      return localDate.plusWeeks(weeks);
+    LocalDate after(LocalDate localDate, long weeksToAdd) {
+      return localDate.plusWeeks(weeksToAdd);
     }
   }
 
   /** Prefer {@link LocalDate#plusMonths(long)} over more contrived alternatives. */
   static final class LocalDatePlusMonths {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int months) {
-      return localDate.plus(Period.ofMonths(months));
+    LocalDate before(LocalDate localDate, int monthsToAdd) {
+      return localDate.plus(Period.ofMonths(monthsToAdd));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long months) {
-      return localDate.plus(months, ChronoUnit.MONTHS);
+    LocalDate before(LocalDate localDate, long monthsToAdd) {
+      return localDate.plus(monthsToAdd, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int months) {
-      return localDate.plusMonths(months);
+    LocalDate after(LocalDate localDate, long monthsToAdd) {
+      return localDate.plusMonths(monthsToAdd);
     }
   }
 
   /** Prefer {@link LocalDate#plusYears(long)} over more contrived alternatives. */
   static final class LocalDatePlusYears {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int years) {
-      return localDate.plus(Period.ofYears(years));
+    LocalDate before(LocalDate localDate, int yearsToAdd) {
+      return localDate.plus(Period.ofYears(yearsToAdd));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long years) {
-      return localDate.plus(years, ChronoUnit.YEARS);
+    LocalDate before(LocalDate localDate, long yearsToAdd) {
+      return localDate.plus(yearsToAdd, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int years) {
-      return localDate.plusYears(years);
+    LocalDate after(LocalDate localDate, long yearsToAdd) {
+      return localDate.plusYears(yearsToAdd);
     }
   }
 
   /** Prefer {@link LocalDate#minusDays(long)} over more contrived alternatives. */
   static final class LocalDateMinusDays {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int days) {
-      return localDate.minus(Period.ofDays(days));
+    LocalDate before(LocalDate localDate, int daysToSubtract) {
+      return localDate.minus(Period.ofDays(daysToSubtract));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long days) {
-      return localDate.minus(days, ChronoUnit.DAYS);
+    LocalDate before(LocalDate localDate, long daysToSubtract) {
+      return localDate.minus(daysToSubtract, ChronoUnit.DAYS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int days) {
-      return localDate.minusDays(days);
+    LocalDate after(LocalDate localDate, long daysToSubtract) {
+      return localDate.minusDays(daysToSubtract);
     }
   }
 
   /** Prefer {@link LocalDate#minusWeeks(long)} over more contrived alternatives. */
   static final class LocalDateMinusWeeks {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int weeks) {
-      return localDate.minus(Period.ofWeeks(weeks));
+    LocalDate before(LocalDate localDate, int weeksToSubtract) {
+      return localDate.minus(Period.ofWeeks(weeksToSubtract));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long weeks) {
-      return localDate.minus(weeks, ChronoUnit.WEEKS);
+    LocalDate before(LocalDate localDate, long weeksToSubtract) {
+      return localDate.minus(weeksToSubtract, ChronoUnit.WEEKS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int weeks) {
-      return localDate.minusWeeks(weeks);
+    LocalDate after(LocalDate localDate, long weeksToSubtract) {
+      return localDate.minusWeeks(weeksToSubtract);
     }
   }
 
   /** Prefer {@link LocalDate#minusMonths(long)} over more contrived alternatives. */
   static final class LocalDateMinusMonths {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int months) {
-      return localDate.minus(Period.ofMonths(months));
+    LocalDate before(LocalDate localDate, int monthsToSubtract) {
+      return localDate.minus(Period.ofMonths(monthsToSubtract));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long months) {
-      return localDate.minus(months, ChronoUnit.MONTHS);
+    LocalDate before(LocalDate localDate, long monthsToSubtract) {
+      return localDate.minus(monthsToSubtract, ChronoUnit.MONTHS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int months) {
-      return localDate.minusMonths(months);
+    LocalDate after(LocalDate localDate, long monthsToSubtract) {
+      return localDate.minusMonths(monthsToSubtract);
     }
   }
 
   /** Prefer {@link LocalDate#minusYears(long)} over more contrived alternatives. */
   static final class LocalDateMinusYears {
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, int years) {
-      return localDate.minus(Period.ofYears(years));
+    LocalDate before(LocalDate localDate, int yearsToSubtract) {
+      return localDate.minus(Period.ofYears(yearsToSubtract));
     }
 
     @BeforeTemplate
-    LocalDate before(LocalDate localDate, long years) {
-      return localDate.minus(years, ChronoUnit.YEARS);
+    LocalDate before(LocalDate localDate, long yearsToSubtract) {
+      return localDate.minus(yearsToSubtract, ChronoUnit.YEARS);
     }
 
     @AfterTemplate
-    LocalDate after(LocalDate localDate, int years) {
-      return localDate.minusYears(years);
+    LocalDate after(LocalDate localDate, long yearsToSubtract) {
+      return localDate.minusYears(yearsToSubtract);
     }
   }
 
   /** Prefer {@link LocalTime#plusNanos(long)} over more contrived alternatives. */
   static final class LocalTimePlusNanos {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int nanos) {
-      return localTime.plus(Duration.ofNanos(nanos));
+    LocalTime before(LocalTime localTime, int nanosToAdd) {
+      return localTime.plus(Duration.ofNanos(nanosToAdd));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long nanos) {
-      return localTime.plus(nanos, ChronoUnit.NANOS);
+    LocalTime before(LocalTime localTime, long nanosToAdd) {
+      return localTime.plus(nanosToAdd, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int nanos) {
-      return localTime.plusNanos(nanos);
+    LocalTime after(LocalTime localTime, long nanosToAdd) {
+      return localTime.plusNanos(nanosToAdd);
     }
   }
 
   /** Prefer {@link LocalTime#plusSeconds(long)} over more contrived alternatives. */
   static final class LocalTimePlusSeconds {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int seconds) {
-      return localTime.plus(Duration.ofSeconds(seconds));
+    LocalTime before(LocalTime localTime, int secondstoAdd) {
+      return localTime.plus(Duration.ofSeconds(secondstoAdd));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long seconds) {
-      return localTime.plus(seconds, ChronoUnit.SECONDS);
+    LocalTime before(LocalTime localTime, long secondstoAdd) {
+      return localTime.plus(secondstoAdd, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int seconds) {
-      return localTime.plusSeconds(seconds);
+    LocalTime after(LocalTime localTime, long secondstoAdd) {
+      return localTime.plusSeconds(secondstoAdd);
     }
   }
 
   /** Prefer {@link LocalTime#plusMinutes(long)} over more contrived alternatives. */
   static final class LocalTimePlusMinutes {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int minutes) {
-      return localTime.plus(Duration.ofMinutes(minutes));
+    LocalTime before(LocalTime localTime, int minutesToAdd) {
+      return localTime.plus(Duration.ofMinutes(minutesToAdd));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long minutes) {
-      return localTime.plus(minutes, ChronoUnit.MINUTES);
+    LocalTime before(LocalTime localTime, long minutesToAdd) {
+      return localTime.plus(minutesToAdd, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int minutes) {
-      return localTime.plusMinutes(minutes);
+    LocalTime after(LocalTime localTime, long minutesToAdd) {
+      return localTime.plusMinutes(minutesToAdd);
     }
   }
 
   /** Prefer {@link LocalTime#plusHours(long)} over more contrived alternatives. */
   static final class LocalTimePlusHours {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int hours) {
-      return localTime.plus(Duration.ofHours(hours));
+    LocalTime before(LocalTime localTime, int hoursToAdd) {
+      return localTime.plus(Duration.ofHours(hoursToAdd));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long hours) {
-      return localTime.plus(hours, ChronoUnit.HOURS);
+    LocalTime before(LocalTime localTime, long hoursToAdd) {
+      return localTime.plus(hoursToAdd, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int hours) {
-      return localTime.plusHours(hours);
+    LocalTime after(LocalTime localTime, long hoursToAdd) {
+      return localTime.plusHours(hoursToAdd);
     }
   }
 
   /** Prefer {@link LocalTime#minusNanos(long)} over more contrived alternatives. */
   static final class LocalTimeMinusNanos {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int nanos) {
-      return localTime.minus(Duration.ofNanos(nanos));
+    LocalTime before(LocalTime localTime, int nanosToSubtract) {
+      return localTime.minus(Duration.ofNanos(nanosToSubtract));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long nanos) {
-      return localTime.minus(nanos, ChronoUnit.NANOS);
+    LocalTime before(LocalTime localTime, long nanosToSubtract) {
+      return localTime.minus(nanosToSubtract, ChronoUnit.NANOS);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int nanos) {
-      return localTime.minusNanos(nanos);
+    LocalTime after(LocalTime localTime, long nanosToSubtract) {
+      return localTime.minusNanos(nanosToSubtract);
     }
   }
 
   /** Prefer {@link LocalTime#minusSeconds(long)} over more contrived alternatives. */
   static final class LocalTimeMinusSeconds {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int seconds) {
-      return localTime.minus(Duration.ofSeconds(seconds));
+    LocalTime before(LocalTime localTime, int secondsToSubtract) {
+      return localTime.minus(Duration.ofSeconds(secondsToSubtract));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long seconds) {
-      return localTime.minus(seconds, ChronoUnit.SECONDS);
+    LocalTime before(LocalTime localTime, long secondsToSubtract) {
+      return localTime.minus(secondsToSubtract, ChronoUnit.SECONDS);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int seconds) {
-      return localTime.minusSeconds(seconds);
+    LocalTime after(LocalTime localTime, long secondsToSubtract) {
+      return localTime.minusSeconds(secondsToSubtract);
     }
   }
 
   /** Prefer {@link LocalTime#minusMinutes(long)} over more contrived alternatives. */
   static final class LocalTimeMinusMinutes {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int minutes) {
-      return localTime.minus(Duration.ofMinutes(minutes));
+    LocalTime before(LocalTime localTime, int minutesToSubtract) {
+      return localTime.minus(Duration.ofMinutes(minutesToSubtract));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long minutes) {
-      return localTime.minus(minutes, ChronoUnit.MINUTES);
+    LocalTime before(LocalTime localTime, long minutesToSubtract) {
+      return localTime.minus(minutesToSubtract, ChronoUnit.MINUTES);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int minutes) {
-      return localTime.minusMinutes(minutes);
+    LocalTime after(LocalTime localTime, long minutesToSubtract) {
+      return localTime.minusMinutes(minutesToSubtract);
     }
   }
 
   /** Prefer {@link LocalTime#minusHours(long)} over more contrived alternatives. */
   static final class LocalTimeMinusHours {
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, int hours) {
-      return localTime.minus(Duration.ofHours(hours));
+    LocalTime before(LocalTime localTime, int hoursToSubtract) {
+      return localTime.minus(Duration.ofHours(hoursToSubtract));
     }
 
     @BeforeTemplate
-    LocalTime before(LocalTime localTime, long hours) {
-      return localTime.minus(hours, ChronoUnit.HOURS);
+    LocalTime before(LocalTime localTime, long hoursToSubtract) {
+      return localTime.minus(hoursToSubtract, ChronoUnit.HOURS);
     }
 
     @AfterTemplate
-    LocalTime after(LocalTime localTime, int hours) {
-      return localTime.minusHours(hours);
+    LocalTime after(LocalTime localTime, long hoursToSubtract) {
+      return localTime.minusHours(hoursToSubtract);
     }
   }
 
@@ -944,7 +923,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int nanos) {
+    OffsetTime after(OffsetTime offsetTime, long nanos) {
       return offsetTime.plusNanos(nanos);
     }
   }
@@ -962,7 +941,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int seconds) {
+    OffsetTime after(OffsetTime offsetTime, long seconds) {
       return offsetTime.plusSeconds(seconds);
     }
   }
@@ -980,7 +959,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int minutes) {
+    OffsetTime after(OffsetTime offsetTime, long minutes) {
       return offsetTime.plusMinutes(minutes);
     }
   }
@@ -998,7 +977,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int hours) {
+    OffsetTime after(OffsetTime offsetTime, long hours) {
       return offsetTime.plusHours(hours);
     }
   }
@@ -1016,7 +995,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int nanos) {
+    OffsetTime after(OffsetTime offsetTime, long nanos) {
       return offsetTime.minusNanos(nanos);
     }
   }
@@ -1034,7 +1013,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int seconds) {
+    OffsetTime after(OffsetTime offsetTime, long seconds) {
       return offsetTime.minusSeconds(seconds);
     }
   }
@@ -1052,7 +1031,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int minutes) {
+    OffsetTime after(OffsetTime offsetTime, long minutes) {
       return offsetTime.minusMinutes(minutes);
     }
   }
@@ -1070,7 +1049,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetTime after(OffsetTime offsetTime, int hours) {
+    OffsetTime after(OffsetTime offsetTime, long hours) {
       return offsetTime.minusHours(hours);
     }
   }
@@ -1088,7 +1067,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int nanos) {
+    LocalDateTime after(LocalDateTime localDateTime, long nanos) {
       return localDateTime.plusNanos(nanos);
     }
   }
@@ -1106,7 +1085,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int seconds) {
+    LocalDateTime after(LocalDateTime localDateTime, long seconds) {
       return localDateTime.plusSeconds(seconds);
     }
   }
@@ -1124,7 +1103,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int minutes) {
+    LocalDateTime after(LocalDateTime localDateTime, long minutes) {
       return localDateTime.plusMinutes(minutes);
     }
   }
@@ -1142,7 +1121,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int hours) {
+    LocalDateTime after(LocalDateTime localDateTime, long hours) {
       return localDateTime.plusHours(hours);
     }
   }
@@ -1160,7 +1139,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int days) {
+    LocalDateTime after(LocalDateTime localDateTime, long days) {
       return localDateTime.plusDays(days);
     }
   }
@@ -1178,7 +1157,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int weeks) {
+    LocalDateTime after(LocalDateTime localDateTime, long weeks) {
       return localDateTime.plusWeeks(weeks);
     }
   }
@@ -1196,7 +1175,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int months) {
+    LocalDateTime after(LocalDateTime localDateTime, long months) {
       return localDateTime.plusMonths(months);
     }
   }
@@ -1214,7 +1193,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int years) {
+    LocalDateTime after(LocalDateTime localDateTime, long years) {
       return localDateTime.plusYears(years);
     }
   }
@@ -1232,7 +1211,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int nanos) {
+    LocalDateTime after(LocalDateTime localDateTime, long nanos) {
       return localDateTime.minusNanos(nanos);
     }
   }
@@ -1250,7 +1229,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int seconds) {
+    LocalDateTime after(LocalDateTime localDateTime, long seconds) {
       return localDateTime.minusSeconds(seconds);
     }
   }
@@ -1268,7 +1247,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int minutes) {
+    LocalDateTime after(LocalDateTime localDateTime, long minutes) {
       return localDateTime.minusMinutes(minutes);
     }
   }
@@ -1286,7 +1265,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int hours) {
+    LocalDateTime after(LocalDateTime localDateTime, long hours) {
       return localDateTime.minusHours(hours);
     }
   }
@@ -1304,7 +1283,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int days) {
+    LocalDateTime after(LocalDateTime localDateTime, long days) {
       return localDateTime.minusDays(days);
     }
   }
@@ -1322,7 +1301,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int weeks) {
+    LocalDateTime after(LocalDateTime localDateTime, long weeks) {
       return localDateTime.minusWeeks(weeks);
     }
   }
@@ -1340,7 +1319,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int months) {
+    LocalDateTime after(LocalDateTime localDateTime, long months) {
       return localDateTime.minusMonths(months);
     }
   }
@@ -1358,7 +1337,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    LocalDateTime after(LocalDateTime localDateTime, int years) {
+    LocalDateTime after(LocalDateTime localDateTime, long years) {
       return localDateTime.minusYears(years);
     }
   }
@@ -1376,7 +1355,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int nanos) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long nanos) {
       return offsetDateTime.plusNanos(nanos);
     }
   }
@@ -1394,7 +1373,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int seconds) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long seconds) {
       return offsetDateTime.plusSeconds(seconds);
     }
   }
@@ -1412,7 +1391,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int minutes) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long minutes) {
       return offsetDateTime.plusMinutes(minutes);
     }
   }
@@ -1430,7 +1409,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int hours) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long hours) {
       return offsetDateTime.plusHours(hours);
     }
   }
@@ -1448,7 +1427,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int days) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long days) {
       return offsetDateTime.plusDays(days);
     }
   }
@@ -1466,7 +1445,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int weeks) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long weeks) {
       return offsetDateTime.plusWeeks(weeks);
     }
   }
@@ -1484,7 +1463,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int months) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long months) {
       return offsetDateTime.plusMonths(months);
     }
   }
@@ -1502,7 +1481,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int years) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long years) {
       return offsetDateTime.plusYears(years);
     }
   }
@@ -1520,7 +1499,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int nanos) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long nanos) {
       return offsetDateTime.minusNanos(nanos);
     }
   }
@@ -1538,7 +1517,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int seconds) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long seconds) {
       return offsetDateTime.minusSeconds(seconds);
     }
   }
@@ -1556,7 +1535,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int minutes) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long minutes) {
       return offsetDateTime.minusMinutes(minutes);
     }
   }
@@ -1574,7 +1553,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int hours) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long hours) {
       return offsetDateTime.minusHours(hours);
     }
   }
@@ -1592,7 +1571,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int days) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long days) {
       return offsetDateTime.minusDays(days);
     }
   }
@@ -1610,7 +1589,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int weeks) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long weeks) {
       return offsetDateTime.minusWeeks(weeks);
     }
   }
@@ -1628,7 +1607,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int months) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long months) {
       return offsetDateTime.minusMonths(months);
     }
   }
@@ -1646,7 +1625,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    OffsetDateTime after(OffsetDateTime offsetDateTime, int years) {
+    OffsetDateTime after(OffsetDateTime offsetDateTime, long years) {
       return offsetDateTime.minusYears(years);
     }
   }
@@ -1664,7 +1643,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int nanos) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long nanos) {
       return zonedDateTime.plusNanos(nanos);
     }
   }
@@ -1682,7 +1661,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int seconds) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long seconds) {
       return zonedDateTime.plusSeconds(seconds);
     }
   }
@@ -1700,7 +1679,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int minutes) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long minutes) {
       return zonedDateTime.plusMinutes(minutes);
     }
   }
@@ -1718,7 +1697,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int hours) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long hours) {
       return zonedDateTime.plusHours(hours);
     }
   }
@@ -1736,7 +1715,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int days) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long days) {
       return zonedDateTime.plusDays(days);
     }
   }
@@ -1754,7 +1733,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int weeks) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long weeks) {
       return zonedDateTime.plusWeeks(weeks);
     }
   }
@@ -1772,7 +1751,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int months) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long months) {
       return zonedDateTime.plusMonths(months);
     }
   }
@@ -1790,7 +1769,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int years) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long years) {
       return zonedDateTime.plusYears(years);
     }
   }
@@ -1808,7 +1787,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int nanos) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long nanos) {
       return zonedDateTime.minusNanos(nanos);
     }
   }
@@ -1826,7 +1805,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int seconds) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long seconds) {
       return zonedDateTime.minusSeconds(seconds);
     }
   }
@@ -1844,7 +1823,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int minutes) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long minutes) {
       return zonedDateTime.minusMinutes(minutes);
     }
   }
@@ -1862,7 +1841,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int hours) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long hours) {
       return zonedDateTime.minusHours(hours);
     }
   }
@@ -1880,7 +1859,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int days) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long days) {
       return zonedDateTime.minusDays(days);
     }
   }
@@ -1898,7 +1877,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int weeks) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long weeks) {
       return zonedDateTime.minusWeeks(weeks);
     }
   }
@@ -1916,7 +1895,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int months) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long months) {
       return zonedDateTime.minusMonths(months);
     }
   }
@@ -1934,7 +1913,7 @@ final class TimeRules {
     }
 
     @AfterTemplate
-    ZonedDateTime after(ZonedDateTime zonedDateTime, int years) {
+    ZonedDateTime after(ZonedDateTime zonedDateTime, long years) {
       return zonedDateTime.minusYears(years);
     }
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/WebClientRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/WebClientRules.java
@@ -12,8 +12,6 @@ import com.google.errorprone.refaster.Refaster;
 import com.google.errorprone.refaster.annotation.AfterTemplate;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Repeated;
-import java.util.function.Function;
-import org.springframework.http.HttpMethod;
 import org.springframework.test.web.reactive.server.WebTestClient;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClient.RequestBodySpec;
@@ -31,91 +29,79 @@ final class WebClientRules {
   private WebClientRules() {}
 
   /** Prefer {@link RequestBodySpec#bodyValue(Object)} over more contrived alternatives. */
-  static final class BodyValue<T> {
+  static final class RequestBodySpecBodyValue<T> {
     @BeforeTemplate
-    RequestHeadersSpec<?> before(RequestBodySpec requestBodySpec, T value) {
-      return requestBodySpec.body(fromValue(value));
+    RequestHeadersSpec<?> before(RequestBodySpec requestBodySpec, T body) {
+      return requestBodySpec.body(fromValue(body));
     }
 
     @BeforeTemplate
     WebTestClient.RequestHeadersSpec<?> before(
-        WebTestClient.RequestBodySpec requestBodySpec, T value) {
-      return requestBodySpec.body(fromValue(value));
+        WebTestClient.RequestBodySpec requestBodySpec, T body) {
+      return requestBodySpec.body(fromValue(body));
     }
 
     @AfterTemplate
-    RequestHeadersSpec<?> after(RequestBodySpec requestBodySpec, T value) {
-      return requestBodySpec.bodyValue(value);
+    RequestHeadersSpec<?> after(RequestBodySpec requestBodySpec, T body) {
+      return requestBodySpec.bodyValue(body);
     }
   }
 
-  /**
-   * Prefer {@link WebClient#get()} over {@link WebClient#method(HttpMethod)} with {@link
-   * HttpMethod#GET}.
-   */
+  /** Prefer {@link WebClient#get()} over less idiomatic alternatives. */
   static final class WebClientGet {
     @BeforeTemplate
-    RequestHeadersSpec<?> before(WebClient webClient) {
+    RequestBodyUriSpec before(WebClient webClient) {
       return webClient.method(GET);
     }
 
     @BeforeTemplate
-    WebTestClient.RequestHeadersSpec<?> before(WebTestClient webClient) {
+    WebTestClient.RequestBodyUriSpec before(WebTestClient webClient) {
       return webClient.method(GET);
     }
 
     @AfterTemplate
-    RequestHeadersSpec<?> after(WebClient webClient) {
+    RequestHeadersUriSpec<?> after(WebClient webClient) {
       return webClient.get();
     }
   }
 
-  /**
-   * Prefer {@link WebClient#head()} over {@link WebClient#method(HttpMethod)} with {@link
-   * HttpMethod#HEAD}.
-   */
+  /** Prefer {@link WebClient#head()} over less idiomatic alternatives. */
   static final class WebClientHead {
     @BeforeTemplate
-    RequestHeadersSpec<?> before(WebClient webClient) {
+    RequestBodyUriSpec before(WebClient webClient) {
       return webClient.method(HEAD);
     }
 
     @BeforeTemplate
-    WebTestClient.RequestHeadersSpec<?> before(WebTestClient webClient) {
+    WebTestClient.RequestBodyUriSpec before(WebTestClient webClient) {
       return webClient.method(HEAD);
     }
 
     @AfterTemplate
-    RequestHeadersSpec<?> after(WebClient webClient) {
+    RequestHeadersUriSpec<?> after(WebClient webClient) {
       return webClient.head();
     }
   }
 
-  /**
-   * Prefer {@link WebClient#options()} over {@link WebClient#method(HttpMethod)} with {@link
-   * HttpMethod#OPTIONS}.
-   */
+  /** Prefer {@link WebClient#options()} over less idiomatic alternatives. */
   static final class WebClientOptions {
     @BeforeTemplate
-    RequestHeadersSpec<?> before(WebClient webClient) {
+    RequestBodyUriSpec before(WebClient webClient) {
       return webClient.method(OPTIONS);
     }
 
     @BeforeTemplate
-    WebTestClient.RequestHeadersSpec<?> before(WebTestClient webClient) {
+    WebTestClient.RequestBodyUriSpec before(WebTestClient webClient) {
       return webClient.method(OPTIONS);
     }
 
     @AfterTemplate
-    RequestHeadersSpec<?> after(WebClient webClient) {
+    RequestHeadersUriSpec<?> after(WebClient webClient) {
       return webClient.options();
     }
   }
 
-  /**
-   * Prefer {@link WebClient#patch()} over {@link WebClient#method(HttpMethod)} with {@link
-   * HttpMethod#PATCH}.
-   */
+  /** Prefer {@link WebClient#patch()} over less idiomatic alternatives. */
   static final class WebClientPatch {
     @BeforeTemplate
     RequestBodyUriSpec before(WebClient webClient) {
@@ -133,10 +119,7 @@ final class WebClientRules {
     }
   }
 
-  /**
-   * Prefer {@link WebClient#post()} over {@link WebClient#method(HttpMethod)} with {@link
-   * HttpMethod#POST}.
-   */
+  /** Prefer {@link WebClient#post()} over less idiomatic alternatives. */
   static final class WebClientPost {
     @BeforeTemplate
     RequestBodyUriSpec before(WebClient webClient) {
@@ -154,10 +137,7 @@ final class WebClientRules {
     }
   }
 
-  /**
-   * Prefer {@link WebClient#put()} over {@link WebClient#method(HttpMethod)} with {@link
-   * HttpMethod#PUT}.
-   */
+  /** Prefer {@link WebClient#put()} over less idiomatic alternatives. */
   static final class WebClientPut {
     @BeforeTemplate
     RequestBodyUriSpec before(WebClient webClient) {
@@ -175,32 +155,34 @@ final class WebClientRules {
     }
   }
 
-  /** Don't unnecessarily use {@link RequestHeadersUriSpec#uri(Function)}. */
-  static final class RequestHeadersUriSpecUri {
+  /**
+   * Prefer {@link RequestHeadersUriSpec#uri(String, Object...)} over more contrived alternatives.
+   */
+  // XXX: Resolve the `RefasterReturnType` warning suppressions by splitting this rule.
+  static final class RequestHeadersUriSpecUri<
+      S extends RequestHeadersSpec<S>, T extends WebTestClient.RequestHeadersSpec<T>> {
     @BeforeTemplate
+    @SuppressWarnings("RefasterReturnType" /* Generic return type influences matching. */)
     RequestHeadersSpec<?> before(
-        RequestHeadersUriSpec<?> requestHeadersUriSpec,
-        String path,
-        @Repeated Object uriVariables) {
+        RequestHeadersUriSpec<S> requestHeadersUriSpec, String uri, @Repeated Object uriVariables) {
       return requestHeadersUriSpec.uri(
-          uriBuilder -> uriBuilder.path(path).build(Refaster.asVarargs(uriVariables)));
+          uriBuilder -> uriBuilder.path(uri).build(Refaster.asVarargs(uriVariables)));
     }
 
     @BeforeTemplate
+    @SuppressWarnings("RefasterReturnType" /* Generic return type influences matching. */)
     WebTestClient.RequestHeadersSpec<?> before(
-        WebTestClient.RequestHeadersUriSpec<?> requestHeadersUriSpec,
-        String path,
+        WebTestClient.RequestHeadersUriSpec<T> requestHeadersUriSpec,
+        String uri,
         @Repeated Object uriVariables) {
       return requestHeadersUriSpec.uri(
-          uriBuilder -> uriBuilder.path(path).build(Refaster.asVarargs(uriVariables)));
+          uriBuilder -> uriBuilder.path(uri).build(Refaster.asVarargs(uriVariables)));
     }
 
     @AfterTemplate
-    RequestHeadersSpec<?> after(
-        RequestHeadersUriSpec<?> requestHeadersUriSpec,
-        String path,
-        @Repeated Object uriVariables) {
-      return requestHeadersUriSpec.uri(path, Refaster.asVarargs(uriVariables));
+    S after(
+        RequestHeadersUriSpec<S> requestHeadersUriSpec, String uri, @Repeated Object uriVariables) {
+      return requestHeadersUriSpec.uri(uri, Refaster.asVarargs(uriVariables));
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJArrayRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJArrayRulesTestInput.java
@@ -9,37 +9,37 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class AssertJArrayRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSize() {
     return ImmutableSet.of(
-        assertThat(new String[0].length).isEqualTo(1),
-        assertThat(new String[0][0].length).isEqualTo(2));
+        assertThat(new String[0][0].length).isEqualTo(1),
+        assertThat(new String[0].length).isEqualTo(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeLessThan() {
     return ImmutableSet.of(
-        assertThat(new String[0].length).isLessThan(1),
-        assertThat(new String[0][0].length).isLessThan(2));
+        assertThat(new String[0][0].length).isLessThan(1),
+        assertThat(new String[0].length).isLessThan(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeLessThanOrEqualTo() {
     return ImmutableSet.of(
-        assertThat(new String[0].length).isLessThanOrEqualTo(1),
-        assertThat(new String[0][0].length).isLessThanOrEqualTo(2));
+        assertThat(new String[0][0].length).isLessThanOrEqualTo(1),
+        assertThat(new String[0].length).isLessThanOrEqualTo(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeGreaterThan() {
     return ImmutableSet.of(
-        assertThat(new String[0].length).isGreaterThan(1),
-        assertThat(new String[0][0].length).isGreaterThan(2));
+        assertThat(new String[0][0].length).isGreaterThan(1),
+        assertThat(new String[0].length).isGreaterThan(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeGreaterThanOrEqualTo() {
     return ImmutableSet.of(
-        assertThat(new String[0].length).isGreaterThanOrEqualTo(1),
-        assertThat(new String[0][0].length).isGreaterThanOrEqualTo(2));
+        assertThat(new String[0][0].length).isGreaterThanOrEqualTo(1),
+        assertThat(new String[0].length).isGreaterThanOrEqualTo(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeBetween() {
     return ImmutableSet.of(
-        assertThat(new String[0].length).isBetween(1, 2),
-        assertThat(new String[0][0].length).isBetween(3, 4));
+        assertThat(new String[0][0].length).isBetween(1, 2),
+        assertThat(new String[0].length).isBetween(3, 4));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJArrayRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJArrayRulesTestOutput.java
@@ -9,36 +9,36 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class AssertJArrayRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSize() {
     return ImmutableSet.of(
-        assertThat(new String[0]).hasSize(1), assertThat(new String[0][0].length).isEqualTo(2));
+        assertThat(new String[0][0].length).isEqualTo(1), assertThat(new String[0]).hasSize(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeLessThan() {
     return ImmutableSet.of(
-        assertThat(new String[0]).hasSizeLessThan(1),
-        assertThat(new String[0][0].length).isLessThan(2));
+        assertThat(new String[0][0].length).isLessThan(1),
+        assertThat(new String[0]).hasSizeLessThan(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeLessThanOrEqualTo() {
     return ImmutableSet.of(
-        assertThat(new String[0]).hasSizeLessThanOrEqualTo(1),
-        assertThat(new String[0][0].length).isLessThanOrEqualTo(2));
+        assertThat(new String[0][0].length).isLessThanOrEqualTo(1),
+        assertThat(new String[0]).hasSizeLessThanOrEqualTo(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeGreaterThan() {
     return ImmutableSet.of(
-        assertThat(new String[0]).hasSizeGreaterThan(1),
-        assertThat(new String[0][0].length).isGreaterThan(2));
+        assertThat(new String[0][0].length).isGreaterThan(1),
+        assertThat(new String[0]).hasSizeGreaterThan(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeGreaterThanOrEqualTo() {
     return ImmutableSet.of(
-        assertThat(new String[0]).hasSizeGreaterThanOrEqualTo(1),
-        assertThat(new String[0][0].length).isGreaterThanOrEqualTo(2));
+        assertThat(new String[0][0].length).isGreaterThanOrEqualTo(1),
+        assertThat(new String[0]).hasSizeGreaterThanOrEqualTo(2));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSizeBetween() {
     return ImmutableSet.of(
-        assertThat(new String[0]).hasSizeBetween(1, 2),
-        assertThat(new String[0][0].length).isBetween(3, 4));
+        assertThat(new String[0][0].length).isBetween(1, 2),
+        assertThat(new String[0]).hasSizeBetween(3, 4));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigDecimalRulesTestInput.java
@@ -18,12 +18,12 @@ final class AssertJBigDecimalRulesTest implements RefasterRuleCollectionTestCase
   ImmutableSet<AbstractBigDecimalAssert<?>> testAbstractBigDecimalAssertIsEqualByComparingTo() {
     return ImmutableSet.of(
         assertThat(BigDecimal.ZERO).isCloseTo(BigDecimal.ONE, offset(BigDecimal.ZERO)),
-        assertThat(BigDecimal.ZERO).isCloseTo(BigDecimal.ONE, withPercentage(0)));
+        assertThat(BigDecimal.ONE).isCloseTo(BigDecimal.TEN, withPercentage(0)));
   }
 
   ImmutableSet<AbstractBigDecimalAssert<?>> testAbstractBigDecimalAssertIsNotEqualByComparingTo() {
     return ImmutableSet.of(
         assertThat(BigDecimal.ZERO).isNotCloseTo(BigDecimal.ONE, offset(BigDecimal.ZERO)),
-        assertThat(BigDecimal.ZERO).isNotCloseTo(BigDecimal.ONE, withPercentage(0)));
+        assertThat(BigDecimal.ONE).isNotCloseTo(BigDecimal.TEN, withPercentage(0)));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigDecimalRulesTestOutput.java
@@ -18,12 +18,12 @@ final class AssertJBigDecimalRulesTest implements RefasterRuleCollectionTestCase
   ImmutableSet<AbstractBigDecimalAssert<?>> testAbstractBigDecimalAssertIsEqualByComparingTo() {
     return ImmutableSet.of(
         assertThat(BigDecimal.ZERO).isEqualByComparingTo(BigDecimal.ONE),
-        assertThat(BigDecimal.ZERO).isEqualByComparingTo(BigDecimal.ONE));
+        assertThat(BigDecimal.ONE).isEqualByComparingTo(BigDecimal.TEN));
   }
 
   ImmutableSet<AbstractBigDecimalAssert<?>> testAbstractBigDecimalAssertIsNotEqualByComparingTo() {
     return ImmutableSet.of(
         assertThat(BigDecimal.ZERO).isNotEqualByComparingTo(BigDecimal.ONE),
-        assertThat(BigDecimal.ZERO).isNotEqualByComparingTo(BigDecimal.ONE));
+        assertThat(BigDecimal.ONE).isNotEqualByComparingTo(BigDecimal.TEN));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRulesTestInput.java
@@ -18,33 +18,33 @@ final class AssertJBigIntegerRulesTest implements RefasterRuleCollectionTestCase
   ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsEqualTo() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isCloseTo(BigInteger.ONE, offset(BigInteger.ZERO)),
-        assertThat(BigInteger.ZERO).isCloseTo(BigInteger.ONE, withPercentage(0)));
+        assertThat(BigInteger.ONE).isCloseTo(BigInteger.TWO, withPercentage(0)));
   }
 
   ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsNotEqualTo() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isNotCloseTo(BigInteger.ONE, offset(BigInteger.ZERO)),
-        assertThat(BigInteger.ZERO).isNotCloseTo(BigInteger.ONE, withPercentage(0)));
+        assertThat(BigInteger.ONE).isNotCloseTo(BigInteger.TWO, withPercentage(0)));
   }
 
-  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsZero() {
+  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsEqualToZero() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isZero(),
-        assertThat(BigInteger.ZERO).isEqualTo(0L),
-        assertThat(BigInteger.ZERO).isEqualTo(BigInteger.ZERO));
+        assertThat(BigInteger.ONE).isEqualTo(0L),
+        assertThat(BigInteger.TWO).isEqualTo(BigInteger.ZERO));
   }
 
-  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsNotZero() {
+  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsNotEqualToZero() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isNotZero(),
-        assertThat(BigInteger.ZERO).isNotEqualTo(0L),
-        assertThat(BigInteger.ZERO).isNotEqualTo(BigInteger.ZERO));
+        assertThat(BigInteger.ONE).isNotEqualTo(0L),
+        assertThat(BigInteger.TWO).isNotEqualTo(BigInteger.ZERO));
   }
 
-  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsOne() {
+  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsEqualToOne() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isOne(),
-        assertThat(BigInteger.ZERO).isEqualTo(1L),
-        assertThat(BigInteger.ZERO).isEqualTo(BigInteger.ONE));
+        assertThat(BigInteger.ONE).isEqualTo(1L),
+        assertThat(BigInteger.TWO).isEqualTo(BigInteger.ONE));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBigIntegerRulesTestOutput.java
@@ -18,33 +18,33 @@ final class AssertJBigIntegerRulesTest implements RefasterRuleCollectionTestCase
   ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsEqualTo() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isEqualTo(BigInteger.ONE),
-        assertThat(BigInteger.ZERO).isEqualTo(BigInteger.ONE));
+        assertThat(BigInteger.ONE).isEqualTo(BigInteger.TWO));
   }
 
   ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsNotEqualTo() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isNotEqualTo(BigInteger.ONE),
-        assertThat(BigInteger.ZERO).isNotEqualTo(BigInteger.ONE));
+        assertThat(BigInteger.ONE).isNotEqualTo(BigInteger.TWO));
   }
 
-  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsZero() {
+  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsEqualToZero() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isEqualTo(0),
-        assertThat(BigInteger.ZERO).isEqualTo(0),
-        assertThat(BigInteger.ZERO).isEqualTo(0));
+        assertThat(BigInteger.ONE).isEqualTo(0),
+        assertThat(BigInteger.TWO).isEqualTo(0));
   }
 
-  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsNotZero() {
+  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsNotEqualToZero() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isNotEqualTo(0),
-        assertThat(BigInteger.ZERO).isNotEqualTo(0),
-        assertThat(BigInteger.ZERO).isNotEqualTo(0));
+        assertThat(BigInteger.ONE).isNotEqualTo(0),
+        assertThat(BigInteger.TWO).isNotEqualTo(0));
   }
 
-  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsOne() {
+  ImmutableSet<AbstractBigIntegerAssert<?>> testAbstractBigIntegerAssertIsEqualToOne() {
     return ImmutableSet.of(
         assertThat(BigInteger.ZERO).isEqualTo(1),
-        assertThat(BigInteger.ZERO).isEqualTo(1),
-        assertThat(BigInteger.ZERO).isEqualTo(1));
+        assertThat(BigInteger.ONE).isEqualTo(1),
+        assertThat(BigInteger.TWO).isEqualTo(1));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBooleanRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBooleanRulesTestInput.java
@@ -16,18 +16,18 @@ final class AssertJBooleanRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsTrue() {
-    return ImmutableSet.of(assertThat(true).isEqualTo(true), assertThat(true).isNotEqualTo(false));
+    return ImmutableSet.of(assertThat(true).isEqualTo(true), assertThat(false).isNotEqualTo(false));
   }
 
-  AbstractBooleanAssert<?> testAssertThatBooleanIsTrue() {
+  AbstractBooleanAssert<?> testAssertThatIsTrue() {
     return assertThat(!Boolean.TRUE).isFalse();
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsFalse() {
-    return ImmutableSet.of(assertThat(true).isEqualTo(false), assertThat(true).isNotEqualTo(true));
+    return ImmutableSet.of(assertThat(true).isEqualTo(false), assertThat(false).isNotEqualTo(true));
   }
 
-  AbstractBooleanAssert<?> testAssertThatBooleanIsFalse() {
+  AbstractBooleanAssert<?> testAssertThatIsFalse() {
     return assertThat(!Boolean.TRUE).isTrue();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBooleanRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJBooleanRulesTestOutput.java
@@ -16,18 +16,18 @@ final class AssertJBooleanRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsTrue() {
-    return ImmutableSet.of(assertThat(true).isTrue(), assertThat(true).isTrue());
+    return ImmutableSet.of(assertThat(true).isTrue(), assertThat(false).isTrue());
   }
 
-  AbstractBooleanAssert<?> testAssertThatBooleanIsTrue() {
+  AbstractBooleanAssert<?> testAssertThatIsTrue() {
     return assertThat(Boolean.TRUE).isTrue();
   }
 
   ImmutableSet<AbstractBooleanAssert<?>> testAbstractBooleanAssertIsFalse() {
-    return ImmutableSet.of(assertThat(true).isFalse(), assertThat(true).isFalse());
+    return ImmutableSet.of(assertThat(true).isFalse(), assertThat(false).isFalse());
   }
 
-  AbstractBooleanAssert<?> testAssertThatBooleanIsFalse() {
+  AbstractBooleanAssert<?> testAssertThatIsFalse() {
     return assertThat(Boolean.TRUE).isFalse();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJByteRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJByteRulesTestInput.java
@@ -16,25 +16,25 @@ final class AssertJByteRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<AbstractByteAssert<?>> testAbstractByteAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isCloseTo((byte) 1, offset((byte) 0)),
-        assertThat((byte) 0).isCloseTo((byte) 1, withPercentage(0)));
+        assertThat((byte) 1).isCloseTo((byte) 2, offset((byte) 0)),
+        assertThat((byte) 1).isCloseTo((byte) 2, withPercentage(0)));
   }
 
   ImmutableSet<AbstractByteAssert<?>> testAbstractByteAssertIsNotEqualTo() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isNotCloseTo((byte) 1, offset((byte) 0)),
-        assertThat((byte) 0).isNotCloseTo((byte) 1, withPercentage(0)));
+        assertThat((byte) 1).isNotCloseTo((byte) 2, offset((byte) 0)),
+        assertThat((byte) 1).isNotCloseTo((byte) 2, withPercentage(0)));
   }
 
-  AbstractByteAssert<?> testAbstractByteAssertIsZero() {
-    return assertThat((byte) 0).isZero();
+  AbstractByteAssert<?> testAbstractByteAssertIsEqualToZero() {
+    return assertThat((byte) 1).isZero();
   }
 
-  AbstractByteAssert<?> testAbstractByteAssertIsNotZero() {
-    return assertThat((byte) 0).isNotZero();
+  AbstractByteAssert<?> testAbstractByteAssertIsNotEqualToZero() {
+    return assertThat((byte) 1).isNotZero();
   }
 
-  AbstractByteAssert<?> testAbstractByteAssertIsOne() {
-    return assertThat((byte) 0).isOne();
+  AbstractByteAssert<?> testAbstractByteAssertIsEqualToOne() {
+    return assertThat((byte) 1).isOne();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJByteRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJByteRulesTestOutput.java
@@ -16,23 +16,23 @@ final class AssertJByteRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<AbstractByteAssert<?>> testAbstractByteAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isEqualTo((byte) 1), assertThat((byte) 0).isEqualTo((byte) 1));
+        assertThat((byte) 1).isEqualTo((byte) 2), assertThat((byte) 1).isEqualTo((byte) 2));
   }
 
   ImmutableSet<AbstractByteAssert<?>> testAbstractByteAssertIsNotEqualTo() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isNotEqualTo((byte) 1), assertThat((byte) 0).isNotEqualTo((byte) 1));
+        assertThat((byte) 1).isNotEqualTo((byte) 2), assertThat((byte) 1).isNotEqualTo((byte) 2));
   }
 
-  AbstractByteAssert<?> testAbstractByteAssertIsZero() {
-    return assertThat((byte) 0).isEqualTo((byte) 0);
+  AbstractByteAssert<?> testAbstractByteAssertIsEqualToZero() {
+    return assertThat((byte) 1).isEqualTo((byte) 0);
   }
 
-  AbstractByteAssert<?> testAbstractByteAssertIsNotZero() {
-    return assertThat((byte) 0).isNotEqualTo((byte) 0);
+  AbstractByteAssert<?> testAbstractByteAssertIsNotEqualToZero() {
+    return assertThat((byte) 1).isNotEqualTo((byte) 0);
   }
 
-  AbstractByteAssert<?> testAbstractByteAssertIsOne() {
-    return assertThat((byte) 0).isEqualTo((byte) 1);
+  AbstractByteAssert<?> testAbstractByteAssertIsEqualToOne() {
+    return assertThat((byte) 1).isEqualTo((byte) 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJCharSequenceRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJCharSequenceRulesTestInput.java
@@ -7,20 +7,20 @@ import org.assertj.core.api.AbstractAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJCharSequenceRulesTest implements RefasterRuleCollectionTestCase {
-  void testAssertThatCharSequenceIsEmpty() {
+  void testAssertThatIsEmpty() {
     assertThat("foo".isEmpty()).isTrue();
     assertThat("bar".length()).isEqualTo(0L);
     assertThat("baz".length()).isNotPositive();
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatCharSequenceIsNotEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEmpty() {
     return ImmutableSet.of(
         assertThat("foo".isEmpty()).isFalse(),
         assertThat("bar".length()).isNotEqualTo(0),
         assertThat("baz".length()).isPositive());
   }
 
-  AbstractAssert<?, ?> testAssertThatCharSequenceHasSize() {
+  AbstractAssert<?, ?> testAssertThatHasSize() {
     return assertThat("foo".length()).isEqualTo(3);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJCharSequenceRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJCharSequenceRulesTestOutput.java
@@ -7,20 +7,20 @@ import org.assertj.core.api.AbstractAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJCharSequenceRulesTest implements RefasterRuleCollectionTestCase {
-  void testAssertThatCharSequenceIsEmpty() {
+  void testAssertThatIsEmpty() {
     assertThat("foo").isEmpty();
     assertThat("bar").isEmpty();
     assertThat("baz").isEmpty();
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatCharSequenceIsNotEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEmpty() {
     return ImmutableSet.of(
         assertThat("foo").isNotEmpty(),
         assertThat("bar").isNotEmpty(),
         assertThat("baz").isNotEmpty());
   }
 
-  AbstractAssert<?, ?> testAssertThatCharSequenceHasSize() {
+  AbstractAssert<?, ?> testAssertThatHasSize() {
     return assertThat("foo").hasSize(3);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDoubleRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDoubleRulesTestInput.java
@@ -14,32 +14,32 @@ final class AssertJDoubleRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(withPercentage(0));
   }
 
-  ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsCloseToWithOffset() {
+  ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsCloseTo() {
     return ImmutableSet.of(
-        assertThat(0.0).isEqualTo(1, offset(0.0)),
-        assertThat(0.0).isEqualTo(Double.valueOf(1), offset(0.0)));
+        assertThat(1.0).isEqualTo(2, offset(0.0)),
+        assertThat(1.0).isEqualTo(Double.valueOf(2), offset(0.0)));
   }
 
   ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat(0.0).isCloseTo(1, offset(0.0)), assertThat(0.0).isCloseTo(1, withPercentage(0)));
+        assertThat(1.0).isCloseTo(2, offset(0.0)), assertThat(1.0).isCloseTo(2, withPercentage(0)));
   }
 
   ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsNotEqualTo() {
     return ImmutableSet.of(
-        assertThat(0.0).isNotCloseTo(1, offset(0.0)),
-        assertThat(0.0).isNotCloseTo(1, withPercentage(0)));
+        assertThat(1.0).isNotCloseTo(2, offset(0.0)),
+        assertThat(1.0).isNotCloseTo(2, withPercentage(0)));
   }
 
-  AbstractDoubleAssert<?> testAbstractDoubleAssertIsZero() {
-    return assertThat(0.0).isZero();
+  AbstractDoubleAssert<?> testAbstractDoubleAssertIsEqualToZero() {
+    return assertThat(1.0).isZero();
   }
 
-  AbstractDoubleAssert<?> testAbstractDoubleAssertIsNotZero() {
-    return assertThat(0.0).isNotZero();
+  AbstractDoubleAssert<?> testAbstractDoubleAssertIsNotEqualToZero() {
+    return assertThat(1.0).isNotZero();
   }
 
-  AbstractDoubleAssert<?> testAbstractDoubleAssertIsOne() {
-    return assertThat(0.0).isOne();
+  AbstractDoubleAssert<?> testAbstractDoubleAssertIsEqualToOne() {
+    return assertThat(1.0).isOne();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDoubleRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJDoubleRulesTestOutput.java
@@ -14,29 +14,29 @@ final class AssertJDoubleRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(withPercentage(0));
   }
 
-  ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsCloseToWithOffset() {
+  ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsCloseTo() {
     return ImmutableSet.of(
-        assertThat(0.0).isCloseTo(1, offset(0.0)),
-        assertThat(0.0).isCloseTo(Double.valueOf(1), offset(0.0)));
+        assertThat(1.0).isCloseTo(2, offset(0.0)),
+        assertThat(1.0).isCloseTo(Double.valueOf(2), offset(0.0)));
   }
 
   ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsEqualTo() {
-    return ImmutableSet.of(assertThat(0.0).isEqualTo(1), assertThat(0.0).isEqualTo(1));
+    return ImmutableSet.of(assertThat(1.0).isEqualTo(2), assertThat(1.0).isEqualTo(2));
   }
 
   ImmutableSet<AbstractDoubleAssert<?>> testAbstractDoubleAssertIsNotEqualTo() {
-    return ImmutableSet.of(assertThat(0.0).isNotEqualTo(1), assertThat(0.0).isNotEqualTo(1));
+    return ImmutableSet.of(assertThat(1.0).isNotEqualTo(2), assertThat(1.0).isNotEqualTo(2));
   }
 
-  AbstractDoubleAssert<?> testAbstractDoubleAssertIsZero() {
-    return assertThat(0.0).isEqualTo(0);
+  AbstractDoubleAssert<?> testAbstractDoubleAssertIsEqualToZero() {
+    return assertThat(1.0).isEqualTo(0);
   }
 
-  AbstractDoubleAssert<?> testAbstractDoubleAssertIsNotZero() {
-    return assertThat(0.0).isNotEqualTo(0);
+  AbstractDoubleAssert<?> testAbstractDoubleAssertIsNotEqualToZero() {
+    return assertThat(1.0).isNotEqualTo(0);
   }
 
-  AbstractDoubleAssert<?> testAbstractDoubleAssertIsOne() {
-    return assertThat(0.0).isEqualTo(1);
+  AbstractDoubleAssert<?> testAbstractDoubleAssertIsEqualToOne() {
+    return assertThat(1.0).isEqualTo(1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestInput.java
@@ -18,16 +18,16 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(1)).hasSize(0);
     assertThat(ImmutableSet.of(2)).hasSizeLessThanOrEqualTo(0);
     assertThat(ImmutableSet.of(3)).hasSizeLessThan(1);
-    assertThat(ImmutableSet.of(4)).hasSameSizeAs(ImmutableSet.of());
-    assertThat(ImmutableSet.of(5)).hasSameSizeAs(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(6)).containsExactlyElementsOf(ImmutableSet.of());
-    assertThat(ImmutableSet.of(7)).containsExactlyElementsOf(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(8)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of());
-    assertThat(ImmutableSet.of(9)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(10)).hasSameElementsAs(ImmutableSet.of());
-    assertThat(ImmutableSet.of(11)).hasSameElementsAs(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(12)).isSubsetOf(ImmutableSet.of());
-    assertThat(ImmutableSet.of(13)).isSubsetOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(4)).hasSameSizeAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(5)).hasSameSizeAs(ImmutableSet.of());
+    assertThat(ImmutableSet.of(6)).containsExactlyElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(7)).containsExactlyElementsOf(ImmutableSet.of());
+    assertThat(ImmutableSet.of(8)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(9)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of());
+    assertThat(ImmutableSet.of(10)).hasSameElementsAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(11)).hasSameElementsAs(ImmutableSet.of());
+    assertThat(ImmutableSet.of(12)).isSubsetOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(13)).isSubsetOf(ImmutableSet.of());
     assertThat(ImmutableSet.of(14)).containsExactly();
     assertThat(ImmutableSet.of(15)).containsExactlyInAnyOrder();
     assertThat(ImmutableSet.of(16)).containsOnly();
@@ -35,9 +35,9 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(18)).size().isNotPositive();
   }
 
-  void testAssertAndEnumerableAssertIsEmpty() {
-    assertThat(ImmutableSet.of(1)).isEqualTo(ImmutableSet.of());
-    assertThat(ImmutableSet.of(2)).isEqualTo(ImmutableSet.of(0));
+  void testAssertIsEmpty() {
+    assertThat(ImmutableSet.of(1)).isEqualTo(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(2)).isEqualTo(ImmutableSet.of());
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJEnumerableRulesTestOutput.java
@@ -18,16 +18,16 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(1)).isEmpty();
     assertThat(ImmutableSet.of(2)).isEmpty();
     assertThat(ImmutableSet.of(3)).isEmpty();
-    assertThat(ImmutableSet.of(4)).isEmpty();
-    assertThat(ImmutableSet.of(5)).hasSameSizeAs(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(6)).isEmpty();
-    assertThat(ImmutableSet.of(7)).containsExactlyElementsOf(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(8)).isEmpty();
-    assertThat(ImmutableSet.of(9)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(10)).isEmpty();
-    assertThat(ImmutableSet.of(11)).hasSameElementsAs(ImmutableSet.of(0));
-    assertThat(ImmutableSet.of(12)).isEmpty();
-    assertThat(ImmutableSet.of(13)).isSubsetOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(4)).hasSameSizeAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(5)).isEmpty();
+    assertThat(ImmutableSet.of(6)).containsExactlyElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(7)).isEmpty();
+    assertThat(ImmutableSet.of(8)).containsExactlyInAnyOrderElementsOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(9)).isEmpty();
+    assertThat(ImmutableSet.of(10)).hasSameElementsAs(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(11)).isEmpty();
+    assertThat(ImmutableSet.of(12)).isSubsetOf(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(13)).isEmpty();
     assertThat(ImmutableSet.of(14)).isEmpty();
     assertThat(ImmutableSet.of(15)).isEmpty();
     assertThat(ImmutableSet.of(16)).isEmpty();
@@ -35,9 +35,9 @@ final class AssertJEnumerableRulesTest implements RefasterRuleCollectionTestCase
     assertThat(ImmutableSet.of(18)).isEmpty();
   }
 
-  void testAssertAndEnumerableAssertIsEmpty() {
-    assertThat(ImmutableSet.of(1)).isEmpty();
-    assertThat(ImmutableSet.of(2)).isEqualTo(ImmutableSet.of(0));
+  void testAssertIsEmpty() {
+    assertThat(ImmutableSet.of(1)).isEqualTo(ImmutableSet.of(0));
+    assertThat(ImmutableSet.of(2)).isEmpty();
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testEnumerableAssertIsNotEmpty() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFloatRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFloatRulesTestInput.java
@@ -14,32 +14,32 @@ final class AssertJFloatRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(withPercentage(0));
   }
 
-  ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsCloseToWithOffset() {
+  ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsCloseTo() {
     return ImmutableSet.of(
-        assertThat(0f).isEqualTo(1, offset(0f)),
-        assertThat(0f).isEqualTo(Float.valueOf(1), offset(0f)));
+        assertThat(1f).isEqualTo(2, offset(0f)),
+        assertThat(1f).isEqualTo(Float.valueOf(2), offset(0f)));
   }
 
   ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat(0f).isCloseTo(1, offset(0f)), assertThat(0f).isCloseTo(1, withPercentage(0)));
+        assertThat(1f).isCloseTo(2, offset(0f)), assertThat(1f).isCloseTo(2, withPercentage(0)));
   }
 
   ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsNotEqualTo() {
     return ImmutableSet.of(
-        assertThat(0f).isNotCloseTo(1, offset(0f)),
-        assertThat(0f).isNotCloseTo(1, withPercentage(0)));
+        assertThat(1f).isNotCloseTo(2, offset(0f)),
+        assertThat(1f).isNotCloseTo(2, withPercentage(0)));
   }
 
-  AbstractFloatAssert<?> testAbstractFloatAssertIsZero() {
-    return assertThat(0f).isZero();
+  AbstractFloatAssert<?> testAbstractFloatAssertIsEqualToZero() {
+    return assertThat(1f).isZero();
   }
 
-  AbstractFloatAssert<?> testAbstractFloatAssertIsNotZero() {
-    return assertThat(0f).isNotZero();
+  AbstractFloatAssert<?> testAbstractFloatAssertIsNotEqualToZero() {
+    return assertThat(1f).isNotZero();
   }
 
-  AbstractFloatAssert<?> testAbstractFloatAssertIsOne() {
-    return assertThat(0f).isOne();
+  AbstractFloatAssert<?> testAbstractFloatAssertIsEqualToOne() {
+    return assertThat(1f).isOne();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFloatRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJFloatRulesTestOutput.java
@@ -14,29 +14,29 @@ final class AssertJFloatRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(withPercentage(0));
   }
 
-  ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsCloseToWithOffset() {
+  ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsCloseTo() {
     return ImmutableSet.of(
-        assertThat(0f).isCloseTo(1, offset(0f)),
-        assertThat(0f).isCloseTo(Float.valueOf(1), offset(0f)));
+        assertThat(1f).isCloseTo(2, offset(0f)),
+        assertThat(1f).isCloseTo(Float.valueOf(2), offset(0f)));
   }
 
   ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsEqualTo() {
-    return ImmutableSet.of(assertThat(0f).isEqualTo(1), assertThat(0f).isEqualTo(1));
+    return ImmutableSet.of(assertThat(1f).isEqualTo(2), assertThat(1f).isEqualTo(2));
   }
 
   ImmutableSet<AbstractFloatAssert<?>> testAbstractFloatAssertIsNotEqualTo() {
-    return ImmutableSet.of(assertThat(0f).isNotEqualTo(1), assertThat(0f).isNotEqualTo(1));
+    return ImmutableSet.of(assertThat(1f).isNotEqualTo(2), assertThat(1f).isNotEqualTo(2));
   }
 
-  AbstractFloatAssert<?> testAbstractFloatAssertIsZero() {
-    return assertThat(0f).isEqualTo(0);
+  AbstractFloatAssert<?> testAbstractFloatAssertIsEqualToZero() {
+    return assertThat(1f).isEqualTo(0);
   }
 
-  AbstractFloatAssert<?> testAbstractFloatAssertIsNotZero() {
-    return assertThat(0f).isNotEqualTo(0);
+  AbstractFloatAssert<?> testAbstractFloatAssertIsNotEqualToZero() {
+    return assertThat(1f).isNotEqualTo(0);
   }
 
-  AbstractFloatAssert<?> testAbstractFloatAssertIsOne() {
-    return assertThat(0f).isEqualTo(1);
+  AbstractFloatAssert<?> testAbstractFloatAssertIsEqualToOne() {
+    return assertThat(1f).isEqualTo(1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIntegerRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIntegerRulesTestInput.java
@@ -16,23 +16,23 @@ final class AssertJIntegerRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<AbstractIntegerAssert<?>> testAbstractIntegerAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat(0).isCloseTo(1, offset(0)), assertThat(0).isCloseTo(1, withPercentage(0)));
+        assertThat(1).isCloseTo(2, offset(0)), assertThat(1).isCloseTo(2, withPercentage(0)));
   }
 
   ImmutableSet<AbstractIntegerAssert<?>> testAbstractIntegerAssertIsNotEqualTo() {
     return ImmutableSet.of(
-        assertThat(0).isNotCloseTo(1, offset(0)), assertThat(0).isNotCloseTo(1, withPercentage(0)));
+        assertThat(1).isNotCloseTo(2, offset(0)), assertThat(1).isNotCloseTo(2, withPercentage(0)));
   }
 
-  AbstractIntegerAssert<?> testAbstractIntegerAssertIsZero() {
-    return assertThat(0).isZero();
+  AbstractIntegerAssert<?> testAbstractIntegerAssertIsEqualToZero() {
+    return assertThat(1).isZero();
   }
 
-  AbstractIntegerAssert<?> testAbstractIntegerAssertIsNotZero() {
-    return assertThat(0).isNotZero();
+  AbstractIntegerAssert<?> testAbstractIntegerAssertIsNotEqualToZero() {
+    return assertThat(1).isNotZero();
   }
 
-  AbstractIntegerAssert<?> testAbstractIntegerAssertIsOne() {
-    return assertThat(0).isOne();
+  AbstractIntegerAssert<?> testAbstractIntegerAssertIsEqualToOne() {
+    return assertThat(1).isOne();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIntegerRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIntegerRulesTestOutput.java
@@ -15,22 +15,22 @@ final class AssertJIntegerRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<AbstractIntegerAssert<?>> testAbstractIntegerAssertIsEqualTo() {
-    return ImmutableSet.of(assertThat(0).isEqualTo(1), assertThat(0).isEqualTo(1));
+    return ImmutableSet.of(assertThat(1).isEqualTo(2), assertThat(1).isEqualTo(2));
   }
 
   ImmutableSet<AbstractIntegerAssert<?>> testAbstractIntegerAssertIsNotEqualTo() {
-    return ImmutableSet.of(assertThat(0).isNotEqualTo(1), assertThat(0).isNotEqualTo(1));
+    return ImmutableSet.of(assertThat(1).isNotEqualTo(2), assertThat(1).isNotEqualTo(2));
   }
 
-  AbstractIntegerAssert<?> testAbstractIntegerAssertIsZero() {
-    return assertThat(0).isEqualTo(0);
+  AbstractIntegerAssert<?> testAbstractIntegerAssertIsEqualToZero() {
+    return assertThat(1).isEqualTo(0);
   }
 
-  AbstractIntegerAssert<?> testAbstractIntegerAssertIsNotZero() {
-    return assertThat(0).isNotEqualTo(0);
+  AbstractIntegerAssert<?> testAbstractIntegerAssertIsNotEqualToZero() {
+    return assertThat(1).isNotEqualTo(0);
   }
 
-  AbstractIntegerAssert<?> testAbstractIntegerAssertIsOne() {
-    return assertThat(0).isEqualTo(1);
+  AbstractIntegerAssert<?> testAbstractIntegerAssertIsEqualToOne() {
+    return assertThat(1).isEqualTo(1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIterableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIterableRulesTestInput.java
@@ -9,22 +9,23 @@ import org.assertj.core.api.AbstractIntegerAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJIterableRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(Iterables.class);
   }
 
-  void testAssertThatIterableIsEmpty() {
+  void testAssertThatIsEmpty() {
     assertThat(ImmutableSet.of(1).iterator()).isExhausted();
     assertThat(ImmutableSet.of(2).isEmpty()).isTrue();
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIterableIsNotEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEmpty() {
     return ImmutableSet.of(
         assertThat(ImmutableSet.of(1).iterator()).hasNext(),
         assertThat(ImmutableSet.of(2).isEmpty()).isFalse());
   }
 
-  ImmutableSet<AbstractIntegerAssert<?>> testAssertThatIterableSize() {
+  ImmutableSet<AbstractIntegerAssert<?>> testAssertThatSize() {
     return ImmutableSet.of(
         assertThat(Iterables.size(ImmutableSet.of(1))), assertThat(ImmutableSet.of(2).size()));
   }
@@ -41,7 +42,7 @@ final class AssertJIterableRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableSet.of(1).containsAll(ImmutableSet.of(2))).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatIterableHasOneElementEqualTo() {
+  AbstractAssert<?, ?> testAssertThatContainsExactly() {
     return assertThat(Iterables.getOnlyElement(ImmutableSet.of(new Object()))).isEqualTo("foo");
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIterableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJIterableRulesTestOutput.java
@@ -9,21 +9,22 @@ import org.assertj.core.api.AbstractIntegerAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJIterableRulesTest implements RefasterRuleCollectionTestCase {
+  @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(Iterables.class);
   }
 
-  void testAssertThatIterableIsEmpty() {
+  void testAssertThatIsEmpty() {
     assertThat(ImmutableSet.of(1)).isEmpty();
     assertThat(ImmutableSet.of(2)).isEmpty();
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIterableIsNotEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEmpty() {
     return ImmutableSet.of(
         assertThat(ImmutableSet.of(1)).isNotEmpty(), assertThat(ImmutableSet.of(2)).isNotEmpty());
   }
 
-  ImmutableSet<AbstractIntegerAssert<?>> testAssertThatIterableSize() {
+  ImmutableSet<AbstractIntegerAssert<?>> testAssertThatSize() {
     return ImmutableSet.of(
         assertThat(ImmutableSet.of(1)).size(), assertThat(ImmutableSet.of(2)).size());
   }
@@ -40,7 +41,7 @@ final class AssertJIterableRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableSet.of(1)).containsAll(ImmutableSet.of(2));
   }
 
-  AbstractAssert<?, ?> testAssertThatIterableHasOneElementEqualTo() {
+  AbstractAssert<?, ?> testAssertThatContainsExactly() {
     return assertThat(ImmutableSet.of(new Object())).containsExactly("foo");
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJLongRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJLongRulesTestInput.java
@@ -16,24 +16,24 @@ final class AssertJLongRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<AbstractLongAssert<?>> testAbstractLongAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat(0L).isCloseTo(1, offset(0L)), assertThat(0L).isCloseTo(1, withPercentage(0)));
+        assertThat(0L).isCloseTo(1, offset(0L)), assertThat(0L).isCloseTo(2, withPercentage(0)));
   }
 
   ImmutableSet<AbstractLongAssert<?>> testAbstractLongAssertIsNotEqualTo() {
     return ImmutableSet.of(
         assertThat(0L).isNotCloseTo(1, offset(0L)),
-        assertThat(0L).isNotCloseTo(1, withPercentage(0)));
+        assertThat(0L).isNotCloseTo(2, withPercentage(0)));
   }
 
-  AbstractLongAssert<?> testAbstractLongAssertIsZero() {
+  AbstractLongAssert<?> testAbstractLongAssertIsEqualToZero() {
     return assertThat(0L).isZero();
   }
 
-  AbstractLongAssert<?> testAbstractLongAssertIsNotZero() {
+  AbstractLongAssert<?> testAbstractLongAssertIsNotEqualToZero() {
     return assertThat(0L).isNotZero();
   }
 
-  AbstractLongAssert<?> testAbstractLongAssertIsOne() {
+  AbstractLongAssert<?> testAbstractLongAssertIsEqualToOne() {
     return assertThat(0L).isOne();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJLongRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJLongRulesTestOutput.java
@@ -15,22 +15,22 @@ final class AssertJLongRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<AbstractLongAssert<?>> testAbstractLongAssertIsEqualTo() {
-    return ImmutableSet.of(assertThat(0L).isEqualTo(1), assertThat(0L).isEqualTo(1));
+    return ImmutableSet.of(assertThat(0L).isEqualTo(1), assertThat(0L).isEqualTo(2));
   }
 
   ImmutableSet<AbstractLongAssert<?>> testAbstractLongAssertIsNotEqualTo() {
-    return ImmutableSet.of(assertThat(0L).isNotEqualTo(1), assertThat(0L).isNotEqualTo(1));
+    return ImmutableSet.of(assertThat(0L).isNotEqualTo(1), assertThat(0L).isNotEqualTo(2));
   }
 
-  AbstractLongAssert<?> testAbstractLongAssertIsZero() {
+  AbstractLongAssert<?> testAbstractLongAssertIsEqualToZero() {
     return assertThat(0L).isEqualTo(0);
   }
 
-  AbstractLongAssert<?> testAbstractLongAssertIsNotZero() {
+  AbstractLongAssert<?> testAbstractLongAssertIsNotEqualToZero() {
     return assertThat(0L).isNotEqualTo(0);
   }
 
-  AbstractLongAssert<?> testAbstractLongAssertIsOne() {
+  AbstractLongAssert<?> testAbstractLongAssertIsEqualToOne() {
     return assertThat(0L).isEqualTo(1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestInput.java
@@ -40,23 +40,23 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAbstractMapAssertIsEmpty() {
-    assertThat(ImmutableMap.of(1, 0)).containsExactlyEntriesOf(ImmutableMap.of());
-    assertThat(ImmutableMap.of(2, 0)).containsExactlyEntriesOf(ImmutableMap.of(1, 2));
-    assertThat(ImmutableMap.of(3, 0)).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of());
-    assertThat(ImmutableMap.of(4, 0))
+    assertThat(ImmutableMap.of(1, 0)).containsExactlyEntriesOf(ImmutableMap.of(1, 2));
+    assertThat(ImmutableMap.of(2, 0)).containsExactlyEntriesOf(ImmutableMap.of());
+    assertThat(ImmutableMap.of(3, 0))
         .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(1, 2, 3, 4));
-    assertThat(ImmutableMap.of(5, 0)).hasSameSizeAs(ImmutableMap.of());
-    assertThat(ImmutableMap.of(6, 0)).hasSameSizeAs(ImmutableMap.of(1, 2));
-    assertThat(ImmutableMap.of(7, 0)).isEqualTo(ImmutableMap.of());
-    assertThat(ImmutableMap.of(8, 0)).isEqualTo(ImmutableMap.of("foo", "bar"));
-    assertThat(ImmutableMap.of(9, 0)).containsOnlyKeys(ImmutableList.of());
-    assertThat(ImmutableMap.of(10, 0)).containsOnlyKeys(ImmutableList.of(1));
+    assertThat(ImmutableMap.of(4, 0)).containsExactlyInAnyOrderEntriesOf(ImmutableMap.of());
+    assertThat(ImmutableMap.of(5, 0)).hasSameSizeAs(ImmutableMap.of(1, 2));
+    assertThat(ImmutableMap.of(6, 0)).hasSameSizeAs(ImmutableMap.of());
+    assertThat(ImmutableMap.of(7, 0)).isEqualTo(ImmutableMap.of("foo", "bar"));
+    assertThat(ImmutableMap.of(8, 0)).isEqualTo(ImmutableMap.of());
+    assertThat(ImmutableMap.of(9, 0)).containsOnlyKeys(ImmutableList.of(1));
+    assertThat(ImmutableMap.of(10, 0)).containsOnlyKeys(ImmutableList.of());
     assertThat(ImmutableMap.of(11, 0)).containsExactly();
     assertThat(ImmutableMap.of(12, 0)).containsOnly();
     assertThat(ImmutableMap.of(13, 0)).containsOnlyKeys();
   }
 
-  void testAssertThatMapIsEmpty() {
+  void testAssertThatIsEmpty() {
     assertThat(ImmutableMap.of(1, 0)).hasSize(0);
     assertThat(ImmutableMap.of(2, 0).isEmpty()).isTrue();
     assertThat(ImmutableMap.of(3, 0).size()).isEqualTo(0L);
@@ -68,11 +68,11 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<MapAssert<Integer, Integer>> testAbstractMapAssertIsNotEmpty() {
     return ImmutableSet.of(
-        assertThat(ImmutableMap.of(1, 0)).isNotEqualTo(ImmutableMap.of()),
-        assertThat(ImmutableMap.of(2, 0)).isNotEqualTo(ImmutableMap.of("foo", "bar")));
+        assertThat(ImmutableMap.of(1, 0)).isNotEqualTo(ImmutableMap.of("foo", "bar")),
+        assertThat(ImmutableMap.of(2, 0)).isNotEqualTo(ImmutableMap.of()));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapIsNotEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEmpty() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 0).isEmpty()).isFalse(),
         assertThat(ImmutableMap.of(2, 0).size()).isNotEqualTo(0),
@@ -86,12 +86,12 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2, 3, 4)).isEqualTo(ImmutableMap.of(1, 2, 3, 4));
   }
 
-  MapAssert<Integer, Integer> testAbstractMapAssertContainsExactlyEntriesOf() {
+  MapAssert<Integer, Integer> testAbstractMapAssertContainsExactlyEntriesOfImmutableMapOf() {
     return assertThat(ImmutableMap.of(1, 2))
         .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(1, 2));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapHasSize() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSize() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2).size()).isEqualTo(1),
         assertThat(ImmutableMap.of(3, 4).keySet()).hasSize(1),
@@ -103,33 +103,33 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2)).hasSize(ImmutableMap.of(3, 4).size());
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsKey() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsKey() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2).containsKey(3)).isTrue(),
         assertThat(ImmutableMap.of(4, 5).keySet()).contains(6));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainKey() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainKey() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2).containsKey(3)).isFalse(),
         assertThat(ImmutableMap.of(4, 5).keySet()).doesNotContain(6));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsOnlyKey() {
+  AbstractAssert<?, ?> testAssertThatContainsOnlyKeysObject() {
     return assertThat(ImmutableMap.of(1, 2).keySet()).containsExactly(3);
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsOnlyKeys() {
+  AbstractAssert<?, ?> testAssertThatContainsOnlyKeysIterable() {
     return assertThat(ImmutableMap.of(1, 2).keySet()).hasSameElementsAs(ImmutableSet.of(3));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsValue() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsValue() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2).containsValue(3)).isTrue(),
         assertThat(ImmutableMap.of(4, 5).values()).contains(6));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainValue() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainValue() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2).containsValue(3)).isFalse(),
         assertThat(ImmutableMap.of(4, 5).values()).doesNotContain(6));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJMapRulesTestOutput.java
@@ -40,23 +40,23 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testAbstractMapAssertIsEmpty() {
-    assertThat(ImmutableMap.of(1, 0)).isEmpty();
-    assertThat(ImmutableMap.of(2, 0)).containsExactlyEntriesOf(ImmutableMap.of(1, 2));
-    assertThat(ImmutableMap.of(3, 0)).isEmpty();
-    assertThat(ImmutableMap.of(4, 0))
+    assertThat(ImmutableMap.of(1, 0)).containsExactlyEntriesOf(ImmutableMap.of(1, 2));
+    assertThat(ImmutableMap.of(2, 0)).isEmpty();
+    assertThat(ImmutableMap.of(3, 0))
         .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(1, 2, 3, 4));
-    assertThat(ImmutableMap.of(5, 0)).isEmpty();
-    assertThat(ImmutableMap.of(6, 0)).hasSameSizeAs(ImmutableMap.of(1, 2));
-    assertThat(ImmutableMap.of(7, 0)).isEmpty();
-    assertThat(ImmutableMap.of(8, 0)).isEqualTo(ImmutableMap.of("foo", "bar"));
-    assertThat(ImmutableMap.of(9, 0)).isEmpty();
-    assertThat(ImmutableMap.of(10, 0)).containsOnlyKeys(ImmutableList.of(1));
+    assertThat(ImmutableMap.of(4, 0)).isEmpty();
+    assertThat(ImmutableMap.of(5, 0)).hasSameSizeAs(ImmutableMap.of(1, 2));
+    assertThat(ImmutableMap.of(6, 0)).isEmpty();
+    assertThat(ImmutableMap.of(7, 0)).isEqualTo(ImmutableMap.of("foo", "bar"));
+    assertThat(ImmutableMap.of(8, 0)).isEmpty();
+    assertThat(ImmutableMap.of(9, 0)).containsOnlyKeys(ImmutableList.of(1));
+    assertThat(ImmutableMap.of(10, 0)).isEmpty();
     assertThat(ImmutableMap.of(11, 0)).isEmpty();
     assertThat(ImmutableMap.of(12, 0)).isEmpty();
     assertThat(ImmutableMap.of(13, 0)).isEmpty();
   }
 
-  void testAssertThatMapIsEmpty() {
+  void testAssertThatIsEmpty() {
     assertThat(ImmutableMap.of(1, 0)).isEmpty();
     assertThat(ImmutableMap.of(2, 0)).isEmpty();
     assertThat(ImmutableMap.of(3, 0)).isEmpty();
@@ -68,11 +68,11 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<MapAssert<Integer, Integer>> testAbstractMapAssertIsNotEmpty() {
     return ImmutableSet.of(
-        assertThat(ImmutableMap.of(1, 0)).isNotEmpty(),
-        assertThat(ImmutableMap.of(2, 0)).isNotEqualTo(ImmutableMap.of("foo", "bar")));
+        assertThat(ImmutableMap.of(1, 0)).isNotEqualTo(ImmutableMap.of("foo", "bar")),
+        assertThat(ImmutableMap.of(2, 0)).isNotEmpty());
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapIsNotEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEmpty() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 0)).isNotEmpty(),
         assertThat(ImmutableMap.of(2, 0)).isNotEmpty(),
@@ -87,11 +87,11 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
         .containsExactlyInAnyOrderEntriesOf(ImmutableMap.of(1, 2, 3, 4));
   }
 
-  MapAssert<Integer, Integer> testAbstractMapAssertContainsExactlyEntriesOf() {
+  MapAssert<Integer, Integer> testAbstractMapAssertContainsExactlyEntriesOfImmutableMapOf() {
     return assertThat(ImmutableMap.of(1, 2)).containsExactlyEntriesOf(ImmutableMap.of(1, 2));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapHasSize() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSize() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2)).hasSize(1),
         assertThat(ImmutableMap.of(3, 4)).hasSize(1),
@@ -103,33 +103,33 @@ final class AssertJMapRulesTest implements RefasterRuleCollectionTestCase {
     return assertThat(ImmutableMap.of(1, 2)).hasSameSizeAs(ImmutableMap.of(3, 4));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsKey() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsKey() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2)).containsKey(3),
         assertThat(ImmutableMap.of(4, 5)).containsKey(6));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainKey() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainKey() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2)).doesNotContainKey(3),
         assertThat(ImmutableMap.of(4, 5)).doesNotContainKey(6));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsOnlyKey() {
+  AbstractAssert<?, ?> testAssertThatContainsOnlyKeysObject() {
     return assertThat(ImmutableMap.of(1, 2)).containsOnlyKeys(3);
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsOnlyKeys() {
+  AbstractAssert<?, ?> testAssertThatContainsOnlyKeysIterable() {
     return assertThat(ImmutableMap.of(1, 2)).containsOnlyKeys(ImmutableSet.of(3));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapContainsValue() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsValue() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2)).containsValue(3),
         assertThat(ImmutableMap.of(4, 5)).containsValue(6));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatMapDoesNotContainValue() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainValue() {
     return ImmutableSet.of(
         assertThat(ImmutableMap.of(1, 2)).doesNotContainValue(3),
         assertThat(ImmutableMap.of(4, 5)).doesNotContainValue(6));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJNumberRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJNumberRulesTestInput.java
@@ -11,97 +11,83 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class AssertJNumberRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsPositive() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isGreaterThan((byte) 0),
-        assertThat((byte) 0).isGreaterThanOrEqualTo((byte) 1),
-        assertThat((short) 0).isGreaterThan((short) 0),
-        assertThat((short) 0).isGreaterThanOrEqualTo((short) 1),
-        assertThat(0).isGreaterThan(0),
-        assertThat(0).isGreaterThanOrEqualTo(1),
-        assertThat(0L).isGreaterThan(0),
-        assertThat(0L).isGreaterThanOrEqualTo(1),
-        assertThat(0.0f).isGreaterThan(0),
-        assertThat(0.0).isGreaterThan(0),
-        assertThat(BigInteger.ZERO).isGreaterThan(BigInteger.ZERO),
-        assertThat(BigInteger.ZERO).isGreaterThanOrEqualTo(BigInteger.valueOf(1)),
-        assertThat(BigDecimal.ZERO).isGreaterThan(BigDecimal.ZERO));
+        assertThat((byte) 1).isGreaterThan((byte) 0),
+        assertThat((byte) 2).isGreaterThanOrEqualTo((byte) 1),
+        assertThat((short) 1).isGreaterThan((short) 0),
+        assertThat((short) 2).isGreaterThanOrEqualTo((short) 1),
+        assertThat(1).isGreaterThan(0),
+        assertThat(2).isGreaterThanOrEqualTo(1),
+        assertThat(1L).isGreaterThan(0),
+        assertThat(2L).isGreaterThanOrEqualTo(1),
+        assertThat(1.0f).isGreaterThan(0),
+        assertThat(1.0).isGreaterThan(0),
+        assertThat(BigInteger.ONE).isGreaterThan(BigInteger.ZERO),
+        assertThat(BigInteger.TWO).isGreaterThanOrEqualTo(BigInteger.valueOf(1)),
+        assertThat(BigDecimal.ONE).isGreaterThan(BigDecimal.ZERO));
   }
 
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsNotPositive() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isLessThanOrEqualTo((byte) 0),
-        assertThat((byte) 0).isLessThan((byte) 1),
-        assertThat((short) 0).isLessThanOrEqualTo((short) 0),
-        assertThat((short) 0).isLessThan((short) 1),
-        assertThat(0).isLessThanOrEqualTo(0),
-        assertThat(0).isLessThan(1),
-        assertThat(0L).isLessThanOrEqualTo(0),
-        assertThat(0L).isLessThan(1),
-        assertThat(0.0f).isLessThanOrEqualTo(0),
-        assertThat(0.0).isLessThanOrEqualTo(0),
-        assertThat(BigInteger.ZERO).isLessThanOrEqualTo(BigInteger.ZERO),
-        assertThat(BigInteger.ZERO).isLessThan(BigInteger.valueOf(1)),
-        assertThat(BigDecimal.ZERO).isLessThanOrEqualTo(BigDecimal.ZERO));
+        assertThat((byte) 1).isLessThanOrEqualTo((byte) 0),
+        assertThat((byte) 2).isLessThan((byte) 1),
+        assertThat((short) 1).isLessThanOrEqualTo((short) 0),
+        assertThat((short) 2).isLessThan((short) 1),
+        assertThat(1).isLessThanOrEqualTo(0),
+        assertThat(2).isLessThan(1),
+        assertThat(1L).isLessThanOrEqualTo(0),
+        assertThat(2L).isLessThan(1),
+        assertThat(1.0f).isLessThanOrEqualTo(0),
+        assertThat(1.0).isLessThanOrEqualTo(0),
+        assertThat(BigInteger.ONE).isLessThanOrEqualTo(BigInteger.ZERO),
+        assertThat(BigInteger.TWO).isLessThan(BigInteger.valueOf(1)),
+        assertThat(BigDecimal.ONE).isLessThanOrEqualTo(BigDecimal.ZERO));
   }
 
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsNegative() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isLessThan((byte) 0),
-        assertThat((byte) 0).isLessThanOrEqualTo((byte) -1),
-        assertThat((short) 0).isLessThan((short) 0),
-        assertThat((short) 0).isLessThanOrEqualTo((short) -1),
-        assertThat(0).isLessThan(0),
-        assertThat(0).isLessThanOrEqualTo(-1),
-        assertThat(0L).isLessThan(0),
-        assertThat(0L).isLessThanOrEqualTo(-1),
-        assertThat(0.0f).isLessThan(0),
-        assertThat(0.0).isLessThan(0),
-        assertThat(BigInteger.ZERO).isLessThan(BigInteger.ZERO),
-        assertThat(BigInteger.ZERO).isLessThanOrEqualTo(BigInteger.valueOf(-1)),
-        assertThat(BigDecimal.ZERO).isLessThan(BigDecimal.ZERO));
+        assertThat((byte) -1).isLessThan((byte) 0),
+        assertThat((byte) -2).isLessThanOrEqualTo((byte) -1),
+        assertThat((short) -1).isLessThan((short) 0),
+        assertThat((short) -2).isLessThanOrEqualTo((short) -1),
+        assertThat(-1).isLessThan(0),
+        assertThat(-2).isLessThanOrEqualTo(-1),
+        assertThat(-1L).isLessThan(0),
+        assertThat(-2L).isLessThanOrEqualTo(-1),
+        assertThat(-1.0f).isLessThan(0),
+        assertThat(-1.0).isLessThan(0),
+        assertThat(BigInteger.valueOf(-1)).isLessThan(BigInteger.ZERO),
+        assertThat(BigInteger.valueOf(-2)).isLessThanOrEqualTo(BigInteger.valueOf(-1)),
+        assertThat(BigDecimal.valueOf(-1)).isLessThan(BigDecimal.ZERO));
   }
 
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsNotNegative() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isGreaterThanOrEqualTo((byte) 0),
-        assertThat((byte) 0).isGreaterThan((byte) -1),
-        assertThat((short) 0).isGreaterThanOrEqualTo((short) 0),
-        assertThat((short) 0).isGreaterThan((short) -1),
-        assertThat(0).isGreaterThanOrEqualTo(0),
-        assertThat(0).isGreaterThan(-1),
-        assertThat(0L).isGreaterThanOrEqualTo(0),
-        assertThat(0L).isGreaterThan(-1),
-        assertThat(0.0f).isGreaterThanOrEqualTo(0),
-        assertThat(0.0).isGreaterThanOrEqualTo(0),
-        assertThat(BigInteger.ZERO).isGreaterThanOrEqualTo(BigInteger.ZERO),
-        assertThat(BigInteger.ZERO).isGreaterThan(BigInteger.valueOf(-1)),
-        assertThat(BigDecimal.ZERO).isGreaterThanOrEqualTo(BigDecimal.ZERO));
+        assertThat((byte) 1).isGreaterThanOrEqualTo((byte) 0),
+        assertThat((byte) 2).isGreaterThan((byte) -1),
+        assertThat((short) 1).isGreaterThanOrEqualTo((short) 0),
+        assertThat((short) 2).isGreaterThan((short) -1),
+        assertThat(1).isGreaterThanOrEqualTo(0),
+        assertThat(2).isGreaterThan(-1),
+        assertThat(1L).isGreaterThanOrEqualTo(0),
+        assertThat(2L).isGreaterThan(-1),
+        assertThat(1.0f).isGreaterThanOrEqualTo(0),
+        assertThat(1.0).isGreaterThanOrEqualTo(0),
+        assertThat(BigInteger.ONE).isGreaterThanOrEqualTo(BigInteger.ZERO),
+        assertThat(BigInteger.TWO).isGreaterThan(BigInteger.valueOf(-1)),
+        assertThat(BigDecimal.ONE).isGreaterThanOrEqualTo(BigDecimal.ZERO));
   }
 
   ImmutableSet<NumberAssert<?, ?>> testAssertThatIsOdd() {
     return ImmutableSet.of(
-        assertThat((byte) 1 % 2).isEqualTo(1),
-        assertThat(Byte.valueOf((byte) 1) % 2).isEqualTo(1),
         assertThat((char) 1 % 2).isEqualTo(1),
-        assertThat(Character.valueOf((char) 1) % 2).isEqualTo(1),
-        assertThat((short) 1 % 2).isEqualTo(1),
-        assertThat(Short.valueOf((short) 1) % 2).isEqualTo(1),
         assertThat(1 % 2).isEqualTo(1),
-        assertThat(Integer.valueOf(1) % 2).isEqualTo(1),
-        assertThat(1L % 2).isEqualTo(1),
-        assertThat(Long.valueOf(1) % 2).isEqualTo(1));
+        assertThat(1L % 2).isEqualTo(1));
   }
 
   ImmutableSet<NumberAssert<?, ?>> testAssertThatIsEven() {
     return ImmutableSet.of(
-        assertThat((byte) 1 % 2).isEqualTo(0),
-        assertThat(Byte.valueOf((byte) 1) % 2).isEqualTo(0),
         assertThat((char) 1 % 2).isEqualTo(0),
-        assertThat(Character.valueOf((char) 1) % 2).isEqualTo(0),
-        assertThat((short) 1 % 2).isEqualTo(0),
-        assertThat(Short.valueOf((short) 1) % 2).isEqualTo(0),
         assertThat(1 % 2).isEqualTo(0),
-        assertThat(Integer.valueOf(1) % 2).isEqualTo(0),
-        assertThat(1L % 2).isEqualTo(0),
-        assertThat(Long.valueOf(1) % 2).isEqualTo(0));
+        assertThat(1L % 2).isEqualTo(0));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJNumberRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJNumberRulesTestOutput.java
@@ -11,97 +11,79 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class AssertJNumberRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsPositive() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isPositive(),
-        assertThat((byte) 0).isPositive(),
-        assertThat((short) 0).isPositive(),
-        assertThat((short) 0).isPositive(),
-        assertThat(0).isPositive(),
-        assertThat(0).isPositive(),
-        assertThat(0L).isPositive(),
-        assertThat(0L).isPositive(),
-        assertThat(0.0f).isPositive(),
-        assertThat(0.0).isPositive(),
-        assertThat(BigInteger.ZERO).isPositive(),
-        assertThat(BigInteger.ZERO).isPositive(),
-        assertThat(BigDecimal.ZERO).isPositive());
+        assertThat((byte) 1).isPositive(),
+        assertThat((byte) 2).isPositive(),
+        assertThat((short) 1).isPositive(),
+        assertThat((short) 2).isPositive(),
+        assertThat(1).isPositive(),
+        assertThat(2).isPositive(),
+        assertThat(1L).isPositive(),
+        assertThat(2L).isPositive(),
+        assertThat(1.0f).isPositive(),
+        assertThat(1.0).isPositive(),
+        assertThat(BigInteger.ONE).isPositive(),
+        assertThat(BigInteger.TWO).isPositive(),
+        assertThat(BigDecimal.ONE).isPositive());
   }
 
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsNotPositive() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isNotPositive(),
-        assertThat((byte) 0).isNotPositive(),
-        assertThat((short) 0).isNotPositive(),
-        assertThat((short) 0).isNotPositive(),
-        assertThat(0).isNotPositive(),
-        assertThat(0).isNotPositive(),
-        assertThat(0L).isNotPositive(),
-        assertThat(0L).isNotPositive(),
-        assertThat(0.0f).isNotPositive(),
-        assertThat(0.0).isNotPositive(),
-        assertThat(BigInteger.ZERO).isNotPositive(),
-        assertThat(BigInteger.ZERO).isNotPositive(),
-        assertThat(BigDecimal.ZERO).isNotPositive());
+        assertThat((byte) 1).isNotPositive(),
+        assertThat((byte) 2).isNotPositive(),
+        assertThat((short) 1).isNotPositive(),
+        assertThat((short) 2).isNotPositive(),
+        assertThat(1).isNotPositive(),
+        assertThat(2).isNotPositive(),
+        assertThat(1L).isNotPositive(),
+        assertThat(2L).isNotPositive(),
+        assertThat(1.0f).isNotPositive(),
+        assertThat(1.0).isNotPositive(),
+        assertThat(BigInteger.ONE).isNotPositive(),
+        assertThat(BigInteger.TWO).isNotPositive(),
+        assertThat(BigDecimal.ONE).isNotPositive());
   }
 
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsNegative() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isNegative(),
-        assertThat((byte) 0).isNegative(),
-        assertThat((short) 0).isNegative(),
-        assertThat((short) 0).isNegative(),
-        assertThat(0).isNegative(),
-        assertThat(0).isNegative(),
-        assertThat(0L).isNegative(),
-        assertThat(0L).isNegative(),
-        assertThat(0.0f).isNegative(),
-        assertThat(0.0).isNegative(),
-        assertThat(BigInteger.ZERO).isNegative(),
-        assertThat(BigInteger.ZERO).isNegative(),
-        assertThat(BigDecimal.ZERO).isNegative());
+        assertThat((byte) -1).isNegative(),
+        assertThat((byte) -2).isNegative(),
+        assertThat((short) -1).isNegative(),
+        assertThat((short) -2).isNegative(),
+        assertThat(-1).isNegative(),
+        assertThat(-2).isNegative(),
+        assertThat(-1L).isNegative(),
+        assertThat(-2L).isNegative(),
+        assertThat(-1.0f).isNegative(),
+        assertThat(-1.0).isNegative(),
+        assertThat(BigInteger.valueOf(-1)).isNegative(),
+        assertThat(BigInteger.valueOf(-2)).isNegative(),
+        assertThat(BigDecimal.valueOf(-1)).isNegative());
   }
 
   ImmutableSet<NumberAssert<?, ?>> testNumberAssertIsNotNegative() {
     return ImmutableSet.of(
-        assertThat((byte) 0).isNotNegative(),
-        assertThat((byte) 0).isNotNegative(),
-        assertThat((short) 0).isNotNegative(),
-        assertThat((short) 0).isNotNegative(),
-        assertThat(0).isNotNegative(),
-        assertThat(0).isNotNegative(),
-        assertThat(0L).isNotNegative(),
-        assertThat(0L).isNotNegative(),
-        assertThat(0.0f).isNotNegative(),
-        assertThat(0.0).isNotNegative(),
-        assertThat(BigInteger.ZERO).isNotNegative(),
-        assertThat(BigInteger.ZERO).isNotNegative(),
-        assertThat(BigDecimal.ZERO).isNotNegative());
+        assertThat((byte) 1).isNotNegative(),
+        assertThat((byte) 2).isNotNegative(),
+        assertThat((short) 1).isNotNegative(),
+        assertThat((short) 2).isNotNegative(),
+        assertThat(1).isNotNegative(),
+        assertThat(2).isNotNegative(),
+        assertThat(1L).isNotNegative(),
+        assertThat(2L).isNotNegative(),
+        assertThat(1.0f).isNotNegative(),
+        assertThat(1.0).isNotNegative(),
+        assertThat(BigInteger.ONE).isNotNegative(),
+        assertThat(BigInteger.TWO).isNotNegative(),
+        assertThat(BigDecimal.ONE).isNotNegative());
   }
 
   ImmutableSet<NumberAssert<?, ?>> testAssertThatIsOdd() {
     return ImmutableSet.of(
-        assertThat((byte) 1).isOdd(),
-        assertThat(Byte.valueOf((byte) 1)).isOdd(),
-        assertThat((char) 1 % 2).isEqualTo(1),
-        assertThat(Character.valueOf((char) 1) % 2).isEqualTo(1),
-        assertThat((short) 1).isOdd(),
-        assertThat(Short.valueOf((short) 1)).isOdd(),
-        assertThat(1).isOdd(),
-        assertThat(Integer.valueOf(1)).isOdd(),
-        assertThat(1L).isOdd(),
-        assertThat(Long.valueOf(1)).isOdd());
+        assertThat((char) 1 % 2).isEqualTo(1), assertThat(1).isOdd(), assertThat(1L).isOdd());
   }
 
   ImmutableSet<NumberAssert<?, ?>> testAssertThatIsEven() {
     return ImmutableSet.of(
-        assertThat((byte) 1).isEven(),
-        assertThat(Byte.valueOf((byte) 1)).isEven(),
-        assertThat((char) 1 % 2).isEqualTo(0),
-        assertThat(Character.valueOf((char) 1) % 2).isEqualTo(0),
-        assertThat((short) 1).isEven(),
-        assertThat(Short.valueOf((short) 1)).isEven(),
-        assertThat(1).isEven(),
-        assertThat(Integer.valueOf(1)).isEven(),
-        assertThat(1L).isEven(),
-        assertThat(Long.valueOf(1)).isEven());
+        assertThat((char) 1 % 2).isEqualTo(0), assertThat(1).isEven(), assertThat(1L).isEven());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJObjectRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJObjectRulesTestInput.java
@@ -7,23 +7,23 @@ import org.assertj.core.api.AbstractAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJObjectRulesTest implements RefasterRuleCollectionTestCase {
-  AbstractAssert<?, ?> testAssertThatIsInstanceOf() {
+  AbstractAssert<?, ?> testAssertThatIsInstanceOfClass() {
     return assertThat("foo" instanceof String).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatIsInstanceOf2() {
+  AbstractAssert<?, ?> testAssertThatIsInstanceOf() {
     return assertThat(String.class.isInstance("foo")).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatIsNotInstanceOf() {
+  AbstractAssert<?, ?> testAssertThatIsNotInstanceOfClass() {
     return assertThat("foo" instanceof String).isFalse();
   }
 
-  AbstractAssert<?, ?> testAssertThatIsIsEqualTo() {
+  AbstractAssert<?, ?> testAssertThatIsEqualTo() {
     return assertThat("foo".equals("bar")).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatIsIsNotEqualTo() {
+  AbstractAssert<?, ?> testAssertThatIsNotEqualTo() {
     return assertThat("foo".equals("bar")).isFalse();
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJObjectRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJObjectRulesTestOutput.java
@@ -7,23 +7,23 @@ import org.assertj.core.api.AbstractAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJObjectRulesTest implements RefasterRuleCollectionTestCase {
+  AbstractAssert<?, ?> testAssertThatIsInstanceOfClass() {
+    return assertThat("foo").isInstanceOf(String.class);
+  }
+
   AbstractAssert<?, ?> testAssertThatIsInstanceOf() {
     return assertThat("foo").isInstanceOf(String.class);
   }
 
-  AbstractAssert<?, ?> testAssertThatIsInstanceOf2() {
-    return assertThat("foo").isInstanceOf(String.class);
-  }
-
-  AbstractAssert<?, ?> testAssertThatIsNotInstanceOf() {
+  AbstractAssert<?, ?> testAssertThatIsNotInstanceOfClass() {
     return assertThat("foo").isNotInstanceOf(String.class);
   }
 
-  AbstractAssert<?, ?> testAssertThatIsIsEqualTo() {
+  AbstractAssert<?, ?> testAssertThatIsEqualTo() {
     return assertThat("foo").isEqualTo("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatIsIsNotEqualTo() {
+  AbstractAssert<?, ?> testAssertThatIsNotEqualTo() {
     return assertThat("foo").isNotEqualTo("bar");
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJOptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJOptionalRulesTestInput.java
@@ -12,7 +12,7 @@ import org.assertj.core.api.OptionalAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
-  AbstractAssert<?, ?> testAssertThatOptional() {
+  AbstractAssert<?, ?> testAssertThatGet() {
     return assertThat(Optional.of(new Object()).orElseThrow());
   }
 
@@ -22,7 +22,7 @@ final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Optional.of(2)).isNotEqualTo(Optional.empty()));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatOptionalIsPresent() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsPresent() {
     return ImmutableSet.of(
         assertThat(Optional.of(1).isPresent()).isTrue(),
         assertThat(Optional.of(2).isEmpty()).isFalse());
@@ -34,7 +34,7 @@ final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Optional.of(2)).isEqualTo(Optional.empty()));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatOptionalIsEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsEmpty() {
     return ImmutableSet.of(
         assertThat(Optional.of(1).isEmpty()).isTrue(),
         assertThat(Optional.of(2).isPresent()).isFalse());
@@ -61,7 +61,7 @@ final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Optional.of(Path.of("bar"))).get().satisfies(Object::toString));
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalHasValueMatching() {
+  AbstractAssert<?, ?> testAssertThatGetMatches() {
     return assertThat(Optional.of("foo").filter(String::isEmpty)).isPresent();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJOptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJOptionalRulesTestOutput.java
@@ -12,7 +12,7 @@ import org.assertj.core.api.OptionalAssert;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
-  AbstractAssert<?, ?> testAssertThatOptional() {
+  AbstractAssert<?, ?> testAssertThatGet() {
     return assertThat(Optional.of(new Object())).get();
   }
 
@@ -21,7 +21,7 @@ final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Optional.of(1)).isPresent(), assertThat(Optional.of(2)).isPresent());
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatOptionalIsPresent() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsPresent() {
     return ImmutableSet.of(
         assertThat(Optional.of(1)).isPresent(), assertThat(Optional.of(2)).isPresent());
   }
@@ -31,7 +31,7 @@ final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Optional.of(1)).isEmpty(), assertThat(Optional.of(2)).isEmpty());
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatOptionalIsEmpty() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsEmpty() {
     return ImmutableSet.of(
         assertThat(Optional.of(1)).isEmpty(), assertThat(Optional.of(2)).isEmpty());
   }
@@ -57,7 +57,7 @@ final class AssertJOptionalRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Optional.of(Path.of("bar"))).hasValueSatisfying(Object::toString));
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalHasValueMatching() {
+  AbstractAssert<?, ?> testAssertThatGetMatches() {
     return assertThat(Optional.of("foo")).get().matches(String::isEmpty);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRulesTestInput.java
@@ -10,40 +10,24 @@ final class AssertJPrimitiveRulesTest implements RefasterRuleCollectionTestCase 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsEqualTo() {
     return ImmutableSet.of(
         assertThat(true).isSameAs(false),
-        assertThat(true).isSameAs(false),
-        assertThat((byte) 1).isSameAs((byte) 2),
         assertThat((byte) 1).isSameAs((byte) 2),
         assertThat((char) 1).isSameAs((char) 2),
-        assertThat((char) 1).isSameAs((char) 2),
-        assertThat((short) 1).isSameAs((short) 2),
         assertThat((short) 1).isSameAs((short) 2),
         assertThat(1).isSameAs(2),
-        assertThat(1).isSameAs(2),
-        assertThat(1L).isSameAs(2L),
         assertThat(1L).isSameAs(2L),
         assertThat(1f).isSameAs(2f),
-        assertThat(1f).isSameAs(2f),
-        assertThat(1.0).isSameAs(2.0),
         assertThat(1.0).isSameAs(2.0));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEqualTo() {
     return ImmutableSet.of(
         assertThat(true).isNotSameAs(false),
-        assertThat(true).isNotSameAs(false),
-        assertThat((byte) 1).isNotSameAs((byte) 2),
         assertThat((byte) 1).isNotSameAs((byte) 2),
         assertThat((char) 1).isNotSameAs((char) 2),
-        assertThat((char) 1).isNotSameAs((char) 2),
-        assertThat((short) 1).isNotSameAs((short) 2),
         assertThat((short) 1).isNotSameAs((short) 2),
         assertThat(1).isNotSameAs(2),
-        assertThat(1).isNotSameAs(2),
-        assertThat(1L).isNotSameAs(2L),
         assertThat(1L).isNotSameAs(2L),
         assertThat(1f).isNotSameAs(2f),
-        assertThat(1f).isNotSameAs(2f),
-        assertThat(1.0).isNotSameAs(2.0),
         assertThat(1.0).isNotSameAs(2.0));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJPrimitiveRulesTestOutput.java
@@ -10,40 +10,24 @@ final class AssertJPrimitiveRulesTest implements RefasterRuleCollectionTestCase 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsEqualTo() {
     return ImmutableSet.of(
         assertThat(true).isEqualTo(false),
-        assertThat(true).isEqualTo(false),
-        assertThat((byte) 1).isEqualTo((byte) 2),
         assertThat((byte) 1).isEqualTo((byte) 2),
         assertThat((char) 1).isEqualTo((char) 2),
-        assertThat((char) 1).isEqualTo((char) 2),
-        assertThat((short) 1).isEqualTo((short) 2),
         assertThat((short) 1).isEqualTo((short) 2),
         assertThat(1).isEqualTo(2),
-        assertThat(1).isEqualTo(2),
-        assertThat(1L).isEqualTo(2L),
         assertThat(1L).isEqualTo(2L),
         assertThat(1f).isEqualTo(2f),
-        assertThat(1f).isEqualTo(2f),
-        assertThat(1.0).isEqualTo(2.0),
         assertThat(1.0).isEqualTo(2.0));
   }
 
   ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsNotEqualTo() {
     return ImmutableSet.of(
         assertThat(true).isNotEqualTo(false),
-        assertThat(true).isNotEqualTo(false),
-        assertThat((byte) 1).isNotEqualTo((byte) 2),
         assertThat((byte) 1).isNotEqualTo((byte) 2),
         assertThat((char) 1).isNotEqualTo((char) 2),
-        assertThat((char) 1).isNotEqualTo((char) 2),
-        assertThat((short) 1).isNotEqualTo((short) 2),
         assertThat((short) 1).isNotEqualTo((short) 2),
         assertThat(1).isNotEqualTo(2),
-        assertThat(1).isNotEqualTo(2),
-        assertThat(1L).isNotEqualTo(2L),
         assertThat(1L).isNotEqualTo(2L),
         assertThat(1f).isNotEqualTo(2f),
-        assertThat(1f).isNotEqualTo(2f),
-        assertThat(1.0).isNotEqualTo(2.0),
         assertThat(1.0).isNotEqualTo(2.0));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJRulesTestInput.java
@@ -27,59 +27,59 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
         Collector.class, toImmutableList(), toImmutableMultiset(), toImmutableSet());
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalDouble() {
+  AbstractAssert<?, ?> testAssertThatHasValueOptionalDouble() {
     return assertThat(OptionalDouble.of(1.0).getAsDouble()).isEqualTo(2.0);
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalInt() {
+  AbstractAssert<?, ?> testAssertThatHasValueOptionalInt() {
     return assertThat(OptionalInt.of(1).getAsInt()).isEqualTo(2);
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalLong() {
+  AbstractAssert<?, ?> testAssertThatHasValueOptionalLong() {
     return assertThat(OptionalLong.of(1L).getAsLong()).isEqualTo(2L);
   }
 
-  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableContainsOneElement() {
+  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableAssertContains() {
     return ImmutableSet.of(
         assertThat(ImmutableList.of("foo")).containsAnyOf("bar"),
         assertThat(ImmutableList.of("baz")).containsSequence("qux"),
         assertThat(ImmutableList.of("quux")).containsSubsequence("corge"));
   }
 
-  ObjectEnumerableAssert<?, String> testObjectEnumerableDoesNotContainOneElement() {
+  ObjectEnumerableAssert<?, String> testObjectEnumerableAssertDoesNotContain() {
     return assertThat(ImmutableList.of("foo")).doesNotContainSequence("bar");
   }
 
-  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableContainsExactlyOneElement() {
+  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableAssertContainsExactly() {
     return ImmutableSet.of(
         assertThat(ImmutableList.of("foo")).containsExactlyInAnyOrder(new String[] {"bar"}),
         assertThat(ImmutableList.of("baz")).containsExactlyInAnyOrder("qux"));
   }
 
-  ObjectEnumerableAssert<?, String> testAssertThatSetContainsExactlyOneElement() {
+  ObjectEnumerableAssert<?, String> testAssertThatContainsExactlySet() {
     return assertThat(ImmutableSet.of("foo")).containsOnly("bar");
   }
 
-  ListAssert<String> testAssertThatListsAreEqual() {
+  ListAssert<String> testAssertThatContainsExactlyElementsOfList() {
     return assertThat(ImmutableList.of("foo")).isEqualTo(ImmutableList.of("bar"));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatSetsAreEqual() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSameElementsAsSet() {
     return ImmutableSet.of(
         assertThat(ImmutableSet.of("foo")).isEqualTo(ImmutableSet.of("bar")),
         assertThat(ImmutableSet.of("baz"))
             .containsExactlyInAnyOrderElementsOf(ImmutableSet.of("qux")));
   }
 
-  AbstractAssert<?, ?> testAssertThatMultisetsAreEqual() {
+  AbstractAssert<?, ?> testAssertThatContainsExactlyInAnyOrderElementsOfMultiset() {
     return assertThat(ImmutableMultiset.of("foo")).isEqualTo(ImmutableMultiset.of("bar"));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsEntry() {
+  AbstractAssert<?, ?> testAssertThatContainsEntry() {
     return assertThat(ImmutableMap.<String, Object>of("foo", 1).get("bar")).isEqualTo(2);
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAnyElementsOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAnyElementsOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .containsAnyElementsOf(ImmutableList.of("bar")),
@@ -89,7 +89,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsAnyElementsOf(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAnyOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAnyOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .containsAnyOf(new String[] {"bar"}),
@@ -98,7 +98,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsAnyOf(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAnyOfVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAnyOfVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .containsAnyOf("bar", "baz"),
@@ -107,7 +107,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsAnyOf("garply", "waldo"));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAll() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAll() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .containsAll(ImmutableList.of("bar")),
@@ -116,7 +116,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsAll(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContains() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContains() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .contains(new String[] {"bar"}),
@@ -124,7 +124,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Stream.of("quux").collect(toImmutableList())).contains(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .contains("bar", "baz"),
@@ -132,21 +132,21 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Stream.of("grault").collect(toImmutableList())).contains("garply", "waldo"));
   }
 
-  ListAssert<String> testAssertThatStreamContainsExactlyElementsOf() {
+  ListAssert<String> testAssertThatContainsExactlyElementsOfStream() {
     return assertThat(Stream.of("foo").collect(toImmutableList()))
         .containsExactlyElementsOf(ImmutableList.of("bar"));
   }
 
-  ListAssert<String> testAssertThatStreamContainsExactly() {
+  ListAssert<String> testAssertThatContainsExactlyStream() {
     return assertThat(Stream.of("foo").collect(toImmutableList()))
         .containsExactly(new String[] {"bar"});
   }
 
-  ListAssert<String> testAssertThatStreamContainsExactlyVarargs() {
+  ListAssert<String> testAssertThatContainsExactlyVarargs() {
     return assertThat(Stream.of("foo").collect(toImmutableList())).containsExactly("bar", "baz");
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsExactlyInAnyOrderElementsOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsExactlyInAnyOrderElementsOfStream() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect(toImmutableList()))
             .containsExactlyInAnyOrderElementsOf(ImmutableList.of("bar")),
@@ -154,7 +154,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsExactlyInAnyOrderElementsOf(ImmutableList.of("qux")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsExactlyInAnyOrder() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsExactlyInAnyOrder() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect(toImmutableList()))
             .containsExactlyInAnyOrder(new String[] {"bar"}),
@@ -162,7 +162,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsExactlyInAnyOrder(new String[] {"qux"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsExactlyInAnyOrderVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsExactlyInAnyOrderVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect(toImmutableList()))
             .containsExactlyInAnyOrder("bar", "baz"),
@@ -170,7 +170,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsExactlyInAnyOrder("quux", "corge"));
   }
 
-  ImmutableSet<ListAssert<String>> testAssertThatStreamContainsSequence() {
+  ImmutableSet<ListAssert<String>> testAssertThatContainsSequence() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect(toImmutableList()))
             .containsSequence(ImmutableList.of("bar")),
@@ -178,11 +178,11 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsSequence(new String[] {"qux"}));
   }
 
-  ListAssert<String> testAssertThatStreamContainsSequenceVarArgs() {
+  ListAssert<String> testAssertThatContainsSequenceVarargs() {
     return assertThat(Stream.of("foo").collect(toImmutableList())).containsSequence("bar", "baz");
   }
 
-  ImmutableSet<ListAssert<String>> testAssertThatStreamContainsSubsequence() {
+  ImmutableSet<ListAssert<String>> testAssertThatContainsSubsequence() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect(toImmutableList()))
             .containsSubsequence(ImmutableList.of("bar")),
@@ -190,12 +190,12 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsSubsequence(new String[] {"qux"}));
   }
 
-  ListAssert<String> testAssertThatStreamContainsSubsequenceVarArgs() {
+  ListAssert<String> testAssertThatContainsSubsequenceVarargs() {
     return assertThat(Stream.of("foo").collect(toImmutableList()))
         .containsSubsequence("bar", "baz");
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamDoesNotContainAnyElementsOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainAnyElementsOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .doesNotContainAnyElementsOf(ImmutableList.of("bar")),
@@ -205,7 +205,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .doesNotContainAnyElementsOf(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamDoesNotContain() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContain() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .doesNotContain(new String[] {"bar"}),
@@ -214,7 +214,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .doesNotContain(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamDoesNotContainVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .doesNotContain("bar", "baz"),
@@ -223,7 +223,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .doesNotContain("garply", "waldo"));
   }
 
-  ImmutableSet<ListAssert<String>> testAssertThatStreamDoesNotContainSequence() {
+  ImmutableSet<ListAssert<String>> testAssertThatDoesNotContainSequence() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect(toImmutableList()))
             .doesNotContainSequence(ImmutableList.of("bar")),
@@ -231,12 +231,12 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .doesNotContainSequence(new String[] {"qux"}));
   }
 
-  ListAssert<String> testAssertThatStreamDoesNotContainSequenceVarArgs() {
+  ListAssert<String> testAssertThatDoesNotContainSequenceVarargs() {
     return assertThat(Stream.of("foo").collect(toImmutableList()))
         .doesNotContainSequence("bar", "baz");
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamHasSameElementsAs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSameElementsAsStream() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .hasSameElementsAs(ImmutableList.of("bar")),
@@ -246,7 +246,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .hasSameElementsAs(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsOnly() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsOnly() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .containsOnly(new String[] {"bar"}),
@@ -255,7 +255,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .containsOnly(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsOnlyVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsOnlyVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .containsOnly("bar", "baz"),
@@ -263,7 +263,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Stream.of("grault").collect(toImmutableList())).containsOnly("garply", "waldo"));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamIsSubsetOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsSubsetOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .isSubsetOf(ImmutableList.of("bar")),
@@ -279,7 +279,7 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
             .isSubsetOf(new String[] {"xyzzy"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamIsSubsetOfVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsSubsetOfVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo").collect((Collector<String, Object, Iterable<String>>) null))
             .isSubsetOf("bar", "baz"),
@@ -287,11 +287,11 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Stream.of("grault").collect(toImmutableList())).isSubsetOf("garply", "waldo"));
   }
 
-  void testAssertThatPredicateAccepts() {
+  void testAssertThatAccepts() {
     assertThat(((Predicate<String>) String::isEmpty).test("foo")).isTrue();
   }
 
-  void testAssertThatPredicateRejects() {
+  void testAssertThatRejects() {
     assertThat(((Predicate<String>) String::isEmpty).test("foo")).isFalse();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJRulesTestOutput.java
@@ -27,203 +27,203 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
         Collector.class, toImmutableList(), toImmutableMultiset(), toImmutableSet());
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalDouble() {
+  AbstractAssert<?, ?> testAssertThatHasValueOptionalDouble() {
     return assertThat(OptionalDouble.of(1.0)).hasValue(2.0);
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalInt() {
+  AbstractAssert<?, ?> testAssertThatHasValueOptionalInt() {
     return assertThat(OptionalInt.of(1)).hasValue(2);
   }
 
-  AbstractAssert<?, ?> testAssertThatOptionalLong() {
+  AbstractAssert<?, ?> testAssertThatHasValueOptionalLong() {
     return assertThat(OptionalLong.of(1L)).hasValue(2L);
   }
 
-  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableContainsOneElement() {
+  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableAssertContains() {
     return ImmutableSet.of(
         assertThat(ImmutableList.of("foo")).contains("bar"),
         assertThat(ImmutableList.of("baz")).contains("qux"),
         assertThat(ImmutableList.of("quux")).contains("corge"));
   }
 
-  ObjectEnumerableAssert<?, String> testObjectEnumerableDoesNotContainOneElement() {
+  ObjectEnumerableAssert<?, String> testObjectEnumerableAssertDoesNotContain() {
     return assertThat(ImmutableList.of("foo")).doesNotContain("bar");
   }
 
-  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableContainsExactlyOneElement() {
+  ImmutableSet<ObjectEnumerableAssert<?, String>> testObjectEnumerableAssertContainsExactly() {
     return ImmutableSet.of(
         assertThat(ImmutableList.of("foo")).containsExactlyInAnyOrder(new String[] {"bar"}),
         assertThat(ImmutableList.of("baz")).containsExactly("qux"));
   }
 
-  ObjectEnumerableAssert<?, String> testAssertThatSetContainsExactlyOneElement() {
+  ObjectEnumerableAssert<?, String> testAssertThatContainsExactlySet() {
     return assertThat(ImmutableSet.of("foo")).containsExactly("bar");
   }
 
-  ListAssert<String> testAssertThatListsAreEqual() {
+  ListAssert<String> testAssertThatContainsExactlyElementsOfList() {
     return assertThat(ImmutableList.of("foo")).containsExactlyElementsOf(ImmutableList.of("bar"));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatSetsAreEqual() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSameElementsAsSet() {
     return ImmutableSet.of(
         assertThat(ImmutableSet.of("foo")).hasSameElementsAs(ImmutableSet.of("bar")),
         assertThat(ImmutableSet.of("baz")).hasSameElementsAs(ImmutableSet.of("qux")));
   }
 
-  AbstractAssert<?, ?> testAssertThatMultisetsAreEqual() {
+  AbstractAssert<?, ?> testAssertThatContainsExactlyInAnyOrderElementsOfMultiset() {
     return assertThat(ImmutableMultiset.of("foo"))
         .containsExactlyInAnyOrderElementsOf(ImmutableMultiset.of("bar"));
   }
 
-  AbstractAssert<?, ?> testAssertThatMapContainsEntry() {
+  AbstractAssert<?, ?> testAssertThatContainsEntry() {
     return assertThat(ImmutableMap.<String, Object>of("foo", 1)).containsEntry("bar", 2);
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAnyElementsOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAnyElementsOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsAnyElementsOf(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).containsAnyElementsOf(ImmutableList.of("qux")),
         assertThat(Stream.of("quux")).containsAnyElementsOf(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAnyOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAnyOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsAnyOf(new String[] {"bar"}),
         assertThat(Stream.of("baz")).containsAnyOf(new String[] {"qux"}),
         assertThat(Stream.of("quux")).containsAnyOf(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAnyOfVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAnyOfVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsAnyOf("bar", "baz"),
         assertThat(Stream.of("qux")).containsAnyOf("quux", "corge"),
         assertThat(Stream.of("grault")).containsAnyOf("garply", "waldo"));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsAll() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsAll() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsAll(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).containsAll(ImmutableList.of("qux")),
         assertThat(Stream.of("quux")).containsAll(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContains() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContains() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).contains(new String[] {"bar"}),
         assertThat(Stream.of("baz")).contains(new String[] {"qux"}),
         assertThat(Stream.of("quux")).contains(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).contains("bar", "baz"),
         assertThat(Stream.of("qux")).contains("quux", "corge"),
         assertThat(Stream.of("grault")).contains("garply", "waldo"));
   }
 
-  ListAssert<String> testAssertThatStreamContainsExactlyElementsOf() {
+  ListAssert<String> testAssertThatContainsExactlyElementsOfStream() {
     return assertThat(Stream.of("foo")).containsExactlyElementsOf(ImmutableList.of("bar"));
   }
 
-  ListAssert<String> testAssertThatStreamContainsExactly() {
+  ListAssert<String> testAssertThatContainsExactlyStream() {
     return assertThat(Stream.of("foo")).containsExactly(new String[] {"bar"});
   }
 
-  ListAssert<String> testAssertThatStreamContainsExactlyVarargs() {
+  ListAssert<String> testAssertThatContainsExactlyVarargs() {
     return assertThat(Stream.of("foo")).containsExactly("bar", "baz");
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsExactlyInAnyOrderElementsOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsExactlyInAnyOrderElementsOfStream() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsExactlyInAnyOrderElementsOf(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).containsExactlyInAnyOrderElementsOf(ImmutableList.of("qux")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsExactlyInAnyOrder() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsExactlyInAnyOrder() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsExactlyInAnyOrder(new String[] {"bar"}),
         assertThat(Stream.of("baz")).containsExactlyInAnyOrder(new String[] {"qux"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsExactlyInAnyOrderVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsExactlyInAnyOrderVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsExactlyInAnyOrder("bar", "baz"),
         assertThat(Stream.of("qux")).containsExactlyInAnyOrder("quux", "corge"));
   }
 
-  ImmutableSet<ListAssert<String>> testAssertThatStreamContainsSequence() {
+  ImmutableSet<ListAssert<String>> testAssertThatContainsSequence() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsSequence(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).containsSequence(new String[] {"qux"}));
   }
 
-  ListAssert<String> testAssertThatStreamContainsSequenceVarArgs() {
+  ListAssert<String> testAssertThatContainsSequenceVarargs() {
     return assertThat(Stream.of("foo")).containsSequence("bar", "baz");
   }
 
-  ImmutableSet<ListAssert<String>> testAssertThatStreamContainsSubsequence() {
+  ImmutableSet<ListAssert<String>> testAssertThatContainsSubsequence() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsSubsequence(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).containsSubsequence(new String[] {"qux"}));
   }
 
-  ListAssert<String> testAssertThatStreamContainsSubsequenceVarArgs() {
+  ListAssert<String> testAssertThatContainsSubsequenceVarargs() {
     return assertThat(Stream.of("foo")).containsSubsequence("bar", "baz");
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamDoesNotContainAnyElementsOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainAnyElementsOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).doesNotContainAnyElementsOf(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).doesNotContainAnyElementsOf(ImmutableList.of("qux")),
         assertThat(Stream.of("quux")).doesNotContainAnyElementsOf(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamDoesNotContain() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContain() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).doesNotContain(new String[] {"bar"}),
         assertThat(Stream.of("baz")).doesNotContain(new String[] {"qux"}),
         assertThat(Stream.of("quux")).doesNotContain(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamDoesNotContainVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatDoesNotContainVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).doesNotContain("bar", "baz"),
         assertThat(Stream.of("qux")).doesNotContain("quux", "corge"),
         assertThat(Stream.of("grault")).doesNotContain("garply", "waldo"));
   }
 
-  ImmutableSet<ListAssert<String>> testAssertThatStreamDoesNotContainSequence() {
+  ImmutableSet<ListAssert<String>> testAssertThatDoesNotContainSequence() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).doesNotContainSequence(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).doesNotContainSequence(new String[] {"qux"}));
   }
 
-  ListAssert<String> testAssertThatStreamDoesNotContainSequenceVarArgs() {
+  ListAssert<String> testAssertThatDoesNotContainSequenceVarargs() {
     return assertThat(Stream.of("foo")).doesNotContainSequence("bar", "baz");
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamHasSameElementsAs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatHasSameElementsAsStream() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).hasSameElementsAs(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).hasSameElementsAs(ImmutableList.of("qux")),
         assertThat(Stream.of("quux")).hasSameElementsAs(ImmutableList.of("corge")));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsOnly() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsOnly() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsOnly(new String[] {"bar"}),
         assertThat(Stream.of("baz")).containsOnly(new String[] {"qux"}),
         assertThat(Stream.of("quux")).containsOnly(new String[] {"corge"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamContainsOnlyVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatContainsOnlyVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).containsOnly("bar", "baz"),
         assertThat(Stream.of("qux")).containsOnly("quux", "corge"),
         assertThat(Stream.of("grault")).containsOnly("garply", "waldo"));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamIsSubsetOf() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsSubsetOf() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).isSubsetOf(ImmutableList.of("bar")),
         assertThat(Stream.of("baz")).isSubsetOf(new String[] {"qux"}),
@@ -233,18 +233,18 @@ final class AssertJRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Stream.of("plugh")).isSubsetOf(new String[] {"xyzzy"}));
   }
 
-  ImmutableSet<AbstractAssert<?, ?>> testAssertThatStreamIsSubsetOfVarArgs() {
+  ImmutableSet<AbstractAssert<?, ?>> testAssertThatIsSubsetOfVarargs() {
     return ImmutableSet.of(
         assertThat(Stream.of("foo")).isSubsetOf("bar", "baz"),
         assertThat(Stream.of("qux")).isSubsetOf("quux", "corge"),
         assertThat(Stream.of("grault")).isSubsetOf("garply", "waldo"));
   }
 
-  void testAssertThatPredicateAccepts() {
+  void testAssertThatAccepts() {
     assertThat(((Predicate<String>) String::isEmpty)).accepts("foo");
   }
 
-  void testAssertThatPredicateRejects() {
+  void testAssertThatRejects() {
     assertThat(((Predicate<String>) String::isEmpty)).rejects("foo");
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJShortRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJShortRulesTestInput.java
@@ -16,25 +16,25 @@ final class AssertJShortRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<AbstractShortAssert<?>> testAbstractShortAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat((short) 0).isCloseTo((short) 1, offset((short) 0)),
-        assertThat((short) 0).isCloseTo((short) 1, withPercentage(0)));
+        assertThat((short) 1).isCloseTo((short) 2, offset((short) 0)),
+        assertThat((short) 1).isCloseTo((short) 2, withPercentage(0)));
   }
 
   ImmutableSet<AbstractShortAssert<?>> testAbstractShortAssertIsNotEqualTo() {
     return ImmutableSet.of(
-        assertThat((short) 0).isNotCloseTo((short) 1, offset((short) 0)),
-        assertThat((short) 0).isNotCloseTo((short) 1, withPercentage(0)));
+        assertThat((short) 1).isNotCloseTo((short) 2, offset((short) 0)),
+        assertThat((short) 1).isNotCloseTo((short) 2, withPercentage(0)));
   }
 
-  AbstractShortAssert<?> testAbstractShortAssertIsZero() {
-    return assertThat((short) 0).isZero();
+  AbstractShortAssert<?> testAbstractShortAssertIsEqualToZero() {
+    return assertThat((short) 1).isZero();
   }
 
-  AbstractShortAssert<?> testAbstractShortAssertIsNotZero() {
-    return assertThat((short) 0).isNotZero();
+  AbstractShortAssert<?> testAbstractShortAssertIsNotEqualToZero() {
+    return assertThat((short) 1).isNotZero();
   }
 
-  AbstractShortAssert<?> testAbstractShortAssertIsOne() {
-    return assertThat((short) 0).isOne();
+  AbstractShortAssert<?> testAbstractShortAssertIsEqualToOne() {
+    return assertThat((short) 1).isOne();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJShortRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJShortRulesTestOutput.java
@@ -16,24 +16,24 @@ final class AssertJShortRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<AbstractShortAssert<?>> testAbstractShortAssertIsEqualTo() {
     return ImmutableSet.of(
-        assertThat((short) 0).isEqualTo((short) 1), assertThat((short) 0).isEqualTo((short) 1));
+        assertThat((short) 1).isEqualTo((short) 2), assertThat((short) 1).isEqualTo((short) 2));
   }
 
   ImmutableSet<AbstractShortAssert<?>> testAbstractShortAssertIsNotEqualTo() {
     return ImmutableSet.of(
-        assertThat((short) 0).isNotEqualTo((short) 1),
-        assertThat((short) 0).isNotEqualTo((short) 1));
+        assertThat((short) 1).isNotEqualTo((short) 2),
+        assertThat((short) 1).isNotEqualTo((short) 2));
   }
 
-  AbstractShortAssert<?> testAbstractShortAssertIsZero() {
-    return assertThat((short) 0).isEqualTo((short) 0);
+  AbstractShortAssert<?> testAbstractShortAssertIsEqualToZero() {
+    return assertThat((short) 1).isEqualTo((short) 0);
   }
 
-  AbstractShortAssert<?> testAbstractShortAssertIsNotZero() {
-    return assertThat((short) 0).isNotEqualTo((short) 0);
+  AbstractShortAssert<?> testAbstractShortAssertIsNotEqualToZero() {
+    return assertThat((short) 1).isNotEqualTo((short) 0);
   }
 
-  AbstractShortAssert<?> testAbstractShortAssertIsOne() {
-    return assertThat((short) 0).isEqualTo((short) 1);
+  AbstractShortAssert<?> testAbstractShortAssertIsEqualToOne() {
+    return assertThat((short) 1).isEqualTo((short) 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStreamRulesTestInput.java
@@ -67,7 +67,7 @@ final class AssertJStreamRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Stream.of(5).noneMatch(i -> i > 6)).isFalse());
   }
 
-  AbstractAssert<?, ?> testAssertThatCollection() {
+  AbstractAssert<?, ?> testAssertThat() {
     return assertThat(ImmutableSet.of("foo").stream());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStreamRulesTestOutput.java
@@ -66,7 +66,7 @@ final class AssertJStreamRulesTest implements RefasterRuleCollectionTestCase {
         assertThat(Stream.of(5)).anyMatch(i -> i > 6));
   }
 
-  AbstractAssert<?, ?> testAssertThatCollection() {
+  AbstractAssert<?, ?> testAssertThat() {
     return assertThat(ImmutableSet.of("foo"));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestInput.java
@@ -17,35 +17,35 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Files.class);
   }
 
-  void testAbstractStringAssertStringIsEmpty() {
+  void testAbstractStringAssertIsEmpty() {
     assertThat("foo").isEqualTo("");
   }
 
-  AbstractStringAssert<?> testAbstractStringAssertStringIsNotEmpty() {
+  AbstractStringAssert<?> testAbstractStringAssertIsNotEmpty() {
     return assertThat("foo").isNotEqualTo("");
   }
 
-  AbstractAssert<?, ?> testAssertThatStringStartsWith() {
+  AbstractAssert<?, ?> testAssertThatStartsWith() {
     return assertThat("foo".startsWith("bar")).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatStringDoesNotStartWith() {
+  AbstractAssert<?, ?> testAssertThatDoesNotStartWith() {
     return assertThat("foo".startsWith("bar")).isFalse();
   }
 
-  AbstractAssert<?, ?> testAssertThatStringEndsWith() {
+  AbstractAssert<?, ?> testAssertThatEndsWith() {
     return assertThat("foo".endsWith("bar")).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatStringDoesNotEndWith() {
+  AbstractAssert<?, ?> testAssertThatDoesNotEndWith() {
     return assertThat("foo".endsWith("bar")).isFalse();
   }
 
-  AbstractAssert<?, ?> testAssertThatStringContains() {
+  AbstractAssert<?, ?> testAssertThatContains() {
     return assertThat("foo".contains("bar")).isTrue();
   }
 
-  AbstractAssert<?, ?> testAssertThatStringDoesNotContain() {
+  AbstractAssert<?, ?> testAssertThatDoesNotContain() {
     return assertThat("foo".contains("bar")).isFalse();
   }
 
@@ -66,18 +66,18 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   AbstractAssert<?, ?> testAssertThatMatches() {
-    return assertThat("foo".matches(".*")).isTrue();
+    return assertThat("foo".matches("bar")).isTrue();
   }
 
   AbstractAssert<?, ?> testAssertThatDoesNotMatch() {
-    return assertThat("foo".matches(".*")).isFalse();
+    return assertThat("foo".matches("bar")).isFalse();
   }
 
-  AbstractStringAssert<?> testAssertThatPathContent() throws IOException {
+  AbstractStringAssert<?> testAssertThatContent() throws IOException {
     return assertThat(Files.readString(Paths.get(""), Charset.defaultCharset()));
   }
 
-  AbstractStringAssert<?> testAssertThatPathContentUtf8() throws IOException {
+  AbstractStringAssert<?> testAssertThatContentUtf8() throws IOException {
     return assertThat(Files.readString(Paths.get("")));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJStringRulesTestOutput.java
@@ -18,35 +18,35 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Files.class);
   }
 
-  void testAbstractStringAssertStringIsEmpty() {
+  void testAbstractStringAssertIsEmpty() {
     assertThat("foo").isEmpty();
   }
 
-  AbstractStringAssert<?> testAbstractStringAssertStringIsNotEmpty() {
+  AbstractStringAssert<?> testAbstractStringAssertIsNotEmpty() {
     return assertThat("foo").isNotEmpty();
   }
 
-  AbstractAssert<?, ?> testAssertThatStringStartsWith() {
+  AbstractAssert<?, ?> testAssertThatStartsWith() {
     return assertThat("foo").startsWith("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatStringDoesNotStartWith() {
+  AbstractAssert<?, ?> testAssertThatDoesNotStartWith() {
     return assertThat("foo").doesNotStartWith("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatStringEndsWith() {
+  AbstractAssert<?, ?> testAssertThatEndsWith() {
     return assertThat("foo").endsWith("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatStringDoesNotEndWith() {
+  AbstractAssert<?, ?> testAssertThatDoesNotEndWith() {
     return assertThat("foo").doesNotEndWith("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatStringContains() {
+  AbstractAssert<?, ?> testAssertThatContains() {
     return assertThat("foo").contains("bar");
   }
 
-  AbstractAssert<?, ?> testAssertThatStringDoesNotContain() {
+  AbstractAssert<?, ?> testAssertThatDoesNotContain() {
     return assertThat("foo").doesNotContain("bar");
   }
 
@@ -67,18 +67,18 @@ final class AssertJStringRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   AbstractAssert<?, ?> testAssertThatMatches() {
-    return assertThat("foo").matches(".*");
+    return assertThat("foo").matches("bar");
   }
 
   AbstractAssert<?, ?> testAssertThatDoesNotMatch() {
-    return assertThat("foo").doesNotMatch(".*");
+    return assertThat("foo").doesNotMatch("bar");
   }
 
-  AbstractStringAssert<?> testAssertThatPathContent() throws IOException {
+  AbstractStringAssert<?> testAssertThatContent() throws IOException {
     return assertThat(Paths.get("")).content(Charset.defaultCharset());
   }
 
-  AbstractStringAssert<?> testAssertThatPathContentUtf8() throws IOException {
+  AbstractStringAssert<?> testAssertThatContentUtf8() throws IOException {
     return assertThat(Paths.get("")).content(UTF_8);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestInput.java
@@ -32,128 +32,148 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     assertThatThrownBy(() -> {}).asInstanceOf(type(IllegalArgumentException.class));
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass() {
     return assertThatIllegalArgumentException().isThrownBy(() -> {});
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessage() {
     return assertThatIllegalArgumentException().isThrownBy(() -> {}).withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassRootCauseHasMessage() {
     return assertThatIllegalArgumentException()
         .isThrownBy(() -> {})
         .havingRootCause()
         .withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageVarargs() {
     return assertThatIllegalArgumentException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
   }
 
   AbstractObjectAssert<?, ?>
-      testAssertThatThrownByIllegalArgumentExceptionHasMessageStartingWith() {
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageStartingWith() {
     return assertThatIllegalArgumentException().isThrownBy(() -> {}).withMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageContaining() {
     return assertThatIllegalArgumentException().isThrownBy(() -> {}).withMessageContaining("foo");
   }
 
   AbstractObjectAssert<?, ?>
-      testAssertThatThrownByIllegalArgumentExceptionHasMessageNotContainingAny() {
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageNotContainingAny() {
     return assertThatIllegalArgumentException()
         .isThrownBy(() -> {})
         .withMessageNotContainingAny("foo", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIllegalStateExceptionClass() {
     return assertThatIllegalStateException().isThrownBy(() -> {});
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessage() {
     return assertThatIllegalStateException().isThrownBy(() -> {}).withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassRootCauseHasMessage() {
     return assertThatIllegalStateException()
         .isThrownBy(() -> {})
         .havingRootCause()
         .withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageVarargs() {
     return assertThatIllegalStateException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageStartingWith() {
     return assertThatIllegalStateException().isThrownBy(() -> {}).withMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageContaining() {
     return assertThatIllegalStateException().isThrownBy(() -> {}).withMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageNotContaining() {
     return assertThatIllegalStateException().isThrownBy(() -> {}).withMessageNotContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfNullPointerExceptionClass() {
     return assertThatNullPointerException().isThrownBy(() -> {});
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessage() {
     return assertThatNullPointerException().isThrownBy(() -> {}).withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassRootCauseHasMessage() {
     return assertThatNullPointerException()
         .isThrownBy(() -> {})
         .havingRootCause()
         .withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageVarargs() {
     return assertThatNullPointerException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageStartingWith() {
     return assertThatNullPointerException().isThrownBy(() -> {}).withMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageContaining() {
     return assertThatNullPointerException().isThrownBy(() -> {}).withMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageNotContaining() {
     return assertThatNullPointerException().isThrownBy(() -> {}).withMessageNotContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIOExceptionClass() {
     return assertThatIOException().isThrownBy(() -> {});
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessage() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessage() {
     return assertThatIOException().isThrownBy(() -> {}).withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassRootCauseHasMessage() {
     return assertThatIOException().isThrownBy(() -> {}).havingRootCause().withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageVarargs() {
     return assertThatIOException().isThrownBy(() -> {}).withMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageStartingWith() {
     return assertThatIOException().isThrownBy(() -> {}).withMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageContaining() {
     return assertThatIOException().isThrownBy(() -> {}).withMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageNotContaining() {
     return assertThatIOException().isThrownBy(() -> {}).withMessageNotContaining("foo");
   }
 
@@ -161,38 +181,38 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> {});
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessage() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessage() {
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
         .withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfRootCauseHasMessage() {
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
         .havingRootCause()
         .withMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageParameters() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageVarargs() {
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
         .withMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageStartingWith() {
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
         .withMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageContaining() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageContaining() {
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
         .withMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageNotContaining() {
     return assertThatExceptionOfType(IllegalArgumentException.class)
         .isThrownBy(() -> {})
         .withMessageNotContaining("foo");

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssertJThrowingCallableRulesTestOutput.java
@@ -33,157 +33,177 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     assertThatThrownBy(() -> {}).isInstanceOf(IllegalArgumentException.class);
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClass() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IllegalArgumentException.class);
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassRootCauseHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .rootCause()
         .hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageVarargs() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("foo %s", "bar");
   }
 
   AbstractObjectAssert<?, ?>
-      testAssertThatThrownByIllegalArgumentExceptionHasMessageStartingWith() {
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageStartingWith() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalArgumentExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("foo");
   }
 
   AbstractObjectAssert<?, ?>
-      testAssertThatThrownByIllegalArgumentExceptionHasMessageNotContainingAny() {
+      testAssertThatThrownByIsInstanceOfIllegalArgumentExceptionClassHasMessageNotContainingAny() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageNotContainingAny("foo", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIllegalStateExceptionClass() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class);
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessage() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class).hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassRootCauseHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalStateException.class)
         .rootCause()
         .hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageVarargs() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalStateException.class)
         .hasMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageStartingWith() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalStateException.class)
         .hasMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalStateException.class)
         .hasMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIllegalStateExceptionHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIllegalStateExceptionClassHasMessageNotContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalStateException.class)
         .hasMessageNotContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfNullPointerExceptionClass() {
     return assertThatThrownBy(() -> {}).isInstanceOf(NullPointerException.class);
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessage() {
     return assertThatThrownBy(() -> {}).isInstanceOf(NullPointerException.class).hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassRootCauseHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(NullPointerException.class)
         .rootCause()
         .hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageVarargs() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(NullPointerException.class)
         .hasMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageStartingWith() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(NullPointerException.class)
         .hasMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(NullPointerException.class)
         .hasMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByNullPointerExceptionHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfNullPointerExceptionClassHasMessageNotContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(NullPointerException.class)
         .hasMessageNotContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOException() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIOExceptionClass() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class);
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessage() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessage() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class).hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassRootCauseHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IOException.class)
         .rootCause()
         .hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageParameters() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageVarargs() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class).hasMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageStartingWith() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IOException.class)
         .hasMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageContaining() {
     return assertThatThrownBy(() -> {}).isInstanceOf(IOException.class).hasMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByIOExceptionHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?>
+      testAssertThatThrownByIsInstanceOfIOExceptionClassHasMessageNotContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IOException.class)
         .hasMessageNotContaining("foo");
@@ -193,38 +213,38 @@ final class AssertJThrowingCallableRulesTest implements RefasterRuleCollectionTe
     return assertThatThrownBy(() -> {}).asInstanceOf(throwable(IllegalArgumentException.class));
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessage() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByRootCauseHasMessage() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfRootCauseHasMessage() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .rootCause()
         .hasMessage("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageParameters() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageVarargs() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessage("foo %s", "bar");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageStartingWith() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageStartingWith() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageStartingWith("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageContaining() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageContaining("foo");
   }
 
-  AbstractObjectAssert<?, ?> testAssertThatThrownByHasMessageNotContaining() {
+  AbstractObjectAssert<?, ?> testAssertThatThrownByIsInstanceOfHasMessageNotContaining() {
     return assertThatThrownBy(() -> {})
         .isInstanceOf(IllegalArgumentException.class)
         .hasMessageNotContaining("foo");

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssortedRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssortedRulesTestInput.java
@@ -15,17 +15,17 @@ final class AssortedRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Iterables.class, Preconditions.class, Splitter.class, Streams.class);
   }
 
-  int testCheckIndex() {
+  int testCheckIndexExpression() {
     return Preconditions.checkElementIndex(0, 1);
   }
 
-  void testCheckIndexConditional() {
+  void testCheckIndexBlock() {
     if (1 < 0 || 1 >= 2) {
       throw new IndexOutOfBoundsException();
     }
   }
 
-  ImmutableSet<String> testIteratorGetNextOrDefault() {
+  ImmutableSet<String> testIteratorsGetNext() {
     return ImmutableSet.of(
         ImmutableList.of("a").iterator().hasNext()
             ? ImmutableList.of("a").iterator().next()
@@ -35,7 +35,7 @@ final class AssortedRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   // XXX: Only the first statement is rewritten. Make smarter.
-  ImmutableSet<Boolean> testLogicalImplication() {
+  ImmutableSet<Boolean> testOr() {
     return ImmutableSet.of(
         toString().isEmpty() || (!toString().isEmpty() && Boolean.TRUE),
         !toString().isEmpty() || (toString().isEmpty() && Boolean.TRUE),
@@ -43,15 +43,15 @@ final class AssortedRulesTest implements RefasterRuleCollectionTestCase {
         3 >= 4 || (3 < 4 && Boolean.TRUE));
   }
 
-  Stream<String> testUnboundedSingleElementStream() {
+  Stream<String> testStreamGenerate() {
     return Streams.stream(Iterables.cycle("foo"));
   }
 
-  boolean testIterableIsEmpty() {
+  boolean testIterablesIsEmpty() {
     return !ImmutableList.of().iterator().hasNext();
   }
 
-  ImmutableSet<Stream<String>> testSplitToStream() {
+  ImmutableSet<Stream<String>> testSplitterSplitToStream() {
     return ImmutableSet.of(
         Streams.stream(Splitter.on(':').split("foo")),
         Splitter.on(',').splitToList(new StringBuilder("bar")).stream());

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssortedRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/AssortedRulesTestOutput.java
@@ -18,15 +18,15 @@ final class AssortedRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Iterables.class, Preconditions.class, Splitter.class, Streams.class);
   }
 
-  int testCheckIndex() {
+  int testCheckIndexExpression() {
     return checkIndex(0, 1);
   }
 
-  void testCheckIndexConditional() {
+  void testCheckIndexBlock() {
     checkIndex(1, 2);
   }
 
-  ImmutableSet<String> testIteratorGetNextOrDefault() {
+  ImmutableSet<String> testIteratorsGetNext() {
     return ImmutableSet.of(
         Iterators.getNext(ImmutableList.of("a").iterator(), "foo"),
         Iterators.getNext(ImmutableList.of("b").iterator(), "bar"),
@@ -34,7 +34,7 @@ final class AssortedRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   // XXX: Only the first statement is rewritten. Make smarter.
-  ImmutableSet<Boolean> testLogicalImplication() {
+  ImmutableSet<Boolean> testOr() {
     return ImmutableSet.of(
         toString().isEmpty() || Boolean.TRUE,
         !toString().isEmpty() || (toString().isEmpty() && Boolean.TRUE),
@@ -42,15 +42,15 @@ final class AssortedRulesTest implements RefasterRuleCollectionTestCase {
         3 >= 4 || (3 < 4 && Boolean.TRUE));
   }
 
-  Stream<String> testUnboundedSingleElementStream() {
+  Stream<String> testStreamGenerate() {
     return Stream.generate(() -> "foo");
   }
 
-  boolean testIterableIsEmpty() {
+  boolean testIterablesIsEmpty() {
     return Iterables.isEmpty(ImmutableList.of());
   }
 
-  ImmutableSet<Stream<String>> testSplitToStream() {
+  ImmutableSet<Stream<String>> testSplitterSplitToStream() {
     return ImmutableSet.of(
         Splitter.on(':').splitToStream("foo"),
         Splitter.on(',').splitToStream(new StringBuilder("bar")));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestInput.java
@@ -22,10 +22,10 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<BigDecimal> testBigDecimalValueOf() {
-    return ImmutableSet.of(new BigDecimal(2), new BigDecimal(2L), new BigDecimal(2.0));
+    return ImmutableSet.of(new BigDecimal(1), new BigDecimal(2L), new BigDecimal(3.0));
   }
 
-  ImmutableSet<Boolean> testBigDecimalSignumIsZero() {
+  ImmutableSet<Boolean> testBigDecimalSignumEqualToZero() {
     return ImmutableSet.of(
         BigDecimal.valueOf(1).compareTo(BigDecimal.ZERO) == 0,
         BigDecimal.ZERO.compareTo(BigDecimal.valueOf(2)) == 0,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BigDecimalRulesTestOutput.java
@@ -22,10 +22,10 @@ final class BigDecimalRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<BigDecimal> testBigDecimalValueOf() {
-    return ImmutableSet.of(BigDecimal.valueOf(2), BigDecimal.valueOf(2L), BigDecimal.valueOf(2.0));
+    return ImmutableSet.of(BigDecimal.valueOf(1), BigDecimal.valueOf(2L), BigDecimal.valueOf(3.0));
   }
 
-  ImmutableSet<Boolean> testBigDecimalSignumIsZero() {
+  ImmutableSet<Boolean> testBigDecimalSignumEqualToZero() {
     return ImmutableSet.of(
         BigDecimal.valueOf(1).signum() == 0,
         BigDecimal.valueOf(2).signum() == 0,

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestInput.java
@@ -31,14 +31,16 @@ final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
         .addOutputLines("A.java", "class A {}");
   }
 
-  ImmutableSet<String> testConstantsFormat() {
+  ImmutableSet<String> testSourceCodeToStringConstantExpression() {
     return ImmutableSet.of(Constants.format("foo"), "\"%s\"".formatted(Convert.quote("bar")));
   }
 
   ImmutableSet<Boolean> testNameContentEquals() {
     return ImmutableSet.of(
         ((Name) null).toString().equals("foo".subSequence(0, 1).toString()),
-        ((com.sun.tools.javac.util.Name) null).toString().equals("bar"));
+        "bar".subSequence(0, 1).toString().equals(((Name) null).toString()),
+        ((com.sun.tools.javac.util.Name) null).toString().equals("bar"),
+        "qux".equals(((com.sun.tools.javac.util.Name) null).toString()));
   }
 
   int testASTHelpersGetStartPosition() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/BugCheckerRulesTestOutput.java
@@ -31,7 +31,7 @@ final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
         .expectUnchanged();
   }
 
-  ImmutableSet<String> testConstantsFormat() {
+  ImmutableSet<String> testSourceCodeToStringConstantExpression() {
     return ImmutableSet.of(
         SourceCode.toStringConstantExpression("foo", /* REPLACEME */ null),
         SourceCode.toStringConstantExpression("bar", /* REPLACEME */ null));
@@ -40,7 +40,9 @@ final class BugCheckerRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Boolean> testNameContentEquals() {
     return ImmutableSet.of(
         ((Name) null).contentEquals("foo".subSequence(0, 1)),
-        ((com.sun.tools.javac.util.Name) null).contentEquals("bar"));
+        ((Name) null).contentEquals("bar".subSequence(0, 1)),
+        ((com.sun.tools.javac.util.Name) null).contentEquals("bar"),
+        ((com.sun.tools.javac.util.Name) null).contentEquals("qux"));
   }
 
   int testASTHelpersGetStartPosition() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestInput.java
@@ -6,11 +6,11 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class CharSequenceRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Boolean> testCharSequenceIsEmpty() {
     return ImmutableSet.of(
-        new StringBuilder("foo").length() == 0,
-        new StringBuilder("bar").length() <= 0,
-        new StringBuilder("baz").length() < 1,
-        new StringBuilder("qux").length() != 0,
-        new StringBuilder("quux").length() > 0,
-        new StringBuilder("corge").length() >= 1);
+        "foo".length() == 0,
+        "bar".length() <= 0,
+        "baz".length() < 1,
+        "qux".length() != 0,
+        "quux".length() > 0,
+        "corge".length() >= 1);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CharSequenceRulesTestOutput.java
@@ -6,11 +6,11 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class CharSequenceRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Boolean> testCharSequenceIsEmpty() {
     return ImmutableSet.of(
-        new StringBuilder("foo").isEmpty(),
-        new StringBuilder("bar").isEmpty(),
-        new StringBuilder("baz").isEmpty(),
-        !new StringBuilder("qux").isEmpty(),
-        !new StringBuilder("quux").isEmpty(),
-        !new StringBuilder("corge").isEmpty());
+        "foo".isEmpty(),
+        "bar".isEmpty(),
+        "baz".isEmpty(),
+        !"qux".isEmpty(),
+        !"quux".isEmpty(),
+        !"corge".isEmpty());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestInput.java
@@ -1,30 +1,28 @@
 package tech.picnic.errorprone.refasterrules;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class ClassRulesTest implements RefasterRuleCollectionTestCase {
-  boolean testClassIsInstance() {
+  boolean testClassIsInstanceWithClassAndObject() {
     return CharSequence.class.isAssignableFrom("foo".getClass());
   }
 
-  ImmutableSet<Boolean> testInstanceof() {
-    Class<?> clazz = CharSequence.class;
-    return ImmutableSet.of(CharSequence.class.isInstance("foo"), clazz.isInstance("bar"));
+  boolean testRefasterIsInstance() {
+    return CharSequence.class.isInstance("foo");
   }
 
-  Predicate<String> testClassLiteralIsInstancePredicate() {
+  Predicate<String> testClassIsInstance() {
     return s -> s instanceof CharSequence;
   }
 
-  Predicate<String> testClassReferenceIsInstancePredicate() {
+  Predicate<String> testClassIsInstanceWithClass() {
     Class<?> clazz = CharSequence.class;
     return s -> clazz.isInstance(s);
   }
 
-  Function<Number, Integer> testClassReferenceCast() {
+  Function<Number, Integer> testClassCast() {
     return i -> Integer.class.cast(i);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ClassRulesTestOutput.java
@@ -1,30 +1,28 @@
 package tech.picnic.errorprone.refasterrules;
 
-import com.google.common.collect.ImmutableSet;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class ClassRulesTest implements RefasterRuleCollectionTestCase {
-  boolean testClassIsInstance() {
+  boolean testClassIsInstanceWithClassAndObject() {
     return CharSequence.class.isInstance("foo");
   }
 
-  ImmutableSet<Boolean> testInstanceof() {
-    Class<?> clazz = CharSequence.class;
-    return ImmutableSet.of("foo" instanceof CharSequence, clazz.isInstance("bar"));
+  boolean testRefasterIsInstance() {
+    return "foo" instanceof CharSequence;
   }
 
-  Predicate<String> testClassLiteralIsInstancePredicate() {
+  Predicate<String> testClassIsInstance() {
     return CharSequence.class::isInstance;
   }
 
-  Predicate<String> testClassReferenceIsInstancePredicate() {
+  Predicate<String> testClassIsInstanceWithClass() {
     Class<?> clazz = CharSequence.class;
     return clazz::isInstance;
   }
 
-  Function<Number, Integer> testClassReferenceCast() {
+  Function<Number, Integer> testClassCast() {
     return Integer.class::cast;
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestInput.java
@@ -51,7 +51,7 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of("foo").stream().anyMatch("bar"::equals);
   }
 
-  ImmutableSet<Boolean> testCollectionsDisjoint() {
+  ImmutableSet<Boolean> testDisjoint() {
     return ImmutableSet.of(
         Sets.intersection(ImmutableSet.of(1), ImmutableSet.of(2)).isEmpty(),
         ImmutableSet.of(3).stream().noneMatch(ImmutableSet.of(4)::contains),
@@ -61,11 +61,11 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         disjoint(ImmutableList.of(11), new HashSet<>(ImmutableList.of(12))));
   }
 
-  boolean testCollectionAddAllToCollectionExpression() {
+  boolean testCollectionAddAllExpression() {
     return Iterables.addAll(new ArrayList<>(), ImmutableSet.of("foo"));
   }
 
-  void testCollectionAddAllToCollectionBlock() {
+  void testCollectionAddAllBlock() {
     ImmutableSet.of("foo").forEach(new ArrayList<>()::add);
     for (Number element : ImmutableSet.of(1)) {
       new ArrayList<Number>().add(element);
@@ -75,11 +75,11 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
-  boolean testCollectionRemoveAllFromCollectionExpression() {
+  boolean testCollectionRemoveAllExpression() {
     return Iterables.removeAll(new ArrayList<>(), ImmutableSet.of("foo"));
   }
 
-  void testCollectionRemoveAllFromCollectionBlock() {
+  void testCollectionRemoveAllBlock() {
     ImmutableSet.of("foo").forEach(new HashSet<>()::remove);
     for (Number element : ImmutableList.of(1)) {
       new HashSet<Number>().remove(element);
@@ -93,20 +93,20 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1).stream().distinct();
   }
 
-  Set<Integer> testSetOfVarargs() {
+  Set<Integer> testSetOf() {
     return Stream.of(1, 2).collect(toUnmodifiableSet());
   }
 
-  ArrayList<String> testNewArrayListFromCollection() {
+  ArrayList<String> testNewArrayList() {
     return Lists.newArrayList(ImmutableList.of("foo"));
-  }
-
-  Stream<Integer> testImmutableCollectionStream() {
-    return ImmutableSet.of(1).asList().stream();
   }
 
   ImmutableList<Integer> testImmutableCollectionAsList() {
     return ImmutableList.copyOf(ImmutableSet.of(1));
+  }
+
+  Stream<Integer> testImmutableCollectionStream() {
+    return ImmutableSet.of(1).asList().stream();
   }
 
   boolean testImmutableCollectionContains() {
@@ -132,11 +132,11 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableSet.of(3).asList().toArray());
   }
 
-  Integer[] testImmutableCollectionToArrayWithArray() {
+  Integer[] testImmutableCollectionToArrayObject() {
     return ImmutableSet.of(1).asList().toArray(new Integer[0]);
   }
 
-  Integer[] testImmutableCollectionToArrayWithGenerator() {
+  Integer[] testImmutableCollectionToArrayIntFunction() {
     return ImmutableSet.of(1).asList().toArray(Integer[]::new);
   }
 
@@ -145,30 +145,30 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableSet.of(1).stream().iterator(), ImmutableSet.of(2).asList().iterator());
   }
 
-  ImmutableSet<Optional<Integer>> testOptionalFirstCollectionElement() {
+  ImmutableSet<Optional<Integer>> testCollectionStreamFindFirst() {
     return ImmutableSet.of(
-        ImmutableSet.of(0).stream().findAny(),
-        ImmutableSet.of(1).isEmpty()
+        ImmutableSet.of(1).stream().findAny(),
+        ImmutableSet.of(2).isEmpty()
             ? Optional.empty()
-            : Optional.of(ImmutableSet.of(1).iterator().next()),
-        ImmutableList.of(2).isEmpty()
+            : Optional.of(ImmutableSet.of(2).iterator().next()),
+        ImmutableList.of(3).isEmpty()
             ? Optional.empty()
-            : Optional.of(ImmutableList.of(2).getFirst()),
-        ImmutableSortedSet.of(3).isEmpty()
+            : Optional.of(ImmutableList.of(3).getFirst()),
+        ImmutableSortedSet.of(4).isEmpty()
             ? Optional.empty()
-            : Optional.of(ImmutableSortedSet.of(3).first()),
-        !ImmutableSet.of(1).isEmpty()
-            ? Optional.of(ImmutableSet.of(1).iterator().next())
+            : Optional.of(ImmutableSortedSet.of(4).first()),
+        !ImmutableSet.of(5).isEmpty()
+            ? Optional.of(ImmutableSet.of(5).iterator().next())
             : Optional.empty(),
-        !ImmutableList.of(2).isEmpty()
-            ? Optional.of(ImmutableList.of(2).getFirst())
+        !ImmutableList.of(6).isEmpty()
+            ? Optional.of(ImmutableList.of(6).getFirst())
             : Optional.empty(),
-        !ImmutableSortedSet.of(3).isEmpty()
-            ? Optional.of(ImmutableSortedSet.of(3).first())
+        !ImmutableSortedSet.of(7).isEmpty()
+            ? Optional.of(ImmutableSortedSet.of(7).first())
             : Optional.empty());
   }
 
-  ImmutableSet<Optional<String>> testOptionalFirstQueueElement() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableQueuePeek() {
     return ImmutableSet.of(
         new LinkedList<String>().stream().findFirst(),
         new LinkedList<String>().isEmpty()
@@ -185,7 +185,7 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
             : Optional.empty());
   }
 
-  ImmutableSet<Optional<String>> testRemoveOptionalFirstNavigableSetElement() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableNavigableSetPollFirst() {
     return ImmutableSet.of(
         new TreeSet<String>().isEmpty()
             ? Optional.empty()
@@ -201,7 +201,7 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
             : Optional.empty());
   }
 
-  ImmutableSet<Optional<String>> testRemoveOptionalFirstQueueElement() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableQueuePoll() {
     return ImmutableSet.of(
         new LinkedList<String>().isEmpty()
             ? Optional.empty()
@@ -254,8 +254,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testListAdd() {
-    new ArrayList<String>(0).addLast("bar");
-    new ArrayList<String>(1).add(new ArrayList<String>(1).size(), "qux");
+    new ArrayList<String>(0).addLast("foo");
+    new ArrayList<String>(1).add(new ArrayList<String>(1).size(), "bar");
   }
 
   String testListRemoveFirst() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/CollectionRulesTestOutput.java
@@ -51,7 +51,7 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of("foo").contains("bar");
   }
 
-  ImmutableSet<Boolean> testCollectionsDisjoint() {
+  ImmutableSet<Boolean> testDisjoint() {
     return ImmutableSet.of(
         disjoint(ImmutableSet.of(1), ImmutableSet.of(2)),
         disjoint(ImmutableSet.of(3), ImmutableSet.of(4)),
@@ -61,21 +61,21 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         disjoint(ImmutableList.of(11), ImmutableList.of(12)));
   }
 
-  boolean testCollectionAddAllToCollectionExpression() {
+  boolean testCollectionAddAllExpression() {
     return new ArrayList<>().addAll(ImmutableSet.of("foo"));
   }
 
-  void testCollectionAddAllToCollectionBlock() {
+  void testCollectionAddAllBlock() {
     new ArrayList<>().addAll(ImmutableSet.of("foo"));
     new ArrayList<Number>().addAll(ImmutableSet.of(1));
     new ArrayList<Number>().addAll(ImmutableSet.of(2));
   }
 
-  boolean testCollectionRemoveAllFromCollectionExpression() {
+  boolean testCollectionRemoveAllExpression() {
     return new ArrayList<>().removeAll(ImmutableSet.of("foo"));
   }
 
-  void testCollectionRemoveAllFromCollectionBlock() {
+  void testCollectionRemoveAllBlock() {
     new HashSet<>().removeAll(ImmutableSet.of("foo"));
     new HashSet<Number>().removeAll(ImmutableList.of(1));
     new HashSet<Number>().removeAll(ImmutableSet.of(2));
@@ -85,20 +85,20 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1).stream();
   }
 
-  Set<Integer> testSetOfVarargs() {
+  Set<Integer> testSetOf() {
     return Set.of(1, 2);
   }
 
-  ArrayList<String> testNewArrayListFromCollection() {
+  ArrayList<String> testNewArrayList() {
     return new ArrayList<>(ImmutableList.of("foo"));
-  }
-
-  Stream<Integer> testImmutableCollectionStream() {
-    return ImmutableSet.of(1).stream();
   }
 
   ImmutableList<Integer> testImmutableCollectionAsList() {
     return ImmutableSet.of(1).asList();
+  }
+
+  Stream<Integer> testImmutableCollectionStream() {
+    return ImmutableSet.of(1).stream();
   }
 
   boolean testImmutableCollectionContains() {
@@ -122,11 +122,11 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableSet.of(1).toArray(), ImmutableSet.of(2).toArray(), ImmutableSet.of(3).toArray());
   }
 
-  Integer[] testImmutableCollectionToArrayWithArray() {
+  Integer[] testImmutableCollectionToArrayObject() {
     return ImmutableSet.of(1).toArray(new Integer[0]);
   }
 
-  Integer[] testImmutableCollectionToArrayWithGenerator() {
+  Integer[] testImmutableCollectionToArrayIntFunction() {
     return ImmutableSet.of(1).toArray(Integer[]::new);
   }
 
@@ -134,18 +134,18 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(ImmutableSet.of(1).iterator(), ImmutableSet.of(2).iterator());
   }
 
-  ImmutableSet<Optional<Integer>> testOptionalFirstCollectionElement() {
+  ImmutableSet<Optional<Integer>> testCollectionStreamFindFirst() {
     return ImmutableSet.of(
-        ImmutableSet.of(0).stream().findFirst(),
         ImmutableSet.of(1).stream().findFirst(),
-        ImmutableList.of(2).stream().findFirst(),
-        ImmutableSortedSet.of(3).stream().findFirst(),
-        ImmutableSet.of(1).stream().findFirst(),
-        ImmutableList.of(2).stream().findFirst(),
-        ImmutableSortedSet.of(3).stream().findFirst());
+        ImmutableSet.of(2).stream().findFirst(),
+        ImmutableList.of(3).stream().findFirst(),
+        ImmutableSortedSet.of(4).stream().findFirst(),
+        ImmutableSet.of(5).stream().findFirst(),
+        ImmutableList.of(6).stream().findFirst(),
+        ImmutableSortedSet.of(7).stream().findFirst());
   }
 
-  ImmutableSet<Optional<String>> testOptionalFirstQueueElement() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableQueuePeek() {
     return ImmutableSet.of(
         Optional.ofNullable(new LinkedList<String>().peek()),
         Optional.ofNullable(new LinkedList<String>().peek()),
@@ -154,7 +154,7 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         Optional.ofNullable(new LinkedList<String>().peek()));
   }
 
-  ImmutableSet<Optional<String>> testRemoveOptionalFirstNavigableSetElement() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableNavigableSetPollFirst() {
     return ImmutableSet.of(
         Optional.ofNullable(new TreeSet<String>().pollFirst()),
         Optional.ofNullable(new TreeSet<String>().pollFirst()),
@@ -162,7 +162,7 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
         Optional.ofNullable(new TreeSet<String>().pollFirst()));
   }
 
-  ImmutableSet<Optional<String>> testRemoveOptionalFirstQueueElement() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableQueuePoll() {
     return ImmutableSet.of(
         Optional.ofNullable(new LinkedList<String>().poll()),
         Optional.ofNullable(new LinkedList<String>().poll()),
@@ -198,8 +198,8 @@ final class CollectionRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testListAdd() {
-    new ArrayList<String>(0).add("bar");
-    new ArrayList<String>(1).add("qux");
+    new ArrayList<String>(0).add("foo");
+    new ArrayList<String>(1).add("bar");
   }
 
   String testListRemoveFirst() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestInput.java
@@ -25,21 +25,14 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(
-        Arrays.class,
-        Collections.class,
-        ImmutableList.class,
-        ImmutableSet.class,
-        Stream.class,
-        identity());
+    return ImmutableSet.of(Stream.class, identity());
   }
 
   ImmutableSet<Comparator<String>> testNaturalOrder() {
     return ImmutableSet.of(
         String::compareTo,
-        Comparator.comparing(identity()),
-        Comparator.comparing(s -> s),
         Comparator.comparing(s -> 0),
+        Comparator.comparing(identity()),
         Collections.<String>reverseOrder(reverseOrder()),
         Comparator.<String>reverseOrder().reversed());
   }
@@ -51,60 +44,58 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Comparator.<String>naturalOrder().reversed());
   }
 
-  ImmutableSet<Comparator<String>> testCustomComparator() {
+  ImmutableSet<Comparator<String>> testComparatorIdentity() {
     return ImmutableSet.of(
-        Comparator.comparing(identity(), Comparator.comparingInt(String::length)),
-        Comparator.comparing(s -> s, Comparator.comparingInt(String::length)),
-        Comparator.comparing(s -> "foo", Comparator.comparingInt(String::length)));
+        Comparator.comparing(s -> "foo", Comparator.comparingInt(String::length)),
+        Comparator.comparing(identity(), Comparator.comparingInt(String::length)));
   }
 
-  Comparator<String> testComparingEnum() {
+  Comparator<String> testComparing() {
     return Comparator.comparingInt(s -> RoundingMode.valueOf(s).ordinal());
   }
 
-  Comparator<String> testThenComparing() {
+  Comparator<String> testComparatorThenComparing() {
     return Comparator.<String>naturalOrder().thenComparing(Comparator.comparing(String::isEmpty));
   }
 
-  Comparator<String> testThenComparingReversed() {
+  Comparator<String> testComparatorThenComparingReverseOrder() {
     return Comparator.<String>naturalOrder()
         .thenComparing(Comparator.comparing(String::isEmpty).reversed());
   }
 
-  Comparator<String> testThenComparingCustom() {
+  Comparator<String> testComparatorThenComparingWithComparator() {
     return Comparator.<String>naturalOrder()
         .thenComparing(Comparator.comparing(String::isEmpty, reverseOrder()));
   }
 
-  Comparator<String> testThenComparingCustomReversed() {
+  Comparator<String> testComparatorThenComparingComparatorReversed() {
     return Comparator.<String>naturalOrder()
         .thenComparing(
             Comparator.comparing(String::isEmpty, Comparator.<Boolean>reverseOrder()).reversed());
   }
 
-  Comparator<Integer> testThenComparingDouble() {
+  Comparator<Integer> testComparatorThenComparingDouble() {
     return Comparator.<Integer>naturalOrder()
         .thenComparing(Comparator.comparingDouble(Integer::doubleValue));
   }
 
-  Comparator<Integer> testThenComparingInt() {
+  Comparator<Integer> testComparatorThenComparingInt() {
     return Comparator.<Integer>naturalOrder()
         .thenComparing(Comparator.comparingInt(Integer::intValue));
   }
 
-  Comparator<Integer> testThenComparingLong() {
+  Comparator<Integer> testComparatorThenComparingLong() {
     return Comparator.<Integer>naturalOrder()
         .thenComparing(Comparator.comparingLong(Integer::longValue));
   }
 
-  ImmutableSet<Comparator<String>> testThenComparingNaturalOrder() {
+  ImmutableSet<Comparator<String>> testComparatorThenComparingNaturalOrder() {
     return ImmutableSet.of(
-        Comparator.<String>naturalOrder().thenComparing(identity()),
-        Comparator.<String>naturalOrder().thenComparing(s -> s),
-        Comparator.<String>naturalOrder().thenComparing(s -> 0));
+        Comparator.<String>naturalOrder().thenComparing(s -> 0),
+        Comparator.<String>naturalOrder().thenComparing(identity()));
   }
 
-  ImmutableSet<Integer> testCompareTo() {
+  ImmutableSet<Integer> testComparableCompareTo() {
     return ImmutableSet.of(
         Comparator.<String>naturalOrder().compare("foo", "bar"),
         Comparator.<String>reverseOrder().compare("baz", "qux"));
@@ -120,7 +111,7 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Collections.max(ImmutableList.of("bar"), reverseOrder()));
   }
 
-  String testMinOfArray() {
+  String testCollectionsMinArraysAsList() {
     return Arrays.stream(new String[0]).min(naturalOrder()).orElseThrow();
   }
 
@@ -128,32 +119,34 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of("foo", "bar").stream().min(naturalOrder()).orElseThrow();
   }
 
-  int testMinOfVarargs() {
+  int testCollectionsMinArraysAsListVarargs() {
     return Stream.of(1, 2).min(naturalOrder()).orElseThrow();
   }
 
-  ImmutableSet<String> testMinOfPairNaturalOrder() {
+  ImmutableSet<String> testComparatorsMin2() {
     return ImmutableSet.of(
-        "a".compareTo("b") <= 0 ? "a" : "b",
-        "a".compareTo("b") > 0 ? "b" : "a",
-        "a".compareTo("b") < 0 ? "a" : "b",
-        "a".compareTo("b") >= 0 ? "b" : "a",
-        Comparators.min("a", "b", naturalOrder()),
-        Comparators.max("a", "b", reverseOrder()),
-        Collections.min(Arrays.asList("a", "b")),
-        Collections.min(ImmutableList.of("a", "b")),
-        Collections.min(ImmutableSet.of("a", "b")));
+        "foo".compareTo("bar") <= 0 ? "foo" : "bar",
+        "baz".compareTo("qux") > 0 ? "qux" : "baz",
+        "quux".compareTo("corge") < 0 ? "quux" : "corge",
+        "grault".compareTo("garply") >= 0 ? "garply" : "grault",
+        Comparators.min("waldo", "fred", naturalOrder()),
+        Comparators.max("plugh", "xyzzy", reverseOrder()),
+        Collections.min(Arrays.asList("thud", "foo")),
+        Collections.min(ImmutableList.of("bar", "baz")),
+        Collections.min(ImmutableSet.of("qux", "quux")));
   }
 
-  ImmutableSet<Object> testMinOfPairCustomOrder() {
+  ImmutableSet<Object> testComparatorsMin3() {
     return ImmutableSet.of(
-        Comparator.comparingInt(String::length).compare("a", "b") <= 0 ? "a" : "b",
-        Comparator.comparingInt(String::length).compare("a", "b") > 0 ? "b" : "a",
-        Comparator.comparingInt(String::length).compare("a", "b") < 0 ? "a" : "b",
-        Comparator.comparingInt(String::length).compare("a", "b") >= 0 ? "b" : "a",
-        Collections.min(Arrays.asList("a", "b"), (a, b) -> -1),
-        Collections.min(ImmutableList.of("a", "b"), (a, b) -> 0),
-        Collections.min(ImmutableSet.of("a", "b"), (a, b) -> 1));
+        Comparator.comparingInt(String::length).compare("foo", "bar") <= 0 ? "foo" : "bar",
+        Comparator.comparingInt(String::length).compare("baz", "qux") > 0 ? "qux" : "baz",
+        Comparator.comparingInt(String::length).compare("quux", "corge") < 0 ? "quux" : "corge",
+        Comparator.comparingInt(String::length).compare("grault", "garply") >= 0
+            ? "garply"
+            : "grault",
+        Collections.min(Arrays.asList("waldo", "fred"), (a, b) -> -1),
+        Collections.min(ImmutableList.of("plugh", "xyzzy"), (a, b) -> 0),
+        Collections.min(ImmutableSet.of("thud", "foo"), (a, b) -> 1));
   }
 
   ImmutableSet<String> testCollectionsMax() {
@@ -162,7 +155,7 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Collections.min(ImmutableList.of("bar"), reverseOrder()));
   }
 
-  String testMaxOfArray() {
+  String testCollectionsMaxArraysAsList() {
     return Arrays.stream(new String[0]).max(naturalOrder()).orElseThrow();
   }
 
@@ -170,32 +163,34 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of("foo", "bar").stream().max(naturalOrder()).orElseThrow();
   }
 
-  int testMaxOfVarargs() {
+  int testCollectionsMaxArraysAsListVarargs() {
     return Stream.of(1, 2).max(naturalOrder()).orElseThrow();
   }
 
-  ImmutableSet<String> testMaxOfPairNaturalOrder() {
+  ImmutableSet<String> testComparatorsMax2() {
     return ImmutableSet.of(
-        "a".compareTo("b") >= 0 ? "a" : "b",
-        "a".compareTo("b") < 0 ? "b" : "a",
-        "a".compareTo("b") > 0 ? "a" : "b",
-        "a".compareTo("b") <= 0 ? "b" : "a",
-        Comparators.max("a", "b", naturalOrder()),
-        Comparators.min("a", "b", reverseOrder()),
-        Collections.max(Arrays.asList("a", "b")),
-        Collections.max(ImmutableList.of("a", "b")),
-        Collections.max(ImmutableSet.of("a", "b")));
+        "foo".compareTo("bar") >= 0 ? "foo" : "bar",
+        "baz".compareTo("qux") < 0 ? "qux" : "baz",
+        "quux".compareTo("corge") > 0 ? "quux" : "corge",
+        "grault".compareTo("garply") <= 0 ? "garply" : "grault",
+        Comparators.max("waldo", "fred", naturalOrder()),
+        Comparators.min("plugh", "xyzzy", reverseOrder()),
+        Collections.max(Arrays.asList("thud", "foo")),
+        Collections.max(ImmutableList.of("bar", "baz")),
+        Collections.max(ImmutableSet.of("qux", "quux")));
   }
 
-  ImmutableSet<Object> testMaxOfPairCustomOrder() {
+  ImmutableSet<Object> testComparatorsMax3() {
     return ImmutableSet.of(
-        Comparator.comparingInt(String::length).compare("a", "b") >= 0 ? "a" : "b",
-        Comparator.comparingInt(String::length).compare("a", "b") < 0 ? "b" : "a",
-        Comparator.comparingInt(String::length).compare("a", "b") > 0 ? "a" : "b",
-        Comparator.comparingInt(String::length).compare("a", "b") <= 0 ? "b" : "a",
-        Collections.max(Arrays.asList("a", "b"), (a, b) -> -1),
-        Collections.max(ImmutableList.of("a", "b"), (a, b) -> 0),
-        Collections.max(ImmutableSet.of("a", "b"), (a, b) -> 1));
+        Comparator.comparingInt(String::length).compare("foo", "bar") >= 0 ? "foo" : "bar",
+        Comparator.comparingInt(String::length).compare("baz", "qux") < 0 ? "qux" : "baz",
+        Comparator.comparingInt(String::length).compare("quux", "corge") > 0 ? "quux" : "corge",
+        Comparator.comparingInt(String::length).compare("grault", "garply") <= 0
+            ? "garply"
+            : "grault",
+        Collections.max(Arrays.asList("waldo", "fred"), (a, b) -> -1),
+        Collections.max(ImmutableList.of("plugh", "xyzzy"), (a, b) -> 0),
+        Collections.max(ImmutableSet.of("thud", "foo"), (a, b) -> 1));
   }
 
   Collector<String, ?, List<String>> testLeast() {
@@ -214,11 +209,11 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return least(1, reverseOrder());
   }
 
-  BinaryOperator<String> testComparatorsMin() {
+  BinaryOperator<String> testComparatorsMin0() {
     return BinaryOperator.minBy(naturalOrder());
   }
 
-  BinaryOperator<String> testComparatorsMax() {
+  BinaryOperator<String> testComparatorsMax0() {
     return BinaryOperator.maxBy(naturalOrder());
   }
 
@@ -230,13 +225,13 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return minBy(reverseOrder());
   }
 
-  ImmutableSet<Boolean> testIsLessThan() {
+  ImmutableSet<Boolean> testEnumIsLessThan() {
     return ImmutableSet.of(
         RoundingMode.UP.ordinal() < RoundingMode.DOWN.ordinal(),
         RoundingMode.UP.ordinal() >= RoundingMode.DOWN.ordinal());
   }
 
-  ImmutableSet<Boolean> testIsLessThanOrEqualTo() {
+  ImmutableSet<Boolean> testEnumIsLessThanOrEqualTo() {
     return ImmutableSet.of(
         RoundingMode.UP.ordinal() <= RoundingMode.DOWN.ordinal(),
         RoundingMode.UP.ordinal() > RoundingMode.DOWN.ordinal());

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ComparatorRulesTestOutput.java
@@ -26,21 +26,14 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
-    return ImmutableSet.of(
-        Arrays.class,
-        Collections.class,
-        ImmutableList.class,
-        ImmutableSet.class,
-        Stream.class,
-        identity());
+    return ImmutableSet.of(Stream.class, identity());
   }
 
   ImmutableSet<Comparator<String>> testNaturalOrder() {
     return ImmutableSet.of(
         naturalOrder(),
-        naturalOrder(),
-        naturalOrder(),
         Comparator.comparing(s -> 0),
+        naturalOrder(),
         naturalOrder(),
         naturalOrder());
   }
@@ -50,54 +43,52 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Comparator.reverseOrder(), Comparator.reverseOrder(), Comparator.reverseOrder());
   }
 
-  ImmutableSet<Comparator<String>> testCustomComparator() {
+  ImmutableSet<Comparator<String>> testComparatorIdentity() {
     return ImmutableSet.of(
-        Comparator.comparingInt(String::length),
-        Comparator.comparingInt(String::length),
-        Comparator.comparing(s -> "foo", Comparator.comparingInt(String::length)));
+        Comparator.comparing(s -> "foo", Comparator.comparingInt(String::length)),
+        Comparator.comparingInt(String::length));
   }
 
-  Comparator<String> testComparingEnum() {
+  Comparator<String> testComparing() {
     return comparing(s -> RoundingMode.valueOf(s));
   }
 
-  Comparator<String> testThenComparing() {
+  Comparator<String> testComparatorThenComparing() {
     return Comparator.<String>naturalOrder().thenComparing(String::isEmpty);
   }
 
-  Comparator<String> testThenComparingReversed() {
+  Comparator<String> testComparatorThenComparingReverseOrder() {
     return Comparator.<String>naturalOrder().thenComparing(String::isEmpty, reverseOrder());
   }
 
-  Comparator<String> testThenComparingCustom() {
+  Comparator<String> testComparatorThenComparingWithComparator() {
     return Comparator.<String>naturalOrder().thenComparing(String::isEmpty, reverseOrder());
   }
 
-  Comparator<String> testThenComparingCustomReversed() {
+  Comparator<String> testComparatorThenComparingComparatorReversed() {
     return Comparator.<String>naturalOrder()
         .thenComparing(String::isEmpty, Comparator.<Boolean>reverseOrder().reversed());
   }
 
-  Comparator<Integer> testThenComparingDouble() {
+  Comparator<Integer> testComparatorThenComparingDouble() {
     return Comparator.<Integer>naturalOrder().thenComparingDouble(Integer::doubleValue);
   }
 
-  Comparator<Integer> testThenComparingInt() {
+  Comparator<Integer> testComparatorThenComparingInt() {
     return Comparator.<Integer>naturalOrder().thenComparingInt(Integer::intValue);
   }
 
-  Comparator<Integer> testThenComparingLong() {
+  Comparator<Integer> testComparatorThenComparingLong() {
     return Comparator.<Integer>naturalOrder().thenComparingLong(Integer::longValue);
   }
 
-  ImmutableSet<Comparator<String>> testThenComparingNaturalOrder() {
+  ImmutableSet<Comparator<String>> testComparatorThenComparingNaturalOrder() {
     return ImmutableSet.of(
-        Comparator.<String>naturalOrder().thenComparing(naturalOrder()),
-        Comparator.<String>naturalOrder().thenComparing(naturalOrder()),
-        Comparator.<String>naturalOrder().thenComparing(s -> 0));
+        Comparator.<String>naturalOrder().thenComparing(s -> 0),
+        Comparator.<String>naturalOrder().thenComparing(naturalOrder()));
   }
 
-  ImmutableSet<Integer> testCompareTo() {
+  ImmutableSet<Integer> testComparableCompareTo() {
     return ImmutableSet.of("foo".compareTo("bar"), "qux".compareTo("baz"));
   }
 
@@ -110,7 +101,7 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Collections.min(ImmutableList.of("foo")), Collections.min(ImmutableList.of("bar")));
   }
 
-  String testMinOfArray() {
+  String testCollectionsMinArraysAsList() {
     return Collections.min(Arrays.asList(new String[0]), naturalOrder());
   }
 
@@ -118,32 +109,32 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return Collections.min(ImmutableSet.of("foo", "bar"), naturalOrder());
   }
 
-  int testMinOfVarargs() {
+  int testCollectionsMinArraysAsListVarargs() {
     return Collections.min(Arrays.asList(1, 2), naturalOrder());
   }
 
-  ImmutableSet<String> testMinOfPairNaturalOrder() {
+  ImmutableSet<String> testComparatorsMin2() {
     return ImmutableSet.of(
-        Comparators.min("a", "b"),
-        Comparators.min("a", "b"),
-        Comparators.min("b", "a"),
-        Comparators.min("b", "a"),
-        Comparators.min("a", "b"),
-        Comparators.min("a", "b"),
-        Comparators.min("a", "b"),
-        Comparators.min("a", "b"),
-        Comparators.min("a", "b"));
+        Comparators.min("foo", "bar"),
+        Comparators.min("baz", "qux"),
+        Comparators.min("corge", "quux"),
+        Comparators.min("garply", "grault"),
+        Comparators.min("waldo", "fred"),
+        Comparators.min("plugh", "xyzzy"),
+        Comparators.min("thud", "foo"),
+        Comparators.min("bar", "baz"),
+        Comparators.min("qux", "quux"));
   }
 
-  ImmutableSet<Object> testMinOfPairCustomOrder() {
+  ImmutableSet<Object> testComparatorsMin3() {
     return ImmutableSet.of(
-        Comparators.min("a", "b", Comparator.comparingInt(String::length)),
-        Comparators.min("a", "b", Comparator.comparingInt(String::length)),
-        Comparators.min("b", "a", Comparator.comparingInt(String::length)),
-        Comparators.min("b", "a", Comparator.comparingInt(String::length)),
-        Comparators.min("a", "b", (a, b) -> -1),
-        Comparators.min("a", "b", (a, b) -> 0),
-        Comparators.min("a", "b", (a, b) -> 1));
+        Comparators.min("foo", "bar", Comparator.comparingInt(String::length)),
+        Comparators.min("baz", "qux", Comparator.comparingInt(String::length)),
+        Comparators.min("corge", "quux", Comparator.comparingInt(String::length)),
+        Comparators.min("garply", "grault", Comparator.comparingInt(String::length)),
+        Comparators.min("waldo", "fred", (a, b) -> -1),
+        Comparators.min("plugh", "xyzzy", (a, b) -> 0),
+        Comparators.min("thud", "foo", (a, b) -> 1));
   }
 
   ImmutableSet<String> testCollectionsMax() {
@@ -151,7 +142,7 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
         Collections.max(ImmutableList.of("foo")), Collections.max(ImmutableList.of("bar")));
   }
 
-  String testMaxOfArray() {
+  String testCollectionsMaxArraysAsList() {
     return Collections.max(Arrays.asList(new String[0]), naturalOrder());
   }
 
@@ -159,32 +150,32 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return Collections.max(ImmutableSet.of("foo", "bar"), naturalOrder());
   }
 
-  int testMaxOfVarargs() {
+  int testCollectionsMaxArraysAsListVarargs() {
     return Collections.max(Arrays.asList(1, 2), naturalOrder());
   }
 
-  ImmutableSet<String> testMaxOfPairNaturalOrder() {
+  ImmutableSet<String> testComparatorsMax2() {
     return ImmutableSet.of(
-        Comparators.max("a", "b"),
-        Comparators.max("a", "b"),
-        Comparators.max("b", "a"),
-        Comparators.max("b", "a"),
-        Comparators.max("a", "b"),
-        Comparators.max("a", "b"),
-        Comparators.max("a", "b"),
-        Comparators.max("a", "b"),
-        Comparators.max("a", "b"));
+        Comparators.max("foo", "bar"),
+        Comparators.max("baz", "qux"),
+        Comparators.max("corge", "quux"),
+        Comparators.max("garply", "grault"),
+        Comparators.max("waldo", "fred"),
+        Comparators.max("plugh", "xyzzy"),
+        Comparators.max("thud", "foo"),
+        Comparators.max("bar", "baz"),
+        Comparators.max("qux", "quux"));
   }
 
-  ImmutableSet<Object> testMaxOfPairCustomOrder() {
+  ImmutableSet<Object> testComparatorsMax3() {
     return ImmutableSet.of(
-        Comparators.max("a", "b", Comparator.comparingInt(String::length)),
-        Comparators.max("a", "b", Comparator.comparingInt(String::length)),
-        Comparators.max("b", "a", Comparator.comparingInt(String::length)),
-        Comparators.max("b", "a", Comparator.comparingInt(String::length)),
-        Comparators.max("a", "b", (a, b) -> -1),
-        Comparators.max("a", "b", (a, b) -> 0),
-        Comparators.max("a", "b", (a, b) -> 1));
+        Comparators.max("foo", "bar", Comparator.comparingInt(String::length)),
+        Comparators.max("baz", "qux", Comparator.comparingInt(String::length)),
+        Comparators.max("corge", "quux", Comparator.comparingInt(String::length)),
+        Comparators.max("garply", "grault", Comparator.comparingInt(String::length)),
+        Comparators.max("waldo", "fred", (a, b) -> -1),
+        Comparators.max("plugh", "xyzzy", (a, b) -> 0),
+        Comparators.max("thud", "foo", (a, b) -> 1));
   }
 
   Collector<String, ?, List<String>> testLeast() {
@@ -203,11 +194,11 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return greatest(1, naturalOrder());
   }
 
-  BinaryOperator<String> testComparatorsMin() {
+  BinaryOperator<String> testComparatorsMin0() {
     return Comparators::min;
   }
 
-  BinaryOperator<String> testComparatorsMax() {
+  BinaryOperator<String> testComparatorsMax0() {
     return Comparators::max;
   }
 
@@ -219,13 +210,13 @@ final class ComparatorRulesTest implements RefasterRuleCollectionTestCase {
     return maxBy(naturalOrder());
   }
 
-  ImmutableSet<Boolean> testIsLessThan() {
+  ImmutableSet<Boolean> testEnumIsLessThan() {
     return ImmutableSet.of(
         RoundingMode.UP.compareTo(RoundingMode.DOWN) < 0,
         RoundingMode.UP.compareTo(RoundingMode.DOWN) >= 0);
   }
 
-  ImmutableSet<Boolean> testIsLessThanOrEqualTo() {
+  ImmutableSet<Boolean> testEnumIsLessThanOrEqualTo() {
     return ImmutableSet.of(
         RoundingMode.UP.compareTo(RoundingMode.DOWN) <= 0,
         RoundingMode.UP.compareTo(RoundingMode.DOWN) > 0);

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DequeRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DequeRulesTestInput.java
@@ -12,12 +12,12 @@ final class DequeRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testDequeAddLast() {
-    new ArrayDeque<String>().add("foo");
-    new LinkedList<String>().add("bar");
+    new LinkedList<String>().add("foo");
+    new ArrayDeque<String>().add("bar");
   }
 
   ImmutableSet<String> testDequeRemoveFirst() {
-    return ImmutableSet.of(new ArrayDeque<String>(0).pop(), new ArrayDeque<String>(1).remove());
+    return ImmutableSet.of(new ArrayDeque<String>(1).pop(), new ArrayDeque<String>(2).remove());
   }
 
   boolean testDequeOfferLast() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DequeRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DequeRulesTestOutput.java
@@ -12,13 +12,13 @@ final class DequeRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   void testDequeAddLast() {
-    new ArrayDeque<String>().addLast("foo");
-    new LinkedList<String>().add("bar");
+    new LinkedList<String>().add("foo");
+    new ArrayDeque<String>().addLast("bar");
   }
 
   ImmutableSet<String> testDequeRemoveFirst() {
     return ImmutableSet.of(
-        new ArrayDeque<String>(0).removeFirst(), new ArrayDeque<String>(1).removeFirst());
+        new ArrayDeque<String>(1).removeFirst(), new ArrayDeque<String>(2).removeFirst());
   }
 
   boolean testDequeOfferLast() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestInput.java
@@ -14,43 +14,43 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
-  DoubleStream testConcatOneDoubleStream() {
+  DoubleStream testDoubleStreamIdentity() {
     return Streams.concat(DoubleStream.of(1));
   }
 
-  DoubleStream testConcatTwoDoubleStreams() {
+  DoubleStream testDoubleStreamConcat() {
     return Streams.concat(DoubleStream.of(1), DoubleStream.of(2));
   }
 
-  DoubleStream testFilterOuterDoubleStreamAfterFlatMap() {
+  DoubleStream testDoubleStreamFlatMapFilter() {
     return DoubleStream.of(1).flatMap(v -> DoubleStream.of(v * v).filter(n -> n > 1));
   }
 
-  DoubleStream testFilterOuterStreamAfterFlatMapToDouble() {
+  DoubleStream testStreamFlatMapToDoubleFilter() {
     return Stream.of(1).flatMapToDouble(v -> DoubleStream.of(v * v).filter(n -> n > 1));
   }
 
-  DoubleStream testMapOuterDoubleStreamAfterFlatMap() {
+  DoubleStream testDoubleStreamFlatMapMap() {
     return DoubleStream.of(1).flatMap(v -> DoubleStream.of(v * v).map(n -> n * 1));
   }
 
-  DoubleStream testMapOuterStreamAfterFlatMapToDouble() {
+  DoubleStream testStreamFlatMapToDoubleMap() {
     return Stream.of(1).flatMapToDouble(v -> DoubleStream.of(v * v).map(n -> n * 1));
   }
 
-  DoubleStream testFlatMapOuterDoubleStreamAfterFlatMap() {
+  DoubleStream testDoubleStreamFlatMapFlatMap() {
     return DoubleStream.of(1).flatMap(v -> DoubleStream.of(v * v).flatMap(DoubleStream::of));
   }
 
-  DoubleStream testFlatMapOuterStreamAfterFlatMapToDouble() {
+  DoubleStream testStreamFlatMapToDoubleFlatMap() {
     return Stream.of(1).flatMapToDouble(v -> DoubleStream.of(v * v).flatMap(DoubleStream::of));
   }
 
   DoubleStream testDoubleStreamFilterSorted() {
-    return DoubleStream.of(1, 4, 3, 2).sorted().filter(d -> d % 2 == 0);
+    return DoubleStream.of(1).sorted().filter(d -> d > 0);
   }
 
-  ImmutableSet<Boolean> testDoubleStreamIsEmpty() {
+  ImmutableSet<Boolean> testDoubleStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         DoubleStream.of(1).count() == 0,
         DoubleStream.of(2).count() <= 0,
@@ -58,7 +58,7 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
         DoubleStream.of(4).findFirst().isEmpty());
   }
 
-  ImmutableSet<Boolean> testDoubleStreamIsNotEmpty() {
+  ImmutableSet<Boolean> testDoubleStreamFindAnyIsPresent() {
     return ImmutableSet.of(
         DoubleStream.of(1).count() != 0,
         DoubleStream.of(2).count() > 0,
@@ -70,7 +70,7 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
     return DoubleStream.of(1).sorted().findFirst();
   }
 
-  ImmutableSet<Boolean> testDoubleStreamNoneMatch() {
+  ImmutableSet<Boolean> testDoubleStreamNoneMatchWithDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return ImmutableSet.of(
         !DoubleStream.of(1).anyMatch(n -> n > 1),
@@ -78,7 +78,7 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
         DoubleStream.of(3).filter(pred).findAny().isEmpty());
   }
 
-  boolean testDoubleStreamNoneMatch2() {
+  boolean testDoubleStreamNoneMatch() {
     return DoubleStream.of(1).allMatch(n -> !(n > 1));
   }
 
@@ -88,12 +88,12 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
         DoubleStream.of(2).filter(n -> n > 2).findAny().isPresent());
   }
 
-  boolean testDoubleStreamAllMatch() {
+  boolean testDoubleStreamAllMatchWithDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return DoubleStream.of(1).noneMatch(pred.negate());
   }
 
-  boolean testDoubleStreamAllMatch2() {
+  boolean testDoubleStreamAllMatch() {
     return DoubleStream.of(1).noneMatch(n -> !(n > 1));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/DoubleStreamRulesTestOutput.java
@@ -14,43 +14,43 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
-  DoubleStream testConcatOneDoubleStream() {
+  DoubleStream testDoubleStreamIdentity() {
     return DoubleStream.of(1);
   }
 
-  DoubleStream testConcatTwoDoubleStreams() {
+  DoubleStream testDoubleStreamConcat() {
     return DoubleStream.concat(DoubleStream.of(1), DoubleStream.of(2));
   }
 
-  DoubleStream testFilterOuterDoubleStreamAfterFlatMap() {
+  DoubleStream testDoubleStreamFlatMapFilter() {
     return DoubleStream.of(1).flatMap(v -> DoubleStream.of(v * v)).filter(n -> n > 1);
   }
 
-  DoubleStream testFilterOuterStreamAfterFlatMapToDouble() {
+  DoubleStream testStreamFlatMapToDoubleFilter() {
     return Stream.of(1).flatMapToDouble(v -> DoubleStream.of(v * v)).filter(n -> n > 1);
   }
 
-  DoubleStream testMapOuterDoubleStreamAfterFlatMap() {
+  DoubleStream testDoubleStreamFlatMapMap() {
     return DoubleStream.of(1).flatMap(v -> DoubleStream.of(v * v)).map(n -> n * 1);
   }
 
-  DoubleStream testMapOuterStreamAfterFlatMapToDouble() {
+  DoubleStream testStreamFlatMapToDoubleMap() {
     return Stream.of(1).flatMapToDouble(v -> DoubleStream.of(v * v)).map(n -> n * 1);
   }
 
-  DoubleStream testFlatMapOuterDoubleStreamAfterFlatMap() {
+  DoubleStream testDoubleStreamFlatMapFlatMap() {
     return DoubleStream.of(1).flatMap(v -> DoubleStream.of(v * v)).flatMap(DoubleStream::of);
   }
 
-  DoubleStream testFlatMapOuterStreamAfterFlatMapToDouble() {
+  DoubleStream testStreamFlatMapToDoubleFlatMap() {
     return Stream.of(1).flatMapToDouble(v -> DoubleStream.of(v * v)).flatMap(DoubleStream::of);
   }
 
   DoubleStream testDoubleStreamFilterSorted() {
-    return DoubleStream.of(1, 4, 3, 2).filter(d -> d % 2 == 0).sorted();
+    return DoubleStream.of(1).filter(d -> d > 0).sorted();
   }
 
-  ImmutableSet<Boolean> testDoubleStreamIsEmpty() {
+  ImmutableSet<Boolean> testDoubleStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         DoubleStream.of(1).findAny().isEmpty(),
         DoubleStream.of(2).findAny().isEmpty(),
@@ -58,7 +58,7 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
         DoubleStream.of(4).findAny().isEmpty());
   }
 
-  ImmutableSet<Boolean> testDoubleStreamIsNotEmpty() {
+  ImmutableSet<Boolean> testDoubleStreamFindAnyIsPresent() {
     return ImmutableSet.of(
         DoubleStream.of(1).findAny().isPresent(),
         DoubleStream.of(2).findAny().isPresent(),
@@ -70,7 +70,7 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
     return DoubleStream.of(1).min();
   }
 
-  ImmutableSet<Boolean> testDoubleStreamNoneMatch() {
+  ImmutableSet<Boolean> testDoubleStreamNoneMatchWithDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return ImmutableSet.of(
         DoubleStream.of(1).noneMatch(n -> n > 1),
@@ -78,7 +78,7 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
         DoubleStream.of(3).noneMatch(pred));
   }
 
-  boolean testDoubleStreamNoneMatch2() {
+  boolean testDoubleStreamNoneMatch() {
     return DoubleStream.of(1).noneMatch(n -> n > 1);
   }
 
@@ -87,12 +87,12 @@ final class DoubleStreamRulesTest implements RefasterRuleCollectionTestCase {
         DoubleStream.of(1).anyMatch(n -> n > 1), DoubleStream.of(2).anyMatch(n -> n > 2));
   }
 
-  boolean testDoubleStreamAllMatch() {
+  boolean testDoubleStreamAllMatchWithDoublePredicate() {
     DoublePredicate pred = i -> i > 0;
     return DoubleStream.of(1).allMatch(pred);
   }
 
-  boolean testDoubleStreamAllMatch2() {
+  boolean testDoubleStreamAllMatch() {
     return DoubleStream.of(1).allMatch(n -> n > 1);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestInput.java
@@ -18,7 +18,7 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Objects.class, Optional.class, isEqual(null), not(null));
   }
 
-  ImmutableSet<Boolean> testEnumReferenceEquality() {
+  ImmutableSet<Boolean> testEqualToWithEnum() {
     return ImmutableSet.of(
         RoundingMode.UP.equals(RoundingMode.DOWN),
         Objects.equals(RoundingMode.UP, RoundingMode.DOWN),
@@ -28,25 +28,25 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
         RoundingMode.UP.ordinal() != RoundingMode.DOWN.ordinal());
   }
 
-  ImmutableSet<Predicate<RoundingMode>> testEnumReferenceEqualityLambda() {
+  ImmutableSet<Predicate<RoundingMode>> testEqualTo() {
     return ImmutableSet.of(isEqual(RoundingMode.DOWN), RoundingMode.UP::equals);
   }
 
-  boolean testEqualsPredicate() {
+  boolean testObjectEquals() {
     // XXX: When boxing is involved this rule seems to break. Example:
     // Stream.of(1).anyMatch(e -> Integer.MIN_VALUE.equals(e));
     return Stream.of("foo").anyMatch(s -> "bar".equals(s));
   }
 
-  boolean testDoubleNegation() {
+  boolean testBooleanIdentity() {
     return !!Boolean.TRUE;
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  ImmutableSet<Boolean> testNegation() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy expressions. */)
+  ImmutableSet<Boolean> testNotEqualTo() {
     return ImmutableSet.of(
-        true ? !false : false,
         !(true == false),
+        true ? !false : false,
         !((byte) 3 == (byte) 4),
         !((char) 3 == (char) 4),
         !((short) 3 == (short) 4),
@@ -57,11 +57,11 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
         !(BoundType.OPEN == BoundType.CLOSED));
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  ImmutableSet<Boolean> testIndirectDoubleNegation() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy expressions. */)
+  ImmutableSet<Boolean> testEqualToWithBoolean() {
     return ImmutableSet.of(
-        true ? false : !false,
         !(true != false),
+        true ? false : !false,
         !((byte) 3 != (byte) 4),
         !((char) 3 != (char) 4),
         !((short) 3 != (short) 4),
@@ -72,15 +72,15 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
         !(BoundType.OPEN != BoundType.CLOSED));
   }
 
-  Predicate<String> testPredicateLambda() {
+  Predicate<String> testNot() {
     return not(v -> v.isEmpty());
   }
 
-  ImmutableSet<Boolean> testEquals() {
+  ImmutableSet<Boolean> testObjectEqualsWithObject() {
     return ImmutableSet.of(
         Optional.of("foo").equals(Optional.of("bar")),
         Optional.of("baz").equals(Optional.ofNullable("qux")),
-        Optional.ofNullable("quux").equals(Optional.of("quuz")));
+        Optional.ofNullable("quux").equals(Optional.of("corge")));
   }
 
   boolean testObjectsEquals() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/EqualityRulesTestOutput.java
@@ -18,7 +18,7 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Objects.class, Optional.class, isEqual(null), not(null));
   }
 
-  ImmutableSet<Boolean> testEnumReferenceEquality() {
+  ImmutableSet<Boolean> testEqualToWithEnum() {
     return ImmutableSet.of(
         RoundingMode.UP == RoundingMode.DOWN,
         RoundingMode.UP == RoundingMode.DOWN,
@@ -28,22 +28,22 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
         RoundingMode.UP != RoundingMode.DOWN);
   }
 
-  ImmutableSet<Predicate<RoundingMode>> testEnumReferenceEqualityLambda() {
+  ImmutableSet<Predicate<RoundingMode>> testEqualTo() {
     return ImmutableSet.of(v -> v == RoundingMode.DOWN, v -> v == RoundingMode.UP);
   }
 
-  boolean testEqualsPredicate() {
+  boolean testObjectEquals() {
     // XXX: When boxing is involved this rule seems to break. Example:
     // Stream.of(1).anyMatch(e -> Integer.MIN_VALUE.equals(e));
     return Stream.of("foo").anyMatch("bar"::equals);
   }
 
-  boolean testDoubleNegation() {
+  boolean testBooleanIdentity() {
     return Boolean.TRUE;
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  ImmutableSet<Boolean> testNegation() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy expressions. */)
+  ImmutableSet<Boolean> testNotEqualTo() {
     return ImmutableSet.of(
         true != false,
         true != false,
@@ -57,8 +57,8 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
         BoundType.OPEN != BoundType.CLOSED);
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  ImmutableSet<Boolean> testIndirectDoubleNegation() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy expressions. */)
+  ImmutableSet<Boolean> testEqualToWithBoolean() {
     return ImmutableSet.of(
         true == false,
         true == false,
@@ -72,12 +72,12 @@ final class EqualityRulesTest implements RefasterRuleCollectionTestCase {
         BoundType.OPEN == BoundType.CLOSED);
   }
 
-  Predicate<String> testPredicateLambda() {
+  Predicate<String> testNot() {
     return v -> !v.isEmpty();
   }
 
-  ImmutableSet<Boolean> testEquals() {
-    return ImmutableSet.of("foo".equals("bar"), "baz".equals("qux"), "quuz".equals("quux"));
+  ImmutableSet<Boolean> testObjectEqualsWithObject() {
+    return ImmutableSet.of("foo".equals("bar"), "baz".equals("qux"), "corge".equals("quux"));
   }
 
   boolean testObjectsEquals() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
@@ -22,15 +22,15 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(FileInputStream.class, FileOutputStream.class, InputStreamReader.class);
   }
 
-  Path testPathOfUri() {
+  Path testPathOf() {
     return Paths.get(URI.create("foo"));
   }
 
-  ImmutableSet<Path> testPathOfString() {
+  ImmutableSet<Path> testPathOfVarargs() {
     return ImmutableSet.of(Paths.get("foo"), Paths.get("bar", "baz", "qux"));
   }
 
-  Path testPathInstance() {
+  Path testPathIdentity() {
     return Path.of("foo").toFile().toPath();
   }
 
@@ -55,17 +55,17 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
         File.createTempFile("foo", "bar"), File.createTempFile("baz", "qux", null));
   }
 
-  File testFilesCreateTempFileInCustomDirectoryToFile() throws IOException {
+  File testFilesCreateTempFileFileToPathToFile() throws IOException {
     return File.createTempFile("foo", "bar", new File("baz"));
   }
 
-  ImmutableSet<Boolean> testPathToFileMkDirsFilesExists() {
+  ImmutableSet<Boolean> testPathToFileMkdirsOrFilesExists() {
     return ImmutableSet.of(
         Files.exists(Path.of("foo")) || Path.of("foo").toFile().mkdirs(),
         !Files.exists(Path.of("bar")) && !Path.of("bar").toFile().mkdirs());
   }
 
-  ImmutableSet<Boolean> testFileMkDirsFileExists() {
+  ImmutableSet<Boolean> testFileMkdirsOrFileExists() {
     return ImmutableSet.of(
         new File("foo").exists() || new File("foo").mkdirs(),
         !new File("bar").exists() && !new File("bar").mkdirs());
@@ -75,7 +75,7 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return new FileInputStream("foo");
   }
 
-  InputStream testFilesNewInputStreamToPath() throws IOException {
+  InputStream testFilesNewInputStreamFileToPath() throws IOException {
     return new FileInputStream(new File("foo"));
   }
 
@@ -83,7 +83,7 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return new FileOutputStream("foo");
   }
 
-  OutputStream testFilesNewOutputStreamToPath() throws IOException {
+  OutputStream testFilesNewOutputStreamFileToPath() throws IOException {
     return new FileOutputStream(new File("foo"));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
@@ -22,15 +22,15 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(FileInputStream.class, FileOutputStream.class, InputStreamReader.class);
   }
 
-  Path testPathOfUri() {
+  Path testPathOf() {
     return Path.of(URI.create("foo"));
   }
 
-  ImmutableSet<Path> testPathOfString() {
+  ImmutableSet<Path> testPathOfVarargs() {
     return ImmutableSet.of(Path.of("foo"), Path.of("bar", "baz", "qux"));
   }
 
-  Path testPathInstance() {
+  Path testPathIdentity() {
     return Path.of("foo");
   }
 
@@ -55,17 +55,17 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
         Files.createTempFile("foo", "bar").toFile(), Files.createTempFile("baz", "qux").toFile());
   }
 
-  File testFilesCreateTempFileInCustomDirectoryToFile() throws IOException {
+  File testFilesCreateTempFileFileToPathToFile() throws IOException {
     return Files.createTempFile(new File("baz").toPath(), "foo", "bar").toFile();
   }
 
-  ImmutableSet<Boolean> testPathToFileMkDirsFilesExists() {
+  ImmutableSet<Boolean> testPathToFileMkdirsOrFilesExists() {
     return ImmutableSet.of(
         Path.of("foo").toFile().mkdirs() || Files.exists(Path.of("foo")),
         !Path.of("bar").toFile().mkdirs() && !Files.exists(Path.of("bar")));
   }
 
-  ImmutableSet<Boolean> testFileMkDirsFileExists() {
+  ImmutableSet<Boolean> testFileMkdirsOrFileExists() {
     return ImmutableSet.of(
         new File("foo").mkdirs() || new File("foo").exists(),
         !new File("bar").mkdirs() && !new File("bar").exists());
@@ -75,7 +75,7 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return Files.newInputStream(Path.of("foo"));
   }
 
-  InputStream testFilesNewInputStreamToPath() throws IOException {
+  InputStream testFilesNewInputStreamFileToPath() throws IOException {
     return Files.newInputStream(new File("foo").toPath());
   }
 
@@ -83,7 +83,7 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return Files.newOutputStream(Path.of("foo"));
   }
 
-  OutputStream testFilesNewOutputStreamToPath() throws IOException {
+  OutputStream testFilesNewOutputStreamFileToPath() throws IOException {
     return Files.newOutputStream(new File("foo").toPath());
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableEnumSetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableEnumSetRulesTestInput.java
@@ -79,7 +79,7 @@ final class ImmutableEnumSetRulesTest implements RefasterRuleCollectionTestCase 
         RoundingMode.HALF_EVEN);
   }
 
-  ImmutableSet<RoundingMode> testSetsImmutableEnumSetVarArgs() {
+  ImmutableSet<RoundingMode> testSetsImmutableEnumSetVarargs() {
     return ImmutableSet.copyOf(
         EnumSet.of(
             RoundingMode.UP,
@@ -90,7 +90,7 @@ final class ImmutableEnumSetRulesTest implements RefasterRuleCollectionTestCase 
             RoundingMode.HALF_EVEN));
   }
 
-  ImmutableSet<BoundType> testStreamToImmutableEnumSet() {
+  ImmutableSet<BoundType> testStreamCollectToImmutableEnumSet() {
     return Stream.of(BoundType.OPEN).collect(toImmutableSet());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableEnumSetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableEnumSetRulesTestOutput.java
@@ -80,7 +80,7 @@ final class ImmutableEnumSetRulesTest implements RefasterRuleCollectionTestCase 
         RoundingMode.HALF_EVEN);
   }
 
-  ImmutableSet<RoundingMode> testSetsImmutableEnumSetVarArgs() {
+  ImmutableSet<RoundingMode> testSetsImmutableEnumSetVarargs() {
     return Sets.immutableEnumSet(
         RoundingMode.UP,
         RoundingMode.DOWN,
@@ -90,7 +90,7 @@ final class ImmutableEnumSetRulesTest implements RefasterRuleCollectionTestCase 
         RoundingMode.HALF_EVEN);
   }
 
-  ImmutableSet<BoundType> testStreamToImmutableEnumSet() {
+  ImmutableSet<BoundType> testStreamCollectToImmutableEnumSet() {
     return Stream.of(BoundType.OPEN).collect(toImmutableEnumSet());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListMultimapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListMultimapRulesTestInput.java
@@ -32,75 +32,71 @@ final class ImmutableListMultimapRulesTest implements RefasterRuleCollectionTest
         ImmutableMultimap.builder());
   }
 
-  ImmutableSet<ImmutableMultimap<String, Integer>> testEmptyImmutableListMultimap() {
+  ImmutableSet<ImmutableMultimap<String, Integer>> testImmutableListMultimapOf0() {
     return ImmutableSet.of(
         ImmutableListMultimap.<String, Integer>builder().build(), ImmutableMultimap.of());
   }
 
-  ImmutableSet<ImmutableMultimap<String, Integer>> testPairToImmutableListMultimap() {
+  ImmutableSet<ImmutableMultimap<String, Integer>> testImmutableListMultimapOf2() {
     return ImmutableSet.of(
         ImmutableListMultimap.<String, Integer>builder().put("foo", 1).build(),
         ImmutableMultimap.of("bar", 2));
   }
 
-  ImmutableList<ImmutableMultimap<String, Integer>> testEntryToImmutableListMultimap() {
-    return ImmutableList.of(
+  ImmutableSet<ImmutableMultimap<String, Integer>>
+      testImmutableListMultimapOfEntryGetKeyEntryGetValue() {
+    return ImmutableSet.of(
         ImmutableListMultimap.<String, Integer>builder().put(Map.entry("foo", 1)).build(),
-        Stream.of(Map.entry("foo", 1))
+        Stream.of(Map.entry("bar", 2))
             .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableList<ImmutableMultimap<String, Integer>> testIterableToImmutableListMultimap() {
-    return ImmutableList.of(
+  ImmutableSet<ImmutableMultimap<String, Integer>> testImmutableListMultimapCopyOf() {
+    return ImmutableSet.of(
         ImmutableListMultimap.copyOf(ImmutableListMultimap.of("foo", 1).entries()),
         ImmutableListMultimap.<String, Integer>builder()
-            .putAll(ImmutableListMultimap.of("foo", 1))
+            .putAll(ImmutableListMultimap.of("bar", 2))
             .build(),
+        ImmutableMultimap.copyOf(ImmutableListMultimap.of("baz", 3)),
+        ImmutableMultimap.copyOf(ImmutableListMultimap.of("qux", 4).entries()),
         ImmutableListMultimap.<String, Integer>builder()
-            .putAll(ImmutableListMultimap.of("foo", 1).entries())
+            .putAll(Iterables.cycle(Map.entry("quux", 5)))
             .build(),
-        ImmutableListMultimap.of("foo", 1).entries().stream()
+        Streams.stream(Iterables.cycle(Map.entry("corge", 6)))
             .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue)),
-        Streams.stream(Iterables.cycle(Map.entry("foo", 1)))
-            .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue)),
-        ImmutableMultimap.copyOf(ImmutableListMultimap.of("foo", 1)),
-        ImmutableMultimap.copyOf(ImmutableListMultimap.of("foo", 1).entries()),
-        ImmutableMultimap.copyOf(Iterables.cycle(Map.entry("foo", 1))));
+        ImmutableMultimap.copyOf(Iterables.cycle(Map.entry("grault", 7))),
+        ImmutableListMultimap.of("garply", 8).entries().stream()
+            .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableListMultimap<Integer, String> testStreamOfMapEntriesToImmutableListMultimap() {
+  ImmutableListMultimap<Integer, String> testStreamCollectToImmutableListMultimap() {
     return Stream.of(1, 2, 3)
         .map(n -> Map.entry(n, n.toString()))
         .collect(toImmutableListMultimap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  ImmutableSet<ImmutableListMultimap<Integer, Integer>> testIndexIterableToImmutableListMultimap() {
+  ImmutableSet<ImmutableListMultimap<Integer, Integer>> testMultimapsIndex() {
     return ImmutableSet.of(
-        Streams.stream(ImmutableList.of(1).iterator())
-            .collect(toImmutableListMultimap(n -> n * 2, identity())),
-        Streams.stream(ImmutableList.of(2).iterator())
-            .collect(toImmutableListMultimap(n -> n * 2, v -> v)),
-        Streams.stream(ImmutableList.of(3).iterator())
-            .collect(toImmutableListMultimap(n -> n * 2, v -> 0)),
-        Streams.stream(ImmutableList.of(4)::iterator)
-            .collect(toImmutableListMultimap(Integer::valueOf, identity())),
-        Streams.stream(ImmutableList.of(5)::iterator)
-            .collect(toImmutableListMultimap(Integer::valueOf, v -> v)),
-        Streams.stream(ImmutableList.of(6)::iterator)
+        Streams.stream(ImmutableList.of(1)::iterator)
             .collect(toImmutableListMultimap(Integer::valueOf, v -> 0)),
-        ImmutableList.of(7).stream()
+        Streams.stream(ImmutableList.of(2)::iterator)
+            .collect(toImmutableListMultimap(Integer::valueOf, identity())),
+        ImmutableList.of(3).stream().collect(toImmutableListMultimap(n -> n.intValue(), v -> 0)),
+        ImmutableList.of(4).stream()
             .collect(toImmutableListMultimap(n -> n.intValue(), identity())),
-        ImmutableList.of(8).stream().collect(toImmutableListMultimap(n -> n.intValue(), v -> v)),
-        ImmutableList.of(9).stream().collect(toImmutableListMultimap(n -> n.intValue(), v -> 0)));
+        Streams.stream(ImmutableList.of(5).iterator())
+            .collect(toImmutableListMultimap(n -> n * 2, v -> 0)),
+        Streams.stream(ImmutableList.of(6).iterator())
+            .collect(toImmutableListMultimap(n -> n * 2, identity())));
   }
 
-  ImmutableListMultimap<String, Integer> testTransformMultimapValuesToImmutableListMultimap() {
+  ImmutableListMultimap<String, Integer> testImmutableListMultimapCopyOfMultimapsTransformValues() {
     return ImmutableListMultimap.of("foo", 1L).entries().stream()
         .collect(toImmutableListMultimap(Map.Entry::getKey, e -> Math.toIntExact(e.getValue())));
   }
 
   ImmutableSet<ImmutableListMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableListMultimap2() {
+      testImmutableListMultimapCopyOfMultimapsTransformValuesWithFunction() {
     return ImmutableSet.of(
         ImmutableSetMultimap.of("foo", 1L).asMap().entrySet().stream()
             .collect(
@@ -126,8 +122,7 @@ final class ImmutableListMultimapRulesTest implements RefasterRuleCollectionTest
                     Map.Entry::getKey, e -> e.getValue().stream().map(Math::toIntExact))));
   }
 
-  ImmutableSet<ImmutableListMultimap.Builder<String, Integer>>
-      testImmutableListMultimapBuilderPut() {
+  ImmutableSet<ImmutableListMultimap.Builder<String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableListMultimap.<String, Integer>builder().put(Map.entry("foo", 1)),
         ImmutableListMultimap.<String, Integer>builder().putAll("bar", 2));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListMultimapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListMultimapRulesTestOutput.java
@@ -32,58 +32,56 @@ final class ImmutableListMultimapRulesTest implements RefasterRuleCollectionTest
         ImmutableListMultimap.builder());
   }
 
-  ImmutableSet<ImmutableMultimap<String, Integer>> testEmptyImmutableListMultimap() {
+  ImmutableSet<ImmutableMultimap<String, Integer>> testImmutableListMultimapOf0() {
     return ImmutableSet.of(ImmutableListMultimap.of(), ImmutableListMultimap.of());
   }
 
-  ImmutableSet<ImmutableMultimap<String, Integer>> testPairToImmutableListMultimap() {
+  ImmutableSet<ImmutableMultimap<String, Integer>> testImmutableListMultimapOf2() {
     return ImmutableSet.of(ImmutableListMultimap.of("foo", 1), ImmutableListMultimap.of("bar", 2));
   }
 
-  ImmutableList<ImmutableMultimap<String, Integer>> testEntryToImmutableListMultimap() {
-    return ImmutableList.of(
+  ImmutableSet<ImmutableMultimap<String, Integer>>
+      testImmutableListMultimapOfEntryGetKeyEntryGetValue() {
+    return ImmutableSet.of(
         ImmutableListMultimap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()),
-        ImmutableListMultimap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()));
+        ImmutableListMultimap.of(Map.entry("bar", 2).getKey(), Map.entry("bar", 2).getValue()));
   }
 
-  ImmutableList<ImmutableMultimap<String, Integer>> testIterableToImmutableListMultimap() {
-    return ImmutableList.of(
+  ImmutableSet<ImmutableMultimap<String, Integer>> testImmutableListMultimapCopyOf() {
+    return ImmutableSet.of(
         ImmutableListMultimap.copyOf(ImmutableListMultimap.of("foo", 1)),
-        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("foo", 1)),
-        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("foo", 1).entries()),
-        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("foo", 1).entries()),
-        ImmutableListMultimap.copyOf(Iterables.cycle(Map.entry("foo", 1))),
-        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("foo", 1)),
-        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("foo", 1)),
-        ImmutableListMultimap.copyOf(Iterables.cycle(Map.entry("foo", 1))));
+        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("bar", 2)),
+        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("baz", 3)),
+        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("qux", 4)),
+        ImmutableListMultimap.copyOf(Iterables.cycle(Map.entry("quux", 5))),
+        ImmutableListMultimap.copyOf(Iterables.cycle(Map.entry("corge", 6))),
+        ImmutableListMultimap.copyOf(Iterables.cycle(Map.entry("grault", 7))),
+        ImmutableListMultimap.copyOf(ImmutableListMultimap.of("garply", 8).entries()));
   }
 
-  ImmutableListMultimap<Integer, String> testStreamOfMapEntriesToImmutableListMultimap() {
+  ImmutableListMultimap<Integer, String> testStreamCollectToImmutableListMultimap() {
     return Stream.of(1, 2, 3).collect(toImmutableListMultimap(n -> n, n -> n.toString()));
   }
 
-  ImmutableSet<ImmutableListMultimap<Integer, Integer>> testIndexIterableToImmutableListMultimap() {
+  ImmutableSet<ImmutableListMultimap<Integer, Integer>> testMultimapsIndex() {
     return ImmutableSet.of(
-        Multimaps.index(ImmutableList.of(1).iterator(), n -> n * 2),
-        Multimaps.index(ImmutableList.of(2).iterator(), n -> n * 2),
-        Streams.stream(ImmutableList.of(3).iterator())
-            .collect(toImmutableListMultimap(n -> n * 2, v -> 0)),
-        Multimaps.index(ImmutableList.of(4)::iterator, Integer::valueOf),
-        Multimaps.index(ImmutableList.of(5)::iterator, Integer::valueOf),
-        Streams.stream(ImmutableList.of(6)::iterator)
+        Streams.stream(ImmutableList.of(1)::iterator)
             .collect(toImmutableListMultimap(Integer::valueOf, v -> 0)),
-        Multimaps.index(ImmutableList.of(7), n -> n.intValue()),
-        Multimaps.index(ImmutableList.of(8), n -> n.intValue()),
-        ImmutableList.of(9).stream().collect(toImmutableListMultimap(n -> n.intValue(), v -> 0)));
+        Multimaps.index(ImmutableList.of(2)::iterator, Integer::valueOf),
+        ImmutableList.of(3).stream().collect(toImmutableListMultimap(n -> n.intValue(), v -> 0)),
+        Multimaps.index(ImmutableList.of(4), n -> n.intValue()),
+        Streams.stream(ImmutableList.of(5).iterator())
+            .collect(toImmutableListMultimap(n -> n * 2, v -> 0)),
+        Multimaps.index(ImmutableList.of(6).iterator(), n -> n * 2));
   }
 
-  ImmutableListMultimap<String, Integer> testTransformMultimapValuesToImmutableListMultimap() {
+  ImmutableListMultimap<String, Integer> testImmutableListMultimapCopyOfMultimapsTransformValues() {
     return ImmutableListMultimap.copyOf(
         Multimaps.transformValues(ImmutableListMultimap.of("foo", 1L), v -> Math.toIntExact(v)));
   }
 
   ImmutableSet<ImmutableListMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableListMultimap2() {
+      testImmutableListMultimapCopyOfMultimapsTransformValuesWithFunction() {
     return ImmutableSet.of(
         ImmutableListMultimap.copyOf(
             Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), Math::toIntExact)),
@@ -99,8 +97,7 @@ final class ImmutableListMultimapRulesTest implements RefasterRuleCollectionTest
             Multimaps.transformValues(TreeMultimap.<String, Long>create(), Math::toIntExact)));
   }
 
-  ImmutableSet<ImmutableListMultimap.Builder<String, Integer>>
-      testImmutableListMultimapBuilderPut() {
+  ImmutableSet<ImmutableListMultimap.Builder<String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableListMultimap.<String, Integer>builder().put("foo", 1),
         ImmutableListMultimap.<String, Integer>builder().put("bar", 2));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListRulesTestInput.java
@@ -26,58 +26,57 @@ final class ImmutableListRulesTest implements RefasterRuleCollectionTestCase {
     return new ImmutableList.Builder<>();
   }
 
-  ImmutableSet<ImmutableList<Integer>> testIterableToImmutableList() {
+  ImmutableSet<ImmutableList<Integer>> testImmutableListCopyOf() {
     return ImmutableSet.of(
-        ImmutableList.of(1).stream().collect(toImmutableList()),
-        Streams.stream(ImmutableList.of(2)::iterator).collect(toImmutableList()),
-        Streams.stream(ImmutableList.of(3).iterator()).collect(toImmutableList()),
-        ImmutableList.<Integer>builder().addAll(ImmutableList.of(4)).build(),
+        ImmutableList.<Integer>builder().add(new Integer[] {1}).build(),
+        Arrays.stream(new Integer[] {2}).collect(toImmutableList()),
+        ImmutableList.<Integer>builder().addAll(ImmutableList.of(3).iterator()).build(),
+        Streams.stream(ImmutableList.of(4).iterator()).collect(toImmutableList()),
         ImmutableList.<Integer>builder().addAll(ImmutableList.of(5)::iterator).build(),
-        ImmutableList.<Integer>builder().addAll(ImmutableList.of(6).iterator()).build(),
-        ImmutableList.<Integer>builder().add(new Integer[] {7}).build(),
-        Arrays.stream(new Integer[] {8}).collect(toImmutableList()));
+        Streams.stream(ImmutableList.of(6)::iterator).collect(toImmutableList()),
+        ImmutableList.of(7).stream().collect(toImmutableList()));
   }
 
-  ImmutableList<Integer> testStreamToImmutableList() {
+  ImmutableList<Integer> testStreamCollectToImmutableList() {
     return ImmutableList.copyOf(Stream.of(1).iterator());
   }
 
   ImmutableSet<ImmutableList<Integer>> testImmutableListSortedCopyOf() {
     return ImmutableSet.of(
         ImmutableList.sortedCopyOf(naturalOrder(), ImmutableSet.of(1)),
-        ImmutableSet.of(2).stream().sorted().collect(toImmutableList()),
-        Streams.stream(ImmutableSet.of(3)::iterator).sorted().collect(toImmutableList()));
+        Streams.stream(ImmutableSet.of(2)::iterator).sorted().collect(toImmutableList()),
+        ImmutableSet.of(3).stream().sorted().collect(toImmutableList()));
   }
 
-  ImmutableSet<ImmutableList<String>> testImmutableListSortedCopyOfWithCustomComparator() {
+  ImmutableSet<ImmutableList<String>> testImmutableListSortedCopyOfWithComparator() {
     return ImmutableSet.of(
-        ImmutableSet.of("foo").stream()
+        Streams.stream(ImmutableSet.of("foo")::iterator)
             .sorted(comparing(String::length))
             .collect(toImmutableList()),
-        Streams.stream(ImmutableSet.of("bar")::iterator)
+        ImmutableSet.of("bar").stream()
             .sorted(comparing(String::isEmpty))
             .collect(toImmutableList()));
   }
 
   ImmutableSet<Iterator<Integer>> testImmutableListSortedCopyOfIterator() {
     return ImmutableSet.of(
-        ImmutableSet.of(1).stream().sorted().iterator(),
-        Streams.stream(ImmutableSet.of(2)::iterator).sorted().iterator());
+        Streams.stream(ImmutableList.of(1)::iterator).sorted().iterator(),
+        ImmutableList.of(2).stream().sorted().iterator());
   }
 
   ImmutableSet<Iterator<String>> testImmutableListSortedCopyOfIteratorWithComparator() {
     return ImmutableSet.of(
-        ImmutableSet.of("foo").stream().sorted(comparing(String::length)).iterator(),
-        Streams.stream(ImmutableSet.of("bar")::iterator)
-            .sorted(comparing(String::isEmpty))
-            .iterator());
+        Streams.stream(ImmutableList.of("foo")::iterator)
+            .sorted(Comparator.comparing(String::length))
+            .iterator(),
+        ImmutableList.of("bar").stream().sorted(Comparator.comparing(String::isEmpty)).iterator());
   }
 
-  ImmutableList<Integer> testStreamToDistinctImmutableList() {
+  ImmutableList<Integer> testStreamCollectToImmutableSetAsList() {
     return Stream.of(1).distinct().collect(toImmutableList());
   }
 
-  ImmutableSet<List<Integer>> testImmutableListOf() {
+  ImmutableSet<List<Integer>> testImmutableListOf0() {
     return ImmutableSet.of(
         ImmutableList.<Integer>builder().build(),
         Stream.<Integer>empty().collect(toImmutableList()),
@@ -86,7 +85,8 @@ final class ImmutableListRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<List<Integer>> testImmutableListOf1() {
-    return ImmutableSet.of(Collections.singletonList(1), List.of(1));
+    return ImmutableSet.of(
+        ImmutableList.<Integer>builder().add(1).build(), Collections.singletonList(2), List.of(3));
   }
 
   List<Integer> testImmutableListOf2() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableListRulesTestOutput.java
@@ -27,59 +27,60 @@ final class ImmutableListRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableList.builder();
   }
 
-  ImmutableSet<ImmutableList<Integer>> testIterableToImmutableList() {
+  ImmutableSet<ImmutableList<Integer>> testImmutableListCopyOf() {
     return ImmutableSet.of(
-        ImmutableList.copyOf(ImmutableList.of(1)),
-        ImmutableList.copyOf(ImmutableList.of(2)::iterator),
+        ImmutableList.copyOf(new Integer[] {1}),
+        ImmutableList.copyOf(new Integer[] {2}),
         ImmutableList.copyOf(ImmutableList.of(3).iterator()),
-        ImmutableList.copyOf(ImmutableList.of(4)),
+        ImmutableList.copyOf(ImmutableList.of(4).iterator()),
         ImmutableList.copyOf(ImmutableList.of(5)::iterator),
-        ImmutableList.copyOf(ImmutableList.of(6).iterator()),
-        ImmutableList.copyOf(new Integer[] {7}),
-        ImmutableList.copyOf(new Integer[] {8}));
+        ImmutableList.copyOf(ImmutableList.of(6)::iterator),
+        ImmutableList.copyOf(ImmutableList.of(7)));
   }
 
-  ImmutableList<Integer> testStreamToImmutableList() {
+  ImmutableList<Integer> testStreamCollectToImmutableList() {
     return Stream.of(1).collect(toImmutableList());
   }
 
   ImmutableSet<ImmutableList<Integer>> testImmutableListSortedCopyOf() {
     return ImmutableSet.of(
         ImmutableList.sortedCopyOf(ImmutableSet.of(1)),
-        ImmutableList.sortedCopyOf(ImmutableSet.of(2)),
-        ImmutableList.sortedCopyOf(ImmutableSet.of(3)::iterator));
+        ImmutableList.sortedCopyOf(ImmutableSet.of(2)::iterator),
+        ImmutableList.sortedCopyOf(ImmutableSet.of(3)));
   }
 
-  ImmutableSet<ImmutableList<String>> testImmutableListSortedCopyOfWithCustomComparator() {
+  ImmutableSet<ImmutableList<String>> testImmutableListSortedCopyOfWithComparator() {
     return ImmutableSet.of(
-        ImmutableList.sortedCopyOf(comparing(String::length), ImmutableSet.of("foo")),
-        ImmutableList.sortedCopyOf(comparing(String::isEmpty), ImmutableSet.of("bar")::iterator));
+        ImmutableList.sortedCopyOf(comparing(String::length), ImmutableSet.of("foo")::iterator),
+        ImmutableList.sortedCopyOf(comparing(String::isEmpty), ImmutableSet.of("bar")));
   }
 
   ImmutableSet<Iterator<Integer>> testImmutableListSortedCopyOfIterator() {
     return ImmutableSet.of(
-        ImmutableList.sortedCopyOf(ImmutableSet.of(1)).iterator(),
-        ImmutableList.sortedCopyOf(ImmutableSet.of(2)::iterator).iterator());
+        ImmutableList.sortedCopyOf(ImmutableList.of(1)::iterator).iterator(),
+        ImmutableList.sortedCopyOf(ImmutableList.of(2)).iterator());
   }
 
   ImmutableSet<Iterator<String>> testImmutableListSortedCopyOfIteratorWithComparator() {
     return ImmutableSet.of(
-        ImmutableList.sortedCopyOf(comparing(String::length), ImmutableSet.of("foo")).iterator(),
-        ImmutableList.sortedCopyOf(comparing(String::isEmpty), ImmutableSet.of("bar")::iterator)
+        ImmutableList.sortedCopyOf(
+                Comparator.comparing(String::length), ImmutableList.of("foo")::iterator)
+            .iterator(),
+        ImmutableList.sortedCopyOf(Comparator.comparing(String::isEmpty), ImmutableList.of("bar"))
             .iterator());
   }
 
-  ImmutableList<Integer> testStreamToDistinctImmutableList() {
+  ImmutableList<Integer> testStreamCollectToImmutableSetAsList() {
     return Stream.of(1).collect(toImmutableSet()).asList();
   }
 
-  ImmutableSet<List<Integer>> testImmutableListOf() {
+  ImmutableSet<List<Integer>> testImmutableListOf0() {
     return ImmutableSet.of(
         ImmutableList.of(), ImmutableList.of(), ImmutableList.of(), ImmutableList.of());
   }
 
   ImmutableSet<List<Integer>> testImmutableListOf1() {
-    return ImmutableSet.of(ImmutableList.of(1), ImmutableList.of(1));
+    return ImmutableSet.of(ImmutableList.of(1), ImmutableList.of(2), ImmutableList.of(3));
   }
 
   List<Integer> testImmutableListOf2() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestInput.java
@@ -24,77 +24,67 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
     return new ImmutableMap.Builder<>();
   }
 
-  ImmutableMap<Object, Object> testImmutableMapBuilderBuildOrThrow() {
+  ImmutableMap<Object, Object> testBuilderBuildOrThrow() {
     return ImmutableMap.builder().build();
   }
 
-  ImmutableSet<ImmutableMap<String, Integer>> testEntryToImmutableMap() {
+  ImmutableSet<ImmutableMap<String, Integer>> testImmutableMapOfEntryGetKeyEntryGetValue() {
     return ImmutableSet.of(
         ImmutableMap.<String, Integer>builder().put(Map.entry("foo", 1)).buildOrThrow(),
-        Stream.of(Map.entry("foo", 1))
+        Stream.of(Map.entry("bar", 2))
             .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableSet<ImmutableMap<Integer, Integer>> testIterableToImmutableMap() {
+  ImmutableSet<ImmutableMap<Integer, Integer>> testMapsToMap() {
     return ImmutableSet.of(
-        ImmutableList.of(1).stream().collect(toImmutableMap(identity(), n -> n * 2)),
-        ImmutableList.of(2).stream().collect(toImmutableMap(k -> k, n -> n * 2)),
-        ImmutableList.of(3).stream().collect(toImmutableMap(k -> 0, n -> n * 2)),
+        Streams.stream(ImmutableList.of(1).iterator())
+            .collect(toImmutableMap(k -> 0, n -> n.intValue())),
+        Streams.stream(ImmutableList.of(2).iterator())
+            .collect(toImmutableMap(identity(), n -> n.intValue())),
+        Streams.stream(ImmutableList.of(3)::iterator)
+            .collect(toImmutableMap(k -> 0, Integer::valueOf)),
         Streams.stream(ImmutableList.of(4)::iterator)
             .collect(toImmutableMap(identity(), Integer::valueOf)),
-        Streams.stream(ImmutableList.of(5)::iterator)
-            .collect(toImmutableMap(k -> k, Integer::valueOf)),
-        Streams.stream(ImmutableList.of(6)::iterator)
-            .collect(toImmutableMap(k -> 0, Integer::valueOf)),
-        Streams.stream(ImmutableList.of(7).iterator())
-            .collect(toImmutableMap(identity(), n -> n.intValue())),
-        Streams.stream(ImmutableList.of(8).iterator())
-            .collect(toImmutableMap(k -> k, n -> n.intValue())),
-        Streams.stream(ImmutableList.of(9).iterator())
-            .collect(toImmutableMap(k -> 0, n -> n.intValue())),
-        ImmutableMap.copyOf(Maps.asMap(ImmutableSet.of(10), Integer::valueOf)));
+        ImmutableList.of(5).stream().collect(toImmutableMap(k -> 0, n -> n * 2)),
+        ImmutableList.of(6).stream().collect(toImmutableMap(identity(), n -> n * 2)),
+        ImmutableMap.copyOf(Maps.asMap(ImmutableSet.of(7), Integer::valueOf)));
   }
 
-  ImmutableSet<Map<String, Integer>> testEntryIterableToImmutableMap() {
+  ImmutableSet<Map<String, Integer>> testImmutableMapCopyOf() {
     return ImmutableSet.of(
         ImmutableMap.copyOf(ImmutableMap.of("foo", 1).entrySet()),
-        ImmutableMap.<String, Integer>builder().putAll(ImmutableMap.of("foo", 1)).buildOrThrow(),
-        Map.copyOf(ImmutableMap.of("foo", 1)),
+        ImmutableMap.<String, Integer>builder().putAll(ImmutableMap.of("bar", 2)).buildOrThrow(),
+        Map.copyOf(ImmutableMap.of("baz", 3)),
         ImmutableMap.<String, Integer>builder()
-            .putAll(ImmutableMap.of("foo", 1).entrySet())
+            .putAll(ImmutableMap.of("qux", 4).entrySet())
             .buildOrThrow(),
-        ImmutableMap.of("foo", 1).entrySet().stream()
+        Streams.stream(Iterables.cycle(Map.entry("corge", 6)))
             .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)),
-        Streams.stream(Iterables.cycle(Map.entry("foo", 1)))
+        ImmutableMap.of("quux", 5).entrySet().stream()
             .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableMap<Integer, String> testStreamOfMapEntriesToImmutableMap() {
+  ImmutableMap<Integer, String> testStreamCollectToImmutableMap() {
     return Stream.of(1, 2, 3)
         .map(n -> Map.entry(n, n.toString()))
         .collect(toImmutableMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  ImmutableSet<ImmutableMap<Integer, Integer>> testIndexIterableToImmutableMap() {
+  ImmutableSet<ImmutableMap<Integer, Integer>> testMapsUniqueIndex() {
     return ImmutableSet.of(
-        ImmutableList.of(1).stream().collect(toImmutableMap(n -> n * 2, identity())),
-        ImmutableList.of(2).stream().collect(toImmutableMap(n -> n * 2, v -> v)),
-        ImmutableList.of(3).stream().collect(toImmutableMap(n -> n * 2, v -> 0)),
+        Streams.stream(ImmutableList.of(1).iterator())
+            .collect(toImmutableMap(n -> n.intValue(), v -> 0)),
+        Streams.stream(ImmutableList.of(2).iterator())
+            .collect(toImmutableMap(n -> n.intValue(), identity())),
+        Streams.stream(ImmutableList.of(3)::iterator)
+            .collect(toImmutableMap(Integer::valueOf, v -> 0)),
         Streams.stream(ImmutableList.of(4)::iterator)
             .collect(toImmutableMap(Integer::valueOf, identity())),
-        Streams.stream(ImmutableList.of(5)::iterator)
-            .collect(toImmutableMap(Integer::valueOf, v -> v)),
-        Streams.stream(ImmutableList.of(6)::iterator)
-            .collect(toImmutableMap(Integer::valueOf, v -> 0)),
-        Streams.stream(ImmutableList.of(7).iterator())
-            .collect(toImmutableMap(n -> n.intValue(), identity())),
-        Streams.stream(ImmutableList.of(8).iterator())
-            .collect(toImmutableMap(n -> n.intValue(), v -> v)),
-        Streams.stream(ImmutableList.of(9).iterator())
-            .collect(toImmutableMap(n -> n.intValue(), v -> 0)));
+        ImmutableList.of(5).stream().collect(toImmutableMap(n -> n * 2, v -> 0)),
+        ImmutableList.of(6).stream().collect(toImmutableMap(n -> n * 2, identity())));
   }
 
-  ImmutableSet<ImmutableMap<String, Integer>> testTransformMapValuesToImmutableMap() {
+  ImmutableSet<ImmutableMap<String, Integer>> testImmutableMapCopyOfMapsTransformValues() {
     return ImmutableSet.of(
         ImmutableMap.of("foo", 1L).entrySet().stream()
             .collect(toImmutableMap(Map.Entry::getKey, e -> Math.toIntExact(e.getValue()))),
@@ -103,7 +93,7 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
             k -> Math.toIntExact(ImmutableMap.of("bar", 2L).get(k))));
   }
 
-  ImmutableSet<Map<String, String>> testImmutableMapOf() {
+  ImmutableSet<Map<String, String>> testImmutableMapOf0() {
     return ImmutableSet.of(
         ImmutableMap.<String, String>builder().buildOrThrow(),
         ImmutableMap.ofEntries(),
@@ -111,45 +101,46 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
         Map.<String, String>of());
   }
 
-  ImmutableSet<Map<String, String>> testImmutableMapOf1() {
-    return ImmutableSet.of(
-        ImmutableMap.<String, String>builder().put("k1", "v1").buildOrThrow(),
-        ImmutableMap.ofEntries(Map.entry("k1", "v1")),
-        Collections.singletonMap("k1", "v1"),
-        Map.of("k1", "v1"));
-  }
-
   ImmutableSet<Map<String, String>> testImmutableMapOf2() {
     return ImmutableSet.of(
-        ImmutableMap.ofEntries(Map.entry("k1", "v1"), Map.entry("k2", "v2")),
-        Map.of("k1", "v1", "k2", "v2"));
-  }
-
-  ImmutableSet<Map<String, String>> testImmutableMapOf3() {
-    return ImmutableSet.of(
-        ImmutableMap.ofEntries(Map.entry("k1", "v1"), Map.entry("k2", "v2"), Map.entry("k3", "v3")),
-        Map.of("k1", "v1", "k2", "v2", "k3", "v3"));
+        ImmutableMap.<String, String>builder().put("foo", "bar").buildOrThrow(),
+        ImmutableMap.ofEntries(Map.entry("baz", "qux")),
+        Collections.singletonMap("quux", "corge"),
+        Map.of("grault", "garply"));
   }
 
   ImmutableSet<Map<String, String>> testImmutableMapOf4() {
     return ImmutableSet.of(
-        ImmutableMap.ofEntries(
-            Map.entry("k1", "v1"),
-            Map.entry("k2", "v2"),
-            Map.entry("k3", "v3"),
-            Map.entry("k4", "v4")),
-        Map.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"));
+        ImmutableMap.ofEntries(Map.entry("foo", "bar"), Map.entry("baz", "qux")),
+        Map.of("quux", "corge", "grault", "garply"));
   }
 
-  ImmutableSet<Map<String, String>> testImmutableMapOf5() {
+  ImmutableSet<Map<String, String>> testImmutableMapOf6() {
     return ImmutableSet.of(
         ImmutableMap.ofEntries(
-            Map.entry("k1", "v1"),
-            Map.entry("k2", "v2"),
-            Map.entry("k3", "v3"),
-            Map.entry("k4", "v4"),
-            Map.entry("k5", "v5")),
-        Map.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4", "k5", "v5"));
+            Map.entry("foo", "bar"), Map.entry("baz", "qux"), Map.entry("quux", "corge")),
+        Map.of("grault", "garply", "waldo", "fred", "plugh", "xyzzy"));
+  }
+
+  ImmutableSet<Map<String, String>> testImmutableMapOf8() {
+    return ImmutableSet.of(
+        ImmutableMap.ofEntries(
+            Map.entry("foo", "bar"),
+            Map.entry("baz", "qux"),
+            Map.entry("quux", "corge"),
+            Map.entry("grault", "garply")),
+        Map.of("waldo", "fred", "plugh", "xyzzy", "thud", "foo", "bar", "baz"));
+  }
+
+  ImmutableSet<Map<String, String>> testImmutableMapOf10() {
+    return ImmutableSet.of(
+        ImmutableMap.ofEntries(
+            Map.entry("foo", "bar"),
+            Map.entry("baz", "qux"),
+            Map.entry("quux", "corge"),
+            Map.entry("grault", "garply"),
+            Map.entry("waldo", "fred")),
+        Map.of("plugh", "xyzzy", "thud", "foo", "bar", "baz", "qux", "quux", "corge", "grault"));
   }
 
   ImmutableMap<String, Integer> testImmutableMapCopyOfMapsFilterKeys() {
@@ -171,7 +162,7 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
         Map.ofEntries(Map.entry("bar", 2), Map.entry("baz", 3)));
   }
 
-  ImmutableSet<ImmutableMap.Builder<String, Integer>> testImmutableMapBuilderPut() {
+  ImmutableSet<ImmutableMap.Builder<String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableMap.<String, Integer>builder().put(Map.entry("foo", 1)),
         ImmutableMap.<String, Integer>builder().putAll(ImmutableMap.of("bar", 2)));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMapRulesTestOutput.java
@@ -24,62 +24,56 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.builder();
   }
 
-  ImmutableMap<Object, Object> testImmutableMapBuilderBuildOrThrow() {
+  ImmutableMap<Object, Object> testBuilderBuildOrThrow() {
     return ImmutableMap.builder().buildOrThrow();
   }
 
-  ImmutableSet<ImmutableMap<String, Integer>> testEntryToImmutableMap() {
+  ImmutableSet<ImmutableMap<String, Integer>> testImmutableMapOfEntryGetKeyEntryGetValue() {
     return ImmutableSet.of(
         ImmutableMap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()),
-        ImmutableMap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()));
+        ImmutableMap.of(Map.entry("bar", 2).getKey(), Map.entry("bar", 2).getValue()));
   }
 
-  ImmutableSet<ImmutableMap<Integer, Integer>> testIterableToImmutableMap() {
+  ImmutableSet<ImmutableMap<Integer, Integer>> testMapsToMap() {
     return ImmutableSet.of(
-        Maps.toMap(ImmutableList.of(1), n -> n * 2),
-        Maps.toMap(ImmutableList.of(2), n -> n * 2),
-        ImmutableList.of(3).stream().collect(toImmutableMap(k -> 0, n -> n * 2)),
-        Maps.toMap(ImmutableList.of(4)::iterator, Integer::valueOf),
-        Maps.toMap(ImmutableList.of(5)::iterator, Integer::valueOf),
-        Streams.stream(ImmutableList.of(6)::iterator)
-            .collect(toImmutableMap(k -> 0, Integer::valueOf)),
-        Maps.toMap(ImmutableList.of(7).iterator(), n -> n.intValue()),
-        Maps.toMap(ImmutableList.of(8).iterator(), n -> n.intValue()),
-        Streams.stream(ImmutableList.of(9).iterator())
+        Streams.stream(ImmutableList.of(1).iterator())
             .collect(toImmutableMap(k -> 0, n -> n.intValue())),
-        Maps.toMap(ImmutableSet.of(10), Integer::valueOf));
+        Maps.toMap(ImmutableList.of(2).iterator(), n -> n.intValue()),
+        Streams.stream(ImmutableList.of(3)::iterator)
+            .collect(toImmutableMap(k -> 0, Integer::valueOf)),
+        Maps.toMap(ImmutableList.of(4)::iterator, Integer::valueOf),
+        ImmutableList.of(5).stream().collect(toImmutableMap(k -> 0, n -> n * 2)),
+        Maps.toMap(ImmutableList.of(6), n -> n * 2),
+        Maps.toMap(ImmutableSet.of(7), Integer::valueOf));
   }
 
-  ImmutableSet<Map<String, Integer>> testEntryIterableToImmutableMap() {
+  ImmutableSet<Map<String, Integer>> testImmutableMapCopyOf() {
     return ImmutableSet.of(
         ImmutableMap.copyOf(ImmutableMap.of("foo", 1)),
-        ImmutableMap.copyOf(ImmutableMap.of("foo", 1)),
-        ImmutableMap.copyOf(ImmutableMap.of("foo", 1)),
-        ImmutableMap.copyOf(ImmutableMap.of("foo", 1).entrySet()),
-        ImmutableMap.copyOf(ImmutableMap.of("foo", 1).entrySet()),
-        ImmutableMap.copyOf(Iterables.cycle(Map.entry("foo", 1))));
+        ImmutableMap.copyOf(ImmutableMap.of("bar", 2)),
+        ImmutableMap.copyOf(ImmutableMap.of("baz", 3)),
+        ImmutableMap.copyOf(ImmutableMap.of("qux", 4).entrySet()),
+        ImmutableMap.copyOf(Iterables.cycle(Map.entry("corge", 6))),
+        ImmutableMap.copyOf(ImmutableMap.of("quux", 5).entrySet()));
   }
 
-  ImmutableMap<Integer, String> testStreamOfMapEntriesToImmutableMap() {
+  ImmutableMap<Integer, String> testStreamCollectToImmutableMap() {
     return Stream.of(1, 2, 3).collect(toImmutableMap(n -> n, n -> n.toString()));
   }
 
-  ImmutableSet<ImmutableMap<Integer, Integer>> testIndexIterableToImmutableMap() {
+  ImmutableSet<ImmutableMap<Integer, Integer>> testMapsUniqueIndex() {
     return ImmutableSet.of(
-        Maps.uniqueIndex(ImmutableList.of(1), n -> n * 2),
-        Maps.uniqueIndex(ImmutableList.of(2), n -> n * 2),
-        ImmutableList.of(3).stream().collect(toImmutableMap(n -> n * 2, v -> 0)),
-        Maps.uniqueIndex(ImmutableList.of(4)::iterator, Integer::valueOf),
-        Maps.uniqueIndex(ImmutableList.of(5)::iterator, Integer::valueOf),
-        Streams.stream(ImmutableList.of(6)::iterator)
+        Streams.stream(ImmutableList.of(1).iterator())
+            .collect(toImmutableMap(n -> n.intValue(), v -> 0)),
+        Maps.uniqueIndex(ImmutableList.of(2).iterator(), n -> n.intValue()),
+        Streams.stream(ImmutableList.of(3)::iterator)
             .collect(toImmutableMap(Integer::valueOf, v -> 0)),
-        Maps.uniqueIndex(ImmutableList.of(7).iterator(), n -> n.intValue()),
-        Maps.uniqueIndex(ImmutableList.of(8).iterator(), n -> n.intValue()),
-        Streams.stream(ImmutableList.of(9).iterator())
-            .collect(toImmutableMap(n -> n.intValue(), v -> 0)));
+        Maps.uniqueIndex(ImmutableList.of(4)::iterator, Integer::valueOf),
+        ImmutableList.of(5).stream().collect(toImmutableMap(n -> n * 2, v -> 0)),
+        Maps.uniqueIndex(ImmutableList.of(6), n -> n * 2));
   }
 
-  ImmutableSet<ImmutableMap<String, Integer>> testTransformMapValuesToImmutableMap() {
+  ImmutableSet<ImmutableMap<String, Integer>> testImmutableMapCopyOfMapsTransformValues() {
     return ImmutableSet.of(
         ImmutableMap.copyOf(
             Maps.transformValues(ImmutableMap.of("foo", 1L), v -> Math.toIntExact(v))),
@@ -87,40 +81,43 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
             Maps.transformValues(ImmutableMap.of("bar", 2L), v -> Math.toIntExact(v))));
   }
 
-  ImmutableSet<Map<String, String>> testImmutableMapOf() {
+  ImmutableSet<Map<String, String>> testImmutableMapOf0() {
     return ImmutableSet.of(
         ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of(), ImmutableMap.of());
   }
 
-  ImmutableSet<Map<String, String>> testImmutableMapOf1() {
-    return ImmutableSet.of(
-        ImmutableMap.of("k1", "v1"),
-        ImmutableMap.of("k1", "v1"),
-        ImmutableMap.of("k1", "v1"),
-        ImmutableMap.of("k1", "v1"));
-  }
-
   ImmutableSet<Map<String, String>> testImmutableMapOf2() {
     return ImmutableSet.of(
-        ImmutableMap.of("k1", "v1", "k2", "v2"), ImmutableMap.of("k1", "v1", "k2", "v2"));
-  }
-
-  ImmutableSet<Map<String, String>> testImmutableMapOf3() {
-    return ImmutableSet.of(
-        ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"),
-        ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3"));
+        ImmutableMap.of("foo", "bar"),
+        ImmutableMap.of("baz", "qux"),
+        ImmutableMap.of("quux", "corge"),
+        ImmutableMap.of("grault", "garply"));
   }
 
   ImmutableSet<Map<String, String>> testImmutableMapOf4() {
     return ImmutableSet.of(
-        ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"),
-        ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4"));
+        ImmutableMap.of("foo", "bar", "baz", "qux"),
+        ImmutableMap.of("quux", "corge", "grault", "garply"));
   }
 
-  ImmutableSet<Map<String, String>> testImmutableMapOf5() {
+  ImmutableSet<Map<String, String>> testImmutableMapOf6() {
     return ImmutableSet.of(
-        ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4", "k5", "v5"),
-        ImmutableMap.of("k1", "v1", "k2", "v2", "k3", "v3", "k4", "v4", "k5", "v5"));
+        ImmutableMap.of("foo", "bar", "baz", "qux", "quux", "corge"),
+        ImmutableMap.of("grault", "garply", "waldo", "fred", "plugh", "xyzzy"));
+  }
+
+  ImmutableSet<Map<String, String>> testImmutableMapOf8() {
+    return ImmutableSet.of(
+        ImmutableMap.of("foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply"),
+        ImmutableMap.of("waldo", "fred", "plugh", "xyzzy", "thud", "foo", "bar", "baz"));
+  }
+
+  ImmutableSet<Map<String, String>> testImmutableMapOf10() {
+    return ImmutableSet.of(
+        ImmutableMap.of(
+            "foo", "bar", "baz", "qux", "quux", "corge", "grault", "garply", "waldo", "fred"),
+        ImmutableMap.of(
+            "plugh", "xyzzy", "thud", "foo", "bar", "baz", "qux", "quux", "corge", "grault"));
   }
 
   ImmutableMap<String, Integer> testImmutableMapCopyOfMapsFilterKeys() {
@@ -138,7 +135,7 @@ final class ImmutableMapRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableMap.ofEntries(Map.entry("bar", 2), Map.entry("baz", 3)));
   }
 
-  ImmutableSet<ImmutableMap.Builder<String, Integer>> testImmutableMapBuilderPut() {
+  ImmutableSet<ImmutableMap.Builder<String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableMap.<String, Integer>builder().put("foo", 1),
         ImmutableMap.<String, Integer>builder().put("bar", 2));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestInput.java
@@ -20,26 +20,25 @@ final class ImmutableMultisetRulesTest implements RefasterRuleCollectionTestCase
     return new ImmutableMultiset.Builder<>();
   }
 
-  ImmutableMultiset<ImmutableMultiset<Integer>> testEmptyImmutableMultiset() {
-    return ImmutableMultiset.of(
+  ImmutableSet<ImmutableMultiset<Integer>> testImmutableMultisetOf() {
+    return ImmutableSet.of(
         ImmutableMultiset.<Integer>builder().build(),
         Stream.<Integer>empty().collect(toImmutableMultiset()));
   }
 
-  @SuppressWarnings("unchecked")
-  ImmutableMultiset<ImmutableMultiset<Integer>> testIterableToImmutableMultiset() {
-    return ImmutableMultiset.of(
-        ImmutableList.of(1).stream().collect(toImmutableMultiset()),
-        Streams.stream(ImmutableList.of(2)::iterator).collect(toImmutableMultiset()),
-        Streams.stream(ImmutableList.of(3).iterator()).collect(toImmutableMultiset()),
-        ImmutableMultiset.<Integer>builder().addAll(ImmutableMultiset.of(4)).build(),
-        ImmutableMultiset.<Integer>builder().addAll(ImmutableMultiset.of(5)::iterator).build(),
-        ImmutableMultiset.<Integer>builder().addAll(ImmutableMultiset.of(6).iterator()).build(),
-        ImmutableMultiset.<Integer>builder().add(new Integer[] {7}).build(),
-        Arrays.stream(new Integer[] {8}).collect(toImmutableMultiset()));
+  @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
+  ImmutableSet<ImmutableMultiset<Integer>> testImmutableMultisetCopyOf() {
+    return ImmutableSet.of(
+        ImmutableMultiset.<Integer>builder().add(new Integer[] {1}).build(),
+        Arrays.stream(new Integer[] {2}).collect(toImmutableMultiset()),
+        ImmutableMultiset.<Integer>builder().addAll(ImmutableMultiset.of(3).iterator()).build(),
+        Streams.stream(ImmutableList.of(4).iterator()).collect(toImmutableMultiset()),
+        ImmutableMultiset.<Integer>builder().addAll(ImmutableMultiset.of(5)).build(),
+        Streams.stream(ImmutableList.of(6)::iterator).collect(toImmutableMultiset()),
+        ImmutableList.of(7).stream().collect(toImmutableMultiset()));
   }
 
-  ImmutableMultiset<Integer> testStreamToImmutableMultiset() {
+  ImmutableMultiset<Integer> testStreamCollectToImmutableMultiset() {
     return ImmutableMultiset.copyOf(Stream.of(1).iterator());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableMultisetRulesTestOutput.java
@@ -20,24 +20,23 @@ final class ImmutableMultisetRulesTest implements RefasterRuleCollectionTestCase
     return ImmutableMultiset.builder();
   }
 
-  ImmutableMultiset<ImmutableMultiset<Integer>> testEmptyImmutableMultiset() {
-    return ImmutableMultiset.of(ImmutableMultiset.of(), ImmutableMultiset.of());
+  ImmutableSet<ImmutableMultiset<Integer>> testImmutableMultisetOf() {
+    return ImmutableSet.of(ImmutableMultiset.of(), ImmutableMultiset.of());
   }
 
-  @SuppressWarnings("unchecked")
-  ImmutableMultiset<ImmutableMultiset<Integer>> testIterableToImmutableMultiset() {
-    return ImmutableMultiset.of(
-        ImmutableMultiset.copyOf(ImmutableList.of(1)),
-        ImmutableMultiset.copyOf(ImmutableList.of(2)::iterator),
-        ImmutableMultiset.copyOf(ImmutableList.of(3).iterator()),
-        ImmutableMultiset.copyOf(ImmutableMultiset.of(4)),
-        ImmutableMultiset.copyOf(ImmutableMultiset.of(5)::iterator),
-        ImmutableMultiset.copyOf(ImmutableMultiset.of(6).iterator()),
-        ImmutableMultiset.copyOf(new Integer[] {7}),
-        ImmutableMultiset.copyOf(new Integer[] {8}));
+  @SuppressWarnings("unchecked" /* Safe generic array type creation. */)
+  ImmutableSet<ImmutableMultiset<Integer>> testImmutableMultisetCopyOf() {
+    return ImmutableSet.of(
+        ImmutableMultiset.copyOf(new Integer[] {1}),
+        ImmutableMultiset.copyOf(new Integer[] {2}),
+        ImmutableMultiset.copyOf(ImmutableMultiset.of(3).iterator()),
+        ImmutableMultiset.copyOf(ImmutableList.of(4).iterator()),
+        ImmutableMultiset.copyOf(ImmutableMultiset.of(5)),
+        ImmutableMultiset.copyOf(ImmutableList.of(6)::iterator),
+        ImmutableMultiset.copyOf(ImmutableList.of(7)));
   }
 
-  ImmutableMultiset<Integer> testStreamToImmutableMultiset() {
+  ImmutableMultiset<Integer> testStreamCollectToImmutableMultiset() {
     return Stream.of(1).collect(toImmutableMultiset());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRulesTestInput.java
@@ -25,49 +25,50 @@ final class ImmutableSetMultimapRulesTest implements RefasterRuleCollectionTestC
     return new ImmutableSetMultimap.Builder<>();
   }
 
-  ImmutableSetMultimap<String, Integer> testEmptyImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapOf0() {
     return ImmutableSetMultimap.<String, Integer>builder().build();
   }
 
-  ImmutableSetMultimap<String, Integer> testPairToImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapOf2() {
     return ImmutableSetMultimap.<String, Integer>builder().put("foo", 1).build();
   }
 
-  ImmutableSet<ImmutableSetMultimap<String, Integer>> testEntryToImmutableSetMultimap() {
+  ImmutableSet<ImmutableSetMultimap<String, Integer>>
+      testImmutableSetMultimapOfEntryGetKeyEntryGetValue() {
     return ImmutableSet.of(
         ImmutableSetMultimap.<String, Integer>builder().put(Map.entry("foo", 1)).build(),
-        Stream.of(Map.entry("foo", 1))
+        Stream.of(Map.entry("bar", 2))
             .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableSet<ImmutableSetMultimap<String, Integer>> testIterableToImmutableSetMultimap() {
+  ImmutableSet<ImmutableSetMultimap<String, Integer>> testImmutableSetMultimapCopyOf() {
     return ImmutableSet.of(
         ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("foo", 1).entries()),
         ImmutableSetMultimap.<String, Integer>builder()
-            .putAll(ImmutableSetMultimap.of("foo", 1))
+            .putAll(ImmutableSetMultimap.of("bar", 2))
             .build(),
         ImmutableSetMultimap.<String, Integer>builder()
-            .putAll(ImmutableSetMultimap.of("foo", 1).entries())
+            .putAll(ImmutableSetMultimap.of("baz", 3).entries())
             .build(),
-        ImmutableSetMultimap.of("foo", 1).entries().stream()
+        Streams.stream(Iterables.cycle(Map.entry("quux", 5)))
             .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue)),
-        Streams.stream(Iterables.cycle(Map.entry("foo", 1)))
+        ImmutableSetMultimap.of("qux", 4).entries().stream()
             .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableSetMultimap<Integer, String> testStreamOfMapEntriesToImmutableSetMultimap() {
+  ImmutableSetMultimap<Integer, String> testStreamCollectToImmutableSetMultimap() {
     return Stream.of(1, 2, 3)
         .map(n -> Map.entry(n, n.toString()))
         .collect(toImmutableSetMultimap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
-  ImmutableSetMultimap<String, Integer> testTransformMultimapValuesToImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapCopyOfMultimapsTransformValues() {
     return ImmutableSetMultimap.of("foo", 1L).entries().stream()
         .collect(toImmutableSetMultimap(Map.Entry::getKey, e -> Math.toIntExact(e.getValue())));
   }
 
   ImmutableSet<ImmutableSetMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableSetMultimap2() {
+      testImmutableSetMultimapCopyOfMultimapsTransformValuesWithFunction() {
     return ImmutableSet.of(
         ImmutableSetMultimap.of("foo", 1L).asMap().entrySet().stream()
             .collect(
@@ -93,7 +94,7 @@ final class ImmutableSetMultimapRulesTest implements RefasterRuleCollectionTestC
                     Map.Entry::getKey, e -> e.getValue().stream().map(Math::toIntExact))));
   }
 
-  ImmutableSet<ImmutableSetMultimap.Builder<String, Integer>> testImmutableSetMultimapBuilderPut() {
+  ImmutableSet<ImmutableSetMultimap.Builder<String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableSetMultimap.<String, Integer>builder().put(Map.entry("foo", 1)),
         ImmutableSetMultimap.<String, Integer>builder().putAll("bar", 2));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetMultimapRulesTestOutput.java
@@ -25,40 +25,41 @@ final class ImmutableSetMultimapRulesTest implements RefasterRuleCollectionTestC
     return ImmutableSetMultimap.builder();
   }
 
-  ImmutableSetMultimap<String, Integer> testEmptyImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapOf0() {
     return ImmutableSetMultimap.of();
   }
 
-  ImmutableSetMultimap<String, Integer> testPairToImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapOf2() {
     return ImmutableSetMultimap.of("foo", 1);
   }
 
-  ImmutableSet<ImmutableSetMultimap<String, Integer>> testEntryToImmutableSetMultimap() {
+  ImmutableSet<ImmutableSetMultimap<String, Integer>>
+      testImmutableSetMultimapOfEntryGetKeyEntryGetValue() {
     return ImmutableSet.of(
         ImmutableSetMultimap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()),
-        ImmutableSetMultimap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()));
+        ImmutableSetMultimap.of(Map.entry("bar", 2).getKey(), Map.entry("bar", 2).getValue()));
   }
 
-  ImmutableSet<ImmutableSetMultimap<String, Integer>> testIterableToImmutableSetMultimap() {
+  ImmutableSet<ImmutableSetMultimap<String, Integer>> testImmutableSetMultimapCopyOf() {
     return ImmutableSet.of(
         ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("foo", 1)),
-        ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("foo", 1)),
-        ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("foo", 1).entries()),
-        ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("foo", 1).entries()),
-        ImmutableSetMultimap.copyOf(Iterables.cycle(Map.entry("foo", 1))));
+        ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("bar", 2)),
+        ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("baz", 3).entries()),
+        ImmutableSetMultimap.copyOf(Iterables.cycle(Map.entry("quux", 5))),
+        ImmutableSetMultimap.copyOf(ImmutableSetMultimap.of("qux", 4).entries()));
   }
 
-  ImmutableSetMultimap<Integer, String> testStreamOfMapEntriesToImmutableSetMultimap() {
+  ImmutableSetMultimap<Integer, String> testStreamCollectToImmutableSetMultimap() {
     return Stream.of(1, 2, 3).collect(toImmutableSetMultimap(n -> n, n -> n.toString()));
   }
 
-  ImmutableSetMultimap<String, Integer> testTransformMultimapValuesToImmutableSetMultimap() {
+  ImmutableSetMultimap<String, Integer> testImmutableSetMultimapCopyOfMultimapsTransformValues() {
     return ImmutableSetMultimap.copyOf(
         Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), e -> Math.toIntExact(e)));
   }
 
   ImmutableSet<ImmutableSetMultimap<String, Integer>>
-      testTransformMultimapValuesToImmutableSetMultimap2() {
+      testImmutableSetMultimapCopyOfMultimapsTransformValuesWithFunction() {
     return ImmutableSet.of(
         ImmutableSetMultimap.copyOf(
             Multimaps.transformValues(ImmutableSetMultimap.of("foo", 1L), Math::toIntExact)),
@@ -74,7 +75,7 @@ final class ImmutableSetMultimapRulesTest implements RefasterRuleCollectionTestC
             Multimaps.transformValues(TreeMultimap.<String, Long>create(), Math::toIntExact)));
   }
 
-  ImmutableSet<ImmutableSetMultimap.Builder<String, Integer>> testImmutableSetMultimapBuilderPut() {
+  ImmutableSet<ImmutableSetMultimap.Builder<String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableSetMultimap.<String, Integer>builder().put("foo", 1),
         ImmutableSetMultimap.<String, Integer>builder().put("bar", 2));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestInput.java
@@ -25,29 +25,28 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
     return new ImmutableSet.Builder<>();
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testIterableToImmutableSet() {
+  ImmutableSet<ImmutableSet<Integer>> testImmutableSetCopyOf() {
     return ImmutableSet.of(
-        ImmutableList.of(1).stream().collect(toImmutableSet()),
-        Streams.stream(ImmutableList.of(2)::iterator).collect(toImmutableSet()),
-        Streams.stream(ImmutableList.of(3).iterator()).collect(toImmutableSet()),
-        ImmutableSet.<Integer>builder().addAll(ImmutableSet.of(4)).build(),
-        ImmutableSet.<Integer>builder().addAll(ImmutableSet.of(5)::iterator).build(),
-        ImmutableSet.<Integer>builder().addAll(ImmutableSet.of(6).iterator()).build(),
-        ImmutableSet.<Integer>builder().add(new Integer[] {7}).build(),
-        Arrays.stream(new Integer[] {8}).collect(toImmutableSet()));
+        ImmutableSet.<Integer>builder().add(new Integer[] {1}).build(),
+        Arrays.stream(new Integer[] {2}).collect(toImmutableSet()),
+        ImmutableSet.<Integer>builder().addAll(ImmutableSet.of(3).iterator()).build(),
+        Streams.stream(ImmutableList.of(4).iterator()).collect(toImmutableSet()),
+        ImmutableSet.<Integer>builder().addAll(ImmutableSet.of(5)).build(),
+        Streams.stream(ImmutableList.of(6)::iterator).collect(toImmutableSet()),
+        ImmutableList.of(7).stream().collect(toImmutableSet()));
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testStreamToImmutableSet() {
+  ImmutableSet<ImmutableSet<Integer>> testStreamCollectToImmutableSet() {
     return ImmutableSet.of(
         ImmutableSet.copyOf(Stream.of(1).iterator()),
         Stream.of(2).distinct().collect(toImmutableSet()));
   }
 
-  ImmutableSet<Integer> testImmutableSetCopyOfSetView() {
+  ImmutableSet<Integer> testSetViewImmutableCopy() {
     return ImmutableSet.copyOf(Sets.difference(ImmutableSet.of(1), ImmutableSet.of(2)));
   }
 
-  ImmutableSet<Set<Integer>> testImmutableSetOf() {
+  ImmutableSet<Set<Integer>> testImmutableSetOf0() {
     return ImmutableSet.of(
         ImmutableSet.<Integer>builder().build(),
         Stream.<Integer>empty().collect(toImmutableSet()),
@@ -57,7 +56,7 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Set<Integer>> testImmutableSetOf1() {
     return ImmutableSet.of(
-        ImmutableSet.<Integer>builder().add(1).build(), Collections.singleton(1), Set.of(1));
+        ImmutableSet.<Integer>builder().add(1).build(), Collections.singleton(2), Set.of(3));
   }
 
   Set<Integer> testImmutableSetOf2() {
@@ -76,7 +75,7 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
     return Set.of(1, 2, 3, 4, 5);
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testSetsDifference() {
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceImmutableCopy() {
     return ImmutableSet.of(
         ImmutableSet.of(1).stream()
             .filter(not(ImmutableSet.of(2)::contains))
@@ -86,7 +85,7 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
             .collect(toImmutableSet()));
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMap() {
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMapKeySetImmutableCopy() {
     return ImmutableSet.of(
         ImmutableSet.of(1).stream()
             .filter(not(ImmutableMap.of(2, 3)::containsKey))
@@ -96,7 +95,7 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
             .collect(toImmutableSet()));
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMultimap() {
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMultimapKeySetImmutableCopy() {
     return ImmutableSet.of(
         ImmutableSet.of(1).stream()
             .filter(not(ImmutableSetMultimap.of(2, 3)::containsKey))
@@ -106,25 +105,25 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
             .collect(toImmutableSet()));
   }
 
-  ImmutableSet<Integer> testSetsIntersection() {
+  ImmutableSet<Integer> testSetsIntersectionImmutableCopy() {
     return ImmutableSet.of(1).stream()
         .filter(ImmutableSet.of(2)::contains)
         .collect(toImmutableSet());
   }
 
-  ImmutableSet<Integer> testSetsIntersectionMap() {
+  ImmutableSet<Integer> testSetsIntersectionMapKeySetImmutableCopy() {
     return ImmutableSet.of(1).stream()
         .filter(ImmutableMap.of(2, 3)::containsKey)
         .collect(toImmutableSet());
   }
 
-  ImmutableSet<Integer> testSetsIntersectionMultimap() {
+  ImmutableSet<Integer> testSetsIntersectionMultimapKeySetImmutableCopy() {
     return ImmutableSet.of(1).stream()
         .filter(ImmutableSetMultimap.of(2, 3)::containsKey)
         .collect(toImmutableSet());
   }
 
-  ImmutableSet<Integer> testSetsUnion() {
+  ImmutableSet<Integer> testSetsUnionImmutableCopy() {
     return Stream.concat(ImmutableSet.of(1).stream(), ImmutableSet.of(2).stream())
         .collect(toImmutableSet());
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSetRulesTestOutput.java
@@ -25,34 +25,33 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.builder();
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testIterableToImmutableSet() {
+  ImmutableSet<ImmutableSet<Integer>> testImmutableSetCopyOf() {
     return ImmutableSet.of(
-        ImmutableSet.copyOf(ImmutableList.of(1)),
-        ImmutableSet.copyOf(ImmutableList.of(2)::iterator),
-        ImmutableSet.copyOf(ImmutableList.of(3).iterator()),
-        ImmutableSet.copyOf(ImmutableSet.of(4)),
-        ImmutableSet.copyOf(ImmutableSet.of(5)::iterator),
-        ImmutableSet.copyOf(ImmutableSet.of(6).iterator()),
-        ImmutableSet.copyOf(new Integer[] {7}),
-        ImmutableSet.copyOf(new Integer[] {8}));
+        ImmutableSet.copyOf(new Integer[] {1}),
+        ImmutableSet.copyOf(new Integer[] {2}),
+        ImmutableSet.copyOf(ImmutableSet.of(3).iterator()),
+        ImmutableSet.copyOf(ImmutableList.of(4).iterator()),
+        ImmutableSet.copyOf(ImmutableSet.of(5)),
+        ImmutableSet.copyOf(ImmutableList.of(6)::iterator),
+        ImmutableSet.copyOf(ImmutableList.of(7)));
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testStreamToImmutableSet() {
+  ImmutableSet<ImmutableSet<Integer>> testStreamCollectToImmutableSet() {
     return ImmutableSet.of(
         Stream.of(1).collect(toImmutableSet()), Stream.of(2).collect(toImmutableSet()));
   }
 
-  ImmutableSet<Integer> testImmutableSetCopyOfSetView() {
+  ImmutableSet<Integer> testSetViewImmutableCopy() {
     return Sets.difference(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy();
   }
 
-  ImmutableSet<Set<Integer>> testImmutableSetOf() {
+  ImmutableSet<Set<Integer>> testImmutableSetOf0() {
     return ImmutableSet.of(
         ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of(), ImmutableSet.of());
   }
 
   ImmutableSet<Set<Integer>> testImmutableSetOf1() {
-    return ImmutableSet.of(ImmutableSet.of(1), ImmutableSet.of(1), ImmutableSet.of(1));
+    return ImmutableSet.of(ImmutableSet.of(1), ImmutableSet.of(2), ImmutableSet.of(3));
   }
 
   Set<Integer> testImmutableSetOf2() {
@@ -71,39 +70,39 @@ final class ImmutableSetRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(1, 2, 3, 4, 5);
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testSetsDifference() {
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceImmutableCopy() {
     return ImmutableSet.of(
         Sets.difference(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy(),
         Sets.difference(ImmutableSet.of(3), ImmutableSet.of(4)).immutableCopy());
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMap() {
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMapKeySetImmutableCopy() {
     return ImmutableSet.of(
         Sets.difference(ImmutableSet.of(1), ImmutableMap.of(2, 3).keySet()).immutableCopy(),
         Sets.difference(ImmutableSet.of(4), ImmutableMap.of(5, 6).keySet()).immutableCopy());
   }
 
-  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMultimap() {
+  ImmutableSet<ImmutableSet<Integer>> testSetsDifferenceMultimapKeySetImmutableCopy() {
     return ImmutableSet.of(
         Sets.difference(ImmutableSet.of(1), ImmutableSetMultimap.of(2, 3).keySet()).immutableCopy(),
         Sets.difference(ImmutableSet.of(4), ImmutableSetMultimap.of(5, 6).keySet())
             .immutableCopy());
   }
 
-  ImmutableSet<Integer> testSetsIntersection() {
+  ImmutableSet<Integer> testSetsIntersectionImmutableCopy() {
     return Sets.intersection(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy();
   }
 
-  ImmutableSet<Integer> testSetsIntersectionMap() {
+  ImmutableSet<Integer> testSetsIntersectionMapKeySetImmutableCopy() {
     return Sets.intersection(ImmutableSet.of(1), ImmutableMap.of(2, 3).keySet()).immutableCopy();
   }
 
-  ImmutableSet<Integer> testSetsIntersectionMultimap() {
+  ImmutableSet<Integer> testSetsIntersectionMultimapKeySetImmutableCopy() {
     return Sets.intersection(ImmutableSet.of(1), ImmutableSetMultimap.of(2, 3).keySet())
         .immutableCopy();
   }
 
-  ImmutableSet<Integer> testSetsUnion() {
+  ImmutableSet<Integer> testSetsUnionImmutableCopy() {
     return Sets.union(ImmutableSet.of(1), ImmutableSet.of(2)).immutableCopy();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRulesTestInput.java
@@ -20,46 +20,48 @@ final class ImmutableSortedMapRulesTest implements RefasterRuleCollectionTestCas
         Stream.class, Streams.class, naturalOrder(), toImmutableSortedMap(null, null));
   }
 
-  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapBuilder() {
+  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapOrderedBy() {
     return new ImmutableSortedMap.Builder<>(Comparator.comparingInt(String::length));
   }
 
-  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapNaturalOrderBuilder() {
+  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapNaturalOrder() {
     return ImmutableSortedMap.orderedBy(Comparator.<String>naturalOrder());
   }
 
-  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapReverseOrderBuilder() {
+  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapReverseOrder() {
     return ImmutableSortedMap.orderedBy(Comparator.<String>reverseOrder());
   }
 
-  ImmutableSortedMap<String, Integer> testEmptyImmutableSortedMap() {
+  ImmutableSortedMap<String, Integer> testImmutableSortedMapOf() {
     return ImmutableSortedMap.<String, Integer>naturalOrder().buildOrThrow();
   }
 
-  ImmutableSortedMap<String, Integer> testPairToImmutableSortedMap() {
+  ImmutableSortedMap<String, Integer> testImmutableSortedMapOfWithComparableAndObject() {
     return ImmutableSortedMap.<String, Integer>naturalOrder().put("foo", 1).buildOrThrow();
   }
 
-  ImmutableSet<ImmutableSortedMap<String, Integer>> testEntryToImmutableSortedMap() {
+  ImmutableSet<ImmutableSortedMap<String, Integer>>
+      testImmutableSortedMapOfEntryGetKeyEntryGetValue() {
     return ImmutableSet.of(
         ImmutableSortedMap.<String, Integer>naturalOrder().put(Map.entry("foo", 1)).buildOrThrow(),
-        Stream.of(Map.entry("foo", 1))
+        Stream.of(Map.entry("bar", 2))
             .collect(toImmutableSortedMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 
-  ImmutableSet<ImmutableSortedMap<String, Integer>> testIterableToImmutableSortedMap() {
+  ImmutableSet<ImmutableSortedMap<String, Integer>> testImmutableSortedMapCopyOf() {
     return ImmutableSet.of(
         ImmutableSortedMap.copyOf(ImmutableSortedMap.of("foo", 1), naturalOrder()),
-        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("foo", 1).entrySet()),
+        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("bar", 2).entrySet()),
         ImmutableSortedMap.<String, Integer>naturalOrder()
-            .putAll(ImmutableSortedMap.of("foo", 1))
+            .putAll(ImmutableSortedMap.of("baz", 3))
             .buildOrThrow(),
+        ImmutableSortedMap.copyOf(Iterables.cycle(Map.entry("qux", 4)), naturalOrder()),
         ImmutableSortedMap.<String, Integer>naturalOrder()
-            .putAll(ImmutableSortedMap.of("foo", 1).entrySet())
+            .putAll(ImmutableSortedMap.of("quux", 5).entrySet())
             .buildOrThrow(),
-        ImmutableSortedMap.of("foo", 1).entrySet().stream()
+        Streams.stream(Iterables.cycle(Map.entry("corge", 6)))
             .collect(toImmutableSortedMap(Map.Entry::getKey, Map.Entry::getValue)),
-        Streams.stream(Iterables.cycle(Map.entry("foo", 1)))
+        ImmutableSortedMap.of("grault", 7).entrySet().stream()
             .collect(toImmutableSortedMap(Map.Entry::getKey, Map.Entry::getValue)));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMapRulesTestOutput.java
@@ -20,40 +20,42 @@ final class ImmutableSortedMapRulesTest implements RefasterRuleCollectionTestCas
         Stream.class, Streams.class, naturalOrder(), toImmutableSortedMap(null, null));
   }
 
-  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapBuilder() {
+  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapOrderedBy() {
     return ImmutableSortedMap.orderedBy(Comparator.comparingInt(String::length));
   }
 
-  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapNaturalOrderBuilder() {
+  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapNaturalOrder() {
     return ImmutableSortedMap.naturalOrder();
   }
 
-  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapReverseOrderBuilder() {
+  ImmutableSortedMap.Builder<String, Integer> testImmutableSortedMapReverseOrder() {
     return ImmutableSortedMap.reverseOrder();
   }
 
-  ImmutableSortedMap<String, Integer> testEmptyImmutableSortedMap() {
+  ImmutableSortedMap<String, Integer> testImmutableSortedMapOf() {
     return ImmutableSortedMap.of();
   }
 
-  ImmutableSortedMap<String, Integer> testPairToImmutableSortedMap() {
+  ImmutableSortedMap<String, Integer> testImmutableSortedMapOfWithComparableAndObject() {
     return ImmutableSortedMap.of("foo", 1);
   }
 
-  ImmutableSet<ImmutableSortedMap<String, Integer>> testEntryToImmutableSortedMap() {
+  ImmutableSet<ImmutableSortedMap<String, Integer>>
+      testImmutableSortedMapOfEntryGetKeyEntryGetValue() {
     return ImmutableSet.of(
         ImmutableSortedMap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()),
-        ImmutableSortedMap.of(Map.entry("foo", 1).getKey(), Map.entry("foo", 1).getValue()));
+        ImmutableSortedMap.of(Map.entry("bar", 2).getKey(), Map.entry("bar", 2).getValue()));
   }
 
-  ImmutableSet<ImmutableSortedMap<String, Integer>> testIterableToImmutableSortedMap() {
+  ImmutableSet<ImmutableSortedMap<String, Integer>> testImmutableSortedMapCopyOf() {
     return ImmutableSet.of(
         ImmutableSortedMap.copyOf(ImmutableSortedMap.of("foo", 1)),
-        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("foo", 1)),
-        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("foo", 1)),
-        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("foo", 1).entrySet()),
-        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("foo", 1).entrySet()),
-        ImmutableSortedMap.copyOf(Iterables.cycle(Map.entry("foo", 1))));
+        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("bar", 2)),
+        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("baz", 3)),
+        ImmutableSortedMap.copyOf(Iterables.cycle(Map.entry("qux", 4))),
+        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("quux", 5).entrySet()),
+        ImmutableSortedMap.copyOf(Iterables.cycle(Map.entry("corge", 6))),
+        ImmutableSortedMap.copyOf(ImmutableSortedMap.of("grault", 7).entrySet()));
   }
 
   Collector<Integer, ?, ImmutableSortedMap<String, Double>> testToImmutableSortedMap() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestInput.java
@@ -19,46 +19,45 @@ final class ImmutableSortedMultisetRulesTest implements RefasterRuleCollectionTe
     return ImmutableSet.of(Arrays.class, Streams.class);
   }
 
-  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetBuilder() {
+  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetOrderedBy() {
     return new ImmutableSortedMultiset.Builder<>(Comparator.comparingInt(String::length));
   }
 
-  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetNaturalOrderBuilder() {
+  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetNaturalOrder() {
     return ImmutableSortedMultiset.orderedBy(Comparator.<String>naturalOrder());
   }
 
-  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetReverseOrderBuilder() {
+  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetReverseOrder() {
     return ImmutableSortedMultiset.orderedBy(Comparator.<String>reverseOrder());
   }
 
-  ImmutableMultiset<ImmutableSortedMultiset<Integer>> testEmptyImmutableSortedMultiset() {
-    return ImmutableMultiset.of(
+  ImmutableSet<ImmutableSortedMultiset<Integer>> testImmutableSortedMultisetOf() {
+    return ImmutableSet.of(
         ImmutableSortedMultiset.<Integer>naturalOrder().build(),
         Stream.<Integer>empty().collect(toImmutableSortedMultiset(naturalOrder())));
   }
 
-  @SuppressWarnings("unchecked")
-  ImmutableMultiset<ImmutableSortedMultiset<Integer>> testIterableToImmutableSortedMultiset() {
-    return ImmutableMultiset.of(
-        ImmutableSortedMultiset.copyOf(naturalOrder(), ImmutableList.of(1)),
-        ImmutableSortedMultiset.copyOf(naturalOrder(), ImmutableList.of(2).iterator()),
-        ImmutableList.of(3).stream().collect(toImmutableSortedMultiset(naturalOrder())),
-        Streams.stream(ImmutableList.of(4)::iterator)
-            .collect(toImmutableSortedMultiset(naturalOrder())),
+  ImmutableSet<ImmutableSortedMultiset<Integer>> testImmutableSortedMultisetCopyOf() {
+    return ImmutableSet.of(
+        ImmutableSortedMultiset.<Integer>naturalOrder().add(new Integer[] {1}).build(),
+        Arrays.stream(new Integer[] {2}).collect(toImmutableSortedMultiset(naturalOrder())),
+        ImmutableSortedMultiset.copyOf(naturalOrder(), ImmutableList.of(3).iterator()),
+        ImmutableSortedMultiset.<Integer>naturalOrder()
+            .addAll(ImmutableMultiset.of(4).iterator())
+            .build(),
         Streams.stream(ImmutableList.of(5).iterator())
             .collect(toImmutableSortedMultiset(naturalOrder())),
-        ImmutableSortedMultiset.<Integer>naturalOrder().addAll(ImmutableMultiset.of(6)).build(),
+        ImmutableSortedMultiset.copyOf(naturalOrder(), ImmutableList.of(6)),
+        ImmutableSortedMultiset.<Integer>naturalOrder().addAll(ImmutableMultiset.of(7)).build(),
         ImmutableSortedMultiset.<Integer>naturalOrder()
-            .addAll(ImmutableMultiset.of(7)::iterator)
+            .addAll(ImmutableMultiset.of(8)::iterator)
             .build(),
-        ImmutableSortedMultiset.<Integer>naturalOrder()
-            .addAll(ImmutableMultiset.of(8).iterator())
-            .build(),
-        ImmutableSortedMultiset.<Integer>naturalOrder().add(new Integer[] {9}).build(),
-        Arrays.stream(new Integer[] {10}).collect(toImmutableSortedMultiset(naturalOrder())));
+        Streams.stream(ImmutableList.of(9)::iterator)
+            .collect(toImmutableSortedMultiset(naturalOrder())),
+        ImmutableList.of(10).stream().collect(toImmutableSortedMultiset(naturalOrder())));
   }
 
-  ImmutableSortedMultiset<Integer> testStreamToImmutableSortedMultiset() {
+  ImmutableSortedMultiset<Integer> testStreamCollectToImmutableSortedMultisetNaturalOrder() {
     return ImmutableSortedMultiset.copyOf(Stream.of(1).iterator());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedMultisetRulesTestOutput.java
@@ -19,38 +19,37 @@ final class ImmutableSortedMultisetRulesTest implements RefasterRuleCollectionTe
     return ImmutableSet.of(Arrays.class, Streams.class);
   }
 
-  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetBuilder() {
+  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetOrderedBy() {
     return ImmutableSortedMultiset.orderedBy(Comparator.comparingInt(String::length));
   }
 
-  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetNaturalOrderBuilder() {
+  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetNaturalOrder() {
     return ImmutableSortedMultiset.naturalOrder();
   }
 
-  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetReverseOrderBuilder() {
+  ImmutableSortedMultiset.Builder<String> testImmutableSortedMultisetReverseOrder() {
     return ImmutableSortedMultiset.reverseOrder();
   }
 
-  ImmutableMultiset<ImmutableSortedMultiset<Integer>> testEmptyImmutableSortedMultiset() {
-    return ImmutableMultiset.of(ImmutableSortedMultiset.of(), ImmutableSortedMultiset.of());
+  ImmutableSet<ImmutableSortedMultiset<Integer>> testImmutableSortedMultisetOf() {
+    return ImmutableSet.of(ImmutableSortedMultiset.of(), ImmutableSortedMultiset.of());
   }
 
-  @SuppressWarnings("unchecked")
-  ImmutableMultiset<ImmutableSortedMultiset<Integer>> testIterableToImmutableSortedMultiset() {
-    return ImmutableMultiset.of(
-        ImmutableSortedMultiset.copyOf(ImmutableList.of(1)),
-        ImmutableSortedMultiset.copyOf(ImmutableList.of(2).iterator()),
-        ImmutableSortedMultiset.copyOf(ImmutableList.of(3)),
-        ImmutableSortedMultiset.copyOf(ImmutableList.of(4)::iterator),
+  ImmutableSet<ImmutableSortedMultiset<Integer>> testImmutableSortedMultisetCopyOf() {
+    return ImmutableSet.of(
+        ImmutableSortedMultiset.copyOf(new Integer[] {1}),
+        ImmutableSortedMultiset.copyOf(new Integer[] {2}),
+        ImmutableSortedMultiset.copyOf(ImmutableList.of(3).iterator()),
+        ImmutableSortedMultiset.copyOf(ImmutableMultiset.of(4).iterator()),
         ImmutableSortedMultiset.copyOf(ImmutableList.of(5).iterator()),
-        ImmutableSortedMultiset.copyOf(ImmutableMultiset.of(6)),
-        ImmutableSortedMultiset.copyOf(ImmutableMultiset.of(7)::iterator),
-        ImmutableSortedMultiset.copyOf(ImmutableMultiset.of(8).iterator()),
-        ImmutableSortedMultiset.copyOf(new Integer[] {9}),
-        ImmutableSortedMultiset.copyOf(new Integer[] {10}));
+        ImmutableSortedMultiset.copyOf(ImmutableList.of(6)),
+        ImmutableSortedMultiset.copyOf(ImmutableMultiset.of(7)),
+        ImmutableSortedMultiset.copyOf(ImmutableMultiset.of(8)::iterator),
+        ImmutableSortedMultiset.copyOf(ImmutableList.of(9)::iterator),
+        ImmutableSortedMultiset.copyOf(ImmutableList.of(10)));
   }
 
-  ImmutableSortedMultiset<Integer> testStreamToImmutableSortedMultiset() {
+  ImmutableSortedMultiset<Integer> testStreamCollectToImmutableSortedMultisetNaturalOrder() {
     return Stream.of(1).collect(toImmutableSortedMultiset(naturalOrder()));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedSetRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedSetRulesTestInput.java
@@ -18,41 +18,41 @@ final class ImmutableSortedSetRulesTest implements RefasterRuleCollectionTestCas
     return ImmutableSet.of(Arrays.class, Streams.class);
   }
 
-  ImmutableSortedSet.Builder<String> testImmutableSortedSetBuilder() {
+  ImmutableSortedSet.Builder<String> testImmutableSortedSetOrderedBy() {
     return new ImmutableSortedSet.Builder<>(Comparator.comparingInt(String::length));
   }
 
-  ImmutableSortedSet.Builder<String> testImmutableSortedSetNaturalOrderBuilder() {
+  ImmutableSortedSet.Builder<String> testImmutableSortedSetNaturalOrder() {
     return ImmutableSortedSet.orderedBy(Comparator.<String>naturalOrder());
   }
 
-  ImmutableSortedSet.Builder<String> testImmutableSortedSetReverseOrderBuilder() {
+  ImmutableSortedSet.Builder<String> testImmutableSortedSetReverseOrder() {
     return ImmutableSortedSet.orderedBy(Comparator.<String>reverseOrder());
   }
 
-  ImmutableSet<ImmutableSortedSet<Integer>> testEmptyImmutableSortedSet() {
+  ImmutableSet<ImmutableSortedSet<Integer>> testImmutableSortedSetOf() {
     return ImmutableSet.of(
         ImmutableSortedSet.<Integer>naturalOrder().build(),
         Stream.<Integer>empty().collect(toImmutableSortedSet(naturalOrder())));
   }
 
-  ImmutableSet<ImmutableSortedSet<Integer>> testIterableToImmutableSortedSet() {
+  ImmutableSet<ImmutableSortedSet<Integer>> testImmutableSortedSetCopyOf() {
     // XXX: The first subexpression is not rewritten (`naturalOrder()` isn't dropped). WHY!?
     return ImmutableSet.of(
-        ImmutableSortedSet.copyOf(naturalOrder(), ImmutableList.of(1)),
-        ImmutableSortedSet.copyOf(naturalOrder(), ImmutableList.of(2).iterator()),
-        ImmutableList.of(3).stream().collect(toImmutableSortedSet(naturalOrder())),
-        Streams.stream(ImmutableList.of(4)::iterator).collect(toImmutableSortedSet(naturalOrder())),
+        ImmutableSortedSet.<Integer>naturalOrder().add(new Integer[] {1}).build(),
+        Arrays.stream(new Integer[] {2}).collect(toImmutableSortedSet(naturalOrder())),
+        ImmutableSortedSet.copyOf(naturalOrder(), ImmutableList.of(3).iterator()),
+        ImmutableSortedSet.<Integer>naturalOrder().addAll(ImmutableSet.of(4).iterator()).build(),
         Streams.stream(ImmutableList.of(5).iterator())
             .collect(toImmutableSortedSet(naturalOrder())),
-        ImmutableSortedSet.<Integer>naturalOrder().addAll(ImmutableSet.of(6)).build(),
-        ImmutableSortedSet.<Integer>naturalOrder().addAll(ImmutableSet.of(7)::iterator).build(),
-        ImmutableSortedSet.<Integer>naturalOrder().addAll(ImmutableSet.of(8).iterator()).build(),
-        ImmutableSortedSet.<Integer>naturalOrder().add(new Integer[] {9}).build(),
-        Arrays.stream(new Integer[] {10}).collect(toImmutableSortedSet(naturalOrder())));
+        ImmutableSortedSet.copyOf(naturalOrder(), ImmutableList.of(6)),
+        ImmutableSortedSet.<Integer>naturalOrder().addAll(ImmutableSet.of(7)).build(),
+        ImmutableSortedSet.<Integer>naturalOrder().addAll(ImmutableSet.of(8)::iterator).build(),
+        Streams.stream(ImmutableList.of(9)::iterator).collect(toImmutableSortedSet(naturalOrder())),
+        ImmutableList.of(10).stream().collect(toImmutableSortedSet(naturalOrder())));
   }
 
-  ImmutableSortedSet<Integer> testStreamToImmutableSortedSet() {
+  ImmutableSortedSet<Integer> testStreamCollectToImmutableSortedSetNaturalOrder() {
     return ImmutableSortedSet.copyOf(Stream.of(1).iterator());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedSetRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableSortedSetRulesTestOutput.java
@@ -18,38 +18,38 @@ final class ImmutableSortedSetRulesTest implements RefasterRuleCollectionTestCas
     return ImmutableSet.of(Arrays.class, Streams.class);
   }
 
-  ImmutableSortedSet.Builder<String> testImmutableSortedSetBuilder() {
+  ImmutableSortedSet.Builder<String> testImmutableSortedSetOrderedBy() {
     return ImmutableSortedSet.orderedBy(Comparator.comparingInt(String::length));
   }
 
-  ImmutableSortedSet.Builder<String> testImmutableSortedSetNaturalOrderBuilder() {
+  ImmutableSortedSet.Builder<String> testImmutableSortedSetNaturalOrder() {
     return ImmutableSortedSet.naturalOrder();
   }
 
-  ImmutableSortedSet.Builder<String> testImmutableSortedSetReverseOrderBuilder() {
+  ImmutableSortedSet.Builder<String> testImmutableSortedSetReverseOrder() {
     return ImmutableSortedSet.reverseOrder();
   }
 
-  ImmutableSet<ImmutableSortedSet<Integer>> testEmptyImmutableSortedSet() {
+  ImmutableSet<ImmutableSortedSet<Integer>> testImmutableSortedSetOf() {
     return ImmutableSet.of(ImmutableSortedSet.of(), ImmutableSortedSet.of());
   }
 
-  ImmutableSet<ImmutableSortedSet<Integer>> testIterableToImmutableSortedSet() {
+  ImmutableSet<ImmutableSortedSet<Integer>> testImmutableSortedSetCopyOf() {
     // XXX: The first subexpression is not rewritten (`naturalOrder()` isn't dropped). WHY!?
     return ImmutableSet.of(
-        ImmutableSortedSet.copyOf(naturalOrder(), ImmutableList.of(1)),
-        ImmutableSortedSet.copyOf(ImmutableList.of(2).iterator()),
-        ImmutableSortedSet.copyOf(ImmutableList.of(3)),
-        ImmutableSortedSet.copyOf(ImmutableList.of(4)::iterator),
+        ImmutableSortedSet.copyOf(new Integer[] {1}),
+        ImmutableSortedSet.copyOf(new Integer[] {2}),
+        ImmutableSortedSet.copyOf(ImmutableList.of(3).iterator()),
+        ImmutableSortedSet.copyOf(ImmutableSet.of(4).iterator()),
         ImmutableSortedSet.copyOf(ImmutableList.of(5).iterator()),
-        ImmutableSortedSet.copyOf(ImmutableSet.of(6)),
-        ImmutableSortedSet.copyOf(ImmutableSet.of(7)::iterator),
-        ImmutableSortedSet.copyOf(ImmutableSet.of(8).iterator()),
-        ImmutableSortedSet.copyOf(new Integer[] {9}),
-        ImmutableSortedSet.copyOf(new Integer[] {10}));
+        ImmutableSortedSet.copyOf(naturalOrder(), ImmutableList.of(6)),
+        ImmutableSortedSet.copyOf(ImmutableSet.of(7)),
+        ImmutableSortedSet.copyOf(ImmutableSet.of(8)::iterator),
+        ImmutableSortedSet.copyOf(ImmutableList.of(9)::iterator),
+        ImmutableSortedSet.copyOf(ImmutableList.of(10)));
   }
 
-  ImmutableSortedSet<Integer> testStreamToImmutableSortedSet() {
+  ImmutableSortedSet<Integer> testStreamCollectToImmutableSortedSetNaturalOrder() {
     return Stream.of(1).collect(toImmutableSortedSet(naturalOrder()));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestInput.java
@@ -19,11 +19,12 @@ final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
     return new ImmutableTable.Builder<>();
   }
 
-  ImmutableTable<Object, Object, Object> testImmutableTableBuilderBuildOrThrow() {
+  ImmutableTable<Object, Object, Object> testBuilderBuildOrThrow() {
     return ImmutableTable.builder().build();
   }
 
-  ImmutableSet<ImmutableTable<String, Integer, String>> testCellToImmutableTable() {
+  ImmutableSet<ImmutableTable<String, Integer, String>>
+      testImmutableTableOfCellGetRowKeyCellGetColumnKeyCellGetValue() {
     return ImmutableSet.of(
         ImmutableTable.<String, Integer, String>builder()
             .put(Tables.immutableCell("foo", 1, "bar"))
@@ -34,7 +35,7 @@ final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
                     Table.Cell::getRowKey, Table.Cell::getColumnKey, Table.Cell::getValue)));
   }
 
-  ImmutableTable<Integer, String, Integer> testStreamOfCellsToImmutableTable() {
+  ImmutableTable<Integer, String, Integer> testStreamCollectToImmutableTable() {
     return Stream.of(1, 2, 3)
         .map(n -> Tables.immutableCell(n, n.toString(), n * 2))
         .collect(
@@ -46,7 +47,7 @@ final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableTable.<String, String, String>builder().buildOrThrow();
   }
 
-  ImmutableSet<ImmutableTable.Builder<String, String, Integer>> testImmutableTableBuilderPut() {
+  ImmutableSet<ImmutableTable.Builder<String, String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableTable.<String, String, Integer>builder()
             .put(Tables.immutableCell("foo", "bar", 1)),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ImmutableTableRulesTestOutput.java
@@ -19,11 +19,12 @@ final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableTable.builder();
   }
 
-  ImmutableTable<Object, Object, Object> testImmutableTableBuilderBuildOrThrow() {
+  ImmutableTable<Object, Object, Object> testBuilderBuildOrThrow() {
     return ImmutableTable.builder().buildOrThrow();
   }
 
-  ImmutableSet<ImmutableTable<String, Integer, String>> testCellToImmutableTable() {
+  ImmutableSet<ImmutableTable<String, Integer, String>>
+      testImmutableTableOfCellGetRowKeyCellGetColumnKeyCellGetValue() {
     return ImmutableSet.of(
         ImmutableTable.of(
             Tables.immutableCell("foo", 1, "bar").getRowKey(),
@@ -35,7 +36,7 @@ final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
             Tables.immutableCell("baz", 2, "qux").getValue()));
   }
 
-  ImmutableTable<Integer, String, Integer> testStreamOfCellsToImmutableTable() {
+  ImmutableTable<Integer, String, Integer> testStreamCollectToImmutableTable() {
     return Stream.of(1, 2, 3).collect(toImmutableTable(n -> n, n -> n.toString(), n -> n * 2));
   }
 
@@ -43,7 +44,7 @@ final class ImmutableTableRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableTable.of();
   }
 
-  ImmutableSet<ImmutableTable.Builder<String, String, Integer>> testImmutableTableBuilderPut() {
+  ImmutableSet<ImmutableTable.Builder<String, String, Integer>> testBuilderPut() {
     return ImmutableSet.of(
         ImmutableTable.<String, String, Integer>builder().put("foo", "bar", 1),
         ImmutableTable.<String, String, Integer>builder().put("baz", "qux", 2));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/InputStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/InputStreamRulesTestInput.java
@@ -27,5 +27,6 @@ final class InputStreamRulesTest implements RefasterRuleCollectionTestCase {
 
   void testInputStreamSkipNBytes() throws IOException {
     ByteStreams.skipFully(new ByteArrayInputStream(new byte[0]), 0);
+    ByteStreams.skipFully(new ByteArrayInputStream(new byte[1]), 0L);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/InputStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/InputStreamRulesTestOutput.java
@@ -27,5 +27,6 @@ final class InputStreamRulesTest implements RefasterRuleCollectionTestCase {
 
   void testInputStreamSkipNBytes() throws IOException {
     new ByteArrayInputStream(new byte[0]).skipNBytes(0);
+    new ByteArrayInputStream(new byte[1]).skipNBytes(0L);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestInput.java
@@ -14,47 +14,47 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
-  IntStream testIntStreamClosedOpenRange() {
+  IntStream testIntStreamRange() {
     return IntStream.rangeClosed(0, 42 - 1);
   }
 
-  IntStream testConcatOneIntStream() {
+  IntStream testIntStreamIdentity() {
     return Streams.concat(IntStream.of(1));
   }
 
-  IntStream testConcatTwoIntStreams() {
+  IntStream testIntStreamConcat() {
     return Streams.concat(IntStream.of(1), IntStream.of(2));
   }
 
-  IntStream testFilterOuterIntStreamAfterFlatMap() {
+  IntStream testIntStreamFlatMapFilter() {
     return IntStream.of(1).flatMap(v -> IntStream.of(v * v).filter(n -> n > 1));
   }
 
-  IntStream testFilterOuterStreamAfterFlatMapToInt() {
+  IntStream testStreamFlatMapToIntFilter() {
     return Stream.of(1).flatMapToInt(v -> IntStream.of(v * v).filter(n -> n > 1));
   }
 
-  IntStream testMapOuterIntStreamAfterFlatMap() {
+  IntStream testIntStreamFlatMapMap() {
     return IntStream.of(1).flatMap(v -> IntStream.of(v * v).map(n -> n * 1));
   }
 
-  IntStream testMapOuterStreamAfterFlatMapToInt() {
+  IntStream testStreamFlatMapToIntMap() {
     return Stream.of(1).flatMapToInt(v -> IntStream.of(v * v).map(n -> n * 1));
   }
 
-  IntStream testFlatMapOuterIntStreamAfterFlatMap() {
+  IntStream testIntStreamFlatMapFlatMap() {
     return IntStream.of(1).flatMap(v -> IntStream.of(v * v).flatMap(IntStream::of));
   }
 
-  IntStream testFlatMapOuterStreamAfterFlatMapToInt() {
+  IntStream testStreamFlatMapToIntFlatMap() {
     return Stream.of(1).flatMapToInt(v -> IntStream.of(v * v).flatMap(IntStream::of));
   }
 
   IntStream testIntStreamFilterSorted() {
-    return IntStream.of(1, 4, 3, 2).sorted().filter(i -> i % 2 == 0);
+    return IntStream.of(1).sorted().filter(i -> i > 0);
   }
 
-  ImmutableSet<Boolean> testIntStreamIsEmpty() {
+  ImmutableSet<Boolean> testIntStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         IntStream.of(1).count() == 0,
         IntStream.of(2).count() <= 0,
@@ -62,7 +62,7 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
         IntStream.of(4).findFirst().isEmpty());
   }
 
-  ImmutableSet<Boolean> testIntStreamIsNotEmpty() {
+  ImmutableSet<Boolean> testIntStreamFindAnyIsPresent() {
     return ImmutableSet.of(
         IntStream.of(1).count() != 0,
         IntStream.of(2).count() > 0,
@@ -74,7 +74,7 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
     return IntStream.of(1).sorted().findFirst();
   }
 
-  ImmutableSet<Boolean> testIntStreamNoneMatch() {
+  ImmutableSet<Boolean> testIntStreamNoneMatchWithIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         !IntStream.of(1).anyMatch(n -> n > 1),
@@ -82,7 +82,7 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
         IntStream.of(3).filter(pred).findAny().isEmpty());
   }
 
-  boolean testIntStreamNoneMatch2() {
+  boolean testIntStreamNoneMatch() {
     return IntStream.of(1).allMatch(n -> !(n > 1));
   }
 
@@ -92,16 +92,16 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
         IntStream.of(2).filter(n -> n > 2).findAny().isPresent());
   }
 
-  boolean testIntStreamAllMatch() {
+  boolean testIntStreamAllMatchWithIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return IntStream.of(1).noneMatch(pred.negate());
   }
 
-  boolean testIntStreamAllMatch2() {
+  boolean testIntStreamAllMatch() {
     return IntStream.of(1).noneMatch(n -> !(n > 1));
   }
 
   IntStream testIntStreamTakeWhile() {
-    return IntStream.of(1, 2, 3).takeWhile(i -> i < 2).filter(i -> i < 2);
+    return IntStream.of(1).takeWhile(i -> i > 0).filter(i -> i > 0);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/IntStreamRulesTestOutput.java
@@ -14,47 +14,47 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
-  IntStream testIntStreamClosedOpenRange() {
+  IntStream testIntStreamRange() {
     return IntStream.range(0, 42);
   }
 
-  IntStream testConcatOneIntStream() {
+  IntStream testIntStreamIdentity() {
     return IntStream.of(1);
   }
 
-  IntStream testConcatTwoIntStreams() {
+  IntStream testIntStreamConcat() {
     return IntStream.concat(IntStream.of(1), IntStream.of(2));
   }
 
-  IntStream testFilterOuterIntStreamAfterFlatMap() {
+  IntStream testIntStreamFlatMapFilter() {
     return IntStream.of(1).flatMap(v -> IntStream.of(v * v)).filter(n -> n > 1);
   }
 
-  IntStream testFilterOuterStreamAfterFlatMapToInt() {
+  IntStream testStreamFlatMapToIntFilter() {
     return Stream.of(1).flatMapToInt(v -> IntStream.of(v * v)).filter(n -> n > 1);
   }
 
-  IntStream testMapOuterIntStreamAfterFlatMap() {
+  IntStream testIntStreamFlatMapMap() {
     return IntStream.of(1).flatMap(v -> IntStream.of(v * v)).map(n -> n * 1);
   }
 
-  IntStream testMapOuterStreamAfterFlatMapToInt() {
+  IntStream testStreamFlatMapToIntMap() {
     return Stream.of(1).flatMapToInt(v -> IntStream.of(v * v)).map(n -> n * 1);
   }
 
-  IntStream testFlatMapOuterIntStreamAfterFlatMap() {
+  IntStream testIntStreamFlatMapFlatMap() {
     return IntStream.of(1).flatMap(v -> IntStream.of(v * v)).flatMap(IntStream::of);
   }
 
-  IntStream testFlatMapOuterStreamAfterFlatMapToInt() {
+  IntStream testStreamFlatMapToIntFlatMap() {
     return Stream.of(1).flatMapToInt(v -> IntStream.of(v * v)).flatMap(IntStream::of);
   }
 
   IntStream testIntStreamFilterSorted() {
-    return IntStream.of(1, 4, 3, 2).filter(i -> i % 2 == 0).sorted();
+    return IntStream.of(1).filter(i -> i > 0).sorted();
   }
 
-  ImmutableSet<Boolean> testIntStreamIsEmpty() {
+  ImmutableSet<Boolean> testIntStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         IntStream.of(1).findAny().isEmpty(),
         IntStream.of(2).findAny().isEmpty(),
@@ -62,7 +62,7 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
         IntStream.of(4).findAny().isEmpty());
   }
 
-  ImmutableSet<Boolean> testIntStreamIsNotEmpty() {
+  ImmutableSet<Boolean> testIntStreamFindAnyIsPresent() {
     return ImmutableSet.of(
         IntStream.of(1).findAny().isPresent(),
         IntStream.of(2).findAny().isPresent(),
@@ -74,7 +74,7 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
     return IntStream.of(1).min();
   }
 
-  ImmutableSet<Boolean> testIntStreamNoneMatch() {
+  ImmutableSet<Boolean> testIntStreamNoneMatchWithIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         IntStream.of(1).noneMatch(n -> n > 1),
@@ -82,7 +82,7 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
         IntStream.of(3).noneMatch(pred));
   }
 
-  boolean testIntStreamNoneMatch2() {
+  boolean testIntStreamNoneMatch() {
     return IntStream.of(1).noneMatch(n -> n > 1);
   }
 
@@ -91,16 +91,16 @@ final class IntStreamRulesTest implements RefasterRuleCollectionTestCase {
         IntStream.of(1).anyMatch(n -> n > 1), IntStream.of(2).anyMatch(n -> n > 2));
   }
 
-  boolean testIntStreamAllMatch() {
+  boolean testIntStreamAllMatchWithIntPredicate() {
     IntPredicate pred = i -> i > 0;
     return IntStream.of(1).allMatch(pred);
   }
 
-  boolean testIntStreamAllMatch2() {
+  boolean testIntStreamAllMatch() {
     return IntStream.of(1).allMatch(n -> n > 1);
   }
 
   IntStream testIntStreamTakeWhile() {
-    return IntStream.of(1, 2, 3).takeWhile(i -> i < 2);
+    return IntStream.of(1).takeWhile(i -> i > 0);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitRulesTestInput.java
@@ -6,7 +6,6 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Arguments> testArgumentsEnumeration() {
-    return ImmutableSet.of(
-        Arguments.of("foo"), Arguments.of(1, "foo", 2, "bar"), Arguments.of(new Object()));
+    return ImmutableSet.of(Arguments.of("foo"), Arguments.of("bar", "baz"));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitRulesTestOutput.java
@@ -8,7 +8,6 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Arguments> testArgumentsEnumeration() {
-    return ImmutableSet.of(
-        arguments("foo"), arguments(1, "foo", 2, "bar"), arguments(new Object()));
+    return ImmutableSet.of(arguments("foo"), arguments("bar", "baz"));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestInput.java
@@ -15,6 +15,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
@@ -36,135 +38,135 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         (Runnable) () -> assertTrue(true));
   }
 
-  void testAssertThatBooleanArrayContainsExactly() {
+  void testAssertThatContainsExactlyBoolean() {
     assertArrayEquals(new boolean[] {true}, new boolean[] {false});
   }
 
-  void testAssertThatBooleanArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyBooleanString() {
     assertArrayEquals(new boolean[] {true}, new boolean[] {false}, "foo");
   }
 
-  void testAssertThatBooleanArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyBooleanSupplier() {
     assertArrayEquals(new boolean[] {true}, new boolean[] {false}, () -> "foo");
   }
 
-  void testAssertThatByteArrayContainsExactly() {
+  void testAssertThatContainsExactlyByte() {
     assertArrayEquals(new byte[] {1}, new byte[] {2});
   }
 
-  void testAssertThatByteArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyByteString() {
     assertArrayEquals(new byte[] {1}, new byte[] {2}, "foo");
   }
 
-  void testAssertThatByteArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyByteSupplier() {
     assertArrayEquals(new byte[] {1}, new byte[] {2}, () -> "foo");
   }
 
-  void testAssertThatCharArrayContainsExactly() {
+  void testAssertThatContainsExactlyChar() {
     assertArrayEquals(new char[] {'a'}, new char[] {'b'});
   }
 
-  void testAssertThatCharArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyCharString() {
     assertArrayEquals(new char[] {'a'}, new char[] {'b'}, "foo");
   }
 
-  void testAssertThatCharArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyCharSupplier() {
     assertArrayEquals(new char[] {'a'}, new char[] {'b'}, () -> "foo");
   }
 
-  void testAssertThatShortArrayContainsExactly() {
+  void testAssertThatContainsExactlyShort() {
     assertArrayEquals(new short[] {1}, new short[] {2});
   }
 
-  void testAssertThatShortArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyShortString() {
     assertArrayEquals(new short[] {1}, new short[] {2}, "foo");
   }
 
-  void testAssertThatShortArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyShortSupplier() {
     assertArrayEquals(new short[] {1}, new short[] {2}, () -> "foo");
   }
 
-  void testAssertThatIntArrayContainsExactly() {
+  void testAssertThatContainsExactlyInt() {
     assertArrayEquals(new int[] {1}, new int[] {2});
   }
 
-  void testAssertThatIntArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyIntString() {
     assertArrayEquals(new int[] {1}, new int[] {2}, "foo");
   }
 
-  void testAssertThatIntArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyIntSupplier() {
     assertArrayEquals(new int[] {1}, new int[] {2}, () -> "foo");
   }
 
-  void testAssertThatLongArrayContainsExactly() {
+  void testAssertThatContainsExactlyLong() {
     assertArrayEquals(new long[] {1L}, new long[] {2L});
   }
 
-  void testAssertThatLongArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyLongString() {
     assertArrayEquals(new long[] {1L}, new long[] {2L}, "foo");
   }
 
-  void testAssertThatLongArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyLongSupplier() {
     assertArrayEquals(new long[] {1L}, new long[] {2L}, () -> "foo");
   }
 
-  void testAssertThatFloatArrayContainsExactly() {
+  void testAssertThatContainsExactlyFloat() {
     assertArrayEquals(new float[] {1.0f}, new float[] {2.0f});
   }
 
-  void testAssertThatFloatArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyFloatString() {
     assertArrayEquals(new float[] {1.0f}, new float[] {2.0f}, "foo");
   }
 
-  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyFloatSupplier() {
     assertArrayEquals(new float[] {1.0f}, new float[] {2.0f}, () -> "foo");
   }
 
-  void testAssertThatFloatArrayContainsExactlyWithOffset() {
+  void testAssertThatContainsExactlyOffsetFloat() {
     assertArrayEquals(new float[] {1.0f}, new float[] {2.0f}, 0.1f);
   }
 
-  void testAssertThatFloatArrayWithFailMessageContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetFloatString() {
     assertArrayEquals(new float[] {1.0f}, new float[] {2.0f}, 0.1f, "foo");
   }
 
-  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetFloatSupplier() {
     assertArrayEquals(new float[] {1.0f}, new float[] {2.0f}, 0.1f, () -> "foo");
   }
 
-  void testAssertThatDoubleArrayContainsExactly() {
+  void testAssertThatContainsExactlyDouble() {
     assertArrayEquals(new double[] {1.0}, new double[] {2.0});
   }
 
-  void testAssertThatDoubleArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyDoubleString() {
     assertArrayEquals(new double[] {1.0}, new double[] {2.0}, "foo");
   }
 
-  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyDoubleSupplier() {
     assertArrayEquals(new double[] {1.0}, new double[] {2.0}, () -> "foo");
   }
 
-  void testAssertThatDoubleArrayContainsExactlyWithOffset() {
+  void testAssertThatContainsExactlyOffsetDouble() {
     assertArrayEquals(new double[] {1.0}, new double[] {2.0}, 0.1);
   }
 
-  void testAssertThatDoubleArrayWithFailMessageContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetDoubleString() {
     assertArrayEquals(new double[] {1.0}, new double[] {2.0}, 0.1, "foo");
   }
 
-  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetDoubleSupplier() {
     assertArrayEquals(new double[] {1.0}, new double[] {2.0}, 0.1, () -> "foo");
   }
 
-  void testAssertThatObjectArrayContainsExactly() {
+  void testAssertThatContainsExactlyObject() {
     assertArrayEquals(new Object[] {"foo"}, new Object[] {"bar"});
   }
 
-  void testAssertThatObjectArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyObjectString() {
     assertArrayEquals(new Object[] {"foo"}, new Object[] {"bar"}, "foo");
   }
 
-  void testAssertThatObjectArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyObjectSupplier() {
     assertArrayEquals(new Object[] {"foo"}, new Object[] {"bar"}, () -> "foo");
   }
 
@@ -172,11 +174,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     return Assertions.fail();
   }
 
-  Object testFailWithMessage() {
+  Object testFailWithString() {
     return Assertions.fail("foo");
   }
 
-  Object testFailWithMessageAndThrowable() {
+  Object testFailWithStringAndThrowable() {
     return Assertions.fail("foo", new IllegalStateException());
   }
 
@@ -188,11 +190,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertTrue(true);
   }
 
-  void testAssertThatWithFailMessageStringIsTrue() {
+  void testAssertThatWithFailMessageIsTrueString() {
     assertTrue(true, "foo");
   }
 
-  void testAssertThatWithFailMessageSupplierIsTrue() {
+  void testAssertThatWithFailMessageIsTrueSupplier() {
     assertTrue(true, () -> "foo");
   }
 
@@ -200,11 +202,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertFalse(true);
   }
 
-  void testAssertThatWithFailMessageStringIsFalse() {
+  void testAssertThatWithFailMessageIsFalseString() {
     assertFalse(true, "foo");
   }
 
-  void testAssertThatWithFailMessageSupplierIsFalse() {
+  void testAssertThatWithFailMessageIsFalseSupplier() {
     assertFalse(true, () -> "foo");
   }
 
@@ -212,11 +214,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertNull(new Object());
   }
 
-  void testAssertThatWithFailMessageStringIsNull() {
+  void testAssertThatWithFailMessageIsNullString() {
     assertNull(new Object(), "foo");
   }
 
-  void testAssertThatWithFailMessageSupplierIsNull() {
+  void testAssertThatWithFailMessageIsNullSupplier() {
     assertNull(new Object(), () -> "foo");
   }
 
@@ -224,11 +226,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertNotNull(new Object());
   }
 
-  void testAssertThatWithFailMessageStringIsNotNull() {
+  void testAssertThatWithFailMessageIsNotNullString() {
     assertNotNull(new Object(), "foo");
   }
 
-  void testAssertThatWithFailMessageSupplierIsNotNull() {
+  void testAssertThatWithFailMessageIsNotNullSupplier() {
     assertNotNull(new Object(), () -> "foo");
   }
 
@@ -236,11 +238,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertSame("foo", "bar");
   }
 
-  void testAssertThatWithFailMessageStringIsSameAs() {
+  void testAssertThatWithFailMessageIsSameAsString() {
     assertSame("foo", "bar", "baz");
   }
 
-  void testAssertThatWithFailMessageSupplierIsSameAs() {
+  void testAssertThatWithFailMessageIsSameAsSupplier() {
     assertSame("foo", "bar", () -> "baz");
   }
 
@@ -248,50 +250,62 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertNotSame("foo", "bar");
   }
 
-  void testAssertThatWithFailMessageStringIsNotSameAs() {
+  void testAssertThatWithFailMessageIsNotSameAsString() {
     assertNotSame("foo", "bar", "baz");
   }
 
-  void testAssertThatWithFailMessageSupplierIsNotSameAs() {
+  void testAssertThatWithFailMessageIsNotSameAsSupplier() {
     assertNotSame("foo", "bar", () -> "baz");
   }
 
   void testAssertThatThrownByIsExactlyInstanceOf() {
+    assertThrowsExactly(IllegalStateException.class, (Executable) null);
     assertThrowsExactly(IllegalStateException.class, () -> {});
   }
 
-  void testAssertThatThrownByWithFailMessageStringIsExactlyInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsExactlyInstanceOfString() {
+    assertThrowsExactly(IllegalStateException.class, (Executable) null, "foo");
     assertThrowsExactly(IllegalStateException.class, () -> {}, "foo");
   }
 
-  void testAssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsExactlyInstanceOfSupplier() {
+    assertThrowsExactly(IllegalStateException.class, (Executable) null, () -> "foo");
     assertThrowsExactly(IllegalStateException.class, () -> {}, () -> "foo");
   }
 
   void testAssertThatThrownByIsInstanceOf() {
+    assertThrows(IllegalStateException.class, (Executable) null);
     assertThrows(IllegalStateException.class, () -> {});
   }
 
-  void testAssertThatThrownByWithFailMessageStringIsInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsInstanceOfString() {
+    assertThrows(IllegalStateException.class, (Executable) null, "foo");
     assertThrows(IllegalStateException.class, () -> {}, "foo");
   }
 
-  void testAssertThatThrownByWithFailMessageSupplierIsInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsInstanceOfSupplier() {
+    assertThrows(IllegalStateException.class, (Executable) null, () -> "foo");
     assertThrows(IllegalStateException.class, () -> {}, () -> "foo");
   }
 
   void testAssertThatCodeDoesNotThrowAnyException() {
+    assertDoesNotThrow((Executable) null);
     assertDoesNotThrow(() -> {});
+    assertDoesNotThrow((ThrowingSupplier<String>) null);
     assertDoesNotThrow(() -> toString());
   }
 
-  void testAssertThatCodeWithFailMessageStringDoesNotThrowAnyException() {
+  void testAssertThatCodeWithFailMessageDoesNotThrowAnyExceptionString() {
+    assertDoesNotThrow((Executable) null);
     assertDoesNotThrow(() -> {}, "foo");
+    assertDoesNotThrow((ThrowingSupplier<String>) null, "bar");
     assertDoesNotThrow(() -> toString(), "bar");
   }
 
-  void testAssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException() {
+  void testAssertThatCodeWithFailMessageDoesNotThrowAnyExceptionSupplier() {
+    assertDoesNotThrow((Executable) null, () -> "foo");
     assertDoesNotThrow(() -> {}, () -> "foo");
+    assertDoesNotThrow((ThrowingSupplier<String>) null, () -> "bar");
     assertDoesNotThrow(() -> toString(), () -> "bar");
   }
 
@@ -299,11 +313,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertInstanceOf(Object.class, new Object());
   }
 
-  void testAssertThatWithFailMessageStringIsInstanceOf() {
+  void testAssertThatWithFailMessageIsInstanceOfString() {
     assertInstanceOf(Object.class, new Object(), "foo");
   }
 
-  void testAssertThatWithFailMessageSupplierIsInstanceOf() {
+  void testAssertThatWithFailMessageIsInstanceOfSupplier() {
     assertInstanceOf(Object.class, new Object(), () -> "foo");
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/JUnitToAssertJRulesTestOutput.java
@@ -18,6 +18,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.google.common.collect.ImmutableSet;
 import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.function.Executable;
+import org.junit.jupiter.api.function.ThrowingSupplier;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
@@ -39,145 +41,145 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
         (Runnable) () -> assertTrue(true));
   }
 
-  void testAssertThatBooleanArrayContainsExactly() {
+  void testAssertThatContainsExactlyBoolean() {
     assertThat(new boolean[] {false}).containsExactly(new boolean[] {true});
   }
 
-  void testAssertThatBooleanArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyBooleanString() {
     assertThat(new boolean[] {false}).withFailMessage("foo").containsExactly(new boolean[] {true});
   }
 
-  void testAssertThatBooleanArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyBooleanSupplier() {
     assertThat(new boolean[] {false})
         .withFailMessage(() -> "foo")
         .containsExactly(new boolean[] {true});
   }
 
-  void testAssertThatByteArrayContainsExactly() {
+  void testAssertThatContainsExactlyByte() {
     assertThat(new byte[] {2}).containsExactly(new byte[] {1});
   }
 
-  void testAssertThatByteArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyByteString() {
     assertThat(new byte[] {2}).withFailMessage("foo").containsExactly(new byte[] {1});
   }
 
-  void testAssertThatByteArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyByteSupplier() {
     assertThat(new byte[] {2}).withFailMessage(() -> "foo").containsExactly(new byte[] {1});
   }
 
-  void testAssertThatCharArrayContainsExactly() {
+  void testAssertThatContainsExactlyChar() {
     assertThat(new char[] {'b'}).containsExactly(new char[] {'a'});
   }
 
-  void testAssertThatCharArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyCharString() {
     assertThat(new char[] {'b'}).withFailMessage("foo").containsExactly(new char[] {'a'});
   }
 
-  void testAssertThatCharArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyCharSupplier() {
     assertThat(new char[] {'b'}).withFailMessage(() -> "foo").containsExactly(new char[] {'a'});
   }
 
-  void testAssertThatShortArrayContainsExactly() {
+  void testAssertThatContainsExactlyShort() {
     assertThat(new short[] {2}).containsExactly(new short[] {1});
   }
 
-  void testAssertThatShortArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyShortString() {
     assertThat(new short[] {2}).withFailMessage("foo").containsExactly(new short[] {1});
   }
 
-  void testAssertThatShortArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyShortSupplier() {
     assertThat(new short[] {2}).withFailMessage(() -> "foo").containsExactly(new short[] {1});
   }
 
-  void testAssertThatIntArrayContainsExactly() {
+  void testAssertThatContainsExactlyInt() {
     assertThat(new int[] {2}).containsExactly(new int[] {1});
   }
 
-  void testAssertThatIntArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyIntString() {
     assertThat(new int[] {2}).withFailMessage("foo").containsExactly(new int[] {1});
   }
 
-  void testAssertThatIntArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyIntSupplier() {
     assertThat(new int[] {2}).withFailMessage(() -> "foo").containsExactly(new int[] {1});
   }
 
-  void testAssertThatLongArrayContainsExactly() {
+  void testAssertThatContainsExactlyLong() {
     assertThat(new long[] {2L}).containsExactly(new long[] {1L});
   }
 
-  void testAssertThatLongArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyLongString() {
     assertThat(new long[] {2L}).withFailMessage("foo").containsExactly(new long[] {1L});
   }
 
-  void testAssertThatLongArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyLongSupplier() {
     assertThat(new long[] {2L}).withFailMessage(() -> "foo").containsExactly(new long[] {1L});
   }
 
-  void testAssertThatFloatArrayContainsExactly() {
+  void testAssertThatContainsExactlyFloat() {
     assertThat(new float[] {2.0f}).containsExactly(new float[] {1.0f});
   }
 
-  void testAssertThatFloatArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyFloatString() {
     assertThat(new float[] {2.0f}).withFailMessage("foo").containsExactly(new float[] {1.0f});
   }
 
-  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyFloatSupplier() {
     assertThat(new float[] {2.0f}).withFailMessage(() -> "foo").containsExactly(new float[] {1.0f});
   }
 
-  void testAssertThatFloatArrayContainsExactlyWithOffset() {
+  void testAssertThatContainsExactlyOffsetFloat() {
     assertThat(new float[] {2.0f}).containsExactly(new float[] {1.0f}, offset(0.1f));
   }
 
-  void testAssertThatFloatArrayWithFailMessageContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetFloatString() {
     assertThat(new float[] {2.0f})
         .withFailMessage("foo")
         .containsExactly(new float[] {1.0f}, offset(0.1f));
   }
 
-  void testAssertThatFloatArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetFloatSupplier() {
     assertThat(new float[] {2.0f})
         .withFailMessage(() -> "foo")
         .containsExactly(new float[] {1.0f}, offset(0.1f));
   }
 
-  void testAssertThatDoubleArrayContainsExactly() {
+  void testAssertThatContainsExactlyDouble() {
     assertThat(new double[] {2.0}).containsExactly(new double[] {1.0});
   }
 
-  void testAssertThatDoubleArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyDoubleString() {
     assertThat(new double[] {2.0}).withFailMessage("foo").containsExactly(new double[] {1.0});
   }
 
-  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyDoubleSupplier() {
     assertThat(new double[] {2.0}).withFailMessage(() -> "foo").containsExactly(new double[] {1.0});
   }
 
-  void testAssertThatDoubleArrayContainsExactlyWithOffset() {
+  void testAssertThatContainsExactlyOffsetDouble() {
     assertThat(new double[] {2.0}).containsExactly(new double[] {1.0}, offset(0.1));
   }
 
-  void testAssertThatDoubleArrayWithFailMessageContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetDoubleString() {
     assertThat(new double[] {2.0})
         .withFailMessage("foo")
         .containsExactly(new double[] {1.0}, offset(0.1));
   }
 
-  void testAssertThatDoubleArrayWithFailMessageSupplierContainsExactlyWithOffset() {
+  void testAssertThatWithFailMessageContainsExactlyOffsetDoubleSupplier() {
     assertThat(new double[] {2.0})
         .withFailMessage(() -> "foo")
         .containsExactly(new double[] {1.0}, offset(0.1));
   }
 
-  void testAssertThatObjectArrayContainsExactly() {
+  void testAssertThatContainsExactlyObject() {
     assertThat(new Object[] {"bar"}).containsExactly(new Object[] {"foo"});
   }
 
-  void testAssertThatObjectArrayWithFailMessageContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyObjectString() {
     assertThat(new Object[] {"bar"}).withFailMessage("foo").containsExactly(new Object[] {"foo"});
   }
 
-  void testAssertThatObjectArrayWithFailMessageSupplierContainsExactly() {
+  void testAssertThatWithFailMessageContainsExactlyObjectSupplier() {
     assertThat(new Object[] {"bar"})
         .withFailMessage(() -> "foo")
         .containsExactly(new Object[] {"foo"});
@@ -187,11 +189,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     return org.assertj.core.api.Assertions.fail();
   }
 
-  Object testFailWithMessage() {
+  Object testFailWithString() {
     return org.assertj.core.api.Assertions.fail("foo");
   }
 
-  Object testFailWithMessageAndThrowable() {
+  Object testFailWithStringAndThrowable() {
     return org.assertj.core.api.Assertions.fail("foo", new IllegalStateException());
   }
 
@@ -203,11 +205,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(true).isTrue();
   }
 
-  void testAssertThatWithFailMessageStringIsTrue() {
+  void testAssertThatWithFailMessageIsTrueString() {
     assertThat(true).withFailMessage("foo").isTrue();
   }
 
-  void testAssertThatWithFailMessageSupplierIsTrue() {
+  void testAssertThatWithFailMessageIsTrueSupplier() {
     assertThat(true).withFailMessage(() -> "foo").isTrue();
   }
 
@@ -215,11 +217,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(true).isFalse();
   }
 
-  void testAssertThatWithFailMessageStringIsFalse() {
+  void testAssertThatWithFailMessageIsFalseString() {
     assertThat(true).withFailMessage("foo").isFalse();
   }
 
-  void testAssertThatWithFailMessageSupplierIsFalse() {
+  void testAssertThatWithFailMessageIsFalseSupplier() {
     assertThat(true).withFailMessage(() -> "foo").isFalse();
   }
 
@@ -227,11 +229,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(new Object()).isNull();
   }
 
-  void testAssertThatWithFailMessageStringIsNull() {
+  void testAssertThatWithFailMessageIsNullString() {
     assertThat(new Object()).withFailMessage("foo").isNull();
   }
 
-  void testAssertThatWithFailMessageSupplierIsNull() {
+  void testAssertThatWithFailMessageIsNullSupplier() {
     assertThat(new Object()).withFailMessage(() -> "foo").isNull();
   }
 
@@ -239,11 +241,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(new Object()).isNotNull();
   }
 
-  void testAssertThatWithFailMessageStringIsNotNull() {
+  void testAssertThatWithFailMessageIsNotNullString() {
     assertThat(new Object()).withFailMessage("foo").isNotNull();
   }
 
-  void testAssertThatWithFailMessageSupplierIsNotNull() {
+  void testAssertThatWithFailMessageIsNotNullSupplier() {
     assertThat(new Object()).withFailMessage(() -> "foo").isNotNull();
   }
 
@@ -251,11 +253,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat("bar").isSameAs("foo");
   }
 
-  void testAssertThatWithFailMessageStringIsSameAs() {
+  void testAssertThatWithFailMessageIsSameAsString() {
     assertThat("bar").withFailMessage("baz").isSameAs("foo");
   }
 
-  void testAssertThatWithFailMessageSupplierIsSameAs() {
+  void testAssertThatWithFailMessageIsSameAsSupplier() {
     assertThat("bar").withFailMessage(() -> "baz").isSameAs("foo");
   }
 
@@ -263,56 +265,68 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat("bar").isNotSameAs("foo");
   }
 
-  void testAssertThatWithFailMessageStringIsNotSameAs() {
+  void testAssertThatWithFailMessageIsNotSameAsString() {
     assertThat("bar").withFailMessage("baz").isNotSameAs("foo");
   }
 
-  void testAssertThatWithFailMessageSupplierIsNotSameAs() {
+  void testAssertThatWithFailMessageIsNotSameAsSupplier() {
     assertThat("bar").withFailMessage(() -> "baz").isNotSameAs("foo");
   }
 
   void testAssertThatThrownByIsExactlyInstanceOf() {
+    assertThrowsExactly(IllegalStateException.class, (Executable) null);
     assertThatThrownBy(() -> {}).isExactlyInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThatThrownByWithFailMessageStringIsExactlyInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsExactlyInstanceOfString() {
+    assertThrowsExactly(IllegalStateException.class, (Executable) null, "foo");
     assertThatThrownBy(() -> {})
         .withFailMessage("foo")
         .isExactlyInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThatThrownByWithFailMessageSupplierIsExactlyInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsExactlyInstanceOfSupplier() {
+    assertThrowsExactly(IllegalStateException.class, (Executable) null, () -> "foo");
     assertThatThrownBy(() -> {})
         .withFailMessage(() -> "foo")
         .isExactlyInstanceOf(IllegalStateException.class);
   }
 
   void testAssertThatThrownByIsInstanceOf() {
+    assertThrows(IllegalStateException.class, (Executable) null);
     assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThatThrownByWithFailMessageStringIsInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsInstanceOfString() {
+    assertThrows(IllegalStateException.class, (Executable) null, "foo");
     assertThatThrownBy(() -> {}).withFailMessage("foo").isInstanceOf(IllegalStateException.class);
   }
 
-  void testAssertThatThrownByWithFailMessageSupplierIsInstanceOf() {
+  void testAssertThatThrownByWithFailMessageIsInstanceOfSupplier() {
+    assertThrows(IllegalStateException.class, (Executable) null, () -> "foo");
     assertThatThrownBy(() -> {})
         .withFailMessage(() -> "foo")
         .isInstanceOf(IllegalStateException.class);
   }
 
   void testAssertThatCodeDoesNotThrowAnyException() {
+    assertDoesNotThrow((Executable) null);
     assertThatCode(() -> {}).doesNotThrowAnyException();
+    assertDoesNotThrow((ThrowingSupplier<String>) null);
     assertThatCode(() -> toString()).doesNotThrowAnyException();
   }
 
-  void testAssertThatCodeWithFailMessageStringDoesNotThrowAnyException() {
+  void testAssertThatCodeWithFailMessageDoesNotThrowAnyExceptionString() {
+    assertDoesNotThrow((Executable) null);
     assertThatCode(() -> {}).withFailMessage("foo").doesNotThrowAnyException();
+    assertDoesNotThrow((ThrowingSupplier<String>) null, "bar");
     assertThatCode(() -> toString()).withFailMessage("bar").doesNotThrowAnyException();
   }
 
-  void testAssertThatCodeWithFailMessageSupplierDoesNotThrowAnyException() {
+  void testAssertThatCodeWithFailMessageDoesNotThrowAnyExceptionSupplier() {
+    assertDoesNotThrow((Executable) null, () -> "foo");
     assertThatCode(() -> {}).withFailMessage(() -> "foo").doesNotThrowAnyException();
+    assertDoesNotThrow((ThrowingSupplier<String>) null, () -> "bar");
     assertThatCode(() -> toString()).withFailMessage(() -> "bar").doesNotThrowAnyException();
   }
 
@@ -320,11 +334,11 @@ final class JUnitToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(new Object()).isInstanceOf(Object.class);
   }
 
-  void testAssertThatWithFailMessageStringIsInstanceOf() {
+  void testAssertThatWithFailMessageIsInstanceOfString() {
     assertThat(new Object()).withFailMessage("foo").isInstanceOf(Object.class);
   }
 
-  void testAssertThatWithFailMessageSupplierIsInstanceOf() {
+  void testAssertThatWithFailMessageIsInstanceOfSupplier() {
     assertThat(new Object()).withFailMessage(() -> "foo").isInstanceOf(Object.class);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson2RulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson2RulesTestInput.java
@@ -35,7 +35,7 @@ final class Jackson2RulesTest implements RefasterRuleCollectionTestCase {
             .readTree(new ObjectMapper(new JsonFactory()).writeValueAsString("bar")));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithClass() throws IOException {
+  ImmutableSet<Number> testObjectMapperConvertValueClass() throws IOException {
     return ImmutableSet.of(
         new ObjectMapper().readValue(new ObjectMapper().writeValueAsBytes("1"), Integer.class),
         new ObjectMapper(new JsonFactory())
@@ -43,7 +43,7 @@ final class Jackson2RulesTest implements RefasterRuleCollectionTestCase {
                 new ObjectMapper(new JsonFactory()).writeValueAsString("2.0"), Double.class));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithJavaType() throws IOException {
+  ImmutableSet<Number> testObjectMapperConvertValueJavaType() throws IOException {
     return ImmutableSet.of(
         new ObjectMapper()
             .readValue(
@@ -55,7 +55,7 @@ final class Jackson2RulesTest implements RefasterRuleCollectionTestCase {
                 SimpleType.constructUnsafe(Double.class)));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithTypeReference() throws IOException {
+  ImmutableSet<Number> testObjectMapperConvertValueTypeReference() throws IOException {
     return ImmutableSet.of(
         new ObjectMapper()
             .readValue(new ObjectMapper().writeValueAsBytes("1"), new TypeReference<Integer>() {}),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson2RulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson2RulesTestOutput.java
@@ -34,20 +34,20 @@ final class Jackson2RulesTest implements RefasterRuleCollectionTestCase {
         new ObjectMapper(new JsonFactory()).valueToTree("bar"));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithClass() throws IOException {
+  ImmutableSet<Number> testObjectMapperConvertValueClass() throws IOException {
     return ImmutableSet.of(
         new ObjectMapper().convertValue("1", Integer.class),
         new ObjectMapper(new JsonFactory()).convertValue("2.0", Double.class));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithJavaType() throws IOException {
+  ImmutableSet<Number> testObjectMapperConvertValueJavaType() throws IOException {
     return ImmutableSet.of(
         new ObjectMapper().convertValue("1", SimpleType.constructUnsafe(Integer.class)),
         new ObjectMapper(new JsonFactory())
             .convertValue("2.0", SimpleType.constructUnsafe(Double.class)));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithTypeReference() throws IOException {
+  ImmutableSet<Number> testObjectMapperConvertValueTypeReference() throws IOException {
     return ImmutableSet.of(
         new ObjectMapper().convertValue("1", new TypeReference<Integer>() {}),
         new ObjectMapper(new JsonFactory()).convertValue("2.0", new TypeReference<Double>() {}));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestInput.java
@@ -33,30 +33,31 @@ final class Jackson3RulesTest implements RefasterRuleCollectionTestCase {
         JsonMapper.shared().readTree(JsonMapper.shared().writeValueAsString("bar")));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithClass() {
+  ImmutableSet<Number> testObjectMapperConvertValueClass() {
     return ImmutableSet.of(
-        new ObjectMapper().readValue(new ObjectMapper().writeValueAsBytes("1"), Integer.class),
-        JsonMapper.shared().readValue(JsonMapper.shared().writeValueAsString("2.0"), Double.class));
+        new ObjectMapper().readValue(new ObjectMapper().writeValueAsBytes("foo"), Integer.class),
+        JsonMapper.shared().readValue(JsonMapper.shared().writeValueAsString("bar"), Double.class));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithJavaType() {
+  ImmutableSet<Number> testObjectMapperConvertValueJavaType() {
     return ImmutableSet.of(
         new ObjectMapper()
             .readValue(
-                new ObjectMapper().writeValueAsBytes("1"),
+                new ObjectMapper().writeValueAsBytes("foo"),
                 SimpleType.constructUnsafe(Integer.class)),
         JsonMapper.shared()
             .readValue(
-                JsonMapper.shared().writeValueAsString("2.0"),
+                JsonMapper.shared().writeValueAsString("bar"),
                 SimpleType.constructUnsafe(Double.class)));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithTypeReference() {
+  ImmutableSet<Number> testObjectMapperConvertValueTypeReference() {
     return ImmutableSet.of(
         new ObjectMapper()
-            .readValue(new ObjectMapper().writeValueAsBytes("1"), new TypeReference<Integer>() {}),
+            .readValue(
+                new ObjectMapper().writeValueAsBytes("foo"), new TypeReference<Integer>() {}),
         JsonMapper.shared()
             .readValue(
-                JsonMapper.shared().writeValueAsString("2.0"), new TypeReference<Double>() {}));
+                JsonMapper.shared().writeValueAsString("bar"), new TypeReference<Double>() {}));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/Jackson3RulesTestOutput.java
@@ -32,21 +32,21 @@ final class Jackson3RulesTest implements RefasterRuleCollectionTestCase {
         new ObjectMapper().valueToTree("foo"), JsonMapper.shared().valueToTree("bar"));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithClass() {
+  ImmutableSet<Number> testObjectMapperConvertValueClass() {
     return ImmutableSet.of(
-        new ObjectMapper().convertValue("1", Integer.class),
-        JsonMapper.shared().convertValue("2.0", Double.class));
+        new ObjectMapper().convertValue("foo", Integer.class),
+        JsonMapper.shared().convertValue("bar", Double.class));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithJavaType() {
+  ImmutableSet<Number> testObjectMapperConvertValueJavaType() {
     return ImmutableSet.of(
-        new ObjectMapper().convertValue("1", SimpleType.constructUnsafe(Integer.class)),
-        JsonMapper.shared().convertValue("2.0", SimpleType.constructUnsafe(Double.class)));
+        new ObjectMapper().convertValue("foo", SimpleType.constructUnsafe(Integer.class)),
+        JsonMapper.shared().convertValue("bar", SimpleType.constructUnsafe(Double.class)));
   }
 
-  ImmutableSet<Number> testObjectMapperConvertValueWithTypeReference() {
+  ImmutableSet<Number> testObjectMapperConvertValueTypeReference() {
     return ImmutableSet.of(
-        new ObjectMapper().convertValue("1", new TypeReference<Integer>() {}),
-        JsonMapper.shared().convertValue("2.0", new TypeReference<Double>() {}));
+        new ObjectMapper().convertValue("foo", new TypeReference<Integer>() {}),
+        JsonMapper.shared().convertValue("bar", new TypeReference<Double>() {}));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestInput.java
@@ -14,39 +14,39 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
-  LongStream testLongStreamClosedOpenRange() {
+  LongStream testLongStreamRange() {
     return LongStream.rangeClosed(0, 42 - 1);
   }
 
-  LongStream testConcatOneLongStream() {
+  LongStream testLongStreamIdentity() {
     return Streams.concat(LongStream.of(1));
   }
 
-  LongStream testConcatTwoLongStreams() {
+  LongStream testLongStreamConcat() {
     return Streams.concat(LongStream.of(1), LongStream.of(2));
   }
 
-  LongStream testFilterOuterLongStreamAfterFlatMap() {
+  LongStream testLongStreamFlatMapFilter() {
     return LongStream.of(1).flatMap(v -> LongStream.of(v * v).filter(n -> n > 1));
   }
 
-  LongStream testFilterOuterStreamAfterFlatMapToLong() {
+  LongStream testStreamFlatMapToLongFilter() {
     return Stream.of(1).flatMapToLong(v -> LongStream.of(v * v).filter(n -> n > 1));
   }
 
-  LongStream testMapOuterLongStreamAfterFlatMap() {
+  LongStream testLongStreamFlatMapMap() {
     return LongStream.of(1).flatMap(v -> LongStream.of(v * v).map(n -> n * 1));
   }
 
-  LongStream testMapOuterStreamAfterFlatMapToLong() {
+  LongStream testStreamFlatMapToLongMap() {
     return Stream.of(1).flatMapToLong(v -> LongStream.of(v * v).map(n -> n * 1));
   }
 
-  LongStream testFlatMapOuterLongStreamAfterFlatMap() {
+  LongStream testLongStreamFlatMapFlatMap() {
     return LongStream.of(1).flatMap(v -> LongStream.of(v * v).flatMap(LongStream::of));
   }
 
-  LongStream testFlatMapOuterStreamAfterFlatMapToLong() {
+  LongStream testStreamFlatMapToLongFlatMap() {
     return Stream.of(1).flatMapToLong(v -> LongStream.of(v * v).flatMap(LongStream::of));
   }
 
@@ -54,7 +54,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
     return LongStream.of(1, 4, 3, 2).sorted().filter(l -> l % 2 == 0);
   }
 
-  ImmutableSet<Boolean> testLongStreamIsEmpty() {
+  ImmutableSet<Boolean> testLongStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         LongStream.of(1).count() == 0,
         LongStream.of(2).count() <= 0,
@@ -62,7 +62,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
         LongStream.of(4).findFirst().isEmpty());
   }
 
-  ImmutableSet<Boolean> testLongStreamIsNotEmpty() {
+  ImmutableSet<Boolean> testLongStreamFindAnyIsPresent() {
     return ImmutableSet.of(
         LongStream.of(1).count() != 0,
         LongStream.of(2).count() > 0,
@@ -74,7 +74,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
     return LongStream.of(1).sorted().findFirst();
   }
 
-  ImmutableSet<Boolean> testLongStreamNoneMatch() {
+  ImmutableSet<Boolean> testLongStreamNoneMatchWithLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         !LongStream.of(1).anyMatch(n -> n > 1),
@@ -82,7 +82,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
         LongStream.of(3).filter(pred).findAny().isEmpty());
   }
 
-  boolean testLongStreamNoneMatch2() {
+  boolean testLongStreamNoneMatch() {
     return LongStream.of(1).allMatch(n -> !(n > 1));
   }
 
@@ -92,12 +92,12 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
         LongStream.of(2).filter(n -> n > 2).findAny().isPresent());
   }
 
-  boolean testLongStreamAllMatch() {
+  boolean testLongStreamAllMatchWithLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return LongStream.of(1).noneMatch(pred.negate());
   }
 
-  boolean testLongStreamAllMatch2() {
+  boolean testLongStreamAllMatch() {
     return LongStream.of(1).noneMatch(n -> !(n > 1));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/LongStreamRulesTestOutput.java
@@ -14,39 +14,39 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Streams.class);
   }
 
-  LongStream testLongStreamClosedOpenRange() {
+  LongStream testLongStreamRange() {
     return LongStream.range(0, 42);
   }
 
-  LongStream testConcatOneLongStream() {
+  LongStream testLongStreamIdentity() {
     return LongStream.of(1);
   }
 
-  LongStream testConcatTwoLongStreams() {
+  LongStream testLongStreamConcat() {
     return LongStream.concat(LongStream.of(1), LongStream.of(2));
   }
 
-  LongStream testFilterOuterLongStreamAfterFlatMap() {
+  LongStream testLongStreamFlatMapFilter() {
     return LongStream.of(1).flatMap(v -> LongStream.of(v * v)).filter(n -> n > 1);
   }
 
-  LongStream testFilterOuterStreamAfterFlatMapToLong() {
+  LongStream testStreamFlatMapToLongFilter() {
     return Stream.of(1).flatMapToLong(v -> LongStream.of(v * v)).filter(n -> n > 1);
   }
 
-  LongStream testMapOuterLongStreamAfterFlatMap() {
+  LongStream testLongStreamFlatMapMap() {
     return LongStream.of(1).flatMap(v -> LongStream.of(v * v)).map(n -> n * 1);
   }
 
-  LongStream testMapOuterStreamAfterFlatMapToLong() {
+  LongStream testStreamFlatMapToLongMap() {
     return Stream.of(1).flatMapToLong(v -> LongStream.of(v * v)).map(n -> n * 1);
   }
 
-  LongStream testFlatMapOuterLongStreamAfterFlatMap() {
+  LongStream testLongStreamFlatMapFlatMap() {
     return LongStream.of(1).flatMap(v -> LongStream.of(v * v)).flatMap(LongStream::of);
   }
 
-  LongStream testFlatMapOuterStreamAfterFlatMapToLong() {
+  LongStream testStreamFlatMapToLongFlatMap() {
     return Stream.of(1).flatMapToLong(v -> LongStream.of(v * v)).flatMap(LongStream::of);
   }
 
@@ -54,7 +54,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
     return LongStream.of(1, 4, 3, 2).filter(l -> l % 2 == 0).sorted();
   }
 
-  ImmutableSet<Boolean> testLongStreamIsEmpty() {
+  ImmutableSet<Boolean> testLongStreamFindAnyIsEmpty() {
     return ImmutableSet.of(
         LongStream.of(1).findAny().isEmpty(),
         LongStream.of(2).findAny().isEmpty(),
@@ -62,7 +62,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
         LongStream.of(4).findAny().isEmpty());
   }
 
-  ImmutableSet<Boolean> testLongStreamIsNotEmpty() {
+  ImmutableSet<Boolean> testLongStreamFindAnyIsPresent() {
     return ImmutableSet.of(
         LongStream.of(1).findAny().isPresent(),
         LongStream.of(2).findAny().isPresent(),
@@ -74,7 +74,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
     return LongStream.of(1).min();
   }
 
-  ImmutableSet<Boolean> testLongStreamNoneMatch() {
+  ImmutableSet<Boolean> testLongStreamNoneMatchWithLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return ImmutableSet.of(
         LongStream.of(1).noneMatch(n -> n > 1),
@@ -82,7 +82,7 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
         LongStream.of(3).noneMatch(pred));
   }
 
-  boolean testLongStreamNoneMatch2() {
+  boolean testLongStreamNoneMatch() {
     return LongStream.of(1).noneMatch(n -> n > 1);
   }
 
@@ -91,12 +91,12 @@ final class LongStreamRulesTest implements RefasterRuleCollectionTestCase {
         LongStream.of(1).anyMatch(n -> n > 1), LongStream.of(2).anyMatch(n -> n > 2));
   }
 
-  boolean testLongStreamAllMatch() {
+  boolean testLongStreamAllMatchWithLongPredicate() {
     LongPredicate pred = i -> i > 0;
     return LongStream.of(1).allMatch(pred);
   }
 
-  boolean testLongStreamAllMatch2() {
+  boolean testLongStreamAllMatch() {
     return LongStream.of(1).allMatch(n -> n > 1);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapEntryRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapEntryRulesTestInput.java
@@ -18,23 +18,23 @@ final class MapEntryRulesTest implements RefasterRuleCollectionTestCase {
         Maps.immutableEntry("foo", 1), new AbstractMap.SimpleImmutableEntry<>("bar", 2));
   }
 
-  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testMapEntryComparingByKey() {
+  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testComparingByKey() {
     return ImmutableSet.of(
         Comparator.comparing(Map.Entry::getKey),
         Map.Entry.comparingByKey(Comparator.naturalOrder()));
   }
 
-  Comparator<Map.Entry<Integer, String>> testMapEntryComparingByKeyWithCustomComparator() {
+  Comparator<Map.Entry<Integer, String>> testComparingByKeyWithComparator() {
     return Comparator.comparing(Map.Entry::getKey, Comparator.comparingInt(i -> i * 2));
   }
 
-  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testMapEntryComparingByValue() {
+  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testComparingByValue() {
     return ImmutableSet.of(
         Comparator.comparing(Map.Entry::getValue),
         Map.Entry.comparingByValue(Comparator.naturalOrder()));
   }
 
-  Comparator<Map.Entry<Integer, String>> testMapEntryComparingByValueWithCustomComparator() {
+  Comparator<Map.Entry<Integer, String>> testComparingByValueWithComparator() {
     return Comparator.comparing(Map.Entry::getValue, Comparator.comparingInt(String::length));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapEntryRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapEntryRulesTestOutput.java
@@ -20,19 +20,19 @@ final class MapEntryRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Map.entry("foo", 1), Map.entry("bar", 2));
   }
 
-  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testMapEntryComparingByKey() {
+  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testComparingByKey() {
     return ImmutableSet.of(comparingByKey(), comparingByKey());
   }
 
-  Comparator<Map.Entry<Integer, String>> testMapEntryComparingByKeyWithCustomComparator() {
+  Comparator<Map.Entry<Integer, String>> testComparingByKeyWithComparator() {
     return comparingByKey(Comparator.comparingInt(i -> i * 2));
   }
 
-  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testMapEntryComparingByValue() {
+  ImmutableSet<Comparator<Map.Entry<Integer, String>>> testComparingByValue() {
     return ImmutableSet.of(comparingByValue(), comparingByValue());
   }
 
-  Comparator<Map.Entry<Integer, String>> testMapEntryComparingByValueWithCustomComparator() {
+  Comparator<Map.Entry<Integer, String>> testComparingByValueWithComparator() {
     return comparingByValue(Comparator.comparingInt(String::length));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestInput.java
@@ -16,11 +16,11 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(HashMap.class, requireNonNullElse(null, null));
   }
 
-  Map<RoundingMode, String> testCreateEnumMap() {
+  Map<RoundingMode, String> testNewEnumMapClass() {
     return new HashMap<>();
   }
 
-  String testMapGetOrNull() {
+  String testMapGet() {
     return ImmutableMap.of(1, "foo").getOrDefault("bar", null);
   }
 
@@ -50,11 +50,13 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.of("foo", 1).values().contains(2);
   }
 
-  Stream<String> testMapKeyStream() {
+  Stream<String> testMapKeySetStream() {
     return ImmutableMap.of("foo", 1).entrySet().stream().map(Map.Entry::getKey);
   }
 
-  Stream<Integer> testMapValueStream() {
-    return ImmutableMap.of("foo", 1).entrySet().stream().map(Map.Entry::getValue);
+  ImmutableSet<Stream<Integer>> testMapValuesStream() {
+    return ImmutableSet.of(
+        ImmutableMap.of("foo", 1).keySet().stream().map(ImmutableMap.of("foo", 1)::get),
+        ImmutableMap.of("bar", 2).entrySet().stream().map(Map.Entry::getValue));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MapRulesTestOutput.java
@@ -17,11 +17,11 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(HashMap.class, requireNonNullElse(null, null));
   }
 
-  Map<RoundingMode, String> testCreateEnumMap() {
+  Map<RoundingMode, String> testNewEnumMapClass() {
     return new EnumMap<>(RoundingMode.class);
   }
 
-  String testMapGetOrNull() {
+  String testMapGet() {
     return ImmutableMap.of(1, "foo").get("bar");
   }
 
@@ -51,11 +51,12 @@ final class MapRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableMap.of("foo", 1).containsValue(2);
   }
 
-  Stream<String> testMapKeyStream() {
+  Stream<String> testMapKeySetStream() {
     return ImmutableMap.of("foo", 1).keySet().stream();
   }
 
-  Stream<Integer> testMapValueStream() {
-    return ImmutableMap.of("foo", 1).values().stream();
+  ImmutableSet<Stream<Integer>> testMapValuesStream() {
+    return ImmutableSet.of(
+        ImmutableMap.of("foo", 1).values().stream(), ImmutableMap.of("bar", 2).values().stream());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MockitoRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MockitoRulesTestInput.java
@@ -19,15 +19,15 @@ final class MockitoRulesTest implements RefasterRuleCollectionTestCase {
     return times(0);
   }
 
-  Object testVerifyOnce() {
+  Object testVerify() {
     return verify(mock(Object.class), times(1));
   }
 
-  Object testInvocationOnMockGetArguments() {
+  Object testInvocationOnMockGetArgument() {
     return ((InvocationOnMock) null).getArguments()[0];
   }
 
-  ImmutableSet<Number> testInvocationOnMockGetArgumentsWithTypeParameter() {
+  ImmutableSet<Number> testInvocationOnMockGetArgumentObject() {
     return ImmutableSet.of(
         ((InvocationOnMock) null).getArgument(0, Integer.class),
         (Double) ((InvocationOnMock) null).getArgument(1));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MockitoRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MockitoRulesTestOutput.java
@@ -20,15 +20,15 @@ final class MockitoRulesTest implements RefasterRuleCollectionTestCase {
     return never();
   }
 
-  Object testVerifyOnce() {
+  Object testVerify() {
     return verify(mock(Object.class));
   }
 
-  Object testInvocationOnMockGetArguments() {
+  Object testInvocationOnMockGetArgument() {
     return ((InvocationOnMock) null).getArgument(0);
   }
 
-  ImmutableSet<Number> testInvocationOnMockGetArgumentsWithTypeParameter() {
+  ImmutableSet<Number> testInvocationOnMockGetArgumentObject() {
     return ImmutableSet.of(
         ((InvocationOnMock) null).<Integer>getArgument(0),
         ((InvocationOnMock) null).<Double>getArgument(1));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MultimapRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MultimapRulesTestInput.java
@@ -25,7 +25,7 @@ final class MultimapRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableSetMultimap.of("foo", 1).keySet().isEmpty(),
         ImmutableSetMultimap.of("bar", 2).keys().isEmpty(),
         ImmutableSetMultimap.of("baz", 3).values().isEmpty(),
-        ImmutableSetMultimap.of("qux", 54).entries().isEmpty());
+        ImmutableSetMultimap.of("qux", 4).entries().isEmpty());
   }
 
   int testMultimapSize() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MultimapRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/MultimapRulesTestOutput.java
@@ -25,7 +25,7 @@ final class MultimapRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableSetMultimap.of("foo", 1).isEmpty(),
         ImmutableSetMultimap.of("bar", 2).isEmpty(),
         ImmutableSetMultimap.of("baz", 3).isEmpty(),
-        ImmutableSetMultimap.of("qux", 54).isEmpty());
+        ImmutableSetMultimap.of("qux", 4).isEmpty());
   }
 
   int testMultimapSize() {

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestInput.java
@@ -15,11 +15,11 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(MoreObjects.class, Optional.class, not(null));
   }
 
-  ImmutableSet<Boolean> testIsNull() {
+  ImmutableSet<Boolean> testEqualToNull() {
     return ImmutableSet.of(null == "foo", Objects.isNull("bar"));
   }
 
-  ImmutableSet<Boolean> testIsNotNull() {
+  ImmutableSet<Boolean> testNotEqualToNull() {
     return ImmutableSet.of(null != "foo", Objects.nonNull("bar"));
   }
 
@@ -32,11 +32,11 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return Optional.ofNullable("foo").orElseGet(() -> "bar");
   }
 
-  ImmutableSet<Predicate<String>> testIsNullFunction() {
+  ImmutableSet<Predicate<String>> testObjectsIsNull() {
     return ImmutableSet.of(s -> s == null, not(Objects::nonNull));
   }
 
-  ImmutableSet<Predicate<String>> testNonNullFunction() {
+  ImmutableSet<Predicate<String>> testObjectsNonNull() {
     return ImmutableSet.of(s -> s != null, not(Objects::isNull));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/NullRulesTestOutput.java
@@ -17,11 +17,11 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(MoreObjects.class, Optional.class, not(null));
   }
 
-  ImmutableSet<Boolean> testIsNull() {
+  ImmutableSet<Boolean> testEqualToNull() {
     return ImmutableSet.of("foo" == null, "bar" == null);
   }
 
-  ImmutableSet<Boolean> testIsNotNull() {
+  ImmutableSet<Boolean> testNotEqualToNull() {
     return ImmutableSet.of("foo" != null, "bar" != null);
   }
 
@@ -33,11 +33,11 @@ final class NullRulesTest implements RefasterRuleCollectionTestCase {
     return requireNonNullElseGet("foo", () -> "bar");
   }
 
-  ImmutableSet<Predicate<String>> testIsNullFunction() {
+  ImmutableSet<Predicate<String>> testObjectsIsNull() {
     return ImmutableSet.of(Objects::isNull, Objects::isNull);
   }
 
-  ImmutableSet<Predicate<String>> testNonNullFunction() {
+  ImmutableSet<Predicate<String>> testObjectsNonNull() {
     return ImmutableSet.of(Objects::nonNull, Objects::nonNull);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
@@ -23,29 +23,29 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         toString() != null ? Optional.of(toString()) : Optional.empty());
   }
 
-  ImmutableSet<Boolean> testOptionalIsEmpty() {
-    return ImmutableSet.of(!Optional.empty().isPresent(), !Optional.of("foo").isPresent());
+  boolean testOptionalIsEmpty() {
+    return !Optional.of("foo").isPresent();
   }
 
-  ImmutableSet<Boolean> testOptionalIsPresent() {
-    return ImmutableSet.of(!Optional.empty().isEmpty(), !Optional.of("foo").isEmpty());
+  boolean testOptionalIsPresent() {
+    return !Optional.of("foo").isEmpty();
   }
 
-  String testOptionalOrElseThrow() {
+  String testOptionalOrElseThrowWithOptional() {
     return Optional.of("foo").get();
   }
 
-  Function<Optional<Integer>, Integer> testOptionalOrElseThrowMethodReference() {
+  Function<Optional<Integer>, Integer> testOptionalOrElseThrow() {
     return Optional::get;
   }
 
-  ImmutableSet<Boolean> testOptionalEqualsOptional() {
+  ImmutableSet<Boolean> testOptionalEqualsOptionalOf() {
     return ImmutableSet.of(
         Optional.of("foo").filter("bar"::equals).isPresent(),
         Optional.of("baz").stream().anyMatch("qux"::equals));
   }
 
-  ImmutableSet<Optional<String>> testOptionalFirstIteratorElement() {
+  ImmutableSet<Optional<String>> testStreamsStreamFindFirst() {
     return ImmutableSet.of(
         ImmutableSet.of("foo").iterator().hasNext()
             ? Optional.of(ImmutableSet.of("foo").iterator().next())
@@ -55,65 +55,69 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
             : Optional.of(ImmutableSet.of("foo").iterator().next()));
   }
 
-  Optional<String> testTernaryOperatorOptionalPositiveFiltering() {
-    return "foo".length() > 5 ? Optional.of("foo") : Optional.empty();
+  ImmutableSet<Optional<String>> testRefasterEmitCommentBeforeOptionalOfFilter() {
+    return ImmutableSet.of(
+        "foo".length() > 5 ? Optional.of("foo") : Optional.empty(),
+        !("bar".length() > 5) ? Optional.empty() : Optional.of("bar"));
   }
 
-  Optional<String> testTernaryOperatorOptionalNegativeFiltering() {
-    return "foo".length() > 5 ? Optional.empty() : Optional.of("foo");
+  ImmutableSet<Optional<String>> testRefasterEmitCommentBeforeOptionalOfFilterNot() {
+    return ImmutableSet.of(
+        "foo".length() > 5 ? Optional.empty() : Optional.of("foo"),
+        !("bar".length() > 5) ? Optional.of("bar") : Optional.empty());
   }
 
-  boolean testMapOptionalToBoolean() {
+  boolean testOptionalFilterIsPresent() {
     return Optional.of("foo").map(String::isEmpty).orElse(false);
   }
 
-  ImmutableSet<Optional<String>> testMapToNullable() {
+  ImmutableSet<Optional<String>> testOptionalMap() {
     return ImmutableSet.of(
         Optional.of(1).flatMap(n -> Optional.of(String.valueOf(n))),
         Optional.of(2).flatMap(n -> Optional.ofNullable(String.valueOf(n))));
   }
 
-  Optional<String> testFlatMapToOptional() {
+  Optional<String> testOptionalFlatMap() {
     return Optional.of(1).map(n -> Optional.of(String.valueOf(n)).orElseThrow());
   }
 
-  String testOrOrElseThrow() {
+  String testOptionalOrOrElseThrow() {
     return Optional.of("foo").orElseGet(() -> Optional.of("bar").orElseThrow());
   }
 
   ImmutableSet<String> testOptionalOrElse() {
     return ImmutableSet.of(
-        Optional.of("foo").orElseGet(() -> "bar"), Optional.of("baz").orElseGet(() -> toString()));
+        Optional.of("foo").orElseGet(() -> toString()), Optional.of("bar").orElseGet(() -> "baz"));
   }
 
-  ImmutableSet<Object> testStreamFlatMapOptional() {
+  ImmutableSet<Object> testStreamFlatMapOptionalStream() {
     return ImmutableSet.of(
         Stream.of(Optional.empty()).filter(Optional::isPresent).map(Optional::orElseThrow),
         Stream.of(Optional.of("foo")).flatMap(Streams::stream));
   }
 
-  Stream<String> testStreamMapToOptionalGet() {
+  Stream<String> testStreamFlatMapStream() {
     return Stream.of(1).map(n -> Optional.of(String.valueOf(n)).orElseThrow());
   }
 
-  Optional<Integer> testFilterOuterOptionalAfterFlatMap() {
+  Optional<Integer> testOptionalFlatMapFilter() {
     return Optional.of("foo").flatMap(v -> Optional.of(v.length()).filter(len -> len > 0));
   }
 
-  Optional<Integer> testMapOuterOptionalAfterFlatMap() {
+  Optional<Integer> testOptionalFlatMapMap() {
     return Optional.of("foo").flatMap(v -> Optional.of(v.length()).map(len -> len * 0));
   }
 
-  Optional<Integer> testFlatMapOuterOptionalAfterFlatMap() {
+  Optional<Integer> testOptionalFlatMapFlatMap() {
     return Optional.of("foo").flatMap(v -> Optional.of(v.length()).flatMap(Optional::of));
   }
 
-  ImmutableSet<Optional<String>> testOptionalOrOtherOptional() {
+  ImmutableSet<Optional<String>> testOptionalOr() {
     return ImmutableSet.of(
         Optional.of("foo").map(Optional::of).orElse(Optional.of("bar")),
         Optional.of("baz").map(Optional::of).orElseGet(() -> Optional.of("qux")),
-        Stream.of(Optional.of("quux"), Optional.of("quuz")).flatMap(Optional::stream).findFirst(),
-        Optional.of("corge").isPresent() ? Optional.of("corge") : Optional.of("grault"));
+        Stream.of(Optional.of("quux"), Optional.of("corge")).flatMap(Optional::stream).findFirst(),
+        Optional.of("grault").isPresent() ? Optional.of("grault") : Optional.of("garply"));
   }
 
   ImmutableSet<Optional<String>> testOptionalIdentity() {
@@ -123,9 +127,9 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("baz").map(Optional::of).orElseGet(() -> Optional.empty()),
         Optional.of("qux").map(Optional::of).orElseGet(Optional::empty),
         Optional.of("quux").stream().findFirst(),
-        Optional.of("quuz").stream().findAny(),
-        Optional.of("corge").stream().min(String::compareTo),
-        Optional.of("grault").stream().max(String::compareTo));
+        Optional.of("corge").stream().findAny(),
+        Optional.of("grault").stream().min(String::compareTo),
+        Optional.of("garply").stream().max(String::compareTo));
   }
 
   ImmutableSet<Optional<String>> testOptionalFilter() {
@@ -134,7 +138,7 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("bar").stream().filter(String::isEmpty).findAny());
   }
 
-  Optional<String> testOptionalMap() {
+  Optional<String> testOptionalMapWithFunction() {
     return Optional.of(1).stream().map(String::valueOf).findAny();
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
@@ -23,94 +23,100 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Optional.ofNullable(toString()), Optional.ofNullable(toString()));
   }
 
-  ImmutableSet<Boolean> testOptionalIsEmpty() {
-    return ImmutableSet.of(Optional.empty().isEmpty(), Optional.of("foo").isEmpty());
+  boolean testOptionalIsEmpty() {
+    return Optional.of("foo").isEmpty();
   }
 
-  ImmutableSet<Boolean> testOptionalIsPresent() {
-    return ImmutableSet.of(Optional.empty().isPresent(), Optional.of("foo").isPresent());
+  boolean testOptionalIsPresent() {
+    return Optional.of("foo").isPresent();
   }
 
-  String testOptionalOrElseThrow() {
+  String testOptionalOrElseThrowWithOptional() {
     return Optional.of("foo").orElseThrow();
   }
 
-  Function<Optional<Integer>, Integer> testOptionalOrElseThrowMethodReference() {
+  Function<Optional<Integer>, Integer> testOptionalOrElseThrow() {
     return Optional::orElseThrow;
   }
 
-  ImmutableSet<Boolean> testOptionalEqualsOptional() {
+  ImmutableSet<Boolean> testOptionalEqualsOptionalOf() {
     return ImmutableSet.of(
         Optional.of("foo").equals(Optional.of("bar")),
         Optional.of("baz").equals(Optional.of("qux")));
   }
 
-  ImmutableSet<Optional<String>> testOptionalFirstIteratorElement() {
+  ImmutableSet<Optional<String>> testStreamsStreamFindFirst() {
     return ImmutableSet.of(
         stream(ImmutableSet.of("foo").iterator()).findFirst(),
         stream(ImmutableSet.of("foo").iterator()).findFirst());
   }
 
-  Optional<String> testTernaryOperatorOptionalPositiveFiltering() {
-    return /* Or Optional.ofNullable (can't auto-infer). */ Optional.of("foo")
-        .filter(v -> v.length() > 5);
+  ImmutableSet<Optional<String>> testRefasterEmitCommentBeforeOptionalOfFilter() {
+    return ImmutableSet.of(
+        /* Or Optional.ofNullable (can't auto-infer). */ Optional.of("foo")
+            .filter(v -> v.length() > 5),
+        /* Or Optional.ofNullable (can't auto-infer). */ Optional.of("bar")
+            .filter(v -> v.length() > 5));
   }
 
-  Optional<String> testTernaryOperatorOptionalNegativeFiltering() {
-    return /* Or Optional.ofNullable (can't auto-infer). */ Optional.of("foo")
-        .filter(v -> v.length() <= 5);
+  ImmutableSet<Optional<String>> testRefasterEmitCommentBeforeOptionalOfFilterNot() {
+    return ImmutableSet.of(
+        /* Or Optional.ofNullable (can't auto-infer). */ Optional.of("foo")
+            .filter(v -> v.length() <= 5),
+        /* Or Optional.ofNullable (can't auto-infer). */ Optional.of("bar")
+            .filter(v -> v.length() <= 5));
   }
 
-  boolean testMapOptionalToBoolean() {
+  boolean testOptionalFilterIsPresent() {
     return Optional.of("foo").filter(String::isEmpty).isPresent();
   }
 
-  ImmutableSet<Optional<String>> testMapToNullable() {
+  ImmutableSet<Optional<String>> testOptionalMap() {
     return ImmutableSet.of(
         Optional.of(1).map(n -> String.valueOf(n)), Optional.of(2).map(n -> String.valueOf(n)));
   }
 
-  Optional<String> testFlatMapToOptional() {
+  Optional<String> testOptionalFlatMap() {
     return Optional.of(1).flatMap(n -> Optional.of(String.valueOf(n)));
   }
 
-  String testOrOrElseThrow() {
+  String testOptionalOrOrElseThrow() {
     return Optional.of("foo").or(() -> Optional.of("bar")).orElseThrow();
   }
 
   ImmutableSet<String> testOptionalOrElse() {
     return ImmutableSet.of(
-        Optional.of("foo").orElse("bar"), Optional.of("baz").orElseGet(() -> toString()));
+        Optional.of("foo").orElseGet(() -> toString()), Optional.of("bar").orElse("baz"));
   }
 
-  ImmutableSet<Object> testStreamFlatMapOptional() {
+  ImmutableSet<Object> testStreamFlatMapOptionalStream() {
     return ImmutableSet.of(
         Stream.of(Optional.empty()).flatMap(Optional::stream),
         Stream.of(Optional.of("foo")).flatMap(Optional::stream));
   }
 
-  Stream<String> testStreamMapToOptionalGet() {
+  Stream<String> testStreamFlatMapStream() {
     return Stream.of(1).flatMap(n -> Optional.of(String.valueOf(n)).stream());
   }
 
-  Optional<Integer> testFilterOuterOptionalAfterFlatMap() {
+  Optional<Integer> testOptionalFlatMapFilter() {
     return Optional.of("foo").flatMap(v -> Optional.of(v.length())).filter(len -> len > 0);
   }
 
-  Optional<Integer> testMapOuterOptionalAfterFlatMap() {
+  Optional<Integer> testOptionalFlatMapMap() {
     return Optional.of("foo").flatMap(v -> Optional.of(v.length())).map(len -> len * 0);
   }
 
-  Optional<Integer> testFlatMapOuterOptionalAfterFlatMap() {
+  Optional<Integer> testOptionalFlatMapFlatMap() {
     return Optional.of("foo").flatMap(v -> Optional.of(v.length())).flatMap(Optional::of);
   }
 
-  ImmutableSet<Optional<String>> testOptionalOrOtherOptional() {
+  ImmutableSet<Optional<String>> testOptionalOr() {
     return ImmutableSet.of(
         Optional.of("foo").or(() -> Optional.of("bar")),
         Optional.of("baz").or(() -> Optional.of("qux")),
-        Optional.of("quux").or(() -> Optional.of("quuz")),
-        Optional.of("corge").or(() -> Optional.of("grault")));
+        Optional.of("quux").or(() -> Optional.of("corge")),
+        Optional.of("grault").or(() -> Optional.of("garply")));
   }
 
   ImmutableSet<Optional<String>> testOptionalIdentity() {
@@ -120,9 +126,9 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("baz"),
         Optional.of("qux"),
         Optional.of("quux"),
-        Optional.of("quuz"),
         Optional.of("corge"),
-        Optional.of("grault"));
+        Optional.of("grault"),
+        Optional.of("garply"));
   }
 
   ImmutableSet<Optional<String>> testOptionalFilter() {
@@ -130,7 +136,7 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
         Optional.of("foo").filter(String::isEmpty), Optional.of("bar").filter(String::isEmpty));
   }
 
-  Optional<String> testOptionalMap() {
+  Optional<String> testOptionalMapWithFunction() {
     return Optional.of(1).map(String::valueOf);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestInput.java
@@ -7,46 +7,52 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
   @Override
-  @SuppressWarnings("RequireNonNull")
+  @SuppressWarnings("RequireNonNullExpression")
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(checkNotNull(null));
   }
 
-  void testCheckArgument() {
+  void testCheckArgumentNot() {
     if ("foo".isEmpty()) {
+      throw new IllegalArgumentException();
+    }
+    if (!"bar".isEmpty()) {
       throw new IllegalArgumentException();
     }
   }
 
-  void testCheckArgumentWithMessage() {
+  void testCheckArgumentNotWithString() {
     if ("foo".isEmpty()) {
-      throw new IllegalArgumentException("The string is empty");
+      throw new IllegalArgumentException("bar");
+    }
+    if (!"baz".isEmpty()) {
+      throw new IllegalArgumentException("qux");
     }
   }
 
-  void testCheckElementIndexWithMessage() {
+  void testCheckElementIndex() {
     if (1 < 0 || 1 >= 2) {
-      throw new IndexOutOfBoundsException("My index");
+      throw new IndexOutOfBoundsException("foo");
     }
   }
 
-  String testRequireNonNull() {
+  String testRequireNonNullExpression() {
     return checkNotNull("foo");
   }
 
-  void testRequireNonNullStatement() {
+  void testRequireNonNullBlock() {
     if ("foo" == null) {
       throw new NullPointerException();
     }
   }
 
-  String testRequireNonNullWithMessage() {
-    return checkNotNull("foo", "The string is null");
+  String testRequireNonNullWithStringExpression() {
+    return checkNotNull("foo", "bar");
   }
 
-  void testRequireNonNullWithMessageStatement() {
+  void testRequireNonNullWithStringBlock() {
     if ("foo" == null) {
-      throw new NullPointerException("The string is null");
+      throw new NullPointerException("bar");
     }
   }
 
@@ -56,21 +62,21 @@ final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
-  void testCheckPositionIndexWithMessage() {
+  void testCheckPositionIndexWithString() {
     if (1 < 0 || 1 > 2) {
-      throw new IndexOutOfBoundsException("My position");
+      throw new IndexOutOfBoundsException("foo");
     }
   }
 
-  void testCheckState() {
+  void testCheckStateNot() {
     if ("foo".isEmpty()) {
       throw new IllegalStateException();
     }
   }
 
-  void testCheckStateWithMessage() {
+  void testCheckStateNotWithString() {
     if ("foo".isEmpty()) {
-      throw new IllegalStateException("The string is empty");
+      throw new IllegalStateException("bar");
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PreconditionsRulesTestOutput.java
@@ -12,52 +12,54 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class PreconditionsRulesTest implements RefasterRuleCollectionTestCase {
   @Override
-  @SuppressWarnings("RequireNonNull")
+  @SuppressWarnings("RequireNonNullExpression")
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(checkNotNull(null));
   }
 
-  void testCheckArgument() {
+  void testCheckArgumentNot() {
     checkArgument(!"foo".isEmpty());
+    checkArgument("bar".isEmpty());
   }
 
-  void testCheckArgumentWithMessage() {
-    checkArgument(!"foo".isEmpty(), "The string is empty");
+  void testCheckArgumentNotWithString() {
+    checkArgument(!"foo".isEmpty(), "bar");
+    checkArgument("baz".isEmpty(), "qux");
   }
 
-  void testCheckElementIndexWithMessage() {
-    checkElementIndex(1, 2, "My index");
+  void testCheckElementIndex() {
+    checkElementIndex(1, 2, "foo");
   }
 
-  String testRequireNonNull() {
+  String testRequireNonNullExpression() {
     return requireNonNull("foo");
   }
 
-  void testRequireNonNullStatement() {
+  void testRequireNonNullBlock() {
     requireNonNull("foo");
   }
 
-  String testRequireNonNullWithMessage() {
-    return requireNonNull("foo", "The string is null");
+  String testRequireNonNullWithStringExpression() {
+    return requireNonNull("foo", "bar");
   }
 
-  void testRequireNonNullWithMessageStatement() {
-    requireNonNull("foo", "The string is null");
+  void testRequireNonNullWithStringBlock() {
+    requireNonNull("foo", "bar");
   }
 
   void testCheckPositionIndex() {
     checkPositionIndex(1, 2);
   }
 
-  void testCheckPositionIndexWithMessage() {
-    checkPositionIndex(1, 2, "My position");
+  void testCheckPositionIndexWithString() {
+    checkPositionIndex(1, 2, "foo");
   }
 
-  void testCheckState() {
+  void testCheckStateNot() {
     checkState(!"foo".isEmpty());
   }
 
-  void testCheckStateWithMessage() {
-    checkState(!"foo".isEmpty(), "The string is empty");
+  void testCheckStateNotWithString() {
+    checkState(!"foo".isEmpty(), "bar");
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestInput.java
@@ -1,8 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.primitives.Booleans;
-import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Chars;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
@@ -19,8 +17,6 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        Booleans.class,
-        Bytes.class,
         Chars.class,
         Doubles.class,
         Floats.class,
@@ -112,7 +108,7 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
         Doubles.constrainToRange(1.0, 2.0, 3.0));
   }
 
-  int testLongToIntExact() {
+  int testMathToIntExact() {
     return Ints.checkedCast(Long.MAX_VALUE);
   }
 
@@ -170,7 +166,7 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
     return UnsignedInts.compare(1, 2);
   }
 
-  long testLongCompareUnsigned() {
+  int testLongCompareUnsigned() {
     return UnsignedLongs.compare(1, 2);
   }
 
@@ -198,11 +194,11 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(UnsignedLongs.parseUnsignedLong("1"), Long.parseUnsignedLong("2", 10));
   }
 
-  int testIntegerParseUnsignedIntWithRadix() {
+  int testIntegerParseUnsignedIntWithInt() {
     return UnsignedInts.parseUnsignedInt("1", 2);
   }
 
-  long testLongParseUnsignedLongWithRadix() {
+  long testLongParseUnsignedLongWithInt() {
     return UnsignedLongs.parseUnsignedLong("1", 2);
   }
 
@@ -214,23 +210,23 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(UnsignedLongs.toString(1), Long.toUnsignedString(2, 10));
   }
 
-  String testIntegerToUnsignedStringWithRadix() {
+  String testIntegerToUnsignedStringWithInt() {
     return UnsignedInts.toString(1, 2);
   }
 
-  String testLongToUnsignedStringWithRadix() {
+  String testLongToUnsignedStringWithInt() {
     return UnsignedLongs.toString(1, 2);
   }
 
-  Comparator<byte[]> testArraysCompareUnsignedBytes() {
+  Comparator<byte[]> testArraysCompareUnsignedByte() {
     return UnsignedBytes.lexicographicalComparator();
   }
 
-  Comparator<int[]> testArraysCompareUnsignedInts() {
+  Comparator<int[]> testArraysCompareUnsignedInt() {
     return UnsignedInts.lexicographicalComparator();
   }
 
-  Comparator<long[]> testArraysCompareUnsignedLongs() {
+  Comparator<long[]> testArraysCompareUnsignedLong() {
     return UnsignedLongs.lexicographicalComparator();
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/PrimitiveRulesTestOutput.java
@@ -1,8 +1,6 @@
 package tech.picnic.errorprone.refasterrules;
 
 import com.google.common.collect.ImmutableSet;
-import com.google.common.primitives.Booleans;
-import com.google.common.primitives.Bytes;
 import com.google.common.primitives.Chars;
 import com.google.common.primitives.Doubles;
 import com.google.common.primitives.Floats;
@@ -20,8 +18,6 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
   @Override
   public ImmutableSet<Object> elidedTypesAndStaticImports() {
     return ImmutableSet.of(
-        Booleans.class,
-        Bytes.class,
         Chars.class,
         Doubles.class,
         Floats.class,
@@ -113,7 +109,7 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
         Math.clamp(1.0, 2.0, 3.0));
   }
 
-  int testLongToIntExact() {
+  int testMathToIntExact() {
     return Math.toIntExact(Long.MAX_VALUE);
   }
 
@@ -171,7 +167,7 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
     return Integer.compareUnsigned(1, 2);
   }
 
-  long testLongCompareUnsigned() {
+  int testLongCompareUnsigned() {
     return Long.compareUnsigned(1, 2);
   }
 
@@ -199,11 +195,11 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Long.parseUnsignedLong("1"), Long.parseUnsignedLong("2"));
   }
 
-  int testIntegerParseUnsignedIntWithRadix() {
+  int testIntegerParseUnsignedIntWithInt() {
     return Integer.parseUnsignedInt("1", 2);
   }
 
-  long testLongParseUnsignedLongWithRadix() {
+  long testLongParseUnsignedLongWithInt() {
     return Long.parseUnsignedLong("1", 2);
   }
 
@@ -215,23 +211,23 @@ final class PrimitiveRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Long.toUnsignedString(1), Long.toUnsignedString(2));
   }
 
-  String testIntegerToUnsignedStringWithRadix() {
+  String testIntegerToUnsignedStringWithInt() {
     return Integer.toUnsignedString(1, 2);
   }
 
-  String testLongToUnsignedStringWithRadix() {
+  String testLongToUnsignedStringWithInt() {
     return Long.toUnsignedString(1, 2);
   }
 
-  Comparator<byte[]> testArraysCompareUnsignedBytes() {
+  Comparator<byte[]> testArraysCompareUnsignedByte() {
     return Arrays::compareUnsigned;
   }
 
-  Comparator<int[]> testArraysCompareUnsignedInts() {
+  Comparator<int[]> testArraysCompareUnsignedInt() {
     return Arrays::compareUnsigned;
   }
 
-  Comparator<long[]> testArraysCompareUnsignedLongs() {
+  Comparator<long[]> testArraysCompareUnsignedLong() {
     return Arrays::compareUnsigned;
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RandomGeneratorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RandomGeneratorRulesTestInput.java
@@ -15,7 +15,7 @@ final class RandomGeneratorRulesTest implements RefasterRuleCollectionTestCase {
         new SecureRandom().nextDouble() * 3.0);
   }
 
-  double testRandomGeneratorNextDoubleWithOrigin() {
+  double testRandomGeneratorNextDoublePlus() {
     return 1.0 + new Random().nextDouble(2.0);
   }
 
@@ -24,7 +24,7 @@ final class RandomGeneratorRulesTest implements RefasterRuleCollectionTestCase {
         (int) new Random().nextDouble(1), (int) Math.round(new SplittableRandom().nextDouble(2)));
   }
 
-  int testRandomGeneratorNextIntWithOrigin() {
+  int testRandomGeneratorNextIntPlus() {
     return 1 + new Random().nextInt(2);
   }
 
@@ -36,7 +36,7 @@ final class RandomGeneratorRulesTest implements RefasterRuleCollectionTestCase {
         Math.round(ThreadLocalRandom.current().nextDouble(4L)));
   }
 
-  long testRandomGeneratorNextLongWithOrigin() {
+  long testRandomGeneratorNextLongPlus() {
     return 1L + new Random().nextLong(2L);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RandomGeneratorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RandomGeneratorRulesTestOutput.java
@@ -15,7 +15,7 @@ final class RandomGeneratorRulesTest implements RefasterRuleCollectionTestCase {
         new SecureRandom().nextDouble(3.0));
   }
 
-  double testRandomGeneratorNextDoubleWithOrigin() {
+  double testRandomGeneratorNextDoublePlus() {
     return new Random().nextDouble(1.0, 1.0 + 2.0);
   }
 
@@ -23,7 +23,7 @@ final class RandomGeneratorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(new Random().nextInt(1), new SplittableRandom().nextInt(2));
   }
 
-  int testRandomGeneratorNextIntWithOrigin() {
+  int testRandomGeneratorNextIntPlus() {
     return new Random().nextInt(1, 1 + 2);
   }
 
@@ -35,7 +35,7 @@ final class RandomGeneratorRulesTest implements RefasterRuleCollectionTestCase {
         ThreadLocalRandom.current().nextLong(4L));
   }
 
-  long testRandomGeneratorNextLongWithOrigin() {
+  long testRandomGeneratorNextLongPlus() {
     return new Random().nextLong(1L, 1L + 2L);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestInput.java
@@ -74,11 +74,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Mono.justOrEmpty(null), Mono.justOrEmpty(Optional.empty()));
   }
 
-  Mono<Integer> testMonoTimeoutDurationMonoEmpty() {
+  Mono<Integer> testMonoTimeoutMonoEmptyDuration() {
     return Mono.just(1).timeout(Duration.ofSeconds(2)).onErrorComplete(TimeoutException.class);
   }
 
-  Mono<Integer> testMonoTimeoutDurationMonoJust() {
+  Mono<Integer> testMonoTimeoutMonoJustDuration() {
     return Mono.just(1).timeout(Duration.ofSeconds(2)).onErrorReturn(TimeoutException.class, 3);
   }
 
@@ -92,11 +92,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
             .onErrorResume(TimeoutException.class, e -> Mono.just(e.toString().hashCode())));
   }
 
-  Mono<Integer> testMonoTimeoutPublisherMonoEmpty() {
+  Mono<Integer> testMonoTimeoutMonoEmptyPublisher() {
     return Mono.just(1).timeout(Mono.just(2)).onErrorComplete(TimeoutException.class);
   }
 
-  Mono<Integer> testMonoTimeoutPublisherMonoJust() {
+  Mono<Integer> testMonoTimeoutMonoJustPublisher() {
     return Mono.just(1).timeout(Mono.just(2)).onErrorReturn(TimeoutException.class, 3);
   }
 
@@ -132,7 +132,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Optional.of("foo").map(Mono::justOrEmpty);
   }
 
-  Mono<Integer> testMonoFromOptionalSwitchIfEmpty() {
+  Mono<Integer> testMonoJustOrEmptySwitchIfEmpty() {
     return Optional.of(1).map(Mono::just).orElse(Mono.just(2));
   }
 
@@ -140,7 +140,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.just("foo").zipWith(Mono.just(1));
   }
 
-  Mono<String> testMonoZipWithCombinator() {
+  Mono<String> testMonoZipMapFunction() {
     return Mono.just("foo").zipWith(Mono.just(1), String::repeat);
   }
 
@@ -148,7 +148,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just("foo", "bar").zipWith(Flux.just(1, 2));
   }
 
-  Flux<String> testFluxZipWithCombinator() {
+  Flux<String> testFluxZipMapFunction() {
     return Flux.just("foo", "bar").zipWith(Flux.just(1, 2), String::repeat);
   }
 
@@ -156,7 +156,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.zip(Flux.just("foo", "bar"), Flux.fromIterable(ImmutableSet.of(1, 2)));
   }
 
-  Flux<String> testFluxZipWithIterableBiFunction() {
+  Flux<String> testFluxZipWithIterableWithBiFunction() {
     return Flux.just("foo", "bar")
         .zipWith(Flux.fromIterable(ImmutableSet.of(1, 2)), String::repeat);
   }
@@ -165,11 +165,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just("foo", "bar").zipWithIterable(ImmutableSet.of(1, 2), String::repeat);
   }
 
-  Mono<Void> testMonoDeferredError() {
+  Mono<Void> testMonoErrorThrowable() {
     return Mono.defer(() -> Mono.error(new IllegalStateException()));
   }
 
-  Flux<Void> testFluxDeferredError() {
+  Flux<Void> testFluxErrorThrowable() {
     return Flux.defer(() -> Flux.error(new IllegalStateException()));
   }
 
@@ -222,12 +222,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.mergeSequential(),
         Flux.mergeSequential(1),
         Flux.mergeSequentialDelayError(1),
-        Flux.fromArray(new String[0]),
         Flux.fromArray(new String[] {"foo"}),
-        Flux.fromIterable(ImmutableList.of()),
+        Flux.fromArray(new String[0]),
         Flux.fromIterable(Iterables.cycle("bar")),
-        Flux.fromStream(() -> Stream.empty()),
+        Flux.fromIterable(ImmutableList.of()),
         Flux.fromStream(() -> Stream.generate(() -> "baz")),
+        Flux.fromStream(() -> Stream.empty()),
         Flux.combineLatest(v -> v),
         Flux.combineLatest(v -> v, 1),
         Flux.mergeComparing(),
@@ -247,7 +247,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just(4).repeat().take(1));
   }
 
-  ImmutableSet<Flux<String>> testFluxJustArray() {
+  ImmutableSet<Flux<String>> testFluxJustVarargs() {
     return ImmutableSet.of(
         Flux.fromStream(() -> Stream.of("foo", "bar")),
         Flux.fromStream(() -> Stream.of("baz", "qux", "quux")));
@@ -275,81 +275,81 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Mono<String>> testMonoUsing() {
     return ImmutableSet.of(
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("foo")).next(),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("bar")).next(),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("baz")).single(),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("qux")).single());
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("foo")).next(),
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("bar")).next(),
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("baz")).single(),
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("qux")).single());
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingEagerBoolean() {
+  ImmutableSet<Mono<String>> testMonoUsingWithBoolean() {
     return ImmutableSet.of(
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("foo"), false)
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("foo"), false)
             .next(),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("bar"), false)
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("bar"), false)
             .next(),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("baz"), true)
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("baz"), true)
             .single(),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("qux"), true)
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("qux"), true)
             .single());
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingResourceCleanup() {
+  ImmutableSet<Mono<String>> testMonoUsingWithConsumer() {
     return ImmutableSet.of(
-        Flux.using(() -> 1, v -> Mono.just("foo"), v -> {}).next(),
-        Flux.using(() -> 2, v -> Flux.just("bar"), v -> {}).next(),
-        Flux.using(() -> 3, v -> Mono.just("baz"), v -> {}).single(),
-        Flux.using(() -> 4, v -> Flux.just("qux"), v -> {}).single());
+        Flux.using(() -> 1, v -> Flux.just("foo"), v -> {}).next(),
+        Flux.using(() -> 2, v -> Mono.just("bar"), v -> {}).next(),
+        Flux.using(() -> 3, v -> Flux.just("baz"), v -> {}).single(),
+        Flux.using(() -> 4, v -> Mono.just("qux"), v -> {}).single());
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingConsumerEagerBoolean() {
+  ImmutableSet<Mono<String>> testMonoUsingWithConsumerAndBoolean() {
     return ImmutableSet.of(
-        Flux.using(() -> 1, v -> Mono.just("foo"), v -> {}, false).next(),
-        Flux.using(() -> 2, v -> Flux.just("bar"), v -> {}, false).next(),
-        Flux.using(() -> 3, v -> Mono.just("baz"), v -> {}, true).single(),
-        Flux.using(() -> 4, v -> Flux.just("qux"), v -> {}, true).single());
+        Flux.using(() -> 1, v -> Flux.just("foo"), v -> {}, false).next(),
+        Flux.using(() -> 2, v -> Mono.just("bar"), v -> {}, false).next(),
+        Flux.using(() -> 3, v -> Flux.just("baz"), v -> {}, true).single(),
+        Flux.using(() -> 4, v -> Mono.just("qux"), v -> {}, true).single());
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingWhenAsyncCleanup() {
+  ImmutableSet<Mono<String>> testMonoUsingWhen() {
     return ImmutableSet.of(
-        Flux.usingWhen(Mono.just(1), v -> Mono.just("foo"), v -> Mono.just(2)).next(),
-        Flux.usingWhen(Mono.just(3), v -> Flux.just("bar"), v -> Mono.just(4)).next(),
-        Flux.usingWhen(Mono.just(5), v -> Mono.just("baz"), v -> Mono.just(6)).single(),
-        Flux.usingWhen(Mono.just(7), v -> Flux.just("qux"), v -> Mono.just(8)).single());
+        Flux.usingWhen(Mono.just(1), v -> Flux.just("foo"), v -> Mono.just(2)).next(),
+        Flux.usingWhen(Mono.just(3), v -> Mono.just("bar"), v -> Mono.just(4)).next(),
+        Flux.usingWhen(Mono.just(5), v -> Flux.just("baz"), v -> Mono.just(6)).single(),
+        Flux.usingWhen(Mono.just(7), v -> Mono.just("qux"), v -> Mono.just(8)).single());
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingWhenAsync() {
+  ImmutableSet<Mono<String>> testMonoUsingWhenWithBiFunctionAndFunction() {
     return ImmutableSet.of(
         Flux.usingWhen(
                 Mono.just(1),
-                v -> Mono.just("foo"),
+                v -> Flux.just("foo"),
                 v -> Mono.just(2),
                 (v, t) -> Mono.just(3),
                 v -> Mono.just(4))
             .next(),
         Flux.usingWhen(
                 Mono.just(5),
-                v -> Flux.just("bar"),
+                v -> Mono.just("bar"),
                 v -> Mono.just(6),
                 (v, t) -> Mono.just(7),
                 v -> Mono.just(8))
             .next(),
         Flux.usingWhen(
                 Mono.just(9),
-                v -> Mono.just("baz"),
+                v -> Flux.just("baz"),
                 v -> Mono.just(10),
                 (v, t) -> Mono.just(11),
                 v -> Mono.just(12))
             .single(),
         Flux.usingWhen(
                 Mono.just(13),
-                v -> Flux.just("qux"),
+                v -> Mono.just("qux"),
                 v -> Mono.just(14),
                 (v, t) -> Mono.just(15),
                 v -> Mono.just(16))
             .single());
   }
 
-  ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
+  ImmutableSet<Flux<Integer>> testFluxIdentity() {
     return ImmutableSet.of(
         Flux.just(1).switchIfEmpty(Mono.empty()), Flux.just(2).switchIfEmpty(Flux.empty()));
   }
@@ -359,27 +359,26 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).concatMap(Mono::just, 0),
         Flux.just(2).flatMap(Mono::just, 1),
         Flux.just(3).flatMapSequential(Mono::just, 1),
-        Flux.just(4).map(Mono::just).concatMap(identity()),
-        Flux.just(5).map(Mono::just).concatMap(v -> v),
-        Flux.just(6).map(Mono::just).concatMap(v -> Mono.empty()));
+        Flux.just(4).map(Mono::just).concatMap(v -> Mono.empty()),
+        Flux.just(5).map(Mono::just).concatMap(identity()),
+        Flux.just(6).map(Mono::just).concatMap(v -> v));
   }
 
-  ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {
+  ImmutableSet<Flux<Integer>> testFluxConcatMapWithInt() {
     return ImmutableSet.of(
         Flux.just(1).flatMap(Mono::just, 1, 3),
         Flux.just(2).flatMapSequential(Mono::just, 1, 4),
-        Flux.just(3).map(Mono::just).concatMap(identity(), 5),
-        Flux.just(4).map(Mono::just).concatMap(v -> v, 6),
-        Flux.just(5).map(Mono::just).concatMap(v -> Mono.empty(), 7));
+        Flux.just(3).map(Mono::just).concatMap(v -> Mono.empty(), 5),
+        Flux.just(4).map(Mono::just).concatMap(identity(), 6),
+        Flux.just(5).map(Mono::just).concatMap(v -> v, 7));
   }
 
   ImmutableSet<Flux<Integer>> testMonoFlatMapIterable() {
     return ImmutableSet.of(
         Mono.just(1).map(ImmutableSet::of).flatMapMany(Flux::fromIterable),
-        Mono.just(2).map(ImmutableSet::of).flatMapIterable(identity()),
-        Mono.just(3).map(ImmutableSet::of).flatMapIterable(v -> v),
-        Mono.just(4).map(ImmutableSet::of).flatMapIterable(v -> ImmutableSet.of()),
-        Mono.just(5).flux().concatMapIterable(ImmutableSet::of));
+        Mono.just(2).map(ImmutableSet::of).flatMapIterable(v -> ImmutableSet.of()),
+        Mono.just(3).map(ImmutableSet::of).flatMapIterable(identity()),
+        Mono.just(4).flux().concatMapIterable(ImmutableSet::of));
   }
 
   Flux<Integer> testMonoFlatMapIterableIdentity() {
@@ -389,20 +388,18 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Flux<Integer>> testFluxConcatMapIterable() {
     return ImmutableSet.of(
         Flux.just(1).flatMapIterable(ImmutableList::of),
-        Flux.just(2).map(ImmutableList::of).concatMapIterable(identity()),
-        Flux.just(3).map(ImmutableList::of).concatMapIterable(v -> v),
-        Flux.just(4).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of()));
+        Flux.just(2).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of()),
+        Flux.just(3).map(ImmutableList::of).concatMapIterable(identity()));
   }
 
-  ImmutableSet<Flux<Integer>> testFluxConcatMapIterableWithPrefetch() {
+  ImmutableSet<Flux<Integer>> testFluxConcatMapIterableWithInt() {
     return ImmutableSet.of(
         Flux.just(1).flatMapIterable(ImmutableList::of, 5),
-        Flux.just(2).map(ImmutableList::of).concatMapIterable(identity(), 5),
-        Flux.just(3).map(ImmutableList::of).concatMapIterable(v -> v, 5),
-        Flux.just(4).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of(), 5));
+        Flux.just(2).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of(), 5),
+        Flux.just(3).map(ImmutableList::of).concatMapIterable(identity(), 5));
   }
 
-  Flux<String> testMonoFlatMapToFlux() {
+  Flux<String> testMonoFlatMapFlux() {
     return Mono.just("foo").flatMapMany(s -> Mono.fromSupplier(() -> s + s));
   }
 
@@ -470,11 +467,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).switchMap(n -> Mono.fromSupplier(() -> n * 2)));
   }
 
-  Flux<String> testFluxMapNotNullTransformationOrElse() {
+  Flux<String> testFluxMapNotNullOrElseNull() {
     return Flux.just(1).map(x -> Optional.of(x.toString())).mapNotNull(x -> x.orElse(null));
   }
 
-  Flux<Integer> testFluxMapNotNullOrElse() {
+  Flux<Integer> testFluxMapNotNullOptionalOrElseNull() {
     return Flux.just(Optional.of(1)).filter(Optional::isPresent).map(Optional::orElseThrow);
   }
 
@@ -512,7 +509,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("baz").ignoreElement().thenMany(Flux.just("qux")));
   }
 
-  Flux<String> testMonoThenMonoFlux() {
+  Flux<String> testMonoThenFlux() {
     return Mono.just("foo").thenMany(Mono.just("bar"));
   }
 
@@ -520,14 +517,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just("foo").ignoreElements().thenMany(Flux.just("bar"));
   }
 
-  ImmutableSet<Mono<?>> testMonoThenMono() {
+  ImmutableSet<Mono<?>> testMonoThenWithMono() {
     return ImmutableSet.of(
         Mono.just("foo").ignoreElement().then(Mono.just("bar")),
         Mono.just("baz").flux().then(Mono.just("qux")),
         Mono.just("quux").thenEmpty(Mono.<Void>empty()));
   }
 
-  ImmutableSet<Mono<?>> testFluxThenMono() {
+  ImmutableSet<Mono<?>> testFluxThenWithMono() {
     return ImmutableSet.of(
         Flux.just("foo").ignoreElements().then(Mono.just("bar")),
         Flux.just("baz").thenEmpty(Mono.<Void>empty()));
@@ -542,11 +539,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("quuz").transform(Mono::singleOptional));
   }
 
-  Mono<Number> testMonoCast() {
+  Mono<Number> testMonoCastClass() {
     return Mono.just(1).map(Number.class::cast);
   }
 
-  Flux<Number> testFluxCast() {
+  Flux<Number> testFluxCastClass() {
     return Flux.just(1).map(Number.class::cast);
   }
 
@@ -560,37 +557,35 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Mono<String>> testMonoFlatMap() {
     return ImmutableSet.of(
-        Mono.just("foo").map(Mono::just).flatMap(identity()),
-        Mono.just("bar").map(Mono::just).flatMap(v -> v),
-        Mono.just("baz").map(Mono::just).flatMap(v -> Mono.empty()));
+        Mono.just("foo").map(Mono::just).flatMap(v -> Mono.empty()),
+        Mono.just("bar").map(Mono::just).flatMap(identity()));
   }
 
   ImmutableSet<Flux<Integer>> testMonoFlatMapMany() {
     return ImmutableSet.of(
-        Mono.just(1).map(Mono::just).flatMapMany(identity()),
-        Mono.just(2).map(Mono::just).flatMapMany(v -> v),
-        Mono.just(3).map(Mono::just).flatMapMany(v -> Flux.empty()),
-        Mono.just(4).flux().concatMap(Mono::just),
-        Mono.just(5).flux().concatMap(Mono::just, 2),
-        Mono.just(6).flux().concatMapDelayError(Mono::just),
-        Mono.just(7).flux().concatMapDelayError(Mono::just, 2),
-        Mono.just(8).flux().concatMapDelayError(Mono::just, false, 2),
-        Mono.just(9).flux().flatMap(Mono::just, 2),
-        Mono.just(10).flux().flatMap(Mono::just, 2, 3),
-        Mono.just(11).flux().flatMapDelayError(Mono::just, 2, 3),
-        Mono.just(12).flux().flatMapSequential(Mono::just, 2),
-        Mono.just(13).flux().flatMapSequential(Mono::just, 2, 3),
-        Mono.just(14).flux().flatMapSequentialDelayError(Mono::just, 2, 3),
-        Mono.just(15).flux().switchMap(Mono::just));
+        Mono.just(1).map(Mono::just).flatMapMany(v -> Flux.empty()),
+        Mono.just(2).map(Mono::just).flatMapMany(identity()),
+        Mono.just(3).flux().concatMap(Mono::just),
+        Mono.just(4).flux().concatMap(Mono::just, 2),
+        Mono.just(5).flux().concatMapDelayError(Mono::just),
+        Mono.just(6).flux().concatMapDelayError(Mono::just, 2),
+        Mono.just(7).flux().concatMapDelayError(Mono::just, false, 2),
+        Mono.just(8).flux().flatMap(Mono::just, 2),
+        Mono.just(9).flux().flatMap(Mono::just, 2, 3),
+        Mono.just(10).flux().flatMapDelayError(Mono::just, 2, 3),
+        Mono.just(11).flux().flatMapSequential(Mono::just, 2),
+        Mono.just(12).flux().flatMapSequential(Mono::just, 2, 3),
+        Mono.just(13).flux().flatMapSequentialDelayError(Mono::just, 2, 3),
+        Mono.just(14).flux().switchMap(Mono::just));
   }
 
-  ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {
+  ImmutableSet<Flux<String>> testFluxConcatMapIterableIdentity() {
     return ImmutableSet.of(
         Flux.just(ImmutableList.of("foo")).concatMap(list -> Flux.fromIterable(list)),
         Flux.just(ImmutableList.of("bar")).concatMap(Flux::fromIterable));
   }
 
-  ImmutableSet<Flux<String>> testConcatMapIterableIdentityWithPrefetch() {
+  ImmutableSet<Flux<String>> testFluxConcatMapIterableIdentityWithInt() {
     return ImmutableSet.of(
         Flux.just(ImmutableList.of("foo")).concatMap(list -> Flux.fromIterable(list), 1),
         Flux.just(ImmutableList.of("bar")).concatMap(Flux::fromIterable, 2));
@@ -637,24 +632,24 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(5).onErrorComplete().doOnError(e -> true, e -> {}));
   }
 
-  ImmutableSet<Mono<Integer>> testMonoOnErrorCompleteClass() {
+  ImmutableSet<Mono<Integer>> testMonoOnErrorCompleteWithClass() {
     return ImmutableSet.of(
         Mono.just(1).onErrorComplete(IllegalArgumentException.class::isInstance),
         Mono.just(2).onErrorResume(IllegalStateException.class, e -> Mono.empty()));
   }
 
-  ImmutableSet<Flux<Integer>> testFluxOnErrorCompleteClass() {
+  ImmutableSet<Flux<Integer>> testFluxOnErrorCompleteWithClass() {
     return ImmutableSet.of(
         Flux.just(1).onErrorComplete(IllegalArgumentException.class::isInstance),
         Flux.just(2).onErrorResume(IllegalStateException.class, e -> Mono.empty()),
         Flux.just(3).onErrorResume(AssertionError.class, e -> Flux.empty()));
   }
 
-  Mono<Integer> testMonoOnErrorCompletePredicate() {
+  Mono<Integer> testMonoOnErrorCompleteWithPredicate() {
     return Mono.just(1).onErrorResume(e -> e.getCause() == null, e -> Mono.empty());
   }
 
-  ImmutableSet<Flux<Integer>> testFluxOnErrorCompletePredicate() {
+  ImmutableSet<Flux<Integer>> testFluxOnErrorCompleteWithPredicate() {
     return ImmutableSet.of(
         Flux.just(1).onErrorResume(e -> e.getCause() == null, e -> Mono.empty()),
         Flux.just(2).onErrorResume(e -> e.getCause() != null, e -> Flux.empty()));
@@ -726,21 +721,21 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).sort(naturalOrder());
   }
 
-  Mono<Integer> testFluxTransformMin() {
+  Mono<Integer> testFluxTransformMathFluxMinSingleOrEmpty() {
     return Flux.just(1).sort().next();
   }
 
-  ImmutableSet<Mono<Integer>> testFluxTransformMinWithComparator() {
+  ImmutableSet<Mono<Integer>> testFluxTransformMathFluxMinSingleOrEmptyWithComparator() {
     return ImmutableSet.of(
         Flux.just(1).sort(reverseOrder()).next(),
         Flux.just(2).collect(minBy(reverseOrder())).flatMap(Mono::justOrEmpty));
   }
 
-  Mono<Integer> testFluxTransformMax() {
+  Mono<Integer> testFluxTransformMathFluxMaxSingleOrEmpty() {
     return Flux.just(1).sort().last();
   }
 
-  ImmutableSet<Mono<Integer>> testFluxTransformMaxWithComparator() {
+  ImmutableSet<Mono<Integer>> testFluxTransformMathFluxMaxSingleOrEmptyWithComparator() {
     return ImmutableSet.of(
         Flux.just(1).sort(reverseOrder()).last(),
         Flux.just(2).collect(maxBy(reverseOrder())).flatMap(Mono::justOrEmpty));
@@ -757,7 +752,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Context> testContextEmpty() {
-    return ImmutableSet.of(Context.of(ImmutableMap.of()), Context.of(ImmutableMap.of(1, 2)));
+    return ImmutableSet.of(Context.of(ImmutableMap.of(1, 2)), Context.of(ImmutableMap.of()));
   }
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {
@@ -793,8 +788,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(PublisherProbe.empty().wasRequested()).isFalse();
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  void testAssertThatPublisherProbeWasSubscribed() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy statements. */)
+  void testAssertThatPublisherProbeWasSubscribedIsEqualTo() {
     if (true) {
       PublisherProbe.of(Mono.just(1)).assertWasSubscribed();
     } else {
@@ -807,8 +802,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  void testAssertThatPublisherProbeWasCancelled() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy statements. */)
+  void testAssertThatPublisherProbeWasCancelledIsEqualTo() {
     if (true) {
       PublisherProbe.of(Mono.just(1)).assertWasCancelled();
     } else {
@@ -821,8 +816,8 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  void testAssertThatPublisherProbeWasRequested() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy statements. */)
+  void testAssertThatPublisherProbeWasRequestedIsEqualTo() {
     if (true) {
       PublisherProbe.of(Mono.just(1)).assertWasRequested();
     } else {
@@ -835,12 +830,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     }
   }
 
-  ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
+  ImmutableSet<StepVerifier.FirstStep<Integer>> testMonoAsStepVerifierCreate() {
     return ImmutableSet.of(
         StepVerifier.create(Mono.just(1)), Mono.just(2).flux().as(StepVerifier::create));
   }
 
-  StepVerifier.FirstStep<Integer> testStepVerifierFromFlux() {
+  StepVerifier.FirstStep<Integer> testFluxAsStepVerifierCreate() {
     return StepVerifier.create(Flux.just(1));
   }
 
@@ -848,7 +843,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat();
   }
 
-  Object testStepVerifierVerifyDuration() {
+  Object testStepVerifierVerifyWithDuration() {
     return Mono.empty().as(StepVerifier::create).expectError().verifyThenAssertThat(Duration.ZERO);
   }
 
@@ -856,36 +851,36 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).expectError().verifyLater().verifyLater();
   }
 
-  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
+  ImmutableSet<StepVerifier.Step<Integer>> testStepIdentity() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create).expectNext(),
         Mono.just(2).as(StepVerifier::create).expectNextCount(0L),
-        Mono.just(3).as(StepVerifier::create).expectNextSequence(ImmutableList.of()),
-        Mono.just(4).as(StepVerifier::create).expectNextSequence(ImmutableList.of(5)));
+        Mono.just(3).as(StepVerifier::create).expectNextSequence(ImmutableList.of(4)),
+        Mono.just(5).as(StepVerifier::create).expectNextSequence(ImmutableList.of()));
   }
 
-  ImmutableSet<StepVerifier.Step<String>> testStepVerifierStepExpectNext() {
+  ImmutableSet<StepVerifier.Step<String>> testStepExpectNext() {
     return ImmutableSet.of(
         Mono.just("foo").as(StepVerifier::create).expectNextMatches(s -> s.equals("bar")),
         Mono.just("baz").as(StepVerifier::create).expectNextMatches("qux"::equals));
   }
 
-  StepVerifier.Step<?> testFluxAsStepVerifierExpectNext() {
+  StepVerifier.Step<?> testFluxAsStepVerifierCreateExpectNext() {
     return Flux.just(1)
         .collect(toImmutableList())
         .as(StepVerifier::create)
         .assertNext(list -> assertThat(list).containsExactly(2));
   }
 
-  Duration testStepVerifierLastStepVerifyComplete() {
+  Duration testLastStepVerifyComplete() {
     return Mono.empty().as(StepVerifier::create).expectComplete().verify();
   }
 
-  Duration testStepVerifierLastStepVerifyError() {
+  Duration testLastStepVerifyError() {
     return Mono.empty().as(StepVerifier::create).expectError().verify();
   }
 
-  ImmutableSet<Duration> testStepVerifierLastStepVerifyErrorClass() {
+  ImmutableSet<Duration> testLastStepVerifyErrorWithClass() {
     return ImmutableSet.of(
         Mono.empty().as(StepVerifier::create).expectError(IllegalArgumentException.class).verify(),
         Mono.empty()
@@ -896,7 +891,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
             .verifyErrorSatisfies(t -> assertThat(t).isInstanceOf(AssertionError.class)));
   }
 
-  ImmutableSet<?> testStepVerifierLastStepVerifyErrorMatches() {
+  ImmutableSet<?> testLastStepVerifyErrorMatches() {
     return ImmutableSet.of(
         Mono.empty()
             .as(StepVerifier::create)
@@ -909,11 +904,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
             .hasOperatorErrorMatching(IllegalStateException.class::equals));
   }
 
-  Duration testStepVerifierLastStepVerifyErrorSatisfies() {
+  Duration testLastStepVerifyErrorSatisfies() {
     return Mono.empty().as(StepVerifier::create).expectErrorSatisfies(t -> {}).verify();
   }
 
-  ImmutableSet<?> testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
+  ImmutableSet<?> testLastStepVerifyErrorSatisfiesAssertThatIsInstanceOfHasMessage() {
     return ImmutableSet.of(
         Mono.empty()
             .as(StepVerifier::create)
@@ -933,32 +928,32 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
             .hasOperatorErrorOfType(AssertionError.class));
   }
 
-  Duration testStepVerifierLastStepVerifyErrorMessage() {
+  Duration testLastStepVerifyErrorMessage() {
     return Mono.empty().as(StepVerifier::create).expectErrorMessage("foo").verify();
   }
 
-  Duration testStepVerifierLastStepVerifyTimeout() {
+  Duration testLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).expectTimeout(Duration.ZERO).verify();
   }
 
-  Mono<Void> testMonoFromFutureSupplier() {
+  Mono<Void> testMonoFromFuture() {
     return Mono.fromFuture(CompletableFuture.completedFuture(null));
   }
 
-  Mono<Void> testMonoFromFutureSupplierBoolean() {
+  Mono<Void> testMonoFromFutureWithBoolean() {
     return Mono.fromFuture(CompletableFuture.completedFuture(null), true);
   }
 
-  Mono<String> testMonoFromFutureAsyncLoadingCacheGet() {
+  Mono<String> testMonoFromFutureAsyncLoadingCacheGetTrue() {
     return Mono.fromFuture(() -> ((AsyncLoadingCache<Integer, String>) null).get(0));
   }
 
-  Mono<Map<Integer, String>> testMonoFromFutureAsyncLoadingCacheGetAll() {
+  Mono<Map<Integer, String>> testMonoFromFutureAsyncLoadingCacheGetAllTrue() {
     return Mono.fromFuture(
         () -> ((AsyncLoadingCache<Integer, String>) null).getAll(ImmutableSet.of()));
   }
 
-  Flux<Integer> testFluxFromStreamSupplier() {
+  Flux<Integer> testFluxFromStream() {
     return Flux.fromStream(Stream.of(1));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/ReactorRulesTestOutput.java
@@ -77,11 +77,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Mono.empty(), Mono.empty());
   }
 
-  Mono<Integer> testMonoTimeoutDurationMonoEmpty() {
+  Mono<Integer> testMonoTimeoutMonoEmptyDuration() {
     return Mono.just(1).timeout(Duration.ofSeconds(2), Mono.empty());
   }
 
-  Mono<Integer> testMonoTimeoutDurationMonoJust() {
+  Mono<Integer> testMonoTimeoutMonoJustDuration() {
     return Mono.just(1).timeout(Duration.ofSeconds(2), Mono.just(3));
   }
 
@@ -93,11 +93,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
             .onErrorResume(TimeoutException.class, e -> Mono.just(e.toString().hashCode())));
   }
 
-  Mono<Integer> testMonoTimeoutPublisherMonoEmpty() {
+  Mono<Integer> testMonoTimeoutMonoEmptyPublisher() {
     return Mono.just(1).timeout(Mono.just(2), Mono.empty());
   }
 
-  Mono<Integer> testMonoTimeoutPublisherMonoJust() {
+  Mono<Integer> testMonoTimeoutMonoJustPublisher() {
     return Mono.just(1).timeout(Mono.just(2), Mono.just(3));
   }
 
@@ -131,7 +131,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Optional.of("foo").map(Mono::just);
   }
 
-  Mono<Integer> testMonoFromOptionalSwitchIfEmpty() {
+  Mono<Integer> testMonoJustOrEmptySwitchIfEmpty() {
     return Mono.justOrEmpty(Optional.of(1)).switchIfEmpty(Mono.just(2));
   }
 
@@ -139,7 +139,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.zip(Mono.just("foo"), Mono.just(1));
   }
 
-  Mono<String> testMonoZipWithCombinator() {
+  Mono<String> testMonoZipMapFunction() {
     return Mono.zip(Mono.just("foo"), Mono.just(1)).map(TupleUtils.function(String::repeat));
   }
 
@@ -147,7 +147,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.zip(Flux.just("foo", "bar"), Flux.just(1, 2));
   }
 
-  Flux<String> testFluxZipWithCombinator() {
+  Flux<String> testFluxZipMapFunction() {
     return Flux.zip(Flux.just("foo", "bar"), Flux.just(1, 2))
         .map(TupleUtils.function(String::repeat));
   }
@@ -156,7 +156,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just("foo", "bar").zipWithIterable(ImmutableSet.of(1, 2));
   }
 
-  Flux<String> testFluxZipWithIterableBiFunction() {
+  Flux<String> testFluxZipWithIterableWithBiFunction() {
     return Flux.just("foo", "bar").zipWithIterable(ImmutableSet.of(1, 2), String::repeat);
   }
 
@@ -166,11 +166,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         .map(function(String::repeat));
   }
 
-  Mono<Void> testMonoDeferredError() {
+  Mono<Void> testMonoErrorThrowable() {
     return Mono.error(() -> new IllegalStateException());
   }
 
-  Flux<Void> testFluxDeferredError() {
+  Flux<Void> testFluxErrorThrowable() {
     return Flux.error(() -> new IllegalStateException());
   }
 
@@ -222,12 +222,12 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.empty(),
         Flux.empty(),
         Flux.empty(),
-        Flux.empty(),
         Flux.fromArray(new String[] {"foo"}),
         Flux.empty(),
         Flux.fromIterable(Iterables.cycle("bar")),
         Flux.empty(),
         Flux.fromStream(() -> Stream.generate(() -> "baz")),
+        Flux.empty(),
         Flux.empty(),
         Flux.empty(),
         Flux.empty(),
@@ -243,7 +243,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Flux.just(0), Flux.just(2), Flux.just(3), Flux.just(4));
   }
 
-  ImmutableSet<Flux<String>> testFluxJustArray() {
+  ImmutableSet<Flux<String>> testFluxJustVarargs() {
     return ImmutableSet.of(Flux.just("foo", "bar"), Flux.just("baz", "qux", "quux"));
   }
 
@@ -268,77 +268,77 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Mono<String>> testMonoUsing() {
     return ImmutableSet.of(
-        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("foo")),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("bar")).next(),
-        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("baz")),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("qux")).single());
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("foo")).next(),
+        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("bar")),
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("baz")).single(),
+        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("qux")));
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingEagerBoolean() {
+  ImmutableSet<Mono<String>> testMonoUsingWithBoolean() {
     return ImmutableSet.of(
-        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("foo"), false),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("bar"), false)
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("foo"), false)
             .next(),
-        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("baz"), true),
-        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("qux"), true)
-            .single());
+        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("bar"), false),
+        Flux.using(() -> new ByteArrayInputStream(new byte[0]), v -> Flux.just("baz"), true)
+            .single(),
+        Mono.using(() -> new ByteArrayInputStream(new byte[0]), v -> Mono.just("qux"), true));
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingResourceCleanup() {
+  ImmutableSet<Mono<String>> testMonoUsingWithConsumer() {
     return ImmutableSet.of(
-        Mono.using(() -> 1, v -> Mono.just("foo"), v -> {}),
-        Flux.using(() -> 2, v -> Flux.just("bar"), v -> {}).next(),
-        Mono.using(() -> 3, v -> Mono.just("baz"), v -> {}),
-        Flux.using(() -> 4, v -> Flux.just("qux"), v -> {}).single());
+        Flux.using(() -> 1, v -> Flux.just("foo"), v -> {}).next(),
+        Mono.using(() -> 2, v -> Mono.just("bar"), v -> {}),
+        Flux.using(() -> 3, v -> Flux.just("baz"), v -> {}).single(),
+        Mono.using(() -> 4, v -> Mono.just("qux"), v -> {}));
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingConsumerEagerBoolean() {
+  ImmutableSet<Mono<String>> testMonoUsingWithConsumerAndBoolean() {
     return ImmutableSet.of(
-        Mono.using(() -> 1, v -> Mono.just("foo"), v -> {}, false),
-        Flux.using(() -> 2, v -> Flux.just("bar"), v -> {}, false).next(),
-        Mono.using(() -> 3, v -> Mono.just("baz"), v -> {}, true),
-        Flux.using(() -> 4, v -> Flux.just("qux"), v -> {}, true).single());
+        Flux.using(() -> 1, v -> Flux.just("foo"), v -> {}, false).next(),
+        Mono.using(() -> 2, v -> Mono.just("bar"), v -> {}, false),
+        Flux.using(() -> 3, v -> Flux.just("baz"), v -> {}, true).single(),
+        Mono.using(() -> 4, v -> Mono.just("qux"), v -> {}, true));
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingWhenAsyncCleanup() {
+  ImmutableSet<Mono<String>> testMonoUsingWhen() {
     return ImmutableSet.of(
-        Mono.usingWhen(Mono.just(1), v -> Mono.just("foo"), v -> Mono.just(2)),
-        Flux.usingWhen(Mono.just(3), v -> Flux.just("bar"), v -> Mono.just(4)).next(),
-        Mono.usingWhen(Mono.just(5), v -> Mono.just("baz"), v -> Mono.just(6)),
-        Flux.usingWhen(Mono.just(7), v -> Flux.just("qux"), v -> Mono.just(8)).single());
+        Flux.usingWhen(Mono.just(1), v -> Flux.just("foo"), v -> Mono.just(2)).next(),
+        Mono.usingWhen(Mono.just(3), v -> Mono.just("bar"), v -> Mono.just(4)),
+        Flux.usingWhen(Mono.just(5), v -> Flux.just("baz"), v -> Mono.just(6)).single(),
+        Mono.usingWhen(Mono.just(7), v -> Mono.just("qux"), v -> Mono.just(8)));
   }
 
-  ImmutableSet<Mono<String>> testMonoUsingWhenAsync() {
+  ImmutableSet<Mono<String>> testMonoUsingWhenWithBiFunctionAndFunction() {
     return ImmutableSet.of(
-        Mono.usingWhen(
-            Mono.just(1),
-            v -> Mono.just("foo"),
-            v -> Mono.just(2),
-            (v, t) -> Mono.just(3),
-            v -> Mono.just(4)),
         Flux.usingWhen(
-                Mono.just(5),
-                v -> Flux.just("bar"),
-                v -> Mono.just(6),
-                (v, t) -> Mono.just(7),
-                v -> Mono.just(8))
+                Mono.just(1),
+                v -> Flux.just("foo"),
+                v -> Mono.just(2),
+                (v, t) -> Mono.just(3),
+                v -> Mono.just(4))
             .next(),
         Mono.usingWhen(
-            Mono.just(9),
-            v -> Mono.just("baz"),
-            v -> Mono.just(10),
-            (v, t) -> Mono.just(11),
-            v -> Mono.just(12)),
+            Mono.just(5),
+            v -> Mono.just("bar"),
+            v -> Mono.just(6),
+            (v, t) -> Mono.just(7),
+            v -> Mono.just(8)),
         Flux.usingWhen(
-                Mono.just(13),
-                v -> Flux.just("qux"),
-                v -> Mono.just(14),
-                (v, t) -> Mono.just(15),
-                v -> Mono.just(16))
-            .single());
+                Mono.just(9),
+                v -> Flux.just("baz"),
+                v -> Mono.just(10),
+                (v, t) -> Mono.just(11),
+                v -> Mono.just(12))
+            .single(),
+        Mono.usingWhen(
+            Mono.just(13),
+            v -> Mono.just("qux"),
+            v -> Mono.just(14),
+            (v, t) -> Mono.just(15),
+            v -> Mono.just(16)));
   }
 
-  ImmutableSet<Flux<Integer>> testFluxSwitchIfEmptyOfEmptyPublisher() {
+  ImmutableSet<Flux<Integer>> testFluxIdentity() {
     return ImmutableSet.of(Flux.just(1), Flux.just(2));
   }
 
@@ -347,27 +347,26 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).concatMap(Mono::just),
         Flux.just(2).concatMap(Mono::just),
         Flux.just(3).concatMap(Mono::just),
-        Flux.just(4).concatMap(Mono::just),
+        Flux.just(4).map(Mono::just).concatMap(v -> Mono.empty()),
         Flux.just(5).concatMap(Mono::just),
-        Flux.just(6).map(Mono::just).concatMap(v -> Mono.empty()));
+        Flux.just(6).concatMap(Mono::just));
   }
 
-  ImmutableSet<Flux<Integer>> testFluxConcatMapWithPrefetch() {
+  ImmutableSet<Flux<Integer>> testFluxConcatMapWithInt() {
     return ImmutableSet.of(
         Flux.just(1).concatMap(Mono::just, 3),
         Flux.just(2).concatMap(Mono::just, 4),
-        Flux.just(3).concatMap(Mono::just, 5),
+        Flux.just(3).map(Mono::just).concatMap(v -> Mono.empty(), 5),
         Flux.just(4).concatMap(Mono::just, 6),
-        Flux.just(5).map(Mono::just).concatMap(v -> Mono.empty(), 7));
+        Flux.just(5).concatMap(Mono::just, 7));
   }
 
   ImmutableSet<Flux<Integer>> testMonoFlatMapIterable() {
     return ImmutableSet.of(
         Mono.just(1).flatMapIterable(ImmutableSet::of),
-        Mono.just(2).flatMapIterable(ImmutableSet::of),
+        Mono.just(2).map(ImmutableSet::of).flatMapIterable(v -> ImmutableSet.of()),
         Mono.just(3).flatMapIterable(ImmutableSet::of),
-        Mono.just(4).map(ImmutableSet::of).flatMapIterable(v -> ImmutableSet.of()),
-        Mono.just(5).flatMapIterable(ImmutableSet::of));
+        Mono.just(4).flatMapIterable(ImmutableSet::of));
   }
 
   Flux<Integer> testMonoFlatMapIterableIdentity() {
@@ -377,20 +376,18 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   ImmutableSet<Flux<Integer>> testFluxConcatMapIterable() {
     return ImmutableSet.of(
         Flux.just(1).concatMapIterable(ImmutableList::of),
-        Flux.just(2).concatMapIterable(ImmutableList::of),
-        Flux.just(3).concatMapIterable(ImmutableList::of),
-        Flux.just(4).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of()));
+        Flux.just(2).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of()),
+        Flux.just(3).concatMapIterable(ImmutableList::of));
   }
 
-  ImmutableSet<Flux<Integer>> testFluxConcatMapIterableWithPrefetch() {
+  ImmutableSet<Flux<Integer>> testFluxConcatMapIterableWithInt() {
     return ImmutableSet.of(
         Flux.just(1).concatMapIterable(ImmutableList::of, 5),
-        Flux.just(2).concatMapIterable(ImmutableList::of, 5),
-        Flux.just(3).concatMapIterable(ImmutableList::of, 5),
-        Flux.just(4).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of(), 5));
+        Flux.just(2).map(ImmutableList::of).concatMapIterable(v -> ImmutableSet.of(), 5),
+        Flux.just(3).concatMapIterable(ImmutableList::of, 5));
   }
 
-  Flux<String> testMonoFlatMapToFlux() {
+  Flux<String> testMonoFlatMapFlux() {
     return Mono.just("foo").flatMap(s -> Mono.fromSupplier(() -> s + s)).flux();
   }
 
@@ -455,11 +452,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(1).mapNotNull(n -> n * 2));
   }
 
-  Flux<String> testFluxMapNotNullTransformationOrElse() {
+  Flux<String> testFluxMapNotNullOrElseNull() {
     return Flux.just(1).mapNotNull(x -> Optional.of(x.toString()).orElse(null));
   }
 
-  Flux<Integer> testFluxMapNotNullOrElse() {
+  Flux<Integer> testFluxMapNotNullOptionalOrElseNull() {
     return Flux.just(Optional.of(1)).mapNotNull(x -> x.orElse(null));
   }
 
@@ -493,7 +490,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("foo").thenMany(Flux.just("bar")), Mono.just("baz").thenMany(Flux.just("qux")));
   }
 
-  Flux<String> testMonoThenMonoFlux() {
+  Flux<String> testMonoThenFlux() {
     return Mono.just("foo").then(Mono.just("bar")).flux();
   }
 
@@ -501,14 +498,14 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just("foo").thenMany(Flux.just("bar"));
   }
 
-  ImmutableSet<Mono<?>> testMonoThenMono() {
+  ImmutableSet<Mono<?>> testMonoThenWithMono() {
     return ImmutableSet.of(
         Mono.just("foo").then(Mono.just("bar")),
         Mono.just("baz").then(Mono.just("qux")),
         Mono.just("quux").then(Mono.<Void>empty()));
   }
 
-  ImmutableSet<Mono<?>> testFluxThenMono() {
+  ImmutableSet<Mono<?>> testFluxThenWithMono() {
     return ImmutableSet.of(
         Flux.just("foo").then(Mono.just("bar")), Flux.just("baz").then(Mono.<Void>empty()));
   }
@@ -522,11 +519,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just("quuz").singleOptional());
   }
 
-  Mono<Number> testMonoCast() {
+  Mono<Number> testMonoCastClass() {
     return Mono.just(1).cast(Number.class);
   }
 
-  Flux<Number> testFluxCast() {
+  Flux<Number> testFluxCastClass() {
     return Flux.just(1).cast(Number.class);
   }
 
@@ -540,16 +537,15 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Mono<String>> testMonoFlatMap() {
     return ImmutableSet.of(
-        Mono.just("foo").flatMap(Mono::just),
-        Mono.just("bar").flatMap(Mono::just),
-        Mono.just("baz").map(Mono::just).flatMap(v -> Mono.empty()));
+        Mono.just("foo").map(Mono::just).flatMap(v -> Mono.empty()),
+        Mono.just("bar").flatMap(Mono::just));
   }
 
   ImmutableSet<Flux<Integer>> testMonoFlatMapMany() {
     return ImmutableSet.of(
-        Mono.just(1).flatMapMany(Mono::just),
+        Mono.just(1).map(Mono::just).flatMapMany(v -> Flux.empty()),
         Mono.just(2).flatMapMany(Mono::just),
-        Mono.just(3).map(Mono::just).flatMapMany(v -> Flux.empty()),
+        Mono.just(3).flatMapMany(Mono::just),
         Mono.just(4).flatMapMany(Mono::just),
         Mono.just(5).flatMapMany(Mono::just),
         Mono.just(6).flatMapMany(Mono::just),
@@ -560,17 +556,16 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Mono.just(11).flatMapMany(Mono::just),
         Mono.just(12).flatMapMany(Mono::just),
         Mono.just(13).flatMapMany(Mono::just),
-        Mono.just(14).flatMapMany(Mono::just),
-        Mono.just(15).flatMapMany(Mono::just));
+        Mono.just(14).flatMapMany(Mono::just));
   }
 
-  ImmutableSet<Flux<String>> testConcatMapIterableIdentity() {
+  ImmutableSet<Flux<String>> testFluxConcatMapIterableIdentity() {
     return ImmutableSet.of(
         Flux.just(ImmutableList.of("foo")).concatMapIterable(identity()),
         Flux.just(ImmutableList.of("bar")).concatMapIterable(identity()));
   }
 
-  ImmutableSet<Flux<String>> testConcatMapIterableIdentityWithPrefetch() {
+  ImmutableSet<Flux<String>> testFluxConcatMapIterableIdentityWithInt() {
     return ImmutableSet.of(
         Flux.just(ImmutableList.of("foo")).concatMapIterable(identity(), 1),
         Flux.just(ImmutableList.of("bar")).concatMapIterable(identity(), 2));
@@ -616,24 +611,24 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
         Flux.just(5).onErrorComplete());
   }
 
-  ImmutableSet<Mono<Integer>> testMonoOnErrorCompleteClass() {
+  ImmutableSet<Mono<Integer>> testMonoOnErrorCompleteWithClass() {
     return ImmutableSet.of(
         Mono.just(1).onErrorComplete(IllegalArgumentException.class),
         Mono.just(2).onErrorComplete(IllegalStateException.class));
   }
 
-  ImmutableSet<Flux<Integer>> testFluxOnErrorCompleteClass() {
+  ImmutableSet<Flux<Integer>> testFluxOnErrorCompleteWithClass() {
     return ImmutableSet.of(
         Flux.just(1).onErrorComplete(IllegalArgumentException.class),
         Flux.just(2).onErrorComplete(IllegalStateException.class),
         Flux.just(3).onErrorComplete(AssertionError.class));
   }
 
-  Mono<Integer> testMonoOnErrorCompletePredicate() {
+  Mono<Integer> testMonoOnErrorCompleteWithPredicate() {
     return Mono.just(1).onErrorComplete(e -> e.getCause() == null);
   }
 
-  ImmutableSet<Flux<Integer>> testFluxOnErrorCompletePredicate() {
+  ImmutableSet<Flux<Integer>> testFluxOnErrorCompleteWithPredicate() {
     return ImmutableSet.of(
         Flux.just(1).onErrorComplete(e -> e.getCause() == null),
         Flux.just(2).onErrorComplete(e -> e.getCause() != null));
@@ -703,21 +698,21 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Flux.just(1).sort();
   }
 
-  Mono<Integer> testFluxTransformMin() {
+  Mono<Integer> testFluxTransformMathFluxMinSingleOrEmpty() {
     return Flux.just(1).transform(MathFlux::min).singleOrEmpty();
   }
 
-  ImmutableSet<Mono<Integer>> testFluxTransformMinWithComparator() {
+  ImmutableSet<Mono<Integer>> testFluxTransformMathFluxMinSingleOrEmptyWithComparator() {
     return ImmutableSet.of(
         Flux.just(1).transform(f -> MathFlux.min(f, reverseOrder())).singleOrEmpty(),
         Flux.just(2).transform(f -> MathFlux.min(f, reverseOrder())).singleOrEmpty());
   }
 
-  Mono<Integer> testFluxTransformMax() {
+  Mono<Integer> testFluxTransformMathFluxMaxSingleOrEmpty() {
     return Flux.just(1).transform(MathFlux::max).singleOrEmpty();
   }
 
-  ImmutableSet<Mono<Integer>> testFluxTransformMaxWithComparator() {
+  ImmutableSet<Mono<Integer>> testFluxTransformMathFluxMaxSingleOrEmptyWithComparator() {
     return ImmutableSet.of(
         Flux.just(1).transform(f -> MathFlux.max(f, reverseOrder())).singleOrEmpty(),
         Flux.just(2).transform(f -> MathFlux.max(f, reverseOrder())).singleOrEmpty());
@@ -732,7 +727,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
   }
 
   ImmutableSet<Context> testContextEmpty() {
-    return ImmutableSet.of(Context.empty(), Context.of(ImmutableMap.of(1, 2)));
+    return ImmutableSet.of(Context.of(ImmutableMap.of(1, 2)), Context.empty());
   }
 
   ImmutableSet<PublisherProbe<Void>> testPublisherProbeEmpty() {
@@ -768,30 +763,30 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     PublisherProbe.empty().assertWasNotRequested();
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  void testAssertThatPublisherProbeWasSubscribed() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy statements. */)
+  void testAssertThatPublisherProbeWasSubscribedIsEqualTo() {
     assertThat(PublisherProbe.of(Mono.just(1)).wasSubscribed()).isEqualTo(true);
     assertThat(PublisherProbe.of(Mono.just(2)).wasSubscribed()).isEqualTo(false);
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  void testAssertThatPublisherProbeWasCancelled() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy statements. */)
+  void testAssertThatPublisherProbeWasCancelledIsEqualTo() {
     assertThat(PublisherProbe.of(Mono.just(1)).wasCancelled()).isEqualTo(true);
     assertThat(PublisherProbe.of(Mono.just(2)).wasCancelled()).isEqualTo(false);
   }
 
-  @SuppressWarnings("SimplifyBooleanExpression")
-  void testAssertThatPublisherProbeWasRequested() {
+  @SuppressWarnings("SimplifyBooleanExpression" /* Tests use dummy statements. */)
+  void testAssertThatPublisherProbeWasRequestedIsEqualTo() {
     assertThat(PublisherProbe.of(Mono.just(1)).wasRequested()).isEqualTo(true);
     assertThat(PublisherProbe.of(Mono.just(2)).wasRequested()).isEqualTo(false);
   }
 
-  ImmutableSet<StepVerifier.FirstStep<Integer>> testStepVerifierFromMono() {
+  ImmutableSet<StepVerifier.FirstStep<Integer>> testMonoAsStepVerifierCreate() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create), Mono.just(2).as(StepVerifier::create));
   }
 
-  StepVerifier.FirstStep<Integer> testStepVerifierFromFlux() {
+  StepVerifier.FirstStep<Integer> testFluxAsStepVerifierCreate() {
     return Flux.just(1).as(StepVerifier::create);
   }
 
@@ -799,7 +794,7 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).expectError().verify();
   }
 
-  Object testStepVerifierVerifyDuration() {
+  Object testStepVerifierVerifyWithDuration() {
     return Mono.empty().as(StepVerifier::create).expectError().verify(Duration.ZERO);
   }
 
@@ -807,40 +802,40 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
     return Mono.empty().as(StepVerifier::create).expectError().verifyLater();
   }
 
-  ImmutableSet<StepVerifier.Step<Integer>> testStepVerifierStepIdentity() {
+  ImmutableSet<StepVerifier.Step<Integer>> testStepIdentity() {
     return ImmutableSet.of(
         Mono.just(1).as(StepVerifier::create),
         Mono.just(2).as(StepVerifier::create),
-        Mono.just(3).as(StepVerifier::create),
-        Mono.just(4).as(StepVerifier::create).expectNextSequence(ImmutableList.of(5)));
+        Mono.just(3).as(StepVerifier::create).expectNextSequence(ImmutableList.of(4)),
+        Mono.just(5).as(StepVerifier::create));
   }
 
-  ImmutableSet<StepVerifier.Step<String>> testStepVerifierStepExpectNext() {
+  ImmutableSet<StepVerifier.Step<String>> testStepExpectNext() {
     return ImmutableSet.of(
         Mono.just("foo").as(StepVerifier::create).expectNext("bar"),
         Mono.just("baz").as(StepVerifier::create).expectNext("qux"));
   }
 
-  StepVerifier.Step<?> testFluxAsStepVerifierExpectNext() {
+  StepVerifier.Step<?> testFluxAsStepVerifierCreateExpectNext() {
     return Flux.just(1).as(StepVerifier::create).expectNext(2);
   }
 
-  Duration testStepVerifierLastStepVerifyComplete() {
+  Duration testLastStepVerifyComplete() {
     return Mono.empty().as(StepVerifier::create).verifyComplete();
   }
 
-  Duration testStepVerifierLastStepVerifyError() {
+  Duration testLastStepVerifyError() {
     return Mono.empty().as(StepVerifier::create).verifyError();
   }
 
-  ImmutableSet<Duration> testStepVerifierLastStepVerifyErrorClass() {
+  ImmutableSet<Duration> testLastStepVerifyErrorWithClass() {
     return ImmutableSet.of(
         Mono.empty().as(StepVerifier::create).verifyError(IllegalArgumentException.class),
         Mono.empty().as(StepVerifier::create).verifyError(IllegalStateException.class),
         Mono.empty().as(StepVerifier::create).verifyError(AssertionError.class));
   }
 
-  ImmutableSet<?> testStepVerifierLastStepVerifyErrorMatches() {
+  ImmutableSet<?> testLastStepVerifyErrorMatches() {
     return ImmutableSet.of(
         Mono.empty()
             .as(StepVerifier::create)
@@ -850,11 +845,11 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
             .verifyErrorMatches(IllegalStateException.class::equals));
   }
 
-  Duration testStepVerifierLastStepVerifyErrorSatisfies() {
+  Duration testLastStepVerifyErrorSatisfies() {
     return Mono.empty().as(StepVerifier::create).verifyErrorSatisfies(t -> {});
   }
 
-  ImmutableSet<?> testStepVerifierLastStepVerifyErrorSatisfiesAssertJ() {
+  ImmutableSet<?> testLastStepVerifyErrorSatisfiesAssertThatIsInstanceOfHasMessage() {
     return ImmutableSet.of(
         Mono.empty()
             .as(StepVerifier::create)
@@ -870,32 +865,32 @@ final class ReactorRulesTest implements RefasterRuleCollectionTestCase {
                 t -> assertThat(t).isInstanceOf(AssertionError.class).hasMessage("baz")));
   }
 
-  Duration testStepVerifierLastStepVerifyErrorMessage() {
+  Duration testLastStepVerifyErrorMessage() {
     return Mono.empty().as(StepVerifier::create).verifyErrorMessage("foo");
   }
 
-  Duration testStepVerifierLastStepVerifyTimeout() {
+  Duration testLastStepVerifyTimeout() {
     return Mono.empty().as(StepVerifier::create).verifyTimeout(Duration.ZERO);
   }
 
-  Mono<Void> testMonoFromFutureSupplier() {
+  Mono<Void> testMonoFromFuture() {
     return Mono.fromFuture(() -> CompletableFuture.completedFuture(null));
   }
 
-  Mono<Void> testMonoFromFutureSupplierBoolean() {
+  Mono<Void> testMonoFromFutureWithBoolean() {
     return Mono.fromFuture(() -> CompletableFuture.completedFuture(null), true);
   }
 
-  Mono<String> testMonoFromFutureAsyncLoadingCacheGet() {
+  Mono<String> testMonoFromFutureAsyncLoadingCacheGetTrue() {
     return Mono.fromFuture(() -> ((AsyncLoadingCache<Integer, String>) null).get(0), true);
   }
 
-  Mono<Map<Integer, String>> testMonoFromFutureAsyncLoadingCacheGetAll() {
+  Mono<Map<Integer, String>> testMonoFromFutureAsyncLoadingCacheGetAllTrue() {
     return Mono.fromFuture(
         () -> ((AsyncLoadingCache<Integer, String>) null).getAll(ImmutableSet.of()), true);
   }
 
-  Flux<Integer> testFluxFromStreamSupplier() {
+  Flux<Integer> testFluxFromStream() {
     return Flux.fromStream(() -> Stream.of(1));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RxJava2AdapterRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RxJava2AdapterRulesTestInput.java
@@ -13,13 +13,13 @@ import reactor.core.publisher.Mono;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class RxJava2AdapterRulesTest implements RefasterRuleCollectionTestCase {
-  ImmutableSet<Mono<Void>> testCompletableToMono() {
+  ImmutableSet<Mono<Void>> testCompletableAsRxJava2AdapterCompletableToMono() {
     return ImmutableSet.of(
         RxJava2Adapter.completableToMono(Completable.complete()),
-        Completable.complete().to(RxJava2Adapter::completableToMono));
+        Completable.never().to(RxJava2Adapter::completableToMono));
   }
 
-  ImmutableSet<Flux<Integer>> testFlowableToFlux() {
+  ImmutableSet<Flux<Integer>> testFlowableAsRxJava2AdapterFlowableToFlux() {
     return ImmutableSet.of(
         Flux.from(Flowable.just(1)),
         Flowable.just(2).to(Flux::from),
@@ -28,52 +28,52 @@ final class RxJava2AdapterRulesTest implements RefasterRuleCollectionTestCase {
         Flowable.just(5).to(RxJava2Adapter::flowableToFlux));
   }
 
-  ImmutableSet<Flowable<String>> testFluxToFlowable() {
+  ImmutableSet<Flowable<String>> testFluxAsRxJava2AdapterFluxToFlowable() {
     return ImmutableSet.of(
         Flowable.fromPublisher(Flux.just("foo")),
         Flux.just("bar").as(Flowable::fromPublisher),
         RxJava2Adapter.fluxToFlowable(Flux.just("baz")));
   }
 
-  ImmutableSet<Observable<Integer>> testFluxToObservable() {
+  ImmutableSet<Observable<Integer>> testFluxAsRxJava2AdapterFluxToObservable() {
     return ImmutableSet.of(
         Observable.fromPublisher(Flux.just(1)),
         Flux.just(2).as(Observable::fromPublisher),
         RxJava2Adapter.fluxToObservable(Flux.just(3)));
   }
 
-  ImmutableSet<Mono<String>> testMaybeToMono() {
+  ImmutableSet<Mono<String>> testMaybeAsRxJava2AdapterMaybeToMono() {
     return ImmutableSet.of(
         RxJava2Adapter.maybeToMono(Maybe.just("foo")),
         Maybe.just("bar").to(RxJava2Adapter::maybeToMono));
   }
 
-  ImmutableSet<Completable> testMonoToCompletable() {
+  ImmutableSet<Completable> testMonoAsRxJava2AdapterMonoToCompletable() {
     return ImmutableSet.of(
         Completable.fromPublisher(Mono.empty()),
-        Mono.empty().as(Completable::fromPublisher),
-        RxJava2Adapter.monoToCompletable(Mono.empty()));
+        Mono.just(1).as(Completable::fromPublisher),
+        RxJava2Adapter.monoToCompletable(Mono.just(2)));
   }
 
-  ImmutableSet<Flowable<Integer>> testMonoToFlowable() {
+  ImmutableSet<Flowable<Integer>> testMonoAsRxJava2AdapterMonoToFlowable() {
     return ImmutableSet.of(
         Flowable.fromPublisher(Mono.just(1)),
         Mono.just(2).as(Flowable::fromPublisher),
         RxJava2Adapter.monoToFlowable(Mono.just(3)));
   }
 
-  Maybe<String> testMonoToMaybe() {
+  Maybe<String> testMonoAsRxJava2AdapterMonoToMaybe() {
     return RxJava2Adapter.monoToMaybe(Mono.just("foo"));
   }
 
-  ImmutableSet<Single<Integer>> testMonoToSingle() {
+  ImmutableSet<Single<Integer>> testMonoAsRxJava2AdapterMonoToSingle() {
     return ImmutableSet.of(
         Single.fromPublisher(Mono.just(1)),
         Mono.just(2).as(Single::fromPublisher),
         RxJava2Adapter.monoToSingle(Mono.just(3)));
   }
 
-  ImmutableSet<Flux<String>> testObservableToFlux() {
+  ImmutableSet<Flux<String>> testObservableToFlowableAsRxJava2AdapterFlowableToFlux() {
     return ImmutableSet.of(
         RxJava2Adapter.observableToFlux(Observable.just("foo"), BackpressureStrategy.BUFFER),
         Observable.just("bar")
@@ -82,7 +82,7 @@ final class RxJava2AdapterRulesTest implements RefasterRuleCollectionTestCase {
             .to(obs -> RxJava2Adapter.observableToFlux(obs, BackpressureStrategy.ERROR)));
   }
 
-  ImmutableSet<Mono<Integer>> testSingleToMono() {
+  ImmutableSet<Mono<Integer>> testSingleAsRxJava2AdapterSingleToMono() {
     return ImmutableSet.of(
         RxJava2Adapter.singleToMono(Single.just(1)),
         Single.just(2).to(RxJava2Adapter::singleToMono));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RxJava2AdapterRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/RxJava2AdapterRulesTestOutput.java
@@ -13,13 +13,13 @@ import reactor.core.publisher.Mono;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class RxJava2AdapterRulesTest implements RefasterRuleCollectionTestCase {
-  ImmutableSet<Mono<Void>> testCompletableToMono() {
+  ImmutableSet<Mono<Void>> testCompletableAsRxJava2AdapterCompletableToMono() {
     return ImmutableSet.of(
         Completable.complete().as(RxJava2Adapter::completableToMono),
-        Completable.complete().as(RxJava2Adapter::completableToMono));
+        Completable.never().as(RxJava2Adapter::completableToMono));
   }
 
-  ImmutableSet<Flux<Integer>> testFlowableToFlux() {
+  ImmutableSet<Flux<Integer>> testFlowableAsRxJava2AdapterFlowableToFlux() {
     return ImmutableSet.of(
         Flowable.just(1).as(RxJava2Adapter::flowableToFlux),
         Flowable.just(2).as(RxJava2Adapter::flowableToFlux),
@@ -28,52 +28,52 @@ final class RxJava2AdapterRulesTest implements RefasterRuleCollectionTestCase {
         Flowable.just(5).as(RxJava2Adapter::flowableToFlux));
   }
 
-  ImmutableSet<Flowable<String>> testFluxToFlowable() {
+  ImmutableSet<Flowable<String>> testFluxAsRxJava2AdapterFluxToFlowable() {
     return ImmutableSet.of(
         Flux.just("foo").as(RxJava2Adapter::fluxToFlowable),
         Flux.just("bar").as(RxJava2Adapter::fluxToFlowable),
         Flux.just("baz").as(RxJava2Adapter::fluxToFlowable));
   }
 
-  ImmutableSet<Observable<Integer>> testFluxToObservable() {
+  ImmutableSet<Observable<Integer>> testFluxAsRxJava2AdapterFluxToObservable() {
     return ImmutableSet.of(
         Flux.just(1).as(RxJava2Adapter::fluxToObservable),
         Flux.just(2).as(RxJava2Adapter::fluxToObservable),
         Flux.just(3).as(RxJava2Adapter::fluxToObservable));
   }
 
-  ImmutableSet<Mono<String>> testMaybeToMono() {
+  ImmutableSet<Mono<String>> testMaybeAsRxJava2AdapterMaybeToMono() {
     return ImmutableSet.of(
         Maybe.just("foo").as(RxJava2Adapter::maybeToMono),
         Maybe.just("bar").as(RxJava2Adapter::maybeToMono));
   }
 
-  ImmutableSet<Completable> testMonoToCompletable() {
+  ImmutableSet<Completable> testMonoAsRxJava2AdapterMonoToCompletable() {
     return ImmutableSet.of(
         Mono.empty().as(RxJava2Adapter::monoToCompletable),
-        Mono.empty().as(RxJava2Adapter::monoToCompletable),
-        Mono.empty().as(RxJava2Adapter::monoToCompletable));
+        Mono.just(1).as(RxJava2Adapter::monoToCompletable),
+        Mono.just(2).as(RxJava2Adapter::monoToCompletable));
   }
 
-  ImmutableSet<Flowable<Integer>> testMonoToFlowable() {
+  ImmutableSet<Flowable<Integer>> testMonoAsRxJava2AdapterMonoToFlowable() {
     return ImmutableSet.of(
         Mono.just(1).as(RxJava2Adapter::monoToFlowable),
         Mono.just(2).as(RxJava2Adapter::monoToFlowable),
         Mono.just(3).as(RxJava2Adapter::monoToFlowable));
   }
 
-  Maybe<String> testMonoToMaybe() {
+  Maybe<String> testMonoAsRxJava2AdapterMonoToMaybe() {
     return Mono.just("foo").as(RxJava2Adapter::monoToMaybe);
   }
 
-  ImmutableSet<Single<Integer>> testMonoToSingle() {
+  ImmutableSet<Single<Integer>> testMonoAsRxJava2AdapterMonoToSingle() {
     return ImmutableSet.of(
         Mono.just(1).as(RxJava2Adapter::monoToSingle),
         Mono.just(2).as(RxJava2Adapter::monoToSingle),
         Mono.just(3).as(RxJava2Adapter::monoToSingle));
   }
 
-  ImmutableSet<Flux<String>> testObservableToFlux() {
+  ImmutableSet<Flux<String>> testObservableToFlowableAsRxJava2AdapterFlowableToFlux() {
     return ImmutableSet.of(
         Observable.just("foo")
             .toFlowable(BackpressureStrategy.BUFFER)
@@ -86,7 +86,7 @@ final class RxJava2AdapterRulesTest implements RefasterRuleCollectionTestCase {
             .as(RxJava2Adapter::flowableToFlux));
   }
 
-  ImmutableSet<Mono<Integer>> testSingleToMono() {
+  ImmutableSet<Mono<Integer>> testSingleAsRxJava2AdapterSingleToMono() {
     return ImmutableSet.of(
         Single.just(1).as(RxJava2Adapter::singleToMono),
         Single.just(2).as(RxJava2Adapter::singleToMono));

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SpringTestRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SpringTestRulesTestInput.java
@@ -6,13 +6,13 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class SpringTestRulesTest implements RefasterRuleCollectionTestCase {
   @SuppressWarnings("deprecation" /* Rule rewrites deprecated method invocation. */)
-  ImmutableSet<BodyContentSpec> testBodyContentSpecJsonLenient() {
+  ImmutableSet<BodyContentSpec> testBodyContentSpecJsonJsonCompareModeLenient() {
     return ImmutableSet.of(
         ((BodyContentSpec) null).json("foo"), ((BodyContentSpec) null).json("bar", false));
   }
 
   @SuppressWarnings("deprecation" /* Rule rewrites deprecated method invocation. */)
-  BodyContentSpec testBodyContentSpecJsonStrict() {
+  BodyContentSpec testBodyContentSpecJsonJsonCompareModeStrict() {
     return ((BodyContentSpec) null).json("foo", true);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SpringTestRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SpringTestRulesTestOutput.java
@@ -7,14 +7,14 @@ import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class SpringTestRulesTest implements RefasterRuleCollectionTestCase {
   @SuppressWarnings("deprecation" /* Rule rewrites deprecated method invocation. */)
-  ImmutableSet<BodyContentSpec> testBodyContentSpecJsonLenient() {
+  ImmutableSet<BodyContentSpec> testBodyContentSpecJsonJsonCompareModeLenient() {
     return ImmutableSet.of(
         ((BodyContentSpec) null).json("foo", JsonCompareMode.LENIENT),
         ((BodyContentSpec) null).json("bar", JsonCompareMode.LENIENT));
   }
 
   @SuppressWarnings("deprecation" /* Rule rewrites deprecated method invocation. */)
-  BodyContentSpec testBodyContentSpecJsonStrict() {
+  BodyContentSpec testBodyContentSpecJsonJsonCompareModeStrict() {
     return ((BodyContentSpec) null).json("foo", JsonCompareMode.STRICT);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestInput.java
@@ -81,18 +81,18 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of("foo").collect(joining(""));
   }
 
-  ImmutableSet<Stream<?>> testEmptyStream() {
+  ImmutableSet<Stream<?>> testStreamEmpty() {
     return ImmutableSet.of(
         Stream.of(),
         Optional.empty().stream(),
-        ImmutableList.of().stream(),
         ImmutableList.of("foo").reverse().stream(),
-        Streams.stream((Iterable<String>) ImmutableSet.<String>of()),
+        ImmutableList.of().stream(),
         Streams.stream(ImmutableSet.of("bar")::iterator),
-        Streams.stream(ImmutableSet.of().iterator()),
+        Streams.stream((Iterable<String>) ImmutableSet.<String>of()),
         Streams.stream(ImmutableSet.of("baz").iterator()),
-        Arrays.stream(new String[0]),
-        Arrays.stream(new String[] {"qux"}));
+        Streams.stream(ImmutableSet.of().iterator()),
+        Arrays.stream(new String[] {"qux"}),
+        Arrays.stream(new String[0]));
   }
 
   ImmutableSet<Stream<String>> testStreamOfNullable() {
@@ -103,27 +103,27 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         "d" == null ? Stream.empty() : Stream.of("d"));
   }
 
-  Stream<String> testStreamOfArray() {
+  Stream<String> testArraysStream() {
     return Stream.of(new String[] {"foo", "bar"});
   }
 
-  Stream<Integer> testConcatOneStream() {
+  Stream<Integer> testStreamIdentity() {
     return Streams.concat(Stream.of(1));
   }
 
-  Stream<Integer> testConcatTwoStreams() {
+  Stream<Integer> testStreamConcat() {
     return Streams.concat(Stream.of(1), Stream.of(2));
   }
 
-  Stream<Integer> testFilterOuterStreamAfterFlatMap() {
+  Stream<Integer> testStreamFlatMapFilter() {
     return Stream.of("foo").flatMap(v -> Stream.of(v.length()).filter(len -> len > 0));
   }
 
-  Stream<Integer> testMapOuterStreamAfterFlatMap() {
+  Stream<Integer> testStreamFlatMapMap() {
     return Stream.of("foo").flatMap(v -> Stream.of(v.length()).map(len -> len * 0));
   }
 
-  Stream<Integer> testFlatMapOuterStreamAfterFlatMap() {
+  Stream<Integer> testStreamFlatMapFlatMap() {
     return Stream.of("foo").flatMap(v -> Stream.of(v.length()).flatMap(Stream::of));
   }
 
@@ -155,7 +155,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).sorted().limit(2);
   }
 
-  ImmutableSet<Optional<Integer>> testStreamMapFirst() {
+  ImmutableSet<Optional<Integer>> testStreamFindFirstMap() {
     return ImmutableSet.of(
         Stream.of("foo").map(s -> s.length()).findFirst(),
         Stream.of("bar").map(String::length).findFirst());
@@ -172,21 +172,22 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of(7).collect(collectingAndThen(toImmutableList(), ImmutableList::isEmpty)),
         Stream.of(8).collect(collectingAndThen(toImmutableMap(k -> k, v -> v), Map::isEmpty)),
         Stream.of(9)
-            .collect(collectingAndThen(toImmutableMap(k -> k, v -> v), ImmutableMap::isEmpty)),
-        Stream.of(10).count() != 0,
-        Stream.of(11).count() > 0,
-        Stream.of(12).count() >= 1);
+            .collect(collectingAndThen(toImmutableMap(k -> k, v -> v), ImmutableMap::isEmpty)));
   }
 
-  boolean testStreamFindAnyIsPresent() {
-    return Stream.of(1).findFirst().isPresent();
+  ImmutableSet<Boolean> testStreamFindAnyIsPresent() {
+    return ImmutableSet.of(
+        Stream.of(1).count() != 0,
+        Stream.of(2).count() > 0,
+        Stream.of(3).count() >= 1,
+        Stream.of(4).findFirst().isPresent());
   }
 
   ImmutableSet<Optional<Integer>> testStreamFindFirst() {
     return ImmutableSet.of(Stream.of(1).limit(2).findFirst(), Stream.of(3).limit(4).findAny());
   }
 
-  Stream<Integer> testStreamMapFilter() {
+  Stream<Integer> testStreamMapMapGetFilterObjectsNonNull() {
     return Stream.of("foo")
         .filter(ImmutableMap.of(1, 2)::containsKey)
         .map(ImmutableMap.of(1, 2)::get);
@@ -216,7 +217,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("foo").min(reverseOrder()), Streams.findLast(Stream.of("bar").sorted()));
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch() {
+  ImmutableSet<Boolean> testStreamNoneMatchWithPredicate() {
     Predicate<String> pred = String::isBlank;
     Function<String, Boolean> toBooleanFunction = Boolean::valueOf;
     return ImmutableSet.of(
@@ -224,12 +225,13 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("bar").allMatch(not(String::isBlank)),
         Stream.of("baz").allMatch(pred.negate()),
         Stream.of("qux").filter(String::isEmpty).findAny().isEmpty(),
-        Stream.of("quux").map(s -> s.isBlank()).noneMatch(Boolean::booleanValue),
-        Stream.of("quuz").map(Boolean::valueOf).noneMatch(r -> r),
-        Stream.of("corge").map(toBooleanFunction).noneMatch(Boolean::booleanValue));
+        Stream.of("quux").map(toBooleanFunction).noneMatch(Boolean::booleanValue),
+        Stream.of("corge").map(s -> s.isBlank()).noneMatch(Boolean::booleanValue),
+        Stream.of("grault").map(toBooleanFunction).noneMatch(r -> r),
+        Stream.of("garply").map(Boolean::valueOf).noneMatch(r -> r));
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch2() {
+  ImmutableSet<Boolean> testStreamNoneMatch() {
     return ImmutableSet.of(
         Stream.of("foo").allMatch(s -> !s.isBlank()), Stream.of(Boolean.TRUE).allMatch(b -> !b));
   }
@@ -239,23 +241,25 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         !Stream.of("foo").noneMatch(s -> s.length() > 1),
         Stream.of("bar").filter(String::isEmpty).findAny().isPresent(),
-        Stream.of("baz").map(s -> s.isBlank()).anyMatch(Boolean::booleanValue),
-        Stream.of("qux").map(Boolean::valueOf).anyMatch(r -> r),
-        Stream.of("quux").map(toBooleanFunction).anyMatch(Boolean::booleanValue));
+        Stream.of("baz").map(toBooleanFunction).anyMatch(Boolean::booleanValue),
+        Stream.of("qux").map(s -> s.isBlank()).anyMatch(Boolean::booleanValue),
+        Stream.of("quux").map(toBooleanFunction).anyMatch(r -> r),
+        Stream.of("corge").map(Boolean::valueOf).anyMatch(r -> r));
   }
 
-  ImmutableSet<Boolean> testStreamAllMatch() {
+  ImmutableSet<Boolean> testStreamAllMatchWithPredicate() {
     Predicate<String> pred = String::isBlank;
     Function<String, Boolean> toBooleanFunction = Boolean::valueOf;
     return ImmutableSet.of(
         Stream.of("foo").noneMatch(not(String::isBlank)),
         Stream.of("bar").noneMatch(pred.negate()),
-        Stream.of("baz").map(s -> s.isBlank()).allMatch(Boolean::booleanValue),
-        Stream.of("qux").map(Boolean::valueOf).allMatch(r -> r),
-        Stream.of("quux").map(toBooleanFunction).anyMatch(Boolean::booleanValue));
+        Stream.of("baz").map(toBooleanFunction).allMatch(Boolean::booleanValue),
+        Stream.of("qux").map(s -> s.isBlank()).allMatch(Boolean::booleanValue),
+        Stream.of("quux").map(toBooleanFunction).allMatch(r -> r),
+        Stream.of("corge").map(Boolean::valueOf).allMatch(r -> r));
   }
 
-  boolean testStreamAllMatch2() {
+  boolean testStreamAllMatch() {
     return Stream.of("foo").noneMatch(s -> !s.isBlank());
   }
 
@@ -263,27 +267,24 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     Function<String, Integer> parseIntFunction = Integer::parseInt;
     return ImmutableSet.of(
         Stream.of("1").collect(summingInt(Integer::parseInt)),
-        Stream.of(2).map(i -> i * 2).reduce(0, Integer::sum),
-        Stream.of("3").map(Integer::parseInt).reduce(0, Integer::sum),
-        Stream.of("4").map(parseIntFunction).reduce(0, Integer::sum));
+        Stream.of("2").map(parseIntFunction).reduce(0, Integer::sum),
+        Stream.of(3).map(i -> i * 2).reduce(0, Integer::sum));
   }
 
   ImmutableSet<Double> testStreamMapToDoubleSum() {
     Function<String, Double> parseDoubleFunction = Double::parseDouble;
     return ImmutableSet.of(
         Stream.of("1").collect(summingDouble(Double::parseDouble)),
-        Stream.of(2).map(i -> i * 2.0).reduce(0.0, Double::sum),
-        Stream.of("3").map(Double::parseDouble).reduce(0.0, Double::sum),
-        Stream.of("4").map(parseDoubleFunction).reduce(0.0, Double::sum));
+        Stream.of("2").map(parseDoubleFunction).reduce(0.0, Double::sum),
+        Stream.of(3).map(i -> i * 2.0).reduce(0.0, Double::sum));
   }
 
   ImmutableSet<Long> testStreamMapToLongSum() {
     Function<String, Long> parseLongFunction = Long::parseLong;
     return ImmutableSet.of(
         Stream.of("1").collect(summingLong(Long::parseLong)),
-        Stream.of(2).map(i -> i * 2L).reduce(0L, Long::sum),
-        Stream.of("3").map(Long::parseLong).reduce(0L, Long::sum),
-        Stream.of("4").map(parseLongFunction).reduce(0L, Long::sum));
+        Stream.of("2").map(parseLongFunction).reduce(0L, Long::sum),
+        Stream.of(3).map(i -> i * 2L).reduce(0L, Long::sum));
   }
 
   IntSummaryStatistics testStreamMapToIntSummaryStatistics() {
@@ -306,7 +307,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).collect(reducing(Integer::sum));
   }
 
-  Integer testStreamReduceWithIdentity() {
+  Integer testStreamReduceWithObject() {
     return Stream.of(1).collect(reducing(0, Integer::sum));
   }
 
@@ -324,9 +325,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Stream<Integer>> testStreamsConcat() {
     return ImmutableSet.of(
-        Stream.of(Stream.of(1), Stream.of(2)).flatMap(identity()),
-        Stream.of(Stream.of(3), Stream.of(4)).flatMap(v -> v),
-        Stream.of(Stream.of(5), Stream.of(6)).flatMap(v -> Stream.empty()));
+        Stream.of(Stream.of(1), Stream.of(2)).flatMap(v -> Stream.empty()),
+        Stream.of(Stream.of(3), Stream.of(4)).flatMap(identity()));
   }
 
   Stream<Integer> testStreamTakeWhile() {
@@ -367,7 +367,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Stream<String>> testCollectionsNCopiesStream() {
     return ImmutableSet.of(
-        Stream.generate(() -> "foo").limit(1),
-        Stream.generate(() -> UUID.randomUUID().toString()).limit(2));
+        Stream.generate(() -> UUID.randomUUID().toString()).limit(1),
+        Stream.generate(() -> "foo").limit(2));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StreamRulesTestOutput.java
@@ -82,9 +82,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of("foo").collect(joining());
   }
 
-  ImmutableSet<Stream<?>> testEmptyStream() {
+  ImmutableSet<Stream<?>> testStreamEmpty() {
     return ImmutableSet.of(
-        Stream.empty(),
         Stream.empty(),
         Stream.empty(),
         ImmutableList.of("foo").reverse().stream(),
@@ -93,7 +92,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.empty(),
         Streams.stream(ImmutableSet.of("baz").iterator()),
         Stream.empty(),
-        Arrays.stream(new String[] {"qux"}));
+        Arrays.stream(new String[] {"qux"}),
+        Stream.empty());
   }
 
   ImmutableSet<Stream<String>> testStreamOfNullable() {
@@ -104,27 +104,27 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.ofNullable("d"));
   }
 
-  Stream<String> testStreamOfArray() {
+  Stream<String> testArraysStream() {
     return Arrays.stream(new String[] {"foo", "bar"});
   }
 
-  Stream<Integer> testConcatOneStream() {
+  Stream<Integer> testStreamIdentity() {
     return Stream.of(1);
   }
 
-  Stream<Integer> testConcatTwoStreams() {
+  Stream<Integer> testStreamConcat() {
     return Stream.concat(Stream.of(1), Stream.of(2));
   }
 
-  Stream<Integer> testFilterOuterStreamAfterFlatMap() {
+  Stream<Integer> testStreamFlatMapFilter() {
     return Stream.of("foo").flatMap(v -> Stream.of(v.length())).filter(len -> len > 0);
   }
 
-  Stream<Integer> testMapOuterStreamAfterFlatMap() {
+  Stream<Integer> testStreamFlatMapMap() {
     return Stream.of("foo").flatMap(v -> Stream.of(v.length())).map(len -> len * 0);
   }
 
-  Stream<Integer> testFlatMapOuterStreamAfterFlatMap() {
+  Stream<Integer> testStreamFlatMapFlatMap() {
     return Stream.of("foo").flatMap(v -> Stream.of(v.length())).flatMap(Stream::of);
   }
 
@@ -156,7 +156,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).collect(least(2, naturalOrder())).stream();
   }
 
-  ImmutableSet<Optional<Integer>> testStreamMapFirst() {
+  ImmutableSet<Optional<Integer>> testStreamFindFirstMap() {
     return ImmutableSet.of(
         Stream.of("foo").findFirst().map(s -> s.length()),
         Stream.of("bar").findFirst().map(String::length));
@@ -172,21 +172,22 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of(6).findAny().isEmpty(),
         Stream.of(7).findAny().isEmpty(),
         Stream.of(8).findAny().isEmpty(),
-        Stream.of(9).findAny().isEmpty(),
-        !Stream.of(10).findAny().isEmpty(),
-        !Stream.of(11).findAny().isEmpty(),
-        !Stream.of(12).findAny().isEmpty());
+        Stream.of(9).findAny().isEmpty());
   }
 
-  boolean testStreamFindAnyIsPresent() {
-    return Stream.of(1).findAny().isPresent();
+  ImmutableSet<Boolean> testStreamFindAnyIsPresent() {
+    return ImmutableSet.of(
+        Stream.of(1).findAny().isPresent(),
+        Stream.of(2).findAny().isPresent(),
+        Stream.of(3).findAny().isPresent(),
+        Stream.of(4).findAny().isPresent());
   }
 
   ImmutableSet<Optional<Integer>> testStreamFindFirst() {
     return ImmutableSet.of(Stream.of(1).findFirst(), Stream.of(3).findFirst());
   }
 
-  Stream<Integer> testStreamMapFilter() {
+  Stream<Integer> testStreamMapMapGetFilterObjectsNonNull() {
     return Stream.of("foo").map(ImmutableMap.of(1, 2)::get).filter(Objects::nonNull);
   }
 
@@ -214,7 +215,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("foo").max(naturalOrder()), Stream.of("bar").max(naturalOrder()));
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch() {
+  ImmutableSet<Boolean> testStreamNoneMatchWithPredicate() {
     Predicate<String> pred = String::isBlank;
     Function<String, Boolean> toBooleanFunction = Boolean::valueOf;
     return ImmutableSet.of(
@@ -222,12 +223,13 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
         Stream.of("bar").noneMatch(String::isBlank),
         Stream.of("baz").noneMatch(pred),
         Stream.of("qux").noneMatch(String::isEmpty),
-        Stream.of("quux").noneMatch(s -> s.isBlank()),
-        Stream.of("quuz").noneMatch(Boolean::valueOf),
-        Stream.of("corge").map(toBooleanFunction).noneMatch(Boolean::booleanValue));
+        Stream.of("quux").map(toBooleanFunction).noneMatch(Boolean::booleanValue),
+        Stream.of("corge").noneMatch(s -> s.isBlank()),
+        Stream.of("grault").map(toBooleanFunction).noneMatch(r -> r),
+        Stream.of("garply").noneMatch(Boolean::valueOf));
   }
 
-  ImmutableSet<Boolean> testStreamNoneMatch2() {
+  ImmutableSet<Boolean> testStreamNoneMatch() {
     return ImmutableSet.of(
         Stream.of("foo").noneMatch(s -> s.isBlank()), Stream.of(Boolean.TRUE).noneMatch(b -> b));
   }
@@ -237,23 +239,25 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(
         Stream.of("foo").anyMatch(s -> s.length() > 1),
         Stream.of("bar").anyMatch(String::isEmpty),
-        Stream.of("baz").anyMatch(s -> s.isBlank()),
-        Stream.of("qux").anyMatch(Boolean::valueOf),
-        Stream.of("quux").map(toBooleanFunction).anyMatch(Boolean::booleanValue));
+        Stream.of("baz").map(toBooleanFunction).anyMatch(Boolean::booleanValue),
+        Stream.of("qux").anyMatch(s -> s.isBlank()),
+        Stream.of("quux").map(toBooleanFunction).anyMatch(r -> r),
+        Stream.of("corge").anyMatch(Boolean::valueOf));
   }
 
-  ImmutableSet<Boolean> testStreamAllMatch() {
+  ImmutableSet<Boolean> testStreamAllMatchWithPredicate() {
     Predicate<String> pred = String::isBlank;
     Function<String, Boolean> toBooleanFunction = Boolean::valueOf;
     return ImmutableSet.of(
         Stream.of("foo").allMatch(String::isBlank),
         Stream.of("bar").allMatch(pred),
-        Stream.of("baz").allMatch(s -> s.isBlank()),
-        Stream.of("qux").allMatch(Boolean::valueOf),
-        Stream.of("quux").map(toBooleanFunction).anyMatch(Boolean::booleanValue));
+        Stream.of("baz").map(toBooleanFunction).allMatch(Boolean::booleanValue),
+        Stream.of("qux").allMatch(s -> s.isBlank()),
+        Stream.of("quux").map(toBooleanFunction).allMatch(r -> r),
+        Stream.of("corge").allMatch(Boolean::valueOf));
   }
 
-  boolean testStreamAllMatch2() {
+  boolean testStreamAllMatch() {
     return Stream.of("foo").allMatch(s -> s.isBlank());
   }
 
@@ -261,27 +265,24 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     Function<String, Integer> parseIntFunction = Integer::parseInt;
     return ImmutableSet.of(
         Stream.of("1").mapToInt(Integer::parseInt).sum(),
-        Stream.of(2).mapToInt(i -> i * 2).sum(),
-        Stream.of("3").mapToInt(Integer::parseInt).sum(),
-        Stream.of("4").map(parseIntFunction).reduce(0, Integer::sum));
+        Stream.of("2").map(parseIntFunction).reduce(0, Integer::sum),
+        Stream.of(3).mapToInt(i -> i * 2).sum());
   }
 
   ImmutableSet<Double> testStreamMapToDoubleSum() {
     Function<String, Double> parseDoubleFunction = Double::parseDouble;
     return ImmutableSet.of(
         Stream.of("1").mapToDouble(Double::parseDouble).sum(),
-        Stream.of(2).mapToDouble(i -> i * 2.0).sum(),
-        Stream.of("3").mapToDouble(Double::parseDouble).sum(),
-        Stream.of("4").map(parseDoubleFunction).reduce(0.0, Double::sum));
+        Stream.of("2").map(parseDoubleFunction).reduce(0.0, Double::sum),
+        Stream.of(3).mapToDouble(i -> i * 2.0).sum());
   }
 
   ImmutableSet<Long> testStreamMapToLongSum() {
     Function<String, Long> parseLongFunction = Long::parseLong;
     return ImmutableSet.of(
         Stream.of("1").mapToLong(Long::parseLong).sum(),
-        Stream.of(2).mapToLong(i -> i * 2L).sum(),
-        Stream.of("3").mapToLong(Long::parseLong).sum(),
-        Stream.of("4").map(parseLongFunction).reduce(0L, Long::sum));
+        Stream.of("2").map(parseLongFunction).reduce(0L, Long::sum),
+        Stream.of(3).mapToLong(i -> i * 2L).sum());
   }
 
   IntSummaryStatistics testStreamMapToIntSummaryStatistics() {
@@ -304,7 +305,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
     return Stream.of(1).reduce(Integer::sum);
   }
 
-  Integer testStreamReduceWithIdentity() {
+  Integer testStreamReduceWithObject() {
     return Stream.of(1).reduce(0, Integer::sum);
   }
 
@@ -322,9 +323,8 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Stream<Integer>> testStreamsConcat() {
     return ImmutableSet.of(
-        Streams.concat(Stream.of(1), Stream.of(2)),
-        Streams.concat(Stream.of(3), Stream.of(4)),
-        Stream.of(Stream.of(5), Stream.of(6)).flatMap(v -> Stream.empty()));
+        Stream.of(Stream.of(1), Stream.of(2)).flatMap(v -> Stream.empty()),
+        Streams.concat(Stream.of(3), Stream.of(4)));
   }
 
   Stream<Integer> testStreamTakeWhile() {
@@ -365,7 +365,7 @@ final class StreamRulesTest implements RefasterRuleCollectionTestCase {
 
   ImmutableSet<Stream<String>> testCollectionsNCopiesStream() {
     return ImmutableSet.of(
-        Collections.nCopies(1, "foo").stream(),
-        Stream.generate(() -> UUID.randomUUID().toString()).limit(2));
+        Stream.generate(() -> UUID.randomUUID().toString()).limit(1),
+        Collections.nCopies(2, "foo").stream());
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestInput.java
@@ -36,7 +36,7 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return new String("foo");
   }
 
-  ImmutableSet<Boolean> testStringIsEmpty() {
+  ImmutableSet<Boolean> testStringIsEmptyWithString() {
     return ImmutableSet.of(
         "foo".length() == 0,
         "bar".length() <= 0,
@@ -46,25 +46,25 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         "corge".length() >= 1);
   }
 
-  boolean testStringIsEmptyPredicate() {
+  boolean testStringIsEmpty() {
     return Stream.of("foo").anyMatch(s -> s.isEmpty());
   }
 
-  boolean testStringIsNotEmptyPredicate() {
+  boolean testNotStringIsEmpty() {
     return Stream.of("foo").anyMatch(s -> !s.isEmpty());
   }
 
-  ImmutableSet<Boolean> testStringIsNullOrEmpty() {
+  ImmutableSet<Boolean> testStringsIsNullOrEmpty() {
     return ImmutableSet.of(
         getClass().getName() == null || getClass().getName().isEmpty(),
         getClass().getName() != null && !getClass().getName().isEmpty());
   }
 
-  boolean testStringIsBlank() {
-    return "foo".trim().isEmpty();
+  ImmutableSet<Boolean> testStringIsBlank() {
+    return ImmutableSet.of("foo".trim().isEmpty(), !"foo".trim().isEmpty());
   }
 
-  ImmutableSet<Optional<String>> testOptionalNonEmptyString() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableFilterNotStringIsEmpty() {
     return ImmutableSet.of(
         Strings.isNullOrEmpty(toString()) ? Optional.empty() : Optional.of(toString()),
         Strings.isNullOrEmpty(toString()) ? Optional.empty() : Optional.ofNullable(toString()),
@@ -72,11 +72,11 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         !Strings.isNullOrEmpty(toString()) ? Optional.ofNullable(toString()) : Optional.empty());
   }
 
-  Optional<String> testFilterEmptyString() {
+  Optional<String> testOptionalFilterNotStringIsEmpty() {
     return Optional.of("foo").map(Strings::emptyToNull);
   }
 
-  ImmutableSet<String> testJoinStrings() {
+  ImmutableSet<String> testStringJoin() {
     return ImmutableSet.of(
         Joiner.on("a").join(new String[] {"foo", "bar"}),
         Joiner.on("b").join(new CharSequence[] {"foo", "bar"}),
@@ -86,31 +86,31 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         ImmutableList.of("foo", "bar").stream().collect(joining("f")));
   }
 
-  String testStringJoinDelimiterVarargs() {
+  String testStringJoinVarargs() {
     return Stream.of("foo", "bar").collect(joining(","));
   }
 
-  String testStringValueOf() {
+  String testStringValueOfWithObject() {
     return Objects.toString("foo");
   }
 
-  ImmutableSet<String> testNewStringFromCharArraySubSequence() {
+  ImmutableSet<String> testNewString3() {
     return ImmutableSet.of(
         String.valueOf(new char[] {'f', 'o', 'o'}, 0, 1),
         String.copyValueOf(new char[] {'b', 'a', 'r'}, 2, 3));
   }
 
-  ImmutableSet<String> testNewStringFromCharArray() {
+  ImmutableSet<String> testNewString1() {
     return ImmutableSet.of(
         String.valueOf(new char[] {'f', 'o', 'o'}),
         new String(new char[] {'b', 'a', 'r'}, 0, new char[] {'b', 'a', 'r'}.length));
   }
 
-  Function<Object, String> testStringValueOfMethodReference() {
+  Function<Object, String> testStringValueOf() {
     return Objects::toString;
   }
 
-  String testSubstringRemainder() {
+  String testStringSubstring() {
     return "foo".substring(1, "foo".length());
   }
 
@@ -118,35 +118,35 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return "foo".getBytes(UTF_8).length;
   }
 
-  int testStringIndexOfCharFromIndex() {
+  int testMathMaxNegativeOneStringIndexOfMinusInt() {
     return "foo".substring(1).indexOf('a');
   }
 
-  int testStringIndexOfCharBetweenIndices() {
+  int testMathMaxNegativeOneStringIndexOfMinusIntWithInt() {
     return "foo".substring(1, 2).indexOf('a');
   }
 
-  int testStringIndexOfStringFromIndex() {
+  int testMathMaxNegativeOneStringIndexOfMinusString() {
     return "foo".substring(1).indexOf("bar");
   }
 
-  int testStringIndexOfStringBetweenIndices() {
+  int testMathMaxNegativeOneStringIndexOfMinusStringWithInt() {
     return "foo".substring(1, 2).indexOf("bar");
   }
 
-  int testStringLastIndexOfChar() {
+  int testMathMaxNegativeOneStringLastIndexOfMinusInt() {
     return "foo".substring(1).lastIndexOf('a');
   }
 
-  int testStringLastIndexOfString() {
+  int testMathMaxNegativeOneStringLastIndexOfMinusString() {
     return "foo".substring(1).lastIndexOf("bar");
   }
 
-  int testStringLastIndexOfCharWithIndex() {
+  int testStringLastIndexOfMinusOneInt() {
     return "foo".substring(0, 2).lastIndexOf('a');
   }
 
-  int testStringLastIndexOfStringWithIndex() {
+  int testStringLastIndexOfMinusOneString() {
     return "foo".substring(0, 2).lastIndexOf("bar");
   }
 
@@ -154,7 +154,7 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return "foo".substring(1).startsWith("bar");
   }
 
-  ImmutableSet<String> testStringFormatted() {
+  ImmutableSet<String> testFormatted() {
     return ImmutableSet.of(
         String.format("Constant"),
         String.format("Number: %d", 42),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/StringRulesTestOutput.java
@@ -34,7 +34,7 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return "foo";
   }
 
-  ImmutableSet<Boolean> testStringIsEmpty() {
+  ImmutableSet<Boolean> testStringIsEmptyWithString() {
     return ImmutableSet.of(
         "foo".isEmpty(),
         "bar".isEmpty(),
@@ -44,24 +44,24 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         !"corge".isEmpty());
   }
 
-  boolean testStringIsEmptyPredicate() {
+  boolean testStringIsEmpty() {
     return Stream.of("foo").anyMatch(String::isEmpty);
   }
 
-  boolean testStringIsNotEmptyPredicate() {
+  boolean testNotStringIsEmpty() {
     return Stream.of("foo").anyMatch(not(String::isEmpty));
   }
 
-  ImmutableSet<Boolean> testStringIsNullOrEmpty() {
+  ImmutableSet<Boolean> testStringsIsNullOrEmpty() {
     return ImmutableSet.of(
         Strings.isNullOrEmpty(getClass().getName()), !Strings.isNullOrEmpty(getClass().getName()));
   }
 
-  boolean testStringIsBlank() {
-    return "foo".isBlank();
+  ImmutableSet<Boolean> testStringIsBlank() {
+    return ImmutableSet.of("foo".isBlank(), !"foo".isBlank());
   }
 
-  ImmutableSet<Optional<String>> testOptionalNonEmptyString() {
+  ImmutableSet<Optional<String>> testOptionalOfNullableFilterNotStringIsEmpty() {
     return ImmutableSet.of(
         Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)),
         Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)),
@@ -69,11 +69,11 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         Optional.ofNullable(toString()).filter(Predicate.not(String::isEmpty)));
   }
 
-  Optional<String> testFilterEmptyString() {
+  Optional<String> testOptionalFilterNotStringIsEmpty() {
     return Optional.of("foo").filter(not(String::isEmpty));
   }
 
-  ImmutableSet<String> testJoinStrings() {
+  ImmutableSet<String> testStringJoin() {
     return ImmutableSet.of(
         String.join("a", new String[] {"foo", "bar"}),
         String.join("b", new CharSequence[] {"foo", "bar"}),
@@ -83,29 +83,29 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
         String.join("f", ImmutableList.of("foo", "bar")));
   }
 
-  String testStringJoinDelimiterVarargs() {
+  String testStringJoinVarargs() {
     return String.join(",", "foo", "bar");
   }
 
-  String testStringValueOf() {
+  String testStringValueOfWithObject() {
     return String.valueOf("foo");
   }
 
-  ImmutableSet<String> testNewStringFromCharArraySubSequence() {
+  ImmutableSet<String> testNewString3() {
     return ImmutableSet.of(
         new String(new char[] {'f', 'o', 'o'}, 0, 1), new String(new char[] {'b', 'a', 'r'}, 2, 3));
   }
 
-  ImmutableSet<String> testNewStringFromCharArray() {
+  ImmutableSet<String> testNewString1() {
     return ImmutableSet.of(
         new String(new char[] {'f', 'o', 'o'}), new String(new char[] {'b', 'a', 'r'}));
   }
 
-  Function<Object, String> testStringValueOfMethodReference() {
+  Function<Object, String> testStringValueOf() {
     return String::valueOf;
   }
 
-  String testSubstringRemainder() {
+  String testStringSubstring() {
     return "foo".substring(1);
   }
 
@@ -113,35 +113,35 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return Utf8.encodedLength("foo");
   }
 
-  int testStringIndexOfCharFromIndex() {
+  int testMathMaxNegativeOneStringIndexOfMinusInt() {
     return Math.max(-1, "foo".indexOf('a', 1) - 1);
   }
 
-  int testStringIndexOfCharBetweenIndices() {
+  int testMathMaxNegativeOneStringIndexOfMinusIntWithInt() {
     return Math.max(-1, "foo".indexOf('a', 1, 2) - 1);
   }
 
-  int testStringIndexOfStringFromIndex() {
+  int testMathMaxNegativeOneStringIndexOfMinusString() {
     return Math.max(-1, "foo".indexOf("bar", 1) - 1);
   }
 
-  int testStringIndexOfStringBetweenIndices() {
+  int testMathMaxNegativeOneStringIndexOfMinusStringWithInt() {
     return Math.max(-1, "foo".indexOf("bar", 1, 2) - 1);
   }
 
-  int testStringLastIndexOfChar() {
+  int testMathMaxNegativeOneStringLastIndexOfMinusInt() {
     return Math.max(-1, "foo".lastIndexOf('a') - 1);
   }
 
-  int testStringLastIndexOfString() {
+  int testMathMaxNegativeOneStringLastIndexOfMinusString() {
     return Math.max(-1, "foo".lastIndexOf("bar") - 1);
   }
 
-  int testStringLastIndexOfCharWithIndex() {
+  int testStringLastIndexOfMinusOneInt() {
     return "foo".lastIndexOf('a', 2 - 1);
   }
 
-  int testStringLastIndexOfStringWithIndex() {
+  int testStringLastIndexOfMinusOneString() {
     return "foo".lastIndexOf("bar", 2 - 1);
   }
 
@@ -149,7 +149,7 @@ final class StringRulesTest implements RefasterRuleCollectionTestCase {
     return "foo".startsWith("bar", 1);
   }
 
-  ImmutableSet<String> testStringFormatted() {
+  ImmutableSet<String> testFormatted() {
     return ImmutableSet.of(
         ("Constant").formatted(),
         ("Number: %d").formatted(42),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SuggestedFixRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SuggestedFixRulesTestInput.java
@@ -15,15 +15,15 @@ final class SuggestedFixRulesTest implements RefasterRuleCollectionTestCase {
     return SuggestedFix.builder().delete((Tree) null).build();
   }
 
-  SuggestedFix testSuggestedFixReplaceTree() {
+  SuggestedFix testSuggestedFixReplace2() {
     return SuggestedFix.builder().replace((Tree) null, "foo").build();
   }
 
-  SuggestedFix testSuggestedFixReplaceStartEnd() {
+  SuggestedFix testSuggestedFixReplace3() {
     return SuggestedFix.builder().replace(1, 2, "foo").build();
   }
 
-  SuggestedFix testSuggestedFixReplaceTreeStartEnd() {
+  SuggestedFix testSuggestedFixReplace4() {
     return SuggestedFix.builder().replace(null, "foo", 1, 2).build();
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SuggestedFixRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/SuggestedFixRulesTestOutput.java
@@ -15,15 +15,15 @@ final class SuggestedFixRulesTest implements RefasterRuleCollectionTestCase {
     return SuggestedFix.delete((Tree) null);
   }
 
-  SuggestedFix testSuggestedFixReplaceTree() {
+  SuggestedFix testSuggestedFixReplace2() {
     return SuggestedFix.replace((Tree) null, "foo");
   }
 
-  SuggestedFix testSuggestedFixReplaceStartEnd() {
+  SuggestedFix testSuggestedFixReplace3() {
     return SuggestedFix.replace(1, 2, "foo");
   }
 
-  SuggestedFix testSuggestedFixReplaceTreeStartEnd() {
+  SuggestedFix testSuggestedFixReplace4() {
     return SuggestedFix.replace(null, "foo", 1, 2);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestInput.java
@@ -15,6 +15,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
+import org.testng.Assert.ThrowingRunnable;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
@@ -37,63 +38,63 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     org.testng.Assert.fail();
   }
 
-  void testFailWithMessage() {
+  void testFailWithString() {
     org.testng.Assert.fail("foo");
   }
 
-  void testFailWithMessageAndThrowable() {
+  void testFailWithStringAndThrowable() {
     org.testng.Assert.fail("foo", new IllegalStateException());
   }
 
-  void testAssertTrue() {
+  void testAssertThatIsTrue() {
     assertTrue(true);
   }
 
-  void testAssertTrueWithMessage() {
+  void testAssertThatWithFailMessageIsTrue() {
     assertTrue(true, "foo");
   }
 
-  void testAssertFalse() {
+  void testAssertThatIsFalse() {
     assertFalse(true);
   }
 
-  void testAssertFalseWithMessage() {
-    assertFalse(true, "message");
+  void testAssertThatWithFailMessageIsFalse() {
+    assertFalse(true, "foo");
   }
 
-  void testAssertNull() {
+  void testAssertThatIsNull() {
     assertNull(new Object());
   }
 
-  void testAssertNullWithMessage() {
+  void testAssertThatWithFailMessageIsNull() {
     assertNull(new Object(), "foo");
   }
 
-  void testAssertNotNull() {
+  void testAssertThatIsNotNull() {
     assertNotNull(new Object());
   }
 
-  void testAssertNotNullWithMessage() {
+  void testAssertThatWithFailMessageIsNotNull() {
     assertNotNull(new Object(), "foo");
   }
 
-  void testAssertSame() {
-    assertSame(new Object(), new Object());
+  void testAssertThatIsSameAs() {
+    assertSame(new Object(), new StringBuilder());
   }
 
-  void testAssertSameWithMessage() {
-    assertSame(new Object(), new Object(), "foo");
+  void testAssertThatWithFailMessageIsSameAs() {
+    assertSame(new Object(), new StringBuilder(), "foo");
   }
 
-  void testAssertNotSame() {
-    assertNotSame(new Object(), new Object());
+  void testAssertThatIsNotSameAs() {
+    assertNotSame(new Object(), new StringBuilder());
   }
 
-  void testAssertNotSameWithMessage() {
-    assertNotSame(new Object(), new Object(), "foo");
+  void testAssertThatWithFailMessageIsNotSameAs() {
+    assertNotSame(new Object(), new StringBuilder(), "foo");
   }
 
-  void testAssertEqual() {
+  void testAssertThatIsEqualTo() {
     assertEquals(true, false);
     assertEquals(true, Boolean.FALSE);
     assertEquals(Boolean.TRUE, false);
@@ -131,7 +132,7 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(ImmutableMap.of(), ImmutableMap.of(1, 2));
   }
 
-  void testAssertEqualWithMessage() {
+  void testAssertThatWithFailMessageIsEqualTo() {
     assertEquals(true, false, "foo");
     assertEquals(true, Boolean.FALSE, "bar");
     assertEquals(Boolean.TRUE, false, "baz");
@@ -169,81 +170,81 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(ImmutableMap.of(), ImmutableMap.of(1, 2), "waldo");
   }
 
-  void testAssertEqualFloatsWithDelta() {
-    assertEquals(0.0f, 0.0f, 0.0f);
+  void testAssertThatIsCloseToOffsetFloat() {
+    assertEquals(1.0f, 2.0f, 0.0f);
   }
 
-  void testAssertEqualFloatsWithDeltaWithMessage() {
-    assertEquals(0.0f, 0.0f, 0.0f, "foo");
+  void testAssertThatWithFailMessageIsCloseToOffsetFloat() {
+    assertEquals(1.0f, 2.0f, 0.0f, "foo");
   }
 
-  void testAssertEqualDoublesWithDelta() {
-    assertEquals(0.0, 0.0, 0.0);
+  void testAssertThatIsCloseToOffsetDouble() {
+    assertEquals(1.0, 2.0, 0.0);
   }
 
-  void testAssertEqualDoublesWithDeltaWithMessage() {
-    assertEquals(0.0, 0.0, 0.0, "foo");
+  void testAssertThatWithFailMessageIsCloseToOffsetDouble() {
+    assertEquals(1.0, 2.0, 0.0, "foo");
   }
 
-  void testAssertEqualArrayIterationOrder() {
-    assertEquals(new boolean[0], new boolean[0]);
-    assertEquals(new byte[0], new byte[0]);
-    assertEquals(new char[0], new char[0]);
-    assertEquals(new short[0], new short[0]);
-    assertEquals(new int[0], new int[0]);
-    assertEquals(new long[0], new long[0]);
-    assertEquals(new float[0], new float[0]);
-    assertEquals(new double[0], new double[0]);
-    assertEquals(new Object[0], new Object[0]);
+  void testAssertThatContainsExactly() {
+    assertEquals(new boolean[] {false}, new boolean[] {true});
+    assertEquals(new byte[] {2}, new byte[] {1});
+    assertEquals(new char[] {'b'}, new char[] {'a'});
+    assertEquals(new short[] {2}, new short[] {1});
+    assertEquals(new int[] {2}, new int[] {1});
+    assertEquals(new long[] {2L}, new long[] {1L});
+    assertEquals(new float[] {2.0f}, new float[] {1.0f});
+    assertEquals(new double[] {2.0}, new double[] {1.0});
+    assertEquals(new Object[] {"bar"}, new Object[] {"foo"});
   }
 
-  void testAssertEqualArrayIterationOrderWithMessage() {
-    assertEquals(new boolean[0], new boolean[0], "foo");
-    assertEquals(new byte[0], new byte[0], "bar");
-    assertEquals(new char[0], new char[0], "baz");
-    assertEquals(new short[0], new short[0], "qux");
-    assertEquals(new int[0], new int[0], "quux");
-    assertEquals(new long[0], new long[0], "quuz");
-    assertEquals(new float[0], new float[0], "corge");
-    assertEquals(new double[0], new double[0], "grault");
-    assertEquals(new Object[0], new Object[0], "garply");
+  void testAssertThatWithFailMessageContainsExactly() {
+    assertEquals(new boolean[] {false}, new boolean[] {true}, "foo");
+    assertEquals(new byte[] {2}, new byte[] {1}, "bar");
+    assertEquals(new char[] {'b'}, new char[] {'a'}, "baz");
+    assertEquals(new short[] {2}, new short[] {1}, "qux");
+    assertEquals(new int[] {2}, new int[] {1}, "quux");
+    assertEquals(new long[] {2L}, new long[] {1L}, "corge");
+    assertEquals(new float[] {2.0f}, new float[] {1.0f}, "grault");
+    assertEquals(new double[] {2.0}, new double[] {1.0}, "garply");
+    assertEquals(new Object[] {"bar"}, new Object[] {"foo"}, "waldo");
   }
 
-  void testAssertEqualFloatArraysWithDelta() {
-    assertEquals(new float[0], new float[0], 0.0f);
+  void testAssertThatContainsExactlyOffsetFloat() {
+    assertEquals(new float[] {2.0f}, new float[] {1.0f}, 0.0f);
   }
 
-  void testAssertEqualFloatArraysWithDeltaWithMessage() {
-    assertEquals(new float[0], new float[0], 0.0f, "foo");
+  void testAssertThatWithFailMessageContainsExactlyOffsetFloat() {
+    assertEquals(new float[] {2.0f}, new float[] {1.0f}, 0.0f, "foo");
   }
 
-  void testAssertEqualDoubleArraysWithDelta() {
-    assertEquals(new double[0], new double[0], 0.0);
+  void testAssertThatContainsExactlyOffsetDouble() {
+    assertEquals(new double[] {2.0}, new double[] {1.0}, 0.0);
   }
 
-  void testAssertEqualDoubleArraysWithDeltaWithMessage() {
-    assertEquals(new double[0], new double[0], 0.0, "foo");
+  void testAssertThatWithFailMessageContainsExactlyOffsetDouble() {
+    assertEquals(new double[] {2.0}, new double[] {1.0}, 0.0, "foo");
   }
 
-  void testAssertEqualArraysIrrespectiveOfOrder() {
-    assertEqualsNoOrder(new Object[0], new Object[0]);
+  void testAssertThatContainsExactlyInAnyOrder() {
+    assertEqualsNoOrder(new Object[] {"bar"}, new Object[] {"foo"});
   }
 
-  void testAssertEqualArraysIrrespectiveOfOrderWithMessage() {
-    assertEqualsNoOrder(new Object[0], new Object[0], "foo");
+  void testAssertThatWithFailMessageContainsExactlyInAnyOrder() {
+    assertEqualsNoOrder(new Object[] {"bar"}, new Object[] {"foo"}, "foo");
   }
 
-  void testAssertEqualIteratorIterationOrder() {
+  void testAssertThatToIterableContainsExactlyElementsOfImmutableListCopyOf() {
     assertEquals(new ArrayList<Number>().iterator(), new ArrayList<Integer>().iterator());
     assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator());
   }
 
-  void testAssertEqualIteratorIterationOrderWithMessage() {
+  void testAssertThatToIterableWithFailMessageContainsExactlyElementsOfImmutableListCopyOf() {
     assertEquals(new ArrayList<Number>().iterator(), new ArrayList<Integer>().iterator(), "foo");
     assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator(), "bar");
   }
 
-  void testAssertEqualIterableIterationOrder() {
+  void testAssertThatContainsExactlyElementsOf() {
     assertEquals(
         Iterables.unmodifiableIterable(new ArrayList<Number>()),
         Iterables.unmodifiableIterable(new ArrayList<Integer>()));
@@ -254,7 +255,7 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(new ArrayList<Number>(), new ArrayList<String>());
   }
 
-  void testAssertEqualIterableIterationOrderWithMessage() {
+  void testAssertThatWithFailMessageContainsExactlyElementsOf() {
     assertEquals(
         Iterables.unmodifiableIterable(new ArrayList<Number>()),
         Iterables.unmodifiableIterable(new ArrayList<Integer>()),
@@ -267,67 +268,69 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(new ArrayList<Number>(), new ArrayList<String>(), "qux");
   }
 
-  void testAssertEqualSets() {
+  void testAssertThatHasSameElementsAs() {
     assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<Integer>of());
     assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of());
   }
 
-  void testAssertEqualSetsWithMessage() {
+  void testAssertThatWithFailMessageHasSameElementsAs() {
     assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<Integer>of(), "foo");
     assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of(), "bar");
   }
 
-  void testAssertUnequal() {
-    assertNotEquals(true, true);
-    assertNotEquals((byte) 0, (byte) 0);
-    assertNotEquals((char) 0, (char) 0);
-    assertNotEquals((short) 0, (short) 0);
-    assertNotEquals(0, 0);
-    assertNotEquals(0L, 0L);
-    assertNotEquals(0.0f, 0.0f);
-    assertNotEquals(0.0, 0.0);
-    assertNotEquals(new Object(), new Object());
-    assertNotEquals("actual", "expected");
-    assertNotEquals(ImmutableSet.of(), ImmutableSet.of());
-    assertNotEquals(ImmutableMap.of(), ImmutableMap.of());
+  void testAssertThatIsNotEqualTo() {
+    assertNotEquals(true, false);
+    assertNotEquals((byte) 0, (byte) 1);
+    assertNotEquals('a', 'b');
+    assertNotEquals((short) 0, (short) 1);
+    assertNotEquals(0, 1);
+    assertNotEquals(0L, 1L);
+    assertNotEquals(0.0f, 1.0f);
+    assertNotEquals(0.0, 1.0);
+    assertNotEquals(new Object(), new StringBuilder());
+    assertNotEquals("foo", "bar");
+    assertNotEquals(ImmutableSet.of(), ImmutableSet.of(1));
+    assertNotEquals(ImmutableMap.of(), ImmutableMap.of(1, 2));
   }
 
-  void testAssertUnequalWithMessage() {
-    assertNotEquals(true, true, "foo");
-    assertNotEquals((byte) 0, (byte) 0, "bar");
-    assertNotEquals((char) 0, (char) 0, "baz");
-    assertNotEquals((short) 0, (short) 0, "qux");
-    assertNotEquals(0, 0, "quux");
-    assertNotEquals(0L, 0L, "quuz");
-    assertNotEquals(0.0f, 0.0f, "corge");
-    assertNotEquals(0.0, 0.0, "grault");
-    assertNotEquals(new Object(), new Object(), "garply");
-    assertNotEquals("actual", "expected", "waldo");
-    assertNotEquals(ImmutableSet.of(), ImmutableSet.of(), "fred");
-    assertNotEquals(ImmutableMap.of(), ImmutableMap.of(), "plugh");
+  void testAssertThatWithFailMessageIsNotEqualTo() {
+    assertNotEquals(true, false, "foo");
+    assertNotEquals((byte) 0, (byte) 1, "bar");
+    assertNotEquals('a', 'b', "baz");
+    assertNotEquals((short) 0, (short) 1, "qux");
+    assertNotEquals(0, 1, "quux");
+    assertNotEquals(0L, 1L, "corge");
+    assertNotEquals(0.0f, 1.0f, "grault");
+    assertNotEquals(0.0, 1.0, "garply");
+    assertNotEquals(new Object(), new StringBuilder(), "waldo");
+    assertNotEquals("foo", "bar", "fred");
+    assertNotEquals(ImmutableSet.of(), ImmutableSet.of(1), "plugh");
+    assertNotEquals(ImmutableMap.of(), ImmutableMap.of(1, 2), "xyzzy");
   }
 
-  void testAssertUnequalFloatsWithDelta() {
-    assertNotEquals(0.0f, 0.0f, 0.0f);
+  void testAssertThatIsNotCloseToOffsetFloat() {
+    assertNotEquals(1.0f, 2.0f, 0.0f);
   }
 
-  void testAssertUnequalFloatsWithDeltaWithMessage() {
-    assertNotEquals(0.0f, 0.0f, 0.0f, "foo");
+  void testAssertThatWithFailMessageIsNotCloseToOffsetFloat() {
+    assertNotEquals(1.0f, 2.0f, 0.0f, "foo");
   }
 
-  void testAssertUnequalDoublesWithDelta() {
-    assertNotEquals(0.0, 0.0, 0.0);
+  void testAssertThatIsNotCloseToOffsetDouble() {
+    assertNotEquals(1.0, 2.0, 0.0);
   }
 
-  void testAssertUnequalDoublesWithDeltaWithMessage() {
-    assertNotEquals(0.0, 0.0, 0.0, "foo");
+  void testAssertThatWithFailMessageIsNotCloseToOffsetDouble() {
+    assertNotEquals(1.0, 2.0, 0.0, "foo");
   }
 
-  void testAssertThrows() {
+  void testAssertThatThrownBy() {
+    assertThrows((ThrowingRunnable) null);
     assertThrows(() -> {});
   }
 
-  void testAssertThrowsWithType() {
+  void testAssertThatThrownByIsInstanceOf() {
+    assertThrows(IllegalStateException.class, (ThrowingRunnable) null);
     assertThrows(IllegalStateException.class, () -> {});
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TestNGToAssertJRulesTestOutput.java
@@ -4,7 +4,7 @@ import static com.google.common.collect.ImmutableList.copyOf;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.Assertions.fail;
-import static org.assertj.core.data.Offset.offset;
+import static org.assertj.core.api.Assertions.offset;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertEqualsNoOrder;
 import static org.testng.Assert.assertFalse;
@@ -20,6 +20,7 @@ import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import java.util.ArrayList;
+import org.testng.Assert.ThrowingRunnable;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
@@ -42,63 +43,63 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     fail();
   }
 
-  void testFailWithMessage() {
+  void testFailWithString() {
     fail("foo");
   }
 
-  void testFailWithMessageAndThrowable() {
+  void testFailWithStringAndThrowable() {
     fail("foo", new IllegalStateException());
   }
 
-  void testAssertTrue() {
+  void testAssertThatIsTrue() {
     assertThat(true).isTrue();
   }
 
-  void testAssertTrueWithMessage() {
+  void testAssertThatWithFailMessageIsTrue() {
     assertThat(true).withFailMessage("foo").isTrue();
   }
 
-  void testAssertFalse() {
+  void testAssertThatIsFalse() {
     assertThat(true).isFalse();
   }
 
-  void testAssertFalseWithMessage() {
-    assertThat(true).withFailMessage("message").isFalse();
+  void testAssertThatWithFailMessageIsFalse() {
+    assertThat(true).withFailMessage("foo").isFalse();
   }
 
-  void testAssertNull() {
+  void testAssertThatIsNull() {
     assertThat(new Object()).isNull();
   }
 
-  void testAssertNullWithMessage() {
+  void testAssertThatWithFailMessageIsNull() {
     assertThat(new Object()).withFailMessage("foo").isNull();
   }
 
-  void testAssertNotNull() {
+  void testAssertThatIsNotNull() {
     assertThat(new Object()).isNotNull();
   }
 
-  void testAssertNotNullWithMessage() {
+  void testAssertThatWithFailMessageIsNotNull() {
     assertThat(new Object()).withFailMessage("foo").isNotNull();
   }
 
-  void testAssertSame() {
-    assertThat(new Object()).isSameAs(new Object());
+  void testAssertThatIsSameAs() {
+    assertThat(new Object()).isSameAs(new StringBuilder());
   }
 
-  void testAssertSameWithMessage() {
-    assertThat(new Object()).withFailMessage("foo").isSameAs(new Object());
+  void testAssertThatWithFailMessageIsSameAs() {
+    assertThat(new Object()).withFailMessage("foo").isSameAs(new StringBuilder());
   }
 
-  void testAssertNotSame() {
-    assertThat(new Object()).isNotSameAs(new Object());
+  void testAssertThatIsNotSameAs() {
+    assertThat(new Object()).isNotSameAs(new StringBuilder());
   }
 
-  void testAssertNotSameWithMessage() {
-    assertThat(new Object()).withFailMessage("foo").isNotSameAs(new Object());
+  void testAssertThatWithFailMessageIsNotSameAs() {
+    assertThat(new Object()).withFailMessage("foo").isNotSameAs(new StringBuilder());
   }
 
-  void testAssertEqual() {
+  void testAssertThatIsEqualTo() {
     assertThat(true).isEqualTo(false);
     assertThat(true).isEqualTo(Boolean.FALSE);
     assertThat(Boolean.TRUE).isEqualTo(false);
@@ -136,7 +137,7 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(ImmutableMap.of()).isEqualTo(ImmutableMap.of(1, 2));
   }
 
-  void testAssertEqualWithMessage() {
+  void testAssertThatWithFailMessageIsEqualTo() {
     assertThat(true).withFailMessage("foo").isEqualTo(false);
     assertThat(true).withFailMessage("bar").isEqualTo(Boolean.FALSE);
     assertThat(Boolean.TRUE).withFailMessage("baz").isEqualTo(false);
@@ -174,78 +175,84 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertThat(ImmutableMap.of()).withFailMessage("waldo").isEqualTo(ImmutableMap.of(1, 2));
   }
 
-  void testAssertEqualFloatsWithDelta() {
-    assertThat(0.0f).isCloseTo(0.0f, offset(0.0f));
+  void testAssertThatIsCloseToOffsetFloat() {
+    assertThat(1.0f).isCloseTo(2.0f, offset(0.0f));
   }
 
-  void testAssertEqualFloatsWithDeltaWithMessage() {
-    assertThat(0.0f).withFailMessage("foo").isCloseTo(0.0f, offset(0.0f));
+  void testAssertThatWithFailMessageIsCloseToOffsetFloat() {
+    assertThat(1.0f).withFailMessage("foo").isCloseTo(2.0f, offset(0.0f));
   }
 
-  void testAssertEqualDoublesWithDelta() {
-    assertThat(0.0).isCloseTo(0.0, offset(0.0));
+  void testAssertThatIsCloseToOffsetDouble() {
+    assertThat(1.0).isCloseTo(2.0, offset(0.0));
   }
 
-  void testAssertEqualDoublesWithDeltaWithMessage() {
-    assertThat(0.0).withFailMessage("foo").isCloseTo(0.0, offset(0.0));
+  void testAssertThatWithFailMessageIsCloseToOffsetDouble() {
+    assertThat(1.0).withFailMessage("foo").isCloseTo(2.0, offset(0.0));
   }
 
-  void testAssertEqualArrayIterationOrder() {
-    assertThat(new boolean[0]).containsExactly(new boolean[0]);
-    assertThat(new byte[0]).containsExactly(new byte[0]);
-    assertThat(new char[0]).containsExactly(new char[0]);
-    assertThat(new short[0]).containsExactly(new short[0]);
-    assertThat(new int[0]).containsExactly(new int[0]);
-    assertThat(new long[0]).containsExactly(new long[0]);
-    assertThat(new float[0]).containsExactly(new float[0]);
-    assertThat(new double[0]).containsExactly(new double[0]);
-    assertThat(new Object[0]).containsExactly(new Object[0]);
+  void testAssertThatContainsExactly() {
+    assertThat(new boolean[] {false}).containsExactly(new boolean[] {true});
+    assertThat(new byte[] {2}).containsExactly(new byte[] {1});
+    assertThat(new char[] {'b'}).containsExactly(new char[] {'a'});
+    assertThat(new short[] {2}).containsExactly(new short[] {1});
+    assertThat(new int[] {2}).containsExactly(new int[] {1});
+    assertThat(new long[] {2L}).containsExactly(new long[] {1L});
+    assertThat(new float[] {2.0f}).containsExactly(new float[] {1.0f});
+    assertThat(new double[] {2.0}).containsExactly(new double[] {1.0});
+    assertThat(new Object[] {"bar"}).containsExactly(new Object[] {"foo"});
   }
 
-  void testAssertEqualArrayIterationOrderWithMessage() {
-    assertThat(new boolean[0]).withFailMessage("foo").containsExactly(new boolean[0]);
-    assertThat(new byte[0]).withFailMessage("bar").containsExactly(new byte[0]);
-    assertThat(new char[0]).withFailMessage("baz").containsExactly(new char[0]);
-    assertThat(new short[0]).withFailMessage("qux").containsExactly(new short[0]);
-    assertThat(new int[0]).withFailMessage("quux").containsExactly(new int[0]);
-    assertThat(new long[0]).withFailMessage("quuz").containsExactly(new long[0]);
-    assertThat(new float[0]).withFailMessage("corge").containsExactly(new float[0]);
-    assertThat(new double[0]).withFailMessage("grault").containsExactly(new double[0]);
-    assertThat(new Object[0]).withFailMessage("garply").containsExactly(new Object[0]);
+  void testAssertThatWithFailMessageContainsExactly() {
+    assertThat(new boolean[] {false}).withFailMessage("foo").containsExactly(new boolean[] {true});
+    assertThat(new byte[] {2}).withFailMessage("bar").containsExactly(new byte[] {1});
+    assertThat(new char[] {'b'}).withFailMessage("baz").containsExactly(new char[] {'a'});
+    assertThat(new short[] {2}).withFailMessage("qux").containsExactly(new short[] {1});
+    assertThat(new int[] {2}).withFailMessage("quux").containsExactly(new int[] {1});
+    assertThat(new long[] {2L}).withFailMessage("corge").containsExactly(new long[] {1L});
+    assertThat(new float[] {2.0f}).withFailMessage("grault").containsExactly(new float[] {1.0f});
+    assertThat(new double[] {2.0}).withFailMessage("garply").containsExactly(new double[] {1.0});
+    assertThat(new Object[] {"bar"}).withFailMessage("waldo").containsExactly(new Object[] {"foo"});
   }
 
-  void testAssertEqualFloatArraysWithDelta() {
-    assertThat(new float[0]).containsExactly(new float[0], offset(0.0f));
+  void testAssertThatContainsExactlyOffsetFloat() {
+    assertThat(new float[] {2.0f}).containsExactly(new float[] {1.0f}, offset(0.0f));
   }
 
-  void testAssertEqualFloatArraysWithDeltaWithMessage() {
-    assertThat(new float[0]).withFailMessage("foo").containsExactly(new float[0], offset(0.0f));
+  void testAssertThatWithFailMessageContainsExactlyOffsetFloat() {
+    assertThat(new float[] {2.0f})
+        .withFailMessage("foo")
+        .containsExactly(new float[] {1.0f}, offset(0.0f));
   }
 
-  void testAssertEqualDoubleArraysWithDelta() {
-    assertThat(new double[0]).containsExactly(new double[0], offset(0.0));
+  void testAssertThatContainsExactlyOffsetDouble() {
+    assertThat(new double[] {2.0}).containsExactly(new double[] {1.0}, offset(0.0));
   }
 
-  void testAssertEqualDoubleArraysWithDeltaWithMessage() {
-    assertThat(new double[0]).withFailMessage("foo").containsExactly(new double[0], offset(0.0));
+  void testAssertThatWithFailMessageContainsExactlyOffsetDouble() {
+    assertThat(new double[] {2.0})
+        .withFailMessage("foo")
+        .containsExactly(new double[] {1.0}, offset(0.0));
   }
 
-  void testAssertEqualArraysIrrespectiveOfOrder() {
-    assertThat(new Object[0]).containsExactlyInAnyOrder(new Object[0]);
+  void testAssertThatContainsExactlyInAnyOrder() {
+    assertThat(new Object[] {"bar"}).containsExactlyInAnyOrder(new Object[] {"foo"});
   }
 
-  void testAssertEqualArraysIrrespectiveOfOrderWithMessage() {
-    assertThat(new Object[0]).withFailMessage("foo").containsExactlyInAnyOrder(new Object[0]);
+  void testAssertThatWithFailMessageContainsExactlyInAnyOrder() {
+    assertThat(new Object[] {"bar"})
+        .withFailMessage("foo")
+        .containsExactlyInAnyOrder(new Object[] {"foo"});
   }
 
-  void testAssertEqualIteratorIterationOrder() {
+  void testAssertThatToIterableContainsExactlyElementsOfImmutableListCopyOf() {
     assertThat(new ArrayList<Number>().iterator())
         .toIterable()
         .containsExactlyElementsOf(copyOf(new ArrayList<Integer>().iterator()));
     assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator());
   }
 
-  void testAssertEqualIteratorIterationOrderWithMessage() {
+  void testAssertThatToIterableWithFailMessageContainsExactlyElementsOfImmutableListCopyOf() {
     assertThat(new ArrayList<Number>().iterator())
         .toIterable()
         .withFailMessage("foo")
@@ -253,7 +260,7 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(new ArrayList<Number>().iterator(), new ArrayList<String>().iterator(), "bar");
   }
 
-  void testAssertEqualIterableIterationOrder() {
+  void testAssertThatContainsExactlyElementsOf() {
     assertThat(Iterables.unmodifiableIterable(new ArrayList<Number>()))
         .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<Integer>()));
     assertEquals(
@@ -263,7 +270,7 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(new ArrayList<Number>(), new ArrayList<String>());
   }
 
-  void testAssertEqualIterableIterationOrderWithMessage() {
+  void testAssertThatWithFailMessageContainsExactlyElementsOf() {
     assertThat(Iterables.unmodifiableIterable(new ArrayList<Number>()))
         .withFailMessage("foo")
         .containsExactlyElementsOf(Iterables.unmodifiableIterable(new ArrayList<Integer>()));
@@ -277,69 +284,71 @@ final class TestNGToAssertJRulesTest implements RefasterRuleCollectionTestCase {
     assertEquals(new ArrayList<Number>(), new ArrayList<String>(), "qux");
   }
 
-  void testAssertEqualSets() {
+  void testAssertThatHasSameElementsAs() {
     assertThat(ImmutableSet.<Number>of()).hasSameElementsAs(ImmutableSet.<Integer>of());
     assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of());
   }
 
-  void testAssertEqualSetsWithMessage() {
+  void testAssertThatWithFailMessageHasSameElementsAs() {
     assertThat(ImmutableSet.<Number>of())
         .withFailMessage("foo")
         .hasSameElementsAs(ImmutableSet.<Integer>of());
     assertEquals(ImmutableSet.<Number>of(), ImmutableSet.<String>of(), "bar");
   }
 
-  void testAssertUnequal() {
-    assertThat(true).isNotEqualTo(true);
-    assertThat((byte) 0).isNotEqualTo((byte) 0);
-    assertThat((char) 0).isNotEqualTo((char) 0);
-    assertThat((short) 0).isNotEqualTo((short) 0);
-    assertThat(0).isNotEqualTo(0);
-    assertThat(0L).isNotEqualTo(0L);
-    assertThat(0.0f).isNotEqualTo(0.0f);
-    assertThat(0.0).isNotEqualTo(0.0);
-    assertThat(new Object()).isNotEqualTo(new Object());
-    assertThat("actual").isNotEqualTo("expected");
-    assertThat(ImmutableSet.of()).isNotEqualTo(ImmutableSet.of());
-    assertThat(ImmutableMap.of()).isNotEqualTo(ImmutableMap.of());
+  void testAssertThatIsNotEqualTo() {
+    assertThat(true).isNotEqualTo(false);
+    assertThat((byte) 0).isNotEqualTo((byte) 1);
+    assertThat('a').isNotEqualTo('b');
+    assertThat((short) 0).isNotEqualTo((short) 1);
+    assertThat(0).isNotEqualTo(1);
+    assertThat(0L).isNotEqualTo(1L);
+    assertThat(0.0f).isNotEqualTo(1.0f);
+    assertThat(0.0).isNotEqualTo(1.0);
+    assertThat(new Object()).isNotEqualTo(new StringBuilder());
+    assertThat("foo").isNotEqualTo("bar");
+    assertThat(ImmutableSet.of()).isNotEqualTo(ImmutableSet.of(1));
+    assertThat(ImmutableMap.of()).isNotEqualTo(ImmutableMap.of(1, 2));
   }
 
-  void testAssertUnequalWithMessage() {
-    assertThat(true).withFailMessage("foo").isNotEqualTo(true);
-    assertThat((byte) 0).withFailMessage("bar").isNotEqualTo((byte) 0);
-    assertThat((char) 0).withFailMessage("baz").isNotEqualTo((char) 0);
-    assertThat((short) 0).withFailMessage("qux").isNotEqualTo((short) 0);
-    assertThat(0).withFailMessage("quux").isNotEqualTo(0);
-    assertThat(0L).withFailMessage("quuz").isNotEqualTo(0L);
-    assertThat(0.0f).withFailMessage("corge").isNotEqualTo(0.0f);
-    assertThat(0.0).withFailMessage("grault").isNotEqualTo(0.0);
-    assertThat(new Object()).withFailMessage("garply").isNotEqualTo(new Object());
-    assertThat("actual").withFailMessage("waldo").isNotEqualTo("expected");
-    assertThat(ImmutableSet.of()).withFailMessage("fred").isNotEqualTo(ImmutableSet.of());
-    assertThat(ImmutableMap.of()).withFailMessage("plugh").isNotEqualTo(ImmutableMap.of());
+  void testAssertThatWithFailMessageIsNotEqualTo() {
+    assertThat(true).withFailMessage("foo").isNotEqualTo(false);
+    assertThat((byte) 0).withFailMessage("bar").isNotEqualTo((byte) 1);
+    assertThat('a').withFailMessage("baz").isNotEqualTo('b');
+    assertThat((short) 0).withFailMessage("qux").isNotEqualTo((short) 1);
+    assertThat(0).withFailMessage("quux").isNotEqualTo(1);
+    assertThat(0L).withFailMessage("corge").isNotEqualTo(1L);
+    assertThat(0.0f).withFailMessage("grault").isNotEqualTo(1.0f);
+    assertThat(0.0).withFailMessage("garply").isNotEqualTo(1.0);
+    assertThat(new Object()).withFailMessage("waldo").isNotEqualTo(new StringBuilder());
+    assertThat("foo").withFailMessage("fred").isNotEqualTo("bar");
+    assertThat(ImmutableSet.of()).withFailMessage("plugh").isNotEqualTo(ImmutableSet.of(1));
+    assertThat(ImmutableMap.of()).withFailMessage("xyzzy").isNotEqualTo(ImmutableMap.of(1, 2));
   }
 
-  void testAssertUnequalFloatsWithDelta() {
-    assertThat(0.0f).isNotCloseTo(0.0f, offset(0.0f));
+  void testAssertThatIsNotCloseToOffsetFloat() {
+    assertThat(1.0f).isNotCloseTo(2.0f, offset(0.0f));
   }
 
-  void testAssertUnequalFloatsWithDeltaWithMessage() {
-    assertThat(0.0f).withFailMessage("foo").isNotCloseTo(0.0f, offset(0.0f));
+  void testAssertThatWithFailMessageIsNotCloseToOffsetFloat() {
+    assertThat(1.0f).withFailMessage("foo").isNotCloseTo(2.0f, offset(0.0f));
   }
 
-  void testAssertUnequalDoublesWithDelta() {
-    assertThat(0.0).isNotCloseTo(0.0, offset(0.0));
+  void testAssertThatIsNotCloseToOffsetDouble() {
+    assertThat(1.0).isNotCloseTo(2.0, offset(0.0));
   }
 
-  void testAssertUnequalDoublesWithDeltaWithMessage() {
-    assertThat(0.0).withFailMessage("foo").isNotCloseTo(0.0, offset(0.0));
+  void testAssertThatWithFailMessageIsNotCloseToOffsetDouble() {
+    assertThat(1.0).withFailMessage("foo").isNotCloseTo(2.0, offset(0.0));
   }
 
-  void testAssertThrows() {
+  void testAssertThatThrownBy() {
+    assertThrows((ThrowingRunnable) null);
     assertThatThrownBy(() -> {});
   }
 
-  void testAssertThrowsWithType() {
+  void testAssertThatThrownByIsInstanceOf() {
+    assertThrows(IllegalStateException.class, (ThrowingRunnable) null);
     assertThatThrownBy(() -> {}).isInstanceOf(IllegalStateException.class);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestInput.java
@@ -28,7 +28,7 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return Instant.now(Clock.systemUTC());
   }
 
-  ImmutableSet<ZoneId> testUtcConstant() {
+  ImmutableSet<ZoneId> testUtc() {
     return ImmutableSet.of(
         ZoneId.of("GMT"),
         ZoneId.of("UTC"),
@@ -84,11 +84,11 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
             Instant.EPOCH.plusMillis(13).getEpochSecond(), Instant.EPOCH.plusMillis(13).getNano()));
   }
 
-  Instant testInstantTruncatedToMilliseconds() {
+  Instant testInstantTruncatedToChronoUnitMillis() {
     return Instant.ofEpochMilli(Instant.EPOCH.toEpochMilli());
   }
 
-  Instant testInstantTruncatedToSeconds() {
+  Instant testInstantTruncatedToChronoUnitSeconds() {
     return Instant.ofEpochSecond(Instant.EPOCH.getEpochSecond());
   }
 
@@ -106,11 +106,11 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return ZonedDateTime.ofInstant(Instant.EPOCH, ZoneOffset.UTC);
   }
 
-  Clock testUtcClock() {
+  Clock testClockSystemUTC() {
     return Clock.system(ZoneOffset.UTC);
   }
 
-  ImmutableSet<Instant> testEpochInstant() {
+  ImmutableSet<Instant> testInstantEpoch() {
     return ImmutableSet.of(
         Instant.ofEpochMilli(0),
         Instant.ofEpochMilli(0L),
@@ -176,19 +176,19 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
         ZonedDateTime.now().compareTo(ZonedDateTime.now()) <= 0);
   }
 
-  ImmutableSet<Boolean> testOffsetDateTimeIsAfter() {
-    return ImmutableSet.of(
-        OffsetDateTime.MIN.compareTo(OffsetDateTime.MAX) > 0,
-        OffsetDateTime.MIN.compareTo(OffsetDateTime.MAX) <= 0);
-  }
-
   ImmutableSet<Boolean> testOffsetDateTimeIsBefore() {
     return ImmutableSet.of(
         OffsetDateTime.MIN.compareTo(OffsetDateTime.MAX) < 0,
         OffsetDateTime.MIN.compareTo(OffsetDateTime.MAX) >= 0);
   }
 
-  ImmutableSet<Duration> testZeroDuration() {
+  ImmutableSet<Boolean> testOffsetDateTimeIsAfter() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.compareTo(OffsetDateTime.MAX) > 0,
+        OffsetDateTime.MIN.compareTo(OffsetDateTime.MAX) <= 0);
+  }
+
+  ImmutableSet<Duration> testDurationZero() {
     return ImmutableSet.of(
         Duration.ofNanos(0),
         Duration.ofMillis(0),
@@ -224,11 +224,11 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return Duration.of(1, ChronoUnit.SECONDS);
   }
 
-  Duration testDurationBetweenInstants() {
+  Duration testDurationBetweenInstant() {
     return Duration.ofMillis(Instant.MAX.toEpochMilli() - Instant.MIN.toEpochMilli());
   }
 
-  Duration testDurationBetweenOffsetDateTimes() {
+  Duration testDurationBetweenOffsetDateTime() {
     return Duration.between(OffsetDateTime.MIN.toInstant(), OffsetDateTime.MAX.toInstant())
         .plus(
             Duration.ofSeconds(
@@ -240,7 +240,7 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
         Duration.ofDays(1).equals(Duration.ZERO), Duration.ZERO.equals(Duration.ofDays(2)));
   }
 
-  ImmutableSet<Period> testZeroPeriod() {
+  ImmutableSet<Period> testPeriodZero() {
     return ImmutableSet.of(
         Period.ofDays(0),
         Period.ofWeeks(0),

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/TimeRulesTestOutput.java
@@ -28,7 +28,7 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return Clock.systemUTC().instant();
   }
 
-  ImmutableSet<ZoneId> testUtcConstant() {
+  ImmutableSet<ZoneId> testUtc() {
     return ImmutableSet.of(
         ZoneOffset.UTC,
         ZoneOffset.UTC,
@@ -83,11 +83,11 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
         Instant.EPOCH.plusMillis(13));
   }
 
-  Instant testInstantTruncatedToMilliseconds() {
+  Instant testInstantTruncatedToChronoUnitMillis() {
     return Instant.EPOCH.truncatedTo(ChronoUnit.MILLIS);
   }
 
-  Instant testInstantTruncatedToSeconds() {
+  Instant testInstantTruncatedToChronoUnitSeconds() {
     return Instant.EPOCH.truncatedTo(ChronoUnit.SECONDS);
   }
 
@@ -105,11 +105,11 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return Instant.EPOCH.atZone(ZoneOffset.UTC);
   }
 
-  Clock testUtcClock() {
+  Clock testClockSystemUTC() {
     return Clock.systemUTC();
   }
 
-  ImmutableSet<Instant> testEpochInstant() {
+  ImmutableSet<Instant> testInstantEpoch() {
     return ImmutableSet.of(Instant.EPOCH, Instant.EPOCH, Instant.EPOCH, Instant.EPOCH);
   }
 
@@ -164,19 +164,19 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
         !ZonedDateTime.now().isAfter(ZonedDateTime.now()));
   }
 
-  ImmutableSet<Boolean> testOffsetDateTimeIsAfter() {
-    return ImmutableSet.of(
-        OffsetDateTime.MIN.isAfter(OffsetDateTime.MAX),
-        !OffsetDateTime.MIN.isAfter(OffsetDateTime.MAX));
-  }
-
   ImmutableSet<Boolean> testOffsetDateTimeIsBefore() {
     return ImmutableSet.of(
         OffsetDateTime.MIN.isBefore(OffsetDateTime.MAX),
         !OffsetDateTime.MIN.isBefore(OffsetDateTime.MAX));
   }
 
-  ImmutableSet<Duration> testZeroDuration() {
+  ImmutableSet<Boolean> testOffsetDateTimeIsAfter() {
+    return ImmutableSet.of(
+        OffsetDateTime.MIN.isAfter(OffsetDateTime.MAX),
+        !OffsetDateTime.MIN.isAfter(OffsetDateTime.MAX));
+  }
+
+  ImmutableSet<Duration> testDurationZero() {
     return ImmutableSet.of(
         Duration.ZERO,
         Duration.ZERO,
@@ -212,11 +212,11 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return Duration.ofSeconds(1);
   }
 
-  Duration testDurationBetweenInstants() {
+  Duration testDurationBetweenInstant() {
     return Duration.between(Instant.MIN, Instant.MAX);
   }
 
-  Duration testDurationBetweenOffsetDateTimes() {
+  Duration testDurationBetweenOffsetDateTime() {
     return Duration.between(OffsetDateTime.MIN, OffsetDateTime.MAX)
         .plus(Duration.between(OffsetDateTime.MIN, OffsetDateTime.MAX));
   }
@@ -225,7 +225,7 @@ final class TimeRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(Duration.ofDays(1).isZero(), Duration.ofDays(2).isZero());
   }
 
-  ImmutableSet<Period> testZeroPeriod() {
+  ImmutableSet<Period> testPeriodZero() {
     return ImmutableSet.of(Period.ZERO, Period.ZERO, Period.ZERO, Period.ZERO, Period.ZERO);
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/WebClientRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/WebClientRulesTestInput.java
@@ -19,9 +19,9 @@ final class WebClientRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(fromValue(""), GET, HEAD, OPTIONS, PATCH, POST, PUT);
   }
 
-  ImmutableSet<?> testBodyValue() {
+  ImmutableSet<?> testRequestBodySpecBodyValue() {
     return ImmutableSet.of(
-        WebClient.create().post().body(fromValue("bar")),
+        WebClient.create().post().body(fromValue("foo")),
         WebTestClient.bindToServer().build().post().body(fromValue("bar")));
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/WebClientRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/WebClientRulesTestOutput.java
@@ -19,9 +19,9 @@ final class WebClientRulesTest implements RefasterRuleCollectionTestCase {
     return ImmutableSet.of(fromValue(""), GET, HEAD, OPTIONS, PATCH, POST, PUT);
   }
 
-  ImmutableSet<?> testBodyValue() {
+  ImmutableSet<?> testRequestBodySpecBodyValue() {
     return ImmutableSet.of(
-        WebClient.create().post().bodyValue("bar"),
+        WebClient.create().post().bodyValue("foo"),
         WebTestClient.bindToServer().build().post().bodyValue("bar"));
   }
 

--- a/refaster-runner/src/test/java/tech/picnic/errorprone/refaster/runner/FooRules.java
+++ b/refaster-runner/src/test/java/tech/picnic/errorprone/refaster/runner/FooRules.java
@@ -17,13 +17,13 @@ final class FooRules {
   /** A simple rule for testing purposes, lacking any custom annotations. */
   static final class StringOfSizeZeroRule {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.toCharArray().length == 0;
+    boolean before(String str) {
+      return str.toCharArray().length == 0;
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 
@@ -33,13 +33,13 @@ final class FooRules {
    */
   static final class StringOfSizeZeroVerboseRule {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.toCharArray().length == 0;
+    boolean before(String str) {
+      return str.toCharArray().length == 0;
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.length() + 1 == 1;
+    boolean after(String str) {
+      return str.length() + 1 == 1;
     }
   }
 
@@ -49,13 +49,13 @@ final class FooRules {
   @Severity(WARNING)
   static final class StringOfSizeOneRule {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.toCharArray().length == 1;
+    boolean before(String str) {
+      return str.toCharArray().length == 1;
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.length() == 1;
+    boolean after(String str) {
+      return str.length() == 1;
     }
   }
 
@@ -69,13 +69,13 @@ final class FooRules {
     /** A simple rule for testing purposes, inheriting custom annotations. */
     static final class StringOfSizeTwoRule {
       @BeforeTemplate
-      boolean before(String string) {
-        return string.toCharArray().length == 2;
+      boolean before(String str) {
+        return str.toCharArray().length == 2;
       }
 
       @AfterTemplate
-      boolean after(String string) {
-        return string.length() == 2;
+      boolean after(String str) {
+        return str.length() == 2;
       }
     }
 
@@ -85,13 +85,13 @@ final class FooRules {
     @Severity(SUGGESTION)
     static final class StringOfSizeThreeRule {
       @BeforeTemplate
-      boolean before(String string) {
-        return string.toCharArray().length == 3;
+      boolean before(String str) {
+        return str.toCharArray().length == 3;
       }
 
       @AfterTemplate
-      boolean after(String string) {
-        return string.length() == 3;
+      boolean after(String str) {
+        return str.length() == 3;
       }
     }
   }

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MatchInWrongMethodRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MatchInWrongMethodRules.java
@@ -9,13 +9,13 @@ final class MatchInWrongMethodRules {
 
   static final class StringIsEmpty {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("");
+    boolean before(String str) {
+      return str.equals("");
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 }

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MethodWithoutPrefixRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MethodWithoutPrefixRules.java
@@ -14,13 +14,13 @@ final class MethodWithoutPrefixRules {
 
   static final class StringIsEmpty {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("");
+    boolean before(String str) {
+      return str.equals("");
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 }

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MisnamedTestClassRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MisnamedTestClassRules.java
@@ -9,13 +9,13 @@ final class MisnamedTestClassRules {
 
   static final class StringIsEmpty {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("");
+    boolean before(String str) {
+      return str.equals("");
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 }

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MissingTestAndWrongTestRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/MissingTestAndWrongTestRules.java
@@ -11,20 +11,20 @@ final class MissingTestAndWrongTestRules {
 
   static final class StringIsEmpty {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("");
+    boolean before(String str) {
+      return str.equals("");
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 
   static final class RuleWithoutTest {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("foo");
+    boolean before(String str) {
+      return str.equals("foo");
     }
   }
 }

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/PartialTestMatchRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/PartialTestMatchRules.java
@@ -12,25 +12,25 @@ final class PartialTestMatchRules {
 
   static final class StringEquals {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.toCharArray().length == 0;
+    boolean before(String str) {
+      return str.toCharArray().length == 0;
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.equals("");
+    boolean after(String str) {
+      return str.equals("");
     }
   }
 
   static final class StringIsEmpty {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("");
+    boolean before(String str) {
+      return str.equals("");
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 }

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/RuleWithoutTestRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/RuleWithoutTestRules.java
@@ -9,27 +9,27 @@ final class RuleWithoutTestRules {
 
   static final class StringIsEmpty {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("");
+    boolean before(String str) {
+      return str.equals("");
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 
   static final class RuleWithoutTest {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("foo");
+    boolean before(String str) {
+      return str.equals("foo");
     }
   }
 
   static final class AnotherRuleWithoutTest {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.equals("bar");
+    boolean before(String str) {
+      return str.equals("bar");
     }
   }
 }

--- a/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/ValidRules.java
+++ b/refaster-test-support/src/test/java/tech/picnic/errorprone/refaster/test/ValidRules.java
@@ -16,13 +16,13 @@ final class ValidRules {
 
   static final class StringIsEmpty2 {
     @BeforeTemplate
-    boolean before(String string) {
-      return string.toCharArray().length == 0;
+    boolean before(String str) {
+      return str.toCharArray().length == 0;
     }
 
     @AfterTemplate
-    boolean after(String string) {
-      return string.isEmpty();
+    boolean after(String str) {
+      return str.isEmpty();
     }
   }
 
@@ -44,17 +44,17 @@ final class ValidRules {
     abstract void doAfterAdd(E element);
 
     @BeforeTemplate
-    void before(Set<E> set, E elem) {
-      if (!set.contains(elem)) {
-        set.add(elem);
-        doAfterAdd(elem);
+    void before(Set<E> set, E element) {
+      if (!set.contains(element)) {
+        set.add(element);
+        doAfterAdd(element);
       }
     }
 
     @AfterTemplate
-    void after(Set<E> set, E elem) {
-      if (set.add(elem)) {
-        doAfterAdd(elem);
+    void after(Set<E> set, E element) {
+      if (set.add(element)) {
+        doAfterAdd(element);
       }
     }
   }


### PR DESCRIPTION
Suggested commit message:
```
Unify Refaster rule definitions

This large changeset contains the result of several rounds of code
cleanup, aiming to improve consistency and clarify. These changes were
performed partially using Claude Code, and partially using unreleased
Error Prone bug checkers.

These changes should make it easier for LLMs to generate compliant code, 
"simply" by matching the approach taken by existing rules.

Summary of changes:
- Unify Javadoc rule description format.
- Unify rule naming, by deriving each rule's name from its
  `@AfterTemplate` code. 
- Apply a more unified template parameter naming scheme, by deriving
  names from the context in which parameters are used, and falling back to
  deriving their name from their type. 
- For each template method, declare its most specific denotable return
  type. This makes it easier to spot rules that introduce possible
  incompatibilities.
- Drop or rephrase some comments.
- Document some semantic changes applied by Refaster rules. (Much more
  to be done here.)
- Drop duplicated expressions from the `AssertThatIs{,Not}EqualTo`
  Refaster rules.
- Drop `@AlsoNegation` from `StreamFindAnyIsEmpty` and extend
  `StreamFindAnyIsPresent` instead.
- Improve some JUnit and TestNG migration rules by adding
  `@Matches(IsLambdaExpressionOrMethodReference.class)` guards.
- Partially clean up test logic by using dummy values more consistently,
  introducing positive and negative test cases for `@{,Not}Matches` and
  `@AlsoNegation` constraints, and ordering test expressions to match 
  template declaration order.
```