### PR TITLE
Support custom `StaticImport` candidates

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -6,10 +6,6 @@ import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static tech.picnic.errorprone.utils.Documentation.BUG_PATTERNS_BASE_URL;
 
 import com.google.auto.service.AutoService;
-import com.google.common.base.Predicates;
-import com.google.common.base.Strings;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableTable;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
@@ -27,13 +23,6 @@ import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.Tree;
 import com.sun.source.util.TreeScanner;
 import com.sun.tools.javac.code.Symbol;
-import java.time.Clock;
-import java.time.InstantSource;
-import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.Locale;
-import java.util.Optional;
-import java.util.regex.Pattern;
 import javax.inject.Inject;
 import org.jspecify.annotations.Nullable;
 import tech.picnic.errorprone.utils.SourceCode;
@@ -42,8 +31,8 @@ import tech.picnic.errorprone.utils.SourceCode;
  * A {@link BugChecker} that flags static imports of type members that should *not* be statically
  * imported.
  *
- * <p>This check honors the {@code StaticImport:CandidateMembers} flag documented by {@link
- * StaticImport}: members thus specified are not flagged.
+ * <p>See {@link StaticImportConfig} for how additional candidates can be configured, and how this
+ * check interacts with {@link StaticImport}.
  */
 // XXX: This check is closely linked to `StaticImport`. Consider merging the two.
 // XXX: Add suppression support. If qualification of one more more identifiers is suppressed, then
@@ -59,114 +48,26 @@ import tech.picnic.errorprone.utils.SourceCode;
     tags = STYLE)
 @SuppressWarnings({
   "java:S2160" /* Super class equality definition suffices. */,
-  "javaarchitecture:S7027" /* `StaticImport` and `NonStaticImport` ensure mutual exclusivity. */,
   "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
 })
 public final class NonStaticImport extends BugChecker implements CompilationUnitTreeMatcher {
   private static final long serialVersionUID = 1L;
 
-  /**
-   * Types whose members should not be statically imported, unless exempted by {@link
-   * StaticImport#STATIC_IMPORT_CANDIDATE_MEMBERS}.
-   *
-   * <p>Types listed here should be mutually exclusive with {@link
-   * StaticImport#STATIC_IMPORT_CANDIDATE_TYPES}.
-   */
-  static final ImmutableSet<String> NON_STATIC_IMPORT_CANDIDATE_TYPES =
-      ImmutableSet.of(
-          ASTHelpers.class.getCanonicalName(),
-          Clock.class.getCanonicalName(),
-          InstantSource.class.getCanonicalName(),
-          Strings.class.getCanonicalName(),
-          VisitorState.class.getCanonicalName(),
-          ZoneOffset.class.getCanonicalName(),
-          "com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode",
-          "reactor.core.publisher.Flux",
-          "reactor.core.publisher.Mono");
-
-  /**
-   * Type members that should never be statically imported.
-   *
-   * <p>Please note that:
-   *
-   * <ul>
-   *   <li>Types listed by {@link #NON_STATIC_IMPORT_CANDIDATE_TYPES} and members listed by {@link
-   *       #NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS} should be omitted from this collection.
-   *   <li>This collection should be mutually exclusive with {@link
-   *       StaticImport#STATIC_IMPORT_CANDIDATE_MEMBERS}.
-   * </ul>
-   */
-  // XXX: Perhaps the set of exempted `java.util.Collections` methods is too strict. For now any
-  // method name that could be considered "too vague" or could conceivably mean something else in a
-  // specific context is left out.
-  static final ImmutableSetMultimap<String, String> NON_STATIC_IMPORT_CANDIDATE_MEMBERS =
-      ImmutableSetMultimap.<String, String>builder()
-          .putAll(
-              Collections.class.getCanonicalName(),
-              "addAll",
-              "copy",
-              "fill",
-              "list",
-              "max",
-              "min",
-              "nCopies",
-              "rotate",
-              "sort",
-              "swap")
-          .put(Locale.class.getCanonicalName(), "ROOT")
-          .put(Optional.class.getCanonicalName(), "empty")
-          .putAll(Pattern.class.getCanonicalName(), "compile", "matches", "quote")
-          .put(Predicates.class.getCanonicalName(), "contains")
-          .put("org.springframework.http.MediaType", "ALL")
-          .build();
-
-  /**
-   * Identifiers that should never be statically imported.
-   *
-   * <p>Please note that:
-   *
-   * <ul>
-   *   <li>Identifiers listed by {@link StaticImport#STATIC_IMPORT_CANDIDATE_MEMBERS} should be
-   *       mutually exclusive with identifiers listed here.
-   *   <li>This list should contain a superset of the identifiers flagged by {@link
-   *       com.google.errorprone.bugpatterns.BadImport}.
-   * </ul>
-   */
-  static final ImmutableSet<String> NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS =
-      ImmutableSet.of(
-          "builder",
-          "copyOf",
-          "create",
-          "EPOCH",
-          "from",
-          "getDefaultInstance",
-          "INSTANCE",
-          "MAX",
-          "MAX_VALUE",
-          "MIN",
-          "MIN_VALUE",
-          "newBuilder",
-          "newInstance",
-          "of",
-          "parse",
-          "valueOf",
-          "values");
-
-  private final ImmutableSetMultimap<String, String> staticImportCandidateMembers;
+  private final StaticImportConfig config;
 
   /** Instantiates a default {@link NonStaticImport} instance. */
   public NonStaticImport() {
-    this(ErrorProneFlags.empty());
+    this(new StaticImportConfig(ErrorProneFlags.empty()));
   }
 
   /**
    * Instantiates a customized {@link NonStaticImport}.
    *
-   * @param flags Any provided command line flags.
+   * @param config The candidate-matching configuration to apply.
    */
   @Inject
-  NonStaticImport(ErrorProneFlags flags) {
-    staticImportCandidateMembers = StaticImport.getCandidateMembers(flags);
+  NonStaticImport(StaticImportConfig config) {
+    this.config = config;
   }
 
   @Override
@@ -196,7 +97,7 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
       if (importTree.isStatic() && qualifiedIdentifier instanceof MemberSelectTree memberSelect) {
         String type = SourceCode.treeToString(memberSelect.getExpression(), state);
         String member = memberSelect.getIdentifier().toString();
-        if (shouldNotBeStaticallyImported(type, member)) {
+        if (config.shouldNotBeStaticallyImported(type, member)) {
           imports.put(
               type,
               member,
@@ -207,13 +108,6 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
     }
 
     return imports.buildOrThrow();
-  }
-
-  private boolean shouldNotBeStaticallyImported(String type, String member) {
-    return (NON_STATIC_IMPORT_CANDIDATE_TYPES.contains(type)
-            && !staticImportCandidateMembers.containsEntry(type, member))
-        || NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type, member)
-        || NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(member);
   }
 
   private static void replaceUndesiredStaticImportUsages(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/NonStaticImport.java
@@ -3,17 +3,16 @@ package tech.picnic.errorprone.bugpatterns;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
-import static tech.picnic.errorprone.bugpatterns.StaticImport.STATIC_IMPORT_CANDIDATE_MEMBERS;
 import static tech.picnic.errorprone.utils.Documentation.BUG_PATTERNS_BASE_URL;
 
 import com.google.auto.service.AutoService;
-import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Predicates;
 import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableSetMultimap;
 import com.google.common.collect.ImmutableTable;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.CompilationUnitTreeMatcher;
@@ -35,12 +34,16 @@ import java.util.Collections;
 import java.util.Locale;
 import java.util.Optional;
 import java.util.regex.Pattern;
+import javax.inject.Inject;
 import org.jspecify.annotations.Nullable;
 import tech.picnic.errorprone.utils.SourceCode;
 
 /**
  * A {@link BugChecker} that flags static imports of type members that should *not* be statically
  * imported.
+ *
+ * <p>This check honors the {@code StaticImport:CandidateMembers} flag documented by {@link
+ * StaticImport}: members thus specified are not flagged.
  */
 // XXX: This check is closely linked to `StaticImport`. Consider merging the two.
 // XXX: Add suppression support. If qualification of one more more identifiers is suppressed, then
@@ -54,8 +57,11 @@ import tech.picnic.errorprone.utils.SourceCode;
     linkType = CUSTOM,
     severity = SUGGESTION,
     tags = STYLE)
-@SuppressWarnings(
-    "javaarchitecture:S7027" /* `StaticImport` and `NonStaticImport` ensure mutual exclusivity. */)
+@SuppressWarnings({
+  "java:S2160" /* Super class equality definition suffices. */,
+  "javaarchitecture:S7027" /* `StaticImport` and `NonStaticImport` ensure mutual exclusivity. */,
+  "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
+})
 public final class NonStaticImport extends BugChecker implements CompilationUnitTreeMatcher {
   private static final long serialVersionUID = 1L;
 
@@ -66,7 +72,6 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
    * <p>Types listed here should be mutually exclusive with {@link
    * StaticImport#STATIC_IMPORT_CANDIDATE_TYPES}.
    */
-  @VisibleForTesting
   static final ImmutableSet<String> NON_STATIC_IMPORT_CANDIDATE_TYPES =
       ImmutableSet.of(
           ASTHelpers.class.getCanonicalName(),
@@ -147,8 +152,22 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
           "valueOf",
           "values");
 
-  /** Instantiates a new {@link NonStaticImport} instance. */
-  public NonStaticImport() {}
+  private final ImmutableSetMultimap<String, String> staticImportCandidateMembers;
+
+  /** Instantiates a default {@link NonStaticImport} instance. */
+  public NonStaticImport() {
+    this(ErrorProneFlags.empty());
+  }
+
+  /**
+   * Instantiates a customized {@link NonStaticImport}.
+   *
+   * @param flags Any provided command line flags.
+   */
+  @Inject
+  NonStaticImport(ErrorProneFlags flags) {
+    staticImportCandidateMembers = StaticImport.getCandidateMembers(flags);
+  }
 
   @Override
   public Description matchCompilationUnit(CompilationUnitTree tree, VisitorState state) {
@@ -168,7 +187,7 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
     return Description.NO_MATCH;
   }
 
-  private static ImmutableTable<String, String, UndesiredStaticImport> getUndesiredStaticImports(
+  private ImmutableTable<String, String, UndesiredStaticImport> getUndesiredStaticImports(
       CompilationUnitTree tree, VisitorState state) {
     ImmutableTable.Builder<String, String, UndesiredStaticImport> imports =
         ImmutableTable.builder();
@@ -190,9 +209,9 @@ public final class NonStaticImport extends BugChecker implements CompilationUnit
     return imports.buildOrThrow();
   }
 
-  private static boolean shouldNotBeStaticallyImported(String type, String member) {
+  private boolean shouldNotBeStaticallyImported(String type, String member) {
     return (NON_STATIC_IMPORT_CANDIDATE_TYPES.contains(type)
-            && !STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type, member))
+            && !staticImportCandidateMembers.containsEntry(type, member))
         || NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type, member)
         || NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(member);
   }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -258,6 +258,17 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
         .orElse(Description.NO_MATCH);
   }
 
+  private Optional<String> getCandidateSimpleName(StaticImportInfo importInfo) {
+    String canonicalName = importInfo.canonicalName();
+    return importInfo
+        .simpleName()
+        .toJavaUtil()
+        .filter(
+            name ->
+                candidateTypes.contains(canonicalName)
+                    || candidateMembers.containsEntry(canonicalName, name));
+  }
+
   private static boolean isCandidateContext(VisitorState state) {
     Tree parentTree =
         requireNonNull(state.getPath().getParentPath(), "MemberSelectTree lacks enclosing node")
@@ -277,17 +288,6 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
     Type type = ASTHelpers.getType(tree.getExpression());
     return type != null
         && !NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type.toString(), identifier);
-  }
-
-  private Optional<String> getCandidateSimpleName(StaticImportInfo importInfo) {
-    String canonicalName = importInfo.canonicalName();
-    return importInfo
-        .simpleName()
-        .toJavaUtil()
-        .filter(
-            name ->
-                candidateTypes.contains(canonicalName)
-                    || candidateMembers.containsEntry(canonicalName, name));
   }
 
   private static Optional<Fix> tryStaticImport(

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -1,18 +1,22 @@
 package tech.picnic.errorprone.bugpatterns;
 
+import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static java.util.Objects.requireNonNull;
 import static tech.picnic.errorprone.bugpatterns.NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS;
 import static tech.picnic.errorprone.bugpatterns.NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_MEMBERS;
+import static tech.picnic.errorprone.bugpatterns.NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_TYPES;
 import static tech.picnic.errorprone.utils.Documentation.BUG_PATTERNS_BASE_URL;
 
 import com.google.auto.service.AutoService;
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
 import com.google.common.base.Functions;
 import com.google.common.base.Preconditions;
 import com.google.common.base.Predicates;
+import com.google.common.base.Splitter;
 import com.google.common.base.Verify;
 import com.google.common.collect.Comparators;
 import com.google.common.collect.ImmutableList;
@@ -29,6 +33,7 @@ import com.google.common.collect.ImmutableTable;
 import com.google.common.collect.MoreCollectors;
 import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
+import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
 import com.google.errorprone.bugpatterns.BugChecker;
 import com.google.errorprone.bugpatterns.BugChecker.MemberSelectTreeMatcher;
@@ -51,6 +56,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.ZoneOffset;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -59,8 +65,18 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
+import javax.inject.Inject;
+import tech.picnic.errorprone.utils.Flags;
 
-/** A {@link BugChecker} that flags type members that can and should be statically imported. */
+/**
+ * A {@link BugChecker} that flags type members that can and should be statically imported.
+ *
+ * <p>Additional candidate types and type members can be specified using the {@code
+ * StaticImport:CandidateTypes} and {@code StaticImport:CandidateMembers} flags, respectively.
+ * Candidate members must be specified in {@code <type>#<member>} format. The latter flag is also
+ * honored by the {@link NonStaticImport} check, such that it does not undo the static imports
+ * introduced by this check.
+ */
 // XXX: This check is closely linked to `NonStaticImport`. Consider merging the two.
 // XXX: Tricky cases:
 // - `org.springframework.http.HttpStatus` (not always an improvement, and `valueOf` must
@@ -74,8 +90,11 @@ import java.util.stream.Collectors;
     linkType = CUSTOM,
     severity = SUGGESTION,
     tags = STYLE)
-@SuppressWarnings(
-    "javaarchitecture:S7027" /* `StaticImport` and `NonStaticImport` ensure mutual exclusivity. */)
+@SuppressWarnings({
+  "java:S2160" /* Super class equality definition suffices. */,
+  "javaarchitecture:S7027" /* `StaticImport` and `NonStaticImport` ensure mutual exclusivity. */,
+  "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
+})
 public final class StaticImport extends BugChecker implements MemberSelectTreeMatcher {
   private static final long serialVersionUID = 1L;
 
@@ -190,8 +209,37 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
           .putAll("org.junit.jupiter.params.provider.Arguments", "argumentSet", "arguments")
           .build();
 
-  /** Instantiates a new {@link StaticImport} instance. */
-  public StaticImport() {}
+  /**
+   * Flag using which additional types whose members should be statically imported (in addition to
+   * those defined by {@link #STATIC_IMPORT_CANDIDATE_TYPES}) can be specified.
+   */
+  private static final String CANDIDATE_TYPES_FLAG = "StaticImport:CandidateTypes";
+
+  /**
+   * Flag using which additional type members that should be statically imported (in addition to
+   * those defined by {@link #STATIC_IMPORT_CANDIDATE_MEMBERS}) can be specified, in {@code
+   * <type>#<member>} format.
+   */
+  private static final String CANDIDATE_MEMBERS_FLAG = "StaticImport:CandidateMembers";
+
+  private final ImmutableSet<String> candidateTypes;
+  private final ImmutableSetMultimap<String, String> candidateMembers;
+
+  /** Instantiates a default {@link StaticImport} instance. */
+  public StaticImport() {
+    this(ErrorProneFlags.empty());
+  }
+
+  /**
+   * Instantiates a customized {@link StaticImport}.
+   *
+   * @param flags Any provided command line flags.
+   */
+  @Inject
+  StaticImport(ErrorProneFlags flags) {
+    candidateTypes = getCandidateTypes(flags);
+    candidateMembers = getCandidateMembers(flags);
+  }
 
   @Override
   public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
@@ -231,15 +279,15 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
         && !NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type.toString(), identifier);
   }
 
-  private static Optional<String> getCandidateSimpleName(StaticImportInfo importInfo) {
+  private Optional<String> getCandidateSimpleName(StaticImportInfo importInfo) {
     String canonicalName = importInfo.canonicalName();
     return importInfo
         .simpleName()
         .toJavaUtil()
         .filter(
             name ->
-                STATIC_IMPORT_CANDIDATE_TYPES.contains(canonicalName)
-                    || STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(canonicalName, name));
+                candidateTypes.contains(canonicalName)
+                    || candidateMembers.containsEntry(canonicalName, name));
   }
 
   private static Optional<Fix> tryStaticImport(
@@ -252,5 +300,63 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
     }
 
     return Optional.of(fix.build());
+  }
+
+  private static ImmutableSet<String> getCandidateTypes(ErrorProneFlags flags) {
+    ImmutableSet<String> additionalTypes = Flags.getSet(flags, CANDIDATE_TYPES_FLAG);
+    for (String type : additionalTypes) {
+      checkArgument(
+          isWellFormed(type),
+          "Invalid `%s` flag value '%s': expected a canonical type name",
+          CANDIDATE_TYPES_FLAG,
+          type);
+      checkArgument(
+          !NON_STATIC_IMPORT_CANDIDATE_TYPES.contains(type),
+          "Invalid `%s` flag value '%s': type is a non-static import candidate",
+          CANDIDATE_TYPES_FLAG,
+          type);
+    }
+
+    // XXX: The parameter swap mutant of this `Sets#union` invocation is unkillable: the argument
+    // order influences only iteration order, while the result is queried exclusively using
+    // `ImmutableSet#contains`.
+    return Sets.union(STATIC_IMPORT_CANDIDATE_TYPES, additionalTypes).immutableCopy();
+  }
+
+  /**
+   * Returns the union of {@link #STATIC_IMPORT_CANDIDATE_MEMBERS} and any additional candidate
+   * members specified using the {@link #CANDIDATE_MEMBERS_FLAG} flag.
+   */
+  static ImmutableSetMultimap<String, String> getCandidateMembers(ErrorProneFlags flags) {
+    ImmutableSetMultimap.Builder<String, String> members =
+        ImmutableSetMultimap.<String, String>builder().putAll(STATIC_IMPORT_CANDIDATE_MEMBERS);
+
+    for (String candidate : Flags.getSet(flags, CANDIDATE_MEMBERS_FLAG)) {
+      List<String> parts = Splitter.on('#').splitToList(candidate);
+      checkArgument(
+          parts.size() == 2 && parts.stream().allMatch(StaticImport::isWellFormed),
+          "Invalid `%s` flag value '%s': expected format is '<type>#<member>'",
+          CANDIDATE_MEMBERS_FLAG,
+          candidate);
+      String type = parts.getFirst();
+      String member = parts.get(1);
+      checkArgument(
+          !NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(member),
+          "Invalid `%s` flag value '%s': identifier is a non-static import candidate",
+          CANDIDATE_MEMBERS_FLAG,
+          candidate);
+      checkArgument(
+          !NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type, member),
+          "Invalid `%s` flag value '%s': member is a non-static import candidate",
+          CANDIDATE_MEMBERS_FLAG,
+          candidate);
+      members.put(type, member);
+    }
+
+    return members.build();
+  }
+
+  private static boolean isWellFormed(String typeOrMember) {
+    return !typeOrMember.isEmpty() && CharMatcher.whitespace().matchesNoneOf(typeOrMember);
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImport.java
@@ -1,37 +1,12 @@
 package tech.picnic.errorprone.bugpatterns;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static com.google.errorprone.BugPattern.LinkType.CUSTOM;
 import static com.google.errorprone.BugPattern.SeverityLevel.SUGGESTION;
 import static com.google.errorprone.BugPattern.StandardTags.STYLE;
 import static java.util.Objects.requireNonNull;
-import static tech.picnic.errorprone.bugpatterns.NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS;
-import static tech.picnic.errorprone.bugpatterns.NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_MEMBERS;
-import static tech.picnic.errorprone.bugpatterns.NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_TYPES;
 import static tech.picnic.errorprone.utils.Documentation.BUG_PATTERNS_BASE_URL;
 
 import com.google.auto.service.AutoService;
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.CharMatcher;
-import com.google.common.base.Functions;
-import com.google.common.base.Preconditions;
-import com.google.common.base.Predicates;
-import com.google.common.base.Splitter;
-import com.google.common.base.Verify;
-import com.google.common.collect.Comparators;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableListMultimap;
-import com.google.common.collect.ImmutableMap;
-import com.google.common.collect.ImmutableMultiset;
-import com.google.common.collect.ImmutableRangeSet;
-import com.google.common.collect.ImmutableSet;
-import com.google.common.collect.ImmutableSetMultimap;
-import com.google.common.collect.ImmutableSortedMap;
-import com.google.common.collect.ImmutableSortedMultiset;
-import com.google.common.collect.ImmutableSortedSet;
-import com.google.common.collect.ImmutableTable;
-import com.google.common.collect.MoreCollectors;
-import com.google.common.collect.Sets;
 import com.google.errorprone.BugPattern;
 import com.google.errorprone.ErrorProneFlags;
 import com.google.errorprone.VisitorState;
@@ -43,39 +18,18 @@ import com.google.errorprone.fixes.Fix;
 import com.google.errorprone.fixes.SuggestedFix;
 import com.google.errorprone.fixes.SuggestedFixes;
 import com.google.errorprone.matchers.Description;
-import com.google.errorprone.matchers.Matchers;
-import com.google.errorprone.predicates.TypePredicates;
-import com.google.errorprone.refaster.ImportPolicy;
-import com.google.errorprone.util.ASTHelpers;
 import com.sun.source.tree.ImportTree;
 import com.sun.source.tree.MemberSelectTree;
 import com.sun.source.tree.MethodInvocationTree;
 import com.sun.source.tree.Tree;
-import com.sun.tools.javac.code.Type;
-import java.nio.charset.StandardCharsets;
-import java.time.ZoneOffset;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
-import java.util.UUID;
-import java.util.function.Function;
-import java.util.function.Predicate;
-import java.util.regex.Pattern;
-import java.util.stream.Collectors;
 import javax.inject.Inject;
-import tech.picnic.errorprone.utils.Flags;
 
 /**
  * A {@link BugChecker} that flags type members that can and should be statically imported.
  *
- * <p>Additional candidate types and type members can be specified using the {@code
- * StaticImport:CandidateTypes} and {@code StaticImport:CandidateMembers} flags, respectively.
- * Candidate members must be specified in {@code <type>#<member>} format. The latter flag is also
- * honored by the {@link NonStaticImport} check, such that it does not undo the static imports
- * introduced by this check.
+ * <p>See {@link StaticImportConfig} for how additional candidates can be configured, and how this
+ * check interacts with {@link NonStaticImport}.
  */
 // XXX: This check is closely linked to `NonStaticImport`. Consider merging the two.
 // XXX: Tricky cases:
@@ -92,158 +46,31 @@ import tech.picnic.errorprone.utils.Flags;
     tags = STYLE)
 @SuppressWarnings({
   "java:S2160" /* Super class equality definition suffices. */,
-  "javaarchitecture:S7027" /* `StaticImport` and `NonStaticImport` ensure mutual exclusivity. */,
   "z-key-to-resolve-AnnotationUseStyle-and-TrailingComment-check-conflict"
 })
 public final class StaticImport extends BugChecker implements MemberSelectTreeMatcher {
   private static final long serialVersionUID = 1L;
 
-  /**
-   * Types whose members should be statically imported, unless exempted by {@link
-   * NonStaticImport#NON_STATIC_IMPORT_CANDIDATE_MEMBERS} or {@link
-   * NonStaticImport#NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS}.
-   *
-   * <p>Types listed here should be mutually exclusive with {@link
-   * NonStaticImport#NON_STATIC_IMPORT_CANDIDATE_TYPES}.
-   */
-  @VisibleForTesting
-  static final ImmutableSet<String> STATIC_IMPORT_CANDIDATE_TYPES =
-      ImmutableSet.of(
-          BugPattern.LinkType.class.getCanonicalName(),
-          BugPattern.SeverityLevel.class.getCanonicalName(),
-          BugPattern.StandardTags.class.getCanonicalName(),
-          Collections.class.getCanonicalName(),
-          Collectors.class.getCanonicalName(),
-          Comparator.class.getCanonicalName(),
-          ImportPolicy.class.getCanonicalName(),
-          Map.Entry.class.getCanonicalName(),
-          Matchers.class.getCanonicalName(),
-          MoreCollectors.class.getCanonicalName(),
-          Pattern.class.getCanonicalName(),
-          Preconditions.class.getCanonicalName(),
-          Predicates.class.getCanonicalName(),
-          StandardCharsets.class.getCanonicalName(),
-          TypePredicates.class.getCanonicalName(),
-          Verify.class.getCanonicalName(),
-          "com.fasterxml.jackson.annotation.JsonCreator.Mode",
-          "com.fasterxml.jackson.annotation.JsonFormat.Shape",
-          "com.fasterxml.jackson.annotation.JsonInclude.Include",
-          "com.fasterxml.jackson.annotation.JsonProperty.Access",
-          "com.mongodb.client.model.Accumulators",
-          "com.mongodb.client.model.Aggregates",
-          "com.mongodb.client.model.Filters",
-          "com.mongodb.client.model.Indexes",
-          "com.mongodb.client.model.Projections",
-          "com.mongodb.client.model.Sorts",
-          "com.mongodb.client.model.Updates",
-          "org.assertj.core.api.Assertions",
-          "org.assertj.core.api.InstanceOfAssertFactories",
-          "org.assertj.core.api.SoftAssertions",
-          "org.assertj.core.data.Offset",
-          "org.assertj.core.groups.Tuple",
-          "org.hamcrest.Matchers",
-          "org.hamcrest.text.MatchesPattern",
-          "org.hibernate.validator.testutil.ConstraintViolationAssert",
-          "org.junit.jupiter.api.Assertions",
-          "org.mockito.AdditionalAnswers",
-          "org.mockito.Answers",
-          "org.mockito.ArgumentMatchers",
-          "org.mockito.Mockito",
-          "org.springframework.boot.test.context.SpringBootTest.WebEnvironment",
-          "org.springframework.format.annotation.DateTimeFormat.ISO",
-          "org.springframework.http.HttpHeaders",
-          "org.springframework.http.HttpMethod",
-          "org.springframework.http.MediaType",
-          "org.testng.Assert",
-          "reactor.function.TupleUtils",
-          "tech.picnic.errorprone.utils.MoreTypes");
-
-  /**
-   * Type members that should be statically imported.
-   *
-   * <p>Please note that:
-   *
-   * <ul>
-   *   <li>Types listed by {@link #STATIC_IMPORT_CANDIDATE_TYPES} should be omitted from this
-   *       collection.
-   *   <li>This collection should be mutually exclusive with {@link
-   *       NonStaticImport#NON_STATIC_IMPORT_CANDIDATE_MEMBERS}.
-   *   <li>This collection should not list members contained in {@link
-   *       NonStaticImport#NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS}.
-   * </ul>
-   */
-  static final ImmutableSetMultimap<String, String> STATIC_IMPORT_CANDIDATE_MEMBERS =
-      ImmutableSetMultimap.<String, String>builder()
-          .putAll(Comparators.class.getCanonicalName(), "emptiesFirst", "emptiesLast")
-          .put(Function.class.getCanonicalName(), "identity")
-          .put(Functions.class.getCanonicalName(), "identity")
-          .put(ImmutableList.class.getCanonicalName(), "toImmutableList")
-          .putAll(
-              ImmutableListMultimap.class.getCanonicalName(),
-              "flatteningToImmutableListMultimap",
-              "toImmutableListMultimap")
-          .put(ImmutableMap.class.getCanonicalName(), "toImmutableMap")
-          .put(ImmutableMultiset.class.getCanonicalName(), "toImmutableMultiset")
-          .put(ImmutableRangeSet.class.getCanonicalName(), "toImmutableRangeSet")
-          .put(ImmutableSet.class.getCanonicalName(), "toImmutableSet")
-          .putAll(
-              ImmutableSetMultimap.class.getCanonicalName(),
-              "flatteningToImmutableSetMultimap",
-              "toImmutableSetMultimap")
-          .put(ImmutableSortedMap.class.getCanonicalName(), "toImmutableSortedMap")
-          .put(ImmutableSortedMultiset.class.getCanonicalName(), "toImmutableSortedMultiset")
-          .put(ImmutableSortedSet.class.getCanonicalName(), "toImmutableSortedSet")
-          .put(ImmutableTable.class.getCanonicalName(), "toImmutableTable")
-          .putAll(
-              Objects.class.getCanonicalName(),
-              "checkIndex",
-              "checkFromIndexSize",
-              "checkFromToIndex",
-              "requireNonNull",
-              "requireNonNullElse",
-              "requireNonNullElseGet")
-          .put(Predicate.class.getCanonicalName(), "not")
-          .put(Sets.class.getCanonicalName(), "toImmutableEnumSet")
-          .put(UUID.class.getCanonicalName(), "randomUUID")
-          .put(ZoneOffset.class.getCanonicalName(), "UTC")
-          .putAll("org.junit.jupiter.params.provider.Arguments", "argumentSet", "arguments")
-          .build();
-
-  /**
-   * Flag using which additional types whose members should be statically imported (in addition to
-   * those defined by {@link #STATIC_IMPORT_CANDIDATE_TYPES}) can be specified.
-   */
-  private static final String CANDIDATE_TYPES_FLAG = "StaticImport:CandidateTypes";
-
-  /**
-   * Flag using which additional type members that should be statically imported (in addition to
-   * those defined by {@link #STATIC_IMPORT_CANDIDATE_MEMBERS}) can be specified, in {@code
-   * <type>#<member>} format.
-   */
-  private static final String CANDIDATE_MEMBERS_FLAG = "StaticImport:CandidateMembers";
-
-  private final ImmutableSet<String> candidateTypes;
-  private final ImmutableSetMultimap<String, String> candidateMembers;
+  private final StaticImportConfig config;
 
   /** Instantiates a default {@link StaticImport} instance. */
   public StaticImport() {
-    this(ErrorProneFlags.empty());
+    this(new StaticImportConfig(ErrorProneFlags.empty()));
   }
 
   /**
    * Instantiates a customized {@link StaticImport}.
    *
-   * @param flags Any provided command line flags.
+   * @param config The candidate-matching configuration to apply.
    */
   @Inject
-  StaticImport(ErrorProneFlags flags) {
-    candidateTypes = getCandidateTypes(flags);
-    candidateMembers = getCandidateMembers(flags);
+  StaticImport(StaticImportConfig config) {
+    this.config = config;
   }
 
   @Override
   public Description matchMemberSelect(MemberSelectTree tree, VisitorState state) {
-    if (!isCandidateContext(state) || !isCandidate(tree)) {
+    if (!isCandidateContext(state) || !config.isCandidate(tree)) {
       return Description.NO_MATCH;
     }
 
@@ -252,21 +79,11 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
       return Description.NO_MATCH;
     }
 
-    return getCandidateSimpleName(importInfo)
+    return config
+        .getCandidateSimpleName(importInfo)
         .flatMap(n -> tryStaticImport(tree, importInfo.canonicalName() + '.' + n, n, state))
         .map(fix -> describeMatch(tree, fix))
         .orElse(Description.NO_MATCH);
-  }
-
-  private Optional<String> getCandidateSimpleName(StaticImportInfo importInfo) {
-    String canonicalName = importInfo.canonicalName();
-    return importInfo
-        .simpleName()
-        .toJavaUtil()
-        .filter(
-            name ->
-                candidateTypes.contains(canonicalName)
-                    || candidateMembers.containsEntry(canonicalName, name));
   }
 
   private static boolean isCandidateContext(VisitorState state) {
@@ -279,17 +96,6 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
         : !(parentTree instanceof ImportTree || parentTree instanceof MemberSelectTree);
   }
 
-  private static boolean isCandidate(MemberSelectTree tree) {
-    String identifier = tree.getIdentifier().toString();
-    if (NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(identifier)) {
-      return false;
-    }
-
-    Type type = ASTHelpers.getType(tree.getExpression());
-    return type != null
-        && !NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type.toString(), identifier);
-  }
-
   private static Optional<Fix> tryStaticImport(
       MemberSelectTree tree, String fullyQualifiedName, String simpleName, VisitorState state) {
     SuggestedFix.Builder fix = SuggestedFix.builder().replace(tree, simpleName);
@@ -300,63 +106,5 @@ public final class StaticImport extends BugChecker implements MemberSelectTreeMa
     }
 
     return Optional.of(fix.build());
-  }
-
-  private static ImmutableSet<String> getCandidateTypes(ErrorProneFlags flags) {
-    ImmutableSet<String> additionalTypes = Flags.getSet(flags, CANDIDATE_TYPES_FLAG);
-    for (String type : additionalTypes) {
-      checkArgument(
-          isWellFormed(type),
-          "Invalid `%s` flag value '%s': expected a canonical type name",
-          CANDIDATE_TYPES_FLAG,
-          type);
-      checkArgument(
-          !NON_STATIC_IMPORT_CANDIDATE_TYPES.contains(type),
-          "Invalid `%s` flag value '%s': type is a non-static import candidate",
-          CANDIDATE_TYPES_FLAG,
-          type);
-    }
-
-    // XXX: The parameter swap mutant of this `Sets#union` invocation is unkillable: the argument
-    // order influences only iteration order, while the result is queried exclusively using
-    // `ImmutableSet#contains`.
-    return Sets.union(STATIC_IMPORT_CANDIDATE_TYPES, additionalTypes).immutableCopy();
-  }
-
-  /**
-   * Returns the union of {@link #STATIC_IMPORT_CANDIDATE_MEMBERS} and any additional candidate
-   * members specified using the {@link #CANDIDATE_MEMBERS_FLAG} flag.
-   */
-  static ImmutableSetMultimap<String, String> getCandidateMembers(ErrorProneFlags flags) {
-    ImmutableSetMultimap.Builder<String, String> members =
-        ImmutableSetMultimap.<String, String>builder().putAll(STATIC_IMPORT_CANDIDATE_MEMBERS);
-
-    for (String candidate : Flags.getSet(flags, CANDIDATE_MEMBERS_FLAG)) {
-      List<String> parts = Splitter.on('#').splitToList(candidate);
-      checkArgument(
-          parts.size() == 2 && parts.stream().allMatch(StaticImport::isWellFormed),
-          "Invalid `%s` flag value '%s': expected format is '<type>#<member>'",
-          CANDIDATE_MEMBERS_FLAG,
-          candidate);
-      String type = parts.getFirst();
-      String member = parts.get(1);
-      checkArgument(
-          !NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(member),
-          "Invalid `%s` flag value '%s': identifier is a non-static import candidate",
-          CANDIDATE_MEMBERS_FLAG,
-          candidate);
-      checkArgument(
-          !NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type, member),
-          "Invalid `%s` flag value '%s': member is a non-static import candidate",
-          CANDIDATE_MEMBERS_FLAG,
-          candidate);
-      members.put(type, member);
-    }
-
-    return members.build();
-  }
-
-  private static boolean isWellFormed(String typeOrMember) {
-    return !typeOrMember.isEmpty() && CharMatcher.whitespace().matchesNoneOf(typeOrMember);
   }
 }

--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImportConfig.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/StaticImportConfig.java
@@ -1,0 +1,380 @@
+package tech.picnic.errorprone.bugpatterns;
+
+import static com.google.common.base.Preconditions.checkArgument;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Functions;
+import com.google.common.base.Preconditions;
+import com.google.common.base.Predicates;
+import com.google.common.base.Strings;
+import com.google.common.base.Verify;
+import com.google.common.collect.Comparators;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableListMultimap;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableMultiset;
+import com.google.common.collect.ImmutableRangeSet;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.collect.ImmutableSetMultimap;
+import com.google.common.collect.ImmutableSortedMap;
+import com.google.common.collect.ImmutableSortedMultiset;
+import com.google.common.collect.ImmutableSortedSet;
+import com.google.common.collect.ImmutableTable;
+import com.google.common.collect.MoreCollectors;
+import com.google.common.collect.Sets;
+import com.google.errorprone.BugPattern;
+import com.google.errorprone.ErrorProneFlags;
+import com.google.errorprone.VisitorState;
+import com.google.errorprone.bugpatterns.StaticImports.StaticImportInfo;
+import com.google.errorprone.matchers.Matchers;
+import com.google.errorprone.predicates.TypePredicates;
+import com.google.errorprone.refaster.ImportPolicy;
+import com.google.errorprone.util.ASTHelpers;
+import com.sun.source.tree.MemberSelectTree;
+import com.sun.tools.javac.code.Type;
+import java.io.Serializable;
+import java.nio.charset.StandardCharsets;
+import java.time.Clock;
+import java.time.InstantSource;
+import java.time.ZoneOffset;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.regex.Pattern;
+import java.util.stream.Collectors;
+import javax.inject.Inject;
+import tech.picnic.errorprone.utils.Flags;
+import tech.picnic.errorprone.utils.TypeMemberSpec;
+
+/**
+ * The shared configuration and matching logic for the {@link StaticImport} and {@link
+ * NonStaticImport} checks.
+ *
+ * <p>Additional candidates can be specified using the {@code StaticImport:AdditionalCandidates}
+ * flag: a comma-separated list of entries, each either a canonical type name (all of whose members
+ * are then eligible for static import) or a {@code <type>#<member>} pair (identifying a single
+ * additional member). Entries specified this way are honored by both checks, so {@link
+ * NonStaticImport} never undoes a static import introduced by {@link StaticImport}.
+ */
+final class StaticImportConfig implements Serializable {
+  private static final long serialVersionUID = 1L;
+
+  /**
+   * Types whose members should be statically imported, unless exempted by {@link
+   * #NON_STATIC_IMPORT_CANDIDATE_MEMBERS} or {@link #NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS}.
+   *
+   * <p>Types listed here should be mutually exclusive with {@link
+   * #NON_STATIC_IMPORT_CANDIDATE_TYPES}.
+   */
+  @VisibleForTesting
+  static final ImmutableSet<String> STATIC_IMPORT_CANDIDATE_TYPES =
+      ImmutableSet.of(
+          BugPattern.LinkType.class.getCanonicalName(),
+          BugPattern.SeverityLevel.class.getCanonicalName(),
+          BugPattern.StandardTags.class.getCanonicalName(),
+          Collections.class.getCanonicalName(),
+          Collectors.class.getCanonicalName(),
+          Comparator.class.getCanonicalName(),
+          ImportPolicy.class.getCanonicalName(),
+          Map.Entry.class.getCanonicalName(),
+          Matchers.class.getCanonicalName(),
+          MoreCollectors.class.getCanonicalName(),
+          Pattern.class.getCanonicalName(),
+          Preconditions.class.getCanonicalName(),
+          Predicates.class.getCanonicalName(),
+          StandardCharsets.class.getCanonicalName(),
+          TypePredicates.class.getCanonicalName(),
+          Verify.class.getCanonicalName(),
+          "com.fasterxml.jackson.annotation.JsonCreator.Mode",
+          "com.fasterxml.jackson.annotation.JsonFormat.Shape",
+          "com.fasterxml.jackson.annotation.JsonInclude.Include",
+          "com.fasterxml.jackson.annotation.JsonProperty.Access",
+          "com.mongodb.client.model.Accumulators",
+          "com.mongodb.client.model.Aggregates",
+          "com.mongodb.client.model.Filters",
+          "com.mongodb.client.model.Indexes",
+          "com.mongodb.client.model.Projections",
+          "com.mongodb.client.model.Sorts",
+          "com.mongodb.client.model.Updates",
+          "org.assertj.core.api.Assertions",
+          "org.assertj.core.api.InstanceOfAssertFactories",
+          "org.assertj.core.api.SoftAssertions",
+          "org.assertj.core.data.Offset",
+          "org.assertj.core.groups.Tuple",
+          "org.hamcrest.Matchers",
+          "org.hamcrest.text.MatchesPattern",
+          "org.hibernate.validator.testutil.ConstraintViolationAssert",
+          "org.junit.jupiter.api.Assertions",
+          "org.mockito.AdditionalAnswers",
+          "org.mockito.Answers",
+          "org.mockito.ArgumentMatchers",
+          "org.mockito.Mockito",
+          "org.springframework.boot.test.context.SpringBootTest.WebEnvironment",
+          "org.springframework.format.annotation.DateTimeFormat.ISO",
+          "org.springframework.http.HttpHeaders",
+          "org.springframework.http.HttpMethod",
+          "org.springframework.http.MediaType",
+          "org.testng.Assert",
+          "reactor.function.TupleUtils",
+          "tech.picnic.errorprone.utils.MoreTypes");
+
+  /**
+   * Type members that should be statically imported.
+   *
+   * <p>Please note that:
+   *
+   * <ul>
+   *   <li>Types listed by {@link #STATIC_IMPORT_CANDIDATE_TYPES} should be omitted from this
+   *       collection.
+   *   <li>This collection should be mutually exclusive with {@link
+   *       #NON_STATIC_IMPORT_CANDIDATE_MEMBERS}.
+   *   <li>This collection should not list members contained in {@link
+   *       #NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS}.
+   * </ul>
+   */
+  @VisibleForTesting
+  static final ImmutableSetMultimap<String, String> STATIC_IMPORT_CANDIDATE_MEMBERS =
+      ImmutableSetMultimap.<String, String>builder()
+          .putAll(Comparators.class.getCanonicalName(), "emptiesFirst", "emptiesLast")
+          .put(Function.class.getCanonicalName(), "identity")
+          .put(Functions.class.getCanonicalName(), "identity")
+          .put(ImmutableList.class.getCanonicalName(), "toImmutableList")
+          .putAll(
+              ImmutableListMultimap.class.getCanonicalName(),
+              "flatteningToImmutableListMultimap",
+              "toImmutableListMultimap")
+          .put(ImmutableMap.class.getCanonicalName(), "toImmutableMap")
+          .put(ImmutableMultiset.class.getCanonicalName(), "toImmutableMultiset")
+          .put(ImmutableRangeSet.class.getCanonicalName(), "toImmutableRangeSet")
+          .put(ImmutableSet.class.getCanonicalName(), "toImmutableSet")
+          .putAll(
+              ImmutableSetMultimap.class.getCanonicalName(),
+              "flatteningToImmutableSetMultimap",
+              "toImmutableSetMultimap")
+          .put(ImmutableSortedMap.class.getCanonicalName(), "toImmutableSortedMap")
+          .put(ImmutableSortedMultiset.class.getCanonicalName(), "toImmutableSortedMultiset")
+          .put(ImmutableSortedSet.class.getCanonicalName(), "toImmutableSortedSet")
+          .put(ImmutableTable.class.getCanonicalName(), "toImmutableTable")
+          .putAll(
+              Objects.class.getCanonicalName(),
+              "checkIndex",
+              "checkFromIndexSize",
+              "checkFromToIndex",
+              "requireNonNull",
+              "requireNonNullElse",
+              "requireNonNullElseGet")
+          .put(Predicate.class.getCanonicalName(), "not")
+          .put(Sets.class.getCanonicalName(), "toImmutableEnumSet")
+          .put(UUID.class.getCanonicalName(), "randomUUID")
+          .put(ZoneOffset.class.getCanonicalName(), "UTC")
+          .putAll("org.junit.jupiter.params.provider.Arguments", "argumentSet", "arguments")
+          .build();
+
+  /**
+   * Types whose members should not be statically imported, unless exempted by {@link
+   * #STATIC_IMPORT_CANDIDATE_MEMBERS}.
+   *
+   * <p>Types listed here should be mutually exclusive with {@link #STATIC_IMPORT_CANDIDATE_TYPES}.
+   */
+  @VisibleForTesting
+  static final ImmutableSet<String> NON_STATIC_IMPORT_CANDIDATE_TYPES =
+      ImmutableSet.of(
+          ASTHelpers.class.getCanonicalName(),
+          Clock.class.getCanonicalName(),
+          InstantSource.class.getCanonicalName(),
+          Strings.class.getCanonicalName(),
+          VisitorState.class.getCanonicalName(),
+          ZoneOffset.class.getCanonicalName(),
+          "com.google.errorprone.BugCheckerRefactoringTestHelper.TestMode",
+          "reactor.core.publisher.Flux",
+          "reactor.core.publisher.Mono");
+
+  /**
+   * Type members that should never be statically imported.
+   *
+   * <p>Please note that:
+   *
+   * <ul>
+   *   <li>Types listed by {@link #NON_STATIC_IMPORT_CANDIDATE_TYPES} and members listed by {@link
+   *       #NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS} should be omitted from this collection.
+   *   <li>This collection should be mutually exclusive with {@link
+   *       #STATIC_IMPORT_CANDIDATE_MEMBERS}.
+   * </ul>
+   */
+  // XXX: Perhaps the set of exempted `java.util.Collections` methods is too strict. For now any
+  // method name that could be considered "too vague" or could conceivably mean something else in a
+  // specific context is left out.
+  @VisibleForTesting
+  static final ImmutableSetMultimap<String, String> NON_STATIC_IMPORT_CANDIDATE_MEMBERS =
+      ImmutableSetMultimap.<String, String>builder()
+          .putAll(
+              Collections.class.getCanonicalName(),
+              "addAll",
+              "copy",
+              "fill",
+              "list",
+              "max",
+              "min",
+              "nCopies",
+              "rotate",
+              "sort",
+              "swap")
+          .put(Locale.class.getCanonicalName(), "ROOT")
+          .put(Optional.class.getCanonicalName(), "empty")
+          .putAll(Pattern.class.getCanonicalName(), "compile", "matches", "quote")
+          .put(Predicates.class.getCanonicalName(), "contains")
+          .put("org.springframework.http.MediaType", "ALL")
+          .build();
+
+  /**
+   * Identifiers that should never be statically imported.
+   *
+   * <p>Please note that:
+   *
+   * <ul>
+   *   <li>Identifiers listed by {@link #STATIC_IMPORT_CANDIDATE_MEMBERS} should be mutually
+   *       exclusive with identifiers listed here.
+   *   <li>This list should contain a superset of the identifiers flagged by {@link
+   *       com.google.errorprone.bugpatterns.BadImport}.
+   * </ul>
+   */
+  @VisibleForTesting
+  static final ImmutableSet<String> NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS =
+      ImmutableSet.of(
+          "builder",
+          "copyOf",
+          "create",
+          "EPOCH",
+          "from",
+          "getDefaultInstance",
+          "INSTANCE",
+          "MAX",
+          "MAX_VALUE",
+          "MIN",
+          "MIN_VALUE",
+          "newBuilder",
+          "newInstance",
+          "of",
+          "parse",
+          "valueOf",
+          "values");
+
+  /**
+   * Flag using which additional candidates can be specified, in {@code <type>} or {@code
+   * <type>#<member>} format.
+   */
+  private static final String ADDITIONAL_CANDIDATES_FLAG = "StaticImport:AdditionalCandidates";
+
+  private final ImmutableSet<String> candidateTypes;
+  private final ImmutableSetMultimap<String, String> candidateMembers;
+
+  /**
+   * Instantiates a {@link StaticImportConfig}.
+   *
+   * @param flags Any provided command line flags.
+   */
+  @Inject
+  StaticImportConfig(ErrorProneFlags flags) {
+    AdditionalCandidates additional = parseAdditionalCandidates(flags);
+    candidateTypes =
+        // XXX: The parameter swap mutant of this `Sets#union` invocation is unkillable: the
+        // argument order influences only iteration order, while the result is queried
+        // exclusively using `ImmutableSet#contains`.
+        Sets.union(STATIC_IMPORT_CANDIDATE_TYPES, additional.types()).immutableCopy();
+    candidateMembers =
+        ImmutableSetMultimap.<String, String>builder()
+            .putAll(STATIC_IMPORT_CANDIDATE_MEMBERS)
+            .putAll(additional.members())
+            .build();
+  }
+
+  /**
+   * Tells whether the given {@link MemberSelectTree} identifies a type member that could be
+   * eligible for static import, regardless of whether it is actually a configured candidate.
+   */
+  boolean isCandidate(MemberSelectTree tree) {
+    String identifier = tree.getIdentifier().toString();
+    if (NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(identifier)) {
+      return false;
+    }
+
+    Type type = ASTHelpers.getType(tree.getExpression());
+    return type != null
+        && !NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type.toString(), identifier);
+  }
+
+  /** Returns the simple name under which the given static import candidate should be imported. */
+  Optional<String> getCandidateSimpleName(StaticImportInfo importInfo) {
+    String canonicalName = importInfo.canonicalName();
+    return importInfo
+        .simpleName()
+        .toJavaUtil()
+        .filter(
+            name ->
+                candidateTypes.contains(canonicalName)
+                    || candidateMembers.containsEntry(canonicalName, name));
+  }
+
+  /** Tells whether the given statically imported type member should not have been. */
+  boolean shouldNotBeStaticallyImported(String type, String member) {
+    return (NON_STATIC_IMPORT_CANDIDATE_TYPES.contains(type)
+            && !candidateMembers.containsEntry(type, member))
+        || NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(type, member)
+        || NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(member);
+  }
+
+  private static AdditionalCandidates parseAdditionalCandidates(ErrorProneFlags flags) {
+    ImmutableSet.Builder<String> types = ImmutableSet.builder();
+    ImmutableSetMultimap.Builder<String, String> members = ImmutableSetMultimap.builder();
+
+    for (String entry : Flags.getSet(flags, ADDITIONAL_CANDIDATES_FLAG)) {
+      TypeMemberSpec spec = TypeMemberSpec.parse(entry);
+      checkArgument(
+          isWellFormed(spec.type())
+              && spec.member().map(StaticImportConfig::isWellFormed).orElse(true),
+          "Invalid `%s` flag value '%s': expected '<type>' or '<type>#<member>'",
+          ADDITIONAL_CANDIDATES_FLAG,
+          entry);
+
+      if (spec.member().isEmpty()) {
+        checkArgument(
+            !NON_STATIC_IMPORT_CANDIDATE_TYPES.contains(spec.type()),
+            "Invalid `%s` flag value '%s': type is a non-static import candidate",
+            ADDITIONAL_CANDIDATES_FLAG,
+            entry);
+        types.add(spec.type());
+      } else {
+        String member = spec.member().orElseThrow();
+        checkArgument(
+            !NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS.contains(member),
+            "Invalid `%s` flag value '%s': identifier is a non-static import candidate",
+            ADDITIONAL_CANDIDATES_FLAG,
+            entry);
+        checkArgument(
+            !NON_STATIC_IMPORT_CANDIDATE_MEMBERS.containsEntry(spec.type(), member),
+            "Invalid `%s` flag value '%s': member is a non-static import candidate",
+            ADDITIONAL_CANDIDATES_FLAG,
+            entry);
+        members.put(spec.type(), member);
+      }
+    }
+
+    return new AdditionalCandidates(types.build(), members.build());
+  }
+
+  private static boolean isWellFormed(String typeOrMember) {
+    return !typeOrMember.isEmpty()
+        && CharMatcher.whitespace().matchesNoneOf(typeOrMember)
+        && typeOrMember.indexOf('#') < 0;
+  }
+
+  private record AdditionalCandidates(
+      ImmutableSet<String> types, ImmutableSetMultimap<String, String> members) {}
+}

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NonStaticImportTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NonStaticImportTest.java
@@ -120,6 +120,25 @@ final class NonStaticImportTest {
   }
 
   @Test
+  void identificationWithAdditionalStaticImportCandidateMembers() {
+    CompilationTestHelper.newInstance(NonStaticImport.class, getClass())
+        .setArgs("-XepOpt:StaticImport:CandidateMembers=reactor.core.publisher.Flux#just")
+        .addSourceLines(
+            "A.java",
+            "import static reactor.core.publisher.Flux.just;",
+            "// BUG: Diagnostic contains:",
+            "import static reactor.core.publisher.Flux.range;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    just(1);",
+            "    range(0, 1);",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
   void replacement() {
     BugCheckerRefactoringTestHelper.newInstance(NonStaticImport.class, getClass())
         .addInputLines(

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NonStaticImportTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/NonStaticImportTest.java
@@ -1,41 +1,10 @@
 package tech.picnic.errorprone.bugpatterns;
 
-import static org.assertj.core.api.Assertions.assertThat;
-
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
 import org.junit.jupiter.api.Test;
 
 final class NonStaticImportTest {
-  @Test
-  void candidateTypesDoNotClash() {
-    assertThat(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_TYPES)
-        .doesNotContainAnyElementsOf(StaticImport.STATIC_IMPORT_CANDIDATE_TYPES);
-  }
-
-  @Test
-  void candidateMembersAreNotRedundant() {
-    assertThat(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_MEMBERS.keySet())
-        .doesNotContainAnyElementsOf(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_TYPES);
-
-    assertThat(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_MEMBERS.values())
-        .doesNotContainAnyElementsOf(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS);
-  }
-
-  @Test
-  void candidateMembersDoNotClash() {
-    assertThat(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_MEMBERS.entries())
-        .doesNotContainAnyElementsOf(StaticImport.STATIC_IMPORT_CANDIDATE_MEMBERS.entries());
-  }
-
-  @SuppressWarnings(
-      "java:S3415" /* Comparing a constant against a non-constant value is intentional here. */)
-  @Test
-  void candidateIdentifiersDoNotClash() {
-    assertThat(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS)
-        .doesNotContainAnyElementsOf(StaticImport.STATIC_IMPORT_CANDIDATE_MEMBERS.values());
-  }
-
   @Test
   void identification() {
     CompilationTestHelper.newInstance(NonStaticImport.class, getClass())
@@ -122,7 +91,7 @@ final class NonStaticImportTest {
   @Test
   void identificationWithAdditionalStaticImportCandidateMembers() {
     CompilationTestHelper.newInstance(NonStaticImport.class, getClass())
-        .setArgs("-XepOpt:StaticImport:CandidateMembers=reactor.core.publisher.Flux#just")
+        .setArgs("-XepOpt:StaticImport:AdditionalCandidates=reactor.core.publisher.Flux#just")
         .addSourceLines(
             "A.java",
             "import static reactor.core.publisher.Flux.just;",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StaticImportConfigTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StaticImportConfigTest.java
@@ -1,0 +1,101 @@
+package tech.picnic.errorprone.bugpatterns;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.errorprone.ErrorProneFlags;
+import java.time.Clock;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+final class StaticImportConfigTest {
+  @Test
+  void candidateTypesDoNotClash() {
+    assertThat(StaticImportConfig.STATIC_IMPORT_CANDIDATE_TYPES)
+        .doesNotContainAnyElementsOf(StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_TYPES);
+  }
+
+  @Test
+  void candidateMembersAreNotRedundant() {
+    assertThat(StaticImportConfig.STATIC_IMPORT_CANDIDATE_MEMBERS.keySet())
+        .doesNotContainAnyElementsOf(StaticImportConfig.STATIC_IMPORT_CANDIDATE_TYPES);
+
+    assertThat(StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_MEMBERS.keySet())
+        .doesNotContainAnyElementsOf(StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_TYPES);
+
+    assertThat(StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_MEMBERS.values())
+        .doesNotContainAnyElementsOf(StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS);
+  }
+
+  @Test
+  void candidateMembersDoNotClash() {
+    assertThat(StaticImportConfig.STATIC_IMPORT_CANDIDATE_MEMBERS.entries())
+        .doesNotContainAnyElementsOf(
+            StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_MEMBERS.entries());
+
+    assertThat(StaticImportConfig.STATIC_IMPORT_CANDIDATE_MEMBERS.values())
+        .doesNotContainAnyElementsOf(StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS);
+  }
+
+  @SuppressWarnings(
+      "java:S3415" /* Comparing a constant against a non-constant value is intentional here. */)
+  @Test
+  void candidateIdentifiersDoNotClash() {
+    assertThat(StaticImportConfig.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS)
+        .doesNotContainAnyElementsOf(StaticImportConfig.STATIC_IMPORT_CANDIDATE_MEMBERS.values());
+  }
+
+  private static Stream<Arguments> additionalCandidateValidationTestCases() {
+    /* { value, expectedError } */
+    return Stream.of(
+        arguments(
+            Clock.class.getCanonicalName(),
+            "Invalid `StaticImport:AdditionalCandidates` flag value 'java.time.Clock': type is a "
+                + "non-static import candidate"),
+        arguments(
+            "java.lang.Math, java.util.UUID",
+            "Invalid `StaticImport:AdditionalCandidates` flag value ' java.util.UUID': expected "
+                + "'<type>' or '<type>#<member>'"),
+        arguments(
+            "java.lang.Math#min#max",
+            "Invalid `StaticImport:AdditionalCandidates` flag value 'java.lang.Math#min#max': "
+                + "expected '<type>' or '<type>#<member>'"),
+        arguments(
+            "#hash",
+            "Invalid `StaticImport:AdditionalCandidates` flag value '#hash': expected '<type>' or "
+                + "'<type>#<member>'"),
+        arguments(
+            "java.util.Objects#",
+            "Invalid `StaticImport:AdditionalCandidates` flag value 'java.util.Objects#': "
+                + "expected '<type>' or '<type>#<member>'"),
+        arguments(
+            "java.lang.Math#max, java.lang.Math#min",
+            "Invalid `StaticImport:AdditionalCandidates` flag value ' java.lang.Math#min': "
+                + "expected '<type>' or '<type>#<member>'"),
+        arguments(
+            "com.example.Foo#of",
+            "Invalid `StaticImport:AdditionalCandidates` flag value 'com.example.Foo#of': "
+                + "identifier is a non-static import candidate"),
+        arguments(
+            "java.util.Locale#ROOT",
+            "Invalid `StaticImport:AdditionalCandidates` flag value 'java.util.Locale#ROOT': "
+                + "member is a non-static import candidate"));
+  }
+
+  @MethodSource("additionalCandidateValidationTestCases")
+  @ParameterizedTest
+  void additionalCandidateValidation(String value, String expectedError) {
+    assertThatThrownBy(
+            () ->
+                new StaticImportConfig(
+                    ErrorProneFlags.fromMap(
+                        ImmutableMap.of("StaticImport:AdditionalCandidates", value))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(expectedError);
+  }
+}

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StaticImportTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StaticImportTest.java
@@ -1,10 +1,19 @@
 package tech.picnic.errorprone.bugpatterns;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
 
+import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
+import com.google.errorprone.ErrorProneFlags;
+import java.time.Clock;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 
 final class StaticImportTest {
   @Test
@@ -26,6 +35,65 @@ final class StaticImportTest {
 
     assertThat(StaticImport.STATIC_IMPORT_CANDIDATE_MEMBERS.values())
         .doesNotContainAnyElementsOf(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS);
+  }
+
+  private static Stream<Arguments> additionalCandidateValidationTestCases() {
+    /* { flag, value, expectedError } */
+    return Stream.of(
+        arguments(
+            "StaticImport:CandidateTypes",
+            Clock.class.getCanonicalName(),
+            "Invalid `StaticImport:CandidateTypes` flag value 'java.time.Clock': type is a "
+                + "non-static import candidate"),
+        arguments(
+            "StaticImport:CandidateTypes",
+            "java.lang.Math, java.util.UUID",
+            "Invalid `StaticImport:CandidateTypes` flag value ' java.util.UUID': expected a "
+                + "canonical type name"),
+        arguments(
+            "StaticImport:CandidateMembers",
+            Math.class.getCanonicalName(),
+            "Invalid `StaticImport:CandidateMembers` flag value 'java.lang.Math': expected format "
+                + "is '<type>#<member>'"),
+        arguments(
+            "StaticImport:CandidateMembers",
+            "java.lang.Math#min#max",
+            "Invalid `StaticImport:CandidateMembers` flag value 'java.lang.Math#min#max': expected "
+                + "format is '<type>#<member>'"),
+        arguments(
+            "StaticImport:CandidateMembers",
+            "#hash",
+            "Invalid `StaticImport:CandidateMembers` flag value '#hash': expected format is "
+                + "'<type>#<member>'"),
+        arguments(
+            "StaticImport:CandidateMembers",
+            "java.util.Objects#",
+            "Invalid `StaticImport:CandidateMembers` flag value 'java.util.Objects#': expected "
+                + "format is '<type>#<member>'"),
+        arguments(
+            "StaticImport:CandidateMembers",
+            "java.lang.Math#max, java.lang.Math#min",
+            "Invalid `StaticImport:CandidateMembers` flag value ' java.lang.Math#min': expected "
+                + "format is '<type>#<member>'"),
+        arguments(
+            "StaticImport:CandidateMembers",
+            "com.example.Foo#of",
+            "Invalid `StaticImport:CandidateMembers` flag value 'com.example.Foo#of': identifier "
+                + "is a non-static import candidate"),
+        arguments(
+            "StaticImport:CandidateMembers",
+            "java.util.Locale#ROOT",
+            "Invalid `StaticImport:CandidateMembers` flag value 'java.util.Locale#ROOT': member "
+                + "is a non-static import candidate"));
+  }
+
+  @MethodSource("additionalCandidateValidationTestCases")
+  @ParameterizedTest
+  void additionalCandidateValidation(String flag, String value, String expectedError) {
+    assertThatThrownBy(
+            () -> new StaticImport(ErrorProneFlags.fromMap(ImmutableMap.of(flag, value))))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessage(expectedError);
   }
 
   @Test
@@ -119,6 +187,33 @@ final class StaticImportTest {
             "  void refasterAfterTemplate() {}",
             "",
             "  void toImmutableMultiset() {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void identificationWithAdditionalCandidates() {
+    CompilationTestHelper.newInstance(StaticImport.class, getClass())
+        .setArgs(
+            "-XepOpt:StaticImport:CandidateTypes=java.lang.Math",
+            "-XepOpt:StaticImport:CandidateMembers=java.util.Objects#hash,reactor.core.publisher.Flux#just")
+        .addSourceLines(
+            "A.java",
+            "import java.util.Objects;",
+            "import reactor.core.publisher.Flux;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    Objects.equals(1, 2);",
+            "    Flux.range(0, 1);",
+            "",
+            "    // BUG: Diagnostic contains:",
+            "    Math.max(1, 2);",
+            "    // BUG: Diagnostic contains:",
+            "    Objects.hash(1, 2);",
+            "    // BUG: Diagnostic contains:",
+            "    Flux.just(1);",
+            "  }",
             "}")
         .doTest();
   }
@@ -291,6 +386,38 @@ final class StaticImportTest {
             "",
             "  @SpringBootTest(webEnvironment = RANDOM_PORT)",
             "  final class Test {}",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void replacementWithAdditionalCandidates() {
+    BugCheckerRefactoringTestHelper.newInstance(StaticImport.class, getClass())
+        .setArgs(
+            "-XepOpt:StaticImport:CandidateTypes=java.lang.Math",
+            "-XepOpt:StaticImport:CandidateMembers=reactor.core.publisher.Flux#just")
+        .addInputLines(
+            "A.java",
+            "import reactor.core.publisher.Flux;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    double d = Math.toRadians(90);",
+            "    Flux<Integer> f = Flux.just(1);",
+            "  }",
+            "}")
+        .addOutputLines(
+            "A.java",
+            "import static java.lang.Math.toRadians;",
+            "import static reactor.core.publisher.Flux.just;",
+            "",
+            "import reactor.core.publisher.Flux;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    double d = toRadians(90);",
+            "    Flux<Integer> f = just(1);",
+            "  }",
             "}")
         .doTest();
   }

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StaticImportTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/StaticImportTest.java
@@ -1,101 +1,10 @@
 package tech.picnic.errorprone.bugpatterns;
 
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.junit.jupiter.params.provider.Arguments.arguments;
-
-import com.google.common.collect.ImmutableMap;
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
-import com.google.errorprone.ErrorProneFlags;
-import java.time.Clock;
-import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.Arguments;
-import org.junit.jupiter.params.provider.MethodSource;
 
 final class StaticImportTest {
-  @Test
-  void candidateTypesDoNotClash() {
-    assertThat(StaticImport.STATIC_IMPORT_CANDIDATE_TYPES)
-        .doesNotContainAnyElementsOf(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_TYPES);
-  }
-
-  @Test
-  void candidateMembersAreNotRedundant() {
-    assertThat(StaticImport.STATIC_IMPORT_CANDIDATE_MEMBERS.keySet())
-        .doesNotContainAnyElementsOf(StaticImport.STATIC_IMPORT_CANDIDATE_TYPES);
-  }
-
-  @Test
-  void candidateMembersDoNotClash() {
-    assertThat(StaticImport.STATIC_IMPORT_CANDIDATE_MEMBERS.entries())
-        .doesNotContainAnyElementsOf(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_MEMBERS.entries());
-
-    assertThat(StaticImport.STATIC_IMPORT_CANDIDATE_MEMBERS.values())
-        .doesNotContainAnyElementsOf(NonStaticImport.NON_STATIC_IMPORT_CANDIDATE_IDENTIFIERS);
-  }
-
-  private static Stream<Arguments> additionalCandidateValidationTestCases() {
-    /* { flag, value, expectedError } */
-    return Stream.of(
-        arguments(
-            "StaticImport:CandidateTypes",
-            Clock.class.getCanonicalName(),
-            "Invalid `StaticImport:CandidateTypes` flag value 'java.time.Clock': type is a "
-                + "non-static import candidate"),
-        arguments(
-            "StaticImport:CandidateTypes",
-            "java.lang.Math, java.util.UUID",
-            "Invalid `StaticImport:CandidateTypes` flag value ' java.util.UUID': expected a "
-                + "canonical type name"),
-        arguments(
-            "StaticImport:CandidateMembers",
-            Math.class.getCanonicalName(),
-            "Invalid `StaticImport:CandidateMembers` flag value 'java.lang.Math': expected format "
-                + "is '<type>#<member>'"),
-        arguments(
-            "StaticImport:CandidateMembers",
-            "java.lang.Math#min#max",
-            "Invalid `StaticImport:CandidateMembers` flag value 'java.lang.Math#min#max': expected "
-                + "format is '<type>#<member>'"),
-        arguments(
-            "StaticImport:CandidateMembers",
-            "#hash",
-            "Invalid `StaticImport:CandidateMembers` flag value '#hash': expected format is "
-                + "'<type>#<member>'"),
-        arguments(
-            "StaticImport:CandidateMembers",
-            "java.util.Objects#",
-            "Invalid `StaticImport:CandidateMembers` flag value 'java.util.Objects#': expected "
-                + "format is '<type>#<member>'"),
-        arguments(
-            "StaticImport:CandidateMembers",
-            "java.lang.Math#max, java.lang.Math#min",
-            "Invalid `StaticImport:CandidateMembers` flag value ' java.lang.Math#min': expected "
-                + "format is '<type>#<member>'"),
-        arguments(
-            "StaticImport:CandidateMembers",
-            "com.example.Foo#of",
-            "Invalid `StaticImport:CandidateMembers` flag value 'com.example.Foo#of': identifier "
-                + "is a non-static import candidate"),
-        arguments(
-            "StaticImport:CandidateMembers",
-            "java.util.Locale#ROOT",
-            "Invalid `StaticImport:CandidateMembers` flag value 'java.util.Locale#ROOT': member "
-                + "is a non-static import candidate"));
-  }
-
-  @MethodSource("additionalCandidateValidationTestCases")
-  @ParameterizedTest
-  void additionalCandidateValidation(String flag, String value, String expectedError) {
-    assertThatThrownBy(
-            () -> new StaticImport(ErrorProneFlags.fromMap(ImmutableMap.of(flag, value))))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessage(expectedError);
-  }
-
   @Test
   void identification() {
     CompilationTestHelper.newInstance(StaticImport.class, getClass())
@@ -195,8 +104,8 @@ final class StaticImportTest {
   void identificationWithAdditionalCandidates() {
     CompilationTestHelper.newInstance(StaticImport.class, getClass())
         .setArgs(
-            "-XepOpt:StaticImport:CandidateTypes=java.lang.Math",
-            "-XepOpt:StaticImport:CandidateMembers=java.util.Objects#hash,reactor.core.publisher.Flux#just")
+            "-XepOpt:StaticImport:AdditionalCandidates=java.lang.Math,"
+                + "java.util.Objects#hash,reactor.core.publisher.Flux#just")
         .addSourceLines(
             "A.java",
             "import java.util.Objects;",
@@ -394,8 +303,8 @@ final class StaticImportTest {
   void replacementWithAdditionalCandidates() {
     BugCheckerRefactoringTestHelper.newInstance(StaticImport.class, getClass())
         .setArgs(
-            "-XepOpt:StaticImport:CandidateTypes=java.lang.Math",
-            "-XepOpt:StaticImport:CandidateMembers=reactor.core.publisher.Flux#just")
+            "-XepOpt:StaticImport:AdditionalCandidates=java.lang.Math,"
+                + "reactor.core.publisher.Flux#just")
         .addInputLines(
             "A.java",
             "import reactor.core.publisher.Flux;",

--- a/error-prone-utils/src/main/java/tech/picnic/errorprone/utils/AnnotationAttributeMatcher.java
+++ b/error-prone-utils/src/main/java/tech/picnic/errorprone/utils/AnnotationAttributeMatcher.java
@@ -23,6 +23,10 @@ import java.util.stream.Stream;
 // XXX: Document design decision that the project stays as close as possible to Error Prone.
 //      ^ ... and *therefore* uses Google Auto Value rather than Immutables.org.
 // XXX: Make this class implement the `MultiMatcher` interface.
+// XXX: Consider generalizing this class into a broader type/member matcher (name TBD), covering
+// e.g. a bare-identifier-only restriction (independent of any type), and have
+// `tech.picnic.errorprone.bugpatterns.StaticImportConfig` delegate its candidate matching to it,
+// rather than just sharing `TypeMemberSpec` parsing.
 /**
  * A matcher of (annotation, attribute) pairs.
  *
@@ -87,14 +91,11 @@ public final class AnnotationAttributeMatcher implements Serializable {
       Set<String> wholeTypes,
       SetMultimap<String, String> attributeRestrictions) {
     for (String entry : enumeration) {
-      int hash = entry.indexOf('#');
-      if (hash < 0) {
-        wholeTypes.add(entry);
-      } else {
-        String annotationType = entry.substring(0, hash);
-        String attribute = entry.substring(hash + 1);
-        attributeRestrictions.put(annotationType, attribute);
-      }
+      TypeMemberSpec spec = TypeMemberSpec.parse(entry);
+      spec.member()
+          .ifPresentOrElse(
+              attribute -> attributeRestrictions.put(spec.type(), attribute),
+              () -> wholeTypes.add(spec.type()));
     }
   }
 

--- a/error-prone-utils/src/main/java/tech/picnic/errorprone/utils/TypeMemberSpec.java
+++ b/error-prone-utils/src/main/java/tech/picnic/errorprone/utils/TypeMemberSpec.java
@@ -1,0 +1,28 @@
+package tech.picnic.errorprone.utils;
+
+import java.util.Optional;
+
+/**
+ * A parsed {@code <type>} or {@code <type>#<member>} specification, as accepted by several flags
+ * throughout this project.
+ *
+ * @param type The (canonical) type name.
+ * @param member The type member, if the specification identifies one.
+ */
+public record TypeMemberSpec(String type, Optional<String> member) {
+  /**
+   * Parses the given specification.
+   *
+   * <p>This method does not validate {@code spec}; callers requiring e.g. well-formedness checks
+   * must perform these themselves.
+   *
+   * @param spec A string of the form {@code <type>} or {@code <type>#<member>}.
+   * @return The parsed specification.
+   */
+  public static TypeMemberSpec parse(String spec) {
+    int hash = spec.indexOf('#');
+    return hash < 0
+        ? new TypeMemberSpec(spec, Optional.empty())
+        : new TypeMemberSpec(spec.substring(0, hash), Optional.of(spec.substring(hash + 1)));
+  }
+}

--- a/error-prone-utils/src/test/java/tech/picnic/errorprone/utils/TypeMemberSpecTest.java
+++ b/error-prone-utils/src/test/java/tech/picnic/errorprone/utils/TypeMemberSpecTest.java
@@ -1,0 +1,26 @@
+package tech.picnic.errorprone.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+final class TypeMemberSpecTest {
+  @Test
+  void parseWholeType() {
+    assertThat(TypeMemberSpec.parse(Math.class.getCanonicalName()))
+        .isEqualTo(new TypeMemberSpec(Math.class.getCanonicalName(), Optional.empty()));
+  }
+
+  @Test
+  void parseTypeAndMember() {
+    assertThat(TypeMemberSpec.parse("java.lang.Math#max"))
+        .isEqualTo(new TypeMemberSpec(Math.class.getCanonicalName(), Optional.of("max")));
+  }
+
+  @Test
+  void parseSplitsOnFirstHashOnly() {
+    assertThat(TypeMemberSpec.parse("java.lang.Math#max#min"))
+        .isEqualTo(new TypeMemberSpec(Math.class.getCanonicalName(), Optional.of("max#min")));
+  }
+}


### PR DESCRIPTION
Suggested commit message:
```
Support custom `StaticImport` candidates (#2280)

The candidate types and members recognized by the `StaticImport` check
are hard-coded, so that project-specific APIs cannot benefit from
static import enforcement. Introduce the `StaticImport:CandidateTypes`
and `StaticImport:CandidateMembers` flags, using which additional
candidates can be specified. The `NonStaticImport` check honors the
latter flag, such that it does not undo static imports introduced by
its sibling check.
```

The `StaticImport` and `NonStaticImport` checks decide which type
members belong behind a static import from hard-coded lists, so
project-specific APIs (e.g. a Picnic-internal `AttributeId#parseAttributeId`)
can never benefit from the enforcement. This PR makes those lists
extensible through two Error Prone flags:

- `-XepOpt:StaticImport:CandidateTypes=<type>,...` — additional types
  all of whose members should be statically imported.
- `-XepOpt:StaticImport:CandidateMembers=<type>#<member>,...` —
  additional individual members.

Both flags are purely additive to the built-in lists. `NonStaticImport`
reads the members flag through the same parser, so it never strips a
static import that `StaticImport` was configured to introduce (avoiding
a fix that oscillates between the two checks).

Configuration is validated at construction time: malformed entries,
whitespace, and values that clash with `NonStaticImport`'s exclusion
lists fail fast with a descriptive `IllegalArgumentException` rather
than being silently ignored.
