### PR TITLE
Introduce `Files{Lines,NewBufferedWriter,ReadAllLines,Write,WriteString}` Refaster rules

### DIFF
--- a/documentation-support/src/test/java/tech/picnic/errorprone/documentation/JsonTest.java
+++ b/documentation-support/src/test/java/tech/picnic/errorprone/documentation/JsonTest.java
@@ -26,7 +26,7 @@ final class JsonTest {
   void read(@TempDir Path directory) throws IOException {
     Path file = directory.resolve("test.json");
 
-    Files.writeString(file, TEST_JSON, UTF_8);
+    Files.writeString(file, TEST_JSON);
 
     assertThat(Json.read(file, TestObject.class)).isEqualTo(TEST_OBJECT);
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/refasterrules/FileRules.java
@@ -8,6 +8,7 @@ import com.google.errorprone.refaster.annotation.AlsoNegation;
 import com.google.errorprone.refaster.annotation.BeforeTemplate;
 import com.google.errorprone.refaster.annotation.Repeated;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
@@ -24,6 +25,8 @@ import java.nio.file.OpenOption;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.nio.file.attribute.FileAttribute;
+import java.util.List;
+import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.annotation.OnlineDocumentation;
 
 /** Refaster rules related to expressions dealing with files. */
@@ -136,6 +139,67 @@ final class FileRules {
     @AfterTemplate
     String after(Path path) throws IOException {
       return Files.readString(path);
+    }
+  }
+
+  /** Prefer {@link Files#readAllLines(Path)} over more verbose alternatives. */
+  static final class FilesReadAllLines {
+    @BeforeTemplate
+    List<String> before(Path path) throws IOException {
+      return Files.readAllLines(path, UTF_8);
+    }
+
+    @AfterTemplate
+    List<String> after(Path path) throws IOException {
+      return Files.readAllLines(path);
+    }
+  }
+
+  /** Prefer {@link Files#lines(Path)} over more verbose alternatives. */
+  static final class FilesLines {
+    @BeforeTemplate
+    @SuppressWarnings(
+        "StreamResourceLeak" /* Matched expressions are in practice embedded in a larger context. */)
+    Stream<String> before(Path path) throws IOException {
+      return Files.lines(path, UTF_8);
+    }
+
+    @AfterTemplate
+    @SuppressWarnings(
+        "StreamResourceLeak" /* Matched expressions are in practice embedded in a larger context. */)
+    Stream<String> after(Path path) throws IOException {
+      return Files.lines(path);
+    }
+  }
+
+  /**
+   * Prefer {@link Files#writeString(Path, CharSequence, OpenOption...)} over more verbose
+   * alternatives.
+   */
+  static final class FilesWriteString {
+    @BeforeTemplate
+    Path before(Path path, CharSequence charSequence, @Repeated OpenOption options)
+        throws IOException {
+      return Files.writeString(path, charSequence, UTF_8, Refaster.asVarargs(options));
+    }
+
+    @AfterTemplate
+    Path after(Path path, CharSequence charSequence, @Repeated OpenOption options)
+        throws IOException {
+      return Files.writeString(path, charSequence, Refaster.asVarargs(options));
+    }
+  }
+
+  /** Prefer {@link Files#write(Path, Iterable, OpenOption...)} over more verbose alternatives. */
+  static final class FilesWrite<T extends CharSequence> {
+    @BeforeTemplate
+    Path before(Path path, Iterable<T> lines, @Repeated OpenOption options) throws IOException {
+      return Files.write(path, lines, UTF_8, Refaster.asVarargs(options));
+    }
+
+    @AfterTemplate
+    Path after(Path path, Iterable<T> lines, @Repeated OpenOption options) throws IOException {
+      return Files.write(path, lines, Refaster.asVarargs(options));
     }
   }
 
@@ -325,6 +389,19 @@ final class FileRules {
     @AfterTemplate
     BufferedReader after(Path path, Charset cs) throws IOException {
       return Files.newBufferedReader(path, cs);
+    }
+  }
+
+  /** Prefer {@link Files#newBufferedWriter(Path, OpenOption...)} over more verbose alternatives. */
+  static final class FilesNewBufferedWriter {
+    @BeforeTemplate
+    BufferedWriter before(Path path, @Repeated OpenOption options) throws IOException {
+      return Files.newBufferedWriter(path, UTF_8, Refaster.asVarargs(options));
+    }
+
+    @AfterTemplate
+    BufferedWriter after(Path path, @Repeated OpenOption options) throws IOException {
+      return Files.newBufferedWriter(path, Refaster.asVarargs(options));
     }
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
@@ -1,7 +1,9 @@
 package tech.picnic.errorprone.refasterrules;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -14,6 +16,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class FileRulesTest implements RefasterRuleCollectionTestCase {
@@ -48,6 +53,24 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
 
   String testFilesReadString() throws IOException {
     return Files.readString(Paths.get("foo"), StandardCharsets.UTF_8);
+  }
+
+  List<String> testFilesReadAllLines() throws IOException {
+    return Files.readAllLines(Path.of("foo"), StandardCharsets.UTF_8);
+  }
+
+  Stream<String> testFilesLines() throws IOException {
+    return Files.lines(Path.of("foo"), StandardCharsets.UTF_8);
+  }
+
+  Path testFilesWriteString() throws IOException {
+    return Files.writeString(
+        Path.of("foo"), "bar", StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+  }
+
+  Path testFilesWrite() throws IOException {
+    return Files.write(
+        Path.of("foo"), ImmutableList.of("bar"), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
   }
 
   ImmutableSet<File> testFilesCreateTempFileToFile() throws IOException {
@@ -96,5 +119,10 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
   BufferedReader testFilesNewBufferedReaderWithCharset() throws IOException {
     return new BufferedReader(
         new InputStreamReader(Files.newInputStream(Path.of("foo")), StandardCharsets.UTF_8));
+  }
+
+  BufferedWriter testFilesNewBufferedWriter() throws IOException {
+    return Files.newBufferedWriter(
+        Path.of("foo"), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestInput.java
@@ -63,14 +63,21 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return Files.lines(Path.of("foo"), StandardCharsets.UTF_8);
   }
 
-  Path testFilesWriteString() throws IOException {
-    return Files.writeString(
-        Path.of("foo"), "bar", StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+  ImmutableSet<Path> testFilesWriteString() throws IOException {
+    return ImmutableSet.of(
+        Files.writeString(Path.of("foo"), "bar", StandardCharsets.UTF_8),
+        Files.writeString(
+            Path.of("baz"), "qux", StandardCharsets.UTF_8, StandardOpenOption.CREATE));
   }
 
-  Path testFilesWrite() throws IOException {
-    return Files.write(
-        Path.of("foo"), ImmutableList.of("bar"), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+  ImmutableSet<Path> testFilesWrite() throws IOException {
+    return ImmutableSet.of(
+        Files.write(Path.of("foo"), ImmutableList.of("bar"), StandardCharsets.UTF_8),
+        Files.write(
+            Path.of("baz"),
+            ImmutableList.of("qux"),
+            StandardCharsets.UTF_8,
+            StandardOpenOption.CREATE));
   }
 
   ImmutableSet<File> testFilesCreateTempFileToFile() throws IOException {
@@ -121,8 +128,9 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
         new InputStreamReader(Files.newInputStream(Path.of("foo")), StandardCharsets.UTF_8));
   }
 
-  BufferedWriter testFilesNewBufferedWriter() throws IOException {
-    return Files.newBufferedWriter(
-        Path.of("foo"), StandardCharsets.UTF_8, StandardOpenOption.CREATE);
+  ImmutableSet<BufferedWriter> testFilesNewBufferedWriter() throws IOException {
+    return ImmutableSet.of(
+        Files.newBufferedWriter(Path.of("foo"), StandardCharsets.UTF_8),
+        Files.newBufferedWriter(Path.of("bar"), StandardCharsets.UTF_8, StandardOpenOption.CREATE));
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
@@ -1,7 +1,9 @@
 package tech.picnic.errorprone.refasterrules;
 
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.io.BufferedReader;
+import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -14,6 +16,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.nio.file.StandardOpenOption;
+import java.util.List;
+import java.util.stream.Stream;
 import tech.picnic.errorprone.refaster.test.RefasterRuleCollectionTestCase;
 
 final class FileRulesTest implements RefasterRuleCollectionTestCase {
@@ -48,6 +53,22 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
 
   String testFilesReadString() throws IOException {
     return Files.readString(Paths.get("foo"));
+  }
+
+  List<String> testFilesReadAllLines() throws IOException {
+    return Files.readAllLines(Path.of("foo"));
+  }
+
+  Stream<String> testFilesLines() throws IOException {
+    return Files.lines(Path.of("foo"));
+  }
+
+  Path testFilesWriteString() throws IOException {
+    return Files.writeString(Path.of("foo"), "bar", StandardOpenOption.CREATE);
+  }
+
+  Path testFilesWrite() throws IOException {
+    return Files.write(Path.of("foo"), ImmutableList.of("bar"), StandardOpenOption.CREATE);
   }
 
   ImmutableSet<File> testFilesCreateTempFileToFile() throws IOException {
@@ -94,5 +115,9 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
 
   BufferedReader testFilesNewBufferedReaderWithCharset() throws IOException {
     return Files.newBufferedReader(Path.of("foo"), StandardCharsets.UTF_8);
+  }
+
+  BufferedWriter testFilesNewBufferedWriter() throws IOException {
+    return Files.newBufferedWriter(Path.of("foo"), StandardOpenOption.CREATE);
   }
 }

--- a/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
+++ b/error-prone-contrib/src/test/resources/tech/picnic/errorprone/refasterrules/FileRulesTestOutput.java
@@ -63,12 +63,16 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return Files.lines(Path.of("foo"));
   }
 
-  Path testFilesWriteString() throws IOException {
-    return Files.writeString(Path.of("foo"), "bar", StandardOpenOption.CREATE);
+  ImmutableSet<Path> testFilesWriteString() throws IOException {
+    return ImmutableSet.of(
+        Files.writeString(Path.of("foo"), "bar"),
+        Files.writeString(Path.of("baz"), "qux", StandardOpenOption.CREATE));
   }
 
-  Path testFilesWrite() throws IOException {
-    return Files.write(Path.of("foo"), ImmutableList.of("bar"), StandardOpenOption.CREATE);
+  ImmutableSet<Path> testFilesWrite() throws IOException {
+    return ImmutableSet.of(
+        Files.write(Path.of("foo"), ImmutableList.of("bar")),
+        Files.write(Path.of("baz"), ImmutableList.of("qux"), StandardOpenOption.CREATE));
   }
 
   ImmutableSet<File> testFilesCreateTempFileToFile() throws IOException {
@@ -117,7 +121,9 @@ final class FileRulesTest implements RefasterRuleCollectionTestCase {
     return Files.newBufferedReader(Path.of("foo"), StandardCharsets.UTF_8);
   }
 
-  BufferedWriter testFilesNewBufferedWriter() throws IOException {
-    return Files.newBufferedWriter(Path.of("foo"), StandardOpenOption.CREATE);
+  ImmutableSet<BufferedWriter> testFilesNewBufferedWriter() throws IOException {
+    return ImmutableSet.of(
+        Files.newBufferedWriter(Path.of("foo")),
+        Files.newBufferedWriter(Path.of("bar"), StandardOpenOption.CREATE));
   }
 }


### PR DESCRIPTION
Suggested commit message:
```
Introduce `Files{Lines,NewBufferedWriter,ReadAllLines,Write,WriteString}` Refaster rules (#2279)
```

These mirror the existing read-side `Files{ReadString,NewBufferedReader}` rules by dropping a redundant explicit `StandardCharsets.UTF_8` argument, since each `java.nio.file.Files` method has a no-charset overload that already defaults to UTF-8. The rules match only `UTF_8` (leaving other charsets such as `ISO_8859_1` untouched) and preserve trailing `OpenOption...` varargs via `@Repeated`. One existing UTF-8 `Files.writeString` usage in `JsonTest` is simplified as a consequence.
