### PR TITLE
Add Refaster rule to rewrite Optional.of(x).orElse(y) to requireNonNull(x)

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -447,10 +447,13 @@ final class OptionalRules {
   }
 
   /**
-   * Prefer {@link java.util.Objects#requireNonNull(Object)} over less explicit alternatives.
+   * Prefer {@link java.util.Objects#requireNonNull(Object)} over an {@link
+   * java.util.Optional#orElse(Object)} call on an {@link java.util.Optional} that is known to be
+   * non-empty.
    *
-   * <p><strong>Warning:</strong> this rewrite is not behaviour-preserving if the fallback
-   * expression has side effects; such side effects will no longer be executed after the rewrite.
+   * <p><strong>Warning:</strong> This rewrite is not behaviour-preserving if the {@code fallback}
+   * expression has side effects: after the rewrite, such side effects will no longer be executed.
+   * In practice such code would be extremely fragile, so this is considered acceptable.
    */
   // XXX: Consider introducing a `BugChecker` that also handles the case where `Optional.of` is
   // used with a possibly-null value, offering two suggested fixes: rewrite to `requireNonNull`

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/OptionalRules.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.errorprone.refaster.ImportPolicy.STATIC_IMPORT_ALWAYS;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.Streams;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
@@ -442,6 +443,28 @@ final class OptionalRules {
     @AfterTemplate
     Optional<V> after(Optional<S> optional, Function<W, V> mapper) {
       return optional.map(mapper);
+    }
+  }
+
+  /**
+   * Prefer {@link java.util.Objects#requireNonNull(Object)} over less explicit alternatives.
+   *
+   * <p><strong>Warning:</strong> this rewrite is not behaviour-preserving if the fallback
+   * expression has side effects; such side effects will no longer be executed after the rewrite.
+   */
+  // XXX: Consider introducing a `BugChecker` that also handles the case where `Optional.of` is
+  // used with a possibly-null value, offering two suggested fixes: rewrite to `requireNonNull`
+  // (non-null case) or rewrite to `Optional.ofNullable` (nullable case).
+  static final class RequireNonNull<T> {
+    @BeforeTemplate
+    T before(T value, T fallback) {
+      return Optional.of(value).orElse(fallback);
+    }
+
+    @AfterTemplate
+    @UseImportPolicy(STATIC_IMPORT_ALWAYS)
+    T after(T value) {
+      return requireNonNull(value);
     }
   }
 

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestInput.java
@@ -142,6 +142,10 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
     return Optional.of(1).stream().map(String::valueOf).findAny();
   }
 
+  String testRequireNonNull() {
+    return Optional.of("foo").orElse("bar");
+  }
+
   Stream<String> testOptionalStream() {
     return Optional.of("foo").map(Stream::of).orElseGet(Stream::empty);
   }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/OptionalRulesTestOutput.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.refasterrules;
 
 import static com.google.common.collect.Streams.stream;
+import static java.util.Objects.requireNonNull;
 
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Streams;
@@ -138,6 +139,10 @@ final class OptionalRulesTest implements RefasterRuleCollectionTestCase {
 
   Optional<String> testOptionalMapWithFunction() {
     return Optional.of(1).map(String::valueOf);
+  }
+
+  String testRequireNonNull() {
+    return requireNonNull("foo");
   }
 
   Stream<String> testOptionalStream() {


### PR DESCRIPTION
Closes #436

Adds a new `RequireNonNull` Refaster rule to `OptionalRules.java` that rewrites `Optional.of(value).orElse(fallback)` to `requireNonNull(value)`. Since `Optional.of` throws `NullPointerException` if `value` is null, `fallback` can never be returned it is permanently dead code. This rewrite makes the non-null intent explicit.

Caveats are documented in the Javadoc and via XXX comment:
- The rewrite is not behaviour-preserving if `fallback` has side effects (documented via `Warning` paragraph in Javadoc).
- A follow-up `BugChecker` could handle the broader case where `Optional.of` is used with a possibly-null value, offering two suggested fixes: rewrite to `requireNonNull` or `Optional.ofNullable` (documented via XXX comment).

Files changed:
- `OptionalRules.java` - new `RequireNonNull` rule + import
- `OptionalRulesTestInput.java`-  before pattern
- `OptionalRulesTestOutput.java` - expected after pattern + import