### PR TITLE
Upgrade Error Prone 2.49.0 -> 2.50.0

### DIFF
--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListenerTest.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/DocumentationGeneratorTaskListenerTest.java
@@ -163,5 +163,5 @@ final class DocumentationGeneratorTaskListenerTest {
     }
   }
 
-  private record ExtractionParameters(String className, ImmutableList<String> path) {}
+  record ExtractionParameters(String className, ImmutableList<String> path) {}
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparison.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/PrimitiveComparison.java
@@ -42,6 +42,8 @@ import tech.picnic.errorprone.utils.SourceCode;
  */
 // XXX: Add more documentation. Explain how this is useful in the face of refactoring to more
 // specific types.
+// XXX: Document how this check differs from Error Prone's built-in `BoxingComparator` check, and
+// consider contributing it upstream.
 @AutoService(BugChecker.class)
 @BugPattern(
     summary =

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJObjectRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/AssertJObjectRules.java
@@ -117,6 +117,7 @@ final class AssertJObjectRules {
   /** Prefer {@link ObjectAssert#isSameAs(Object)} over more contrived alternatives. */
   static final class AssertThatIsSameAs<T> {
     @BeforeTemplate
+    @SuppressWarnings("ReferenceEquality" /* This violation will be rewritten. */)
     AbstractBooleanAssert<?> before(T actual, T expected) {
       return Refaster.anyOf(
           assertThat(actual == expected).isTrue(), assertThat(actual != expected).isFalse());
@@ -132,6 +133,7 @@ final class AssertJObjectRules {
   /** Prefer {@link ObjectAssert#isNotSameAs(Object)} over more contrived alternatives. */
   static final class AssertThatIsNotSameAs<T> {
     @BeforeTemplate
+    @SuppressWarnings("ReferenceEquality" /* This violation will be rewritten. */)
     AbstractBooleanAssert<?> before(T actual, T other) {
       return Refaster.anyOf(
           assertThat(actual == other).isFalse(), assertThat(actual != other).isTrue());

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/ComparatorRules.java
@@ -54,7 +54,10 @@ final class ComparatorRules {
   static final class NaturalOrder<T extends Comparable<? super T>, U extends T> {
     // XXX: Ideally `? super T` would also be replaced by a class-level type parameter, but Java
     // does not allow a type variable to be followed by other bounds.
+    // XXX: Drop the `TypeParameterQualifier` suppression if
+    // https://github.com/google/error-prone/pull/5884 is merged and released.
     @BeforeTemplate
+    @SuppressWarnings("TypeParameterQualifier" /* We aim to match `T::compareTo` for any `T`. */)
     Comparator<T> before(
         @Matches(IsIdentityOperation.class) Function<? super T, U> identityKeyExtractor) {
       return Refaster.anyOf(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/EqualityRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/EqualityRules.java
@@ -110,6 +110,7 @@ final class EqualityRules {
     }
 
     @BeforeTemplate
+    @SuppressWarnings("ReferenceEquality" /* This violation will be rewritten. */)
     boolean before(Object b1, Object b2) {
       return !(b1 == b2);
     }
@@ -138,6 +139,7 @@ final class EqualityRules {
     }
 
     @BeforeTemplate
+    @SuppressWarnings("ReferenceEquality" /* This violation will be rewritten. */)
     boolean before(Object b1, Object b2) {
       return !(b1 != b2);
     }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/StreamRules.java
@@ -350,7 +350,10 @@ final class StreamRules {
   // (Perhaps we could add a `@Matches` guard that validates that the collector expression does not
   // contain a `Collectors#filtering` call. That'd still not be 100% accurate, though.)
   static final class StreamFindAnyIsEmpty<T, K, V, C extends Collection<K>, M extends Map<K, V>> {
+    // XXX: Drop the `TypeParameterQualifier` suppression if
+    // https://github.com/google/error-prone/pull/5884 is merged and released.
     @BeforeTemplate
+    @SuppressWarnings("TypeParameterQualifier" /* We aim to match `C::isEmpty` for any `C`. */)
     Boolean before(Stream<T> stream, Collector<? super T, ?, ? extends C> downstream) {
       return Refaster.anyOf(
           stream.count() == 0,
@@ -361,7 +364,10 @@ final class StreamRules {
           stream.collect(collectingAndThen(downstream, C::isEmpty)));
     }
 
+    // XXX: Drop the `TypeParameterQualifier` suppression if
+    // https://github.com/google/error-prone/pull/5884 is merged and released.
     @BeforeTemplate
+    @SuppressWarnings("TypeParameterQualifier" /* We aim to match `M::isEmpty` for any `M`. */)
     Boolean before2(Stream<T> stream, Collector<? super T, ?, ? extends M> downstream) {
       return stream.collect(collectingAndThen(downstream, M::isEmpty));
     }

--- a/pom.xml
+++ b/pom.xml
@@ -2010,11 +2010,11 @@
                                     -XepOpt:RedundantNullCheck:CheckRequireNonNull=true
                                     -XepOpt:RefactorSwitch:EnableAssignmentSwitch=true
                                     -XepOpt:RefactorSwitch:EnableSimplifySwitch=true
-                                    <!-- Refaster `@BeforeTemplate` methods
-                                    legitimately use type-parameter-qualified
-                                    method references such as `T::compareTo` to
-                                    match user code; this (unsuppressible) check
-                                    must not flag them. -->
+                                    <!-- XXX: Enable once
+                                    https://github.com/google/error-prone/pull/5883
+                                    or
+                                    https://github.com/google/error-prone/pull/5884
+                                    is merged and released. -->
                                     -XepOpt:TypeParameterQualifier:MatchMethodReferences=false
                                     -XepOpt:UnnamedVariable:OnlyRenameVariablesNamedUnused=false
                                     <!-- Append additional custom arguments. -->

--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
         <version.auto-service>1.1.1</version.auto-service>
         <version.error-prone>${version.error-prone-orig}</version.error-prone>
         <version.error-prone-fork>${version.error-prone-orig}-picnic-1</version.error-prone-fork>
-        <version.error-prone-orig>2.49.0</version.error-prone-orig>
+        <version.error-prone-orig>2.50.0</version.error-prone-orig>
         <version.jdk>21</version.jdk>
         <version.maven>3.9.14</version.maven>
         <version.pitest-git>2.3.2</version.pitest-git>
@@ -2009,8 +2009,13 @@
                                     -XepOpt:Nullness:Conservative=false
                                     -XepOpt:RedundantNullCheck:CheckRequireNonNull=true
                                     -XepOpt:RefactorSwitch:EnableAssignmentSwitch=true
-                                    -XepOpt:RefactorSwitch:EnableReturnSwitch=true
                                     -XepOpt:RefactorSwitch:EnableSimplifySwitch=true
+                                    <!-- Refaster `@BeforeTemplate` methods
+                                    legitimately use type-parameter-qualified
+                                    method references such as `T::compareTo` to
+                                    match user code; this (unsuppressible) check
+                                    must not flag them. -->
+                                    -XepOpt:TypeParameterQualifier:MatchMethodReferences=false
                                     -XepOpt:UnnamedVariable:OnlyRenameVariablesNamedUnused=false
                                     <!-- Append additional custom arguments. -->
                                     ${error-prone.patch-args}


### PR DESCRIPTION
Suggested commit message:
```
Upgrade Error Prone 2.49.0 -> 2.50.0 (#2274)

Resolves #2273.

See:
- https://github.com/google/error-prone/releases/tag/v2.50.0
- https://github.com/google/error-prone/compare/v2.49.0...v2.50.0
- https://github.com/PicnicSupermarket/error-prone/compare/v2.49.0-picnic-1...v2.50.0-picnic-1
```
