### PR TITLE
Fix suggested commit message workflow

### DIFF
--- a/.github/workflows/suggest-commit-message.yml
+++ b/.github/workflows/suggest-commit-message.yml
@@ -224,7 +224,7 @@ jobs:
           sandbox: danger-full-access
           openai-api-key: ${{ secrets.OPENAI_API_KEY }}
           prompt-file: /tmp/codex-prompt-suggest-commit-message.md
-          model: gpt-5.4-nano
+          model: gpt-5.4-mini
           output-schema: |
             {
               "type": "object",

--- a/.github/workflows/suggest-commit-message.yml
+++ b/.github/workflows/suggest-commit-message.yml
@@ -22,7 +22,9 @@ env:
     api.openai.com:443
     chatgpt.com:443
     github.com:443
+    objects.githubusercontent.com:443
     registry.npmjs.org:443
+    release-assets.githubusercontent.com:443
 jobs:
   suggest:
     # No commit message is suggested for code originating from forked

--- a/.github/workflows/suggest-commit-message.yml
+++ b/.github/workflows/suggest-commit-message.yml
@@ -22,7 +22,6 @@ env:
     api.openai.com:443
     chatgpt.com:443
     github.com:443
-    objects.githubusercontent.com:443
     registry.npmjs.org:443
     release-assets.githubusercontent.com:443
 jobs:


### PR DESCRIPTION
Suggested commit message:
```
Fix `suggest` workflow (#2256)

Two independent regressions broke the `suggest` and `StepSecurity
Harden-Runner` PR checks:

1. Harden-Runner blocked `actions/setup-node`'s Node 20 download from
   `release-assets.githubusercontent.com` and
   `objects.githubusercontent.com`; allowlist both, as other workflows
   in this repository already do.
2. `openai/codex@0.133.0` (bundled with `openai/codex-action@v1.8`)
   made `tool_search` non-optional, which `gpt-5.4-nano` does not
   support. Bump the model to `gpt-5.4-mini`.

See:
- https://github.com/openai/codex/pull/23389
- https://github.com/openai/codex-action/releases/tag/v1.8
```
