### PR TITLE
Upgrade JDKs used by GitHub Actions builds

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -42,9 +42,9 @@ Please replace this sentence with log output, if applicable.
 <!-- Please complete the following information: -->
 
 - Operating system (e.g. MacOS Tahoe).
-- Java version (i.e. `java --version`, e.g. `21.0.10`).
-- Error Prone version (e.g. `2.48.0`).
-- Error Prone Support version (e.g. `0.28.0`).
+- Java version (i.e. `java --version`, e.g. `21.0.12`).
+- Error Prone version (e.g. `2.50.0`).
+- Error Prone Support version (e.g. `0.30.0`).
 
 ### Additional context
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,12 +19,12 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-24.04, macos-15, windows-2025 ]
-        build-jdk: [ 25.0.2 ]
-        target-jdk: [ 21.0.10 ]
+        build-jdk: [ 25.0.4 ]
+        target-jdk: [ 21.0.12 ]
         include:
           - os: ubuntu-24.04
-            build-jdk: 26
-            target-jdk: 21.0.10
+            build-jdk: 26.0.2
+            target-jdk: 21.0.12
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Harden-Runner
@@ -82,7 +82,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
-          java-version: 25.0.2
+          java-version: 25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Build and deploy

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
-          java-version: 25.0.2
+          java-version: 25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Initialize CodeQL

--- a/.github/workflows/error-prone-compat.yml
+++ b/.github/workflows/error-prone-compat.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
-          java-version: 25.0.2
+          java-version: 25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Quickly build and install project

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -138,8 +138,8 @@ jobs:
         with:
           checkout-ref: ${{ env.CHECKOUT_REF }}
           java-version: |
-            21.0.10
-            25.0.2
+            21.0.12
+            25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Install project to local Maven repository

--- a/.github/workflows/pitest-analyze-pr.yml
+++ b/.github/workflows/pitest-analyze-pr.yml
@@ -28,7 +28,7 @@ jobs:
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
           checkout-fetch-depth: 2
-          java-version: 25.0.2
+          java-version: 25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Run Pitest

--- a/.github/workflows/pitest-update-pr.yml
+++ b/.github/workflows/pitest-update-pr.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
-          java-version: 25.0.2
+          java-version: 25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Download Pitest analysis artifact

--- a/.github/workflows/reviewdog.yml
+++ b/.github/workflows/reviewdog.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
-          java-version: 25.0.2
+          java-version: 25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Set up Reviewdog

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -39,7 +39,7 @@ jobs:
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
           checkout-fetch-depth: 0
-          java-version: 25.0.2
+          java-version: 25.0.4
           java-distribution: temurin
           maven-version: 3.9.16
       - name: Create missing `test` directory

--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,3 +1,3 @@
-java=25.0.2-tem
+java=25.0.4-tem
 maven=3.9.16
 mvnd=1.0.5

--- a/website/generate-version-compatibility-overview.sh
+++ b/website/generate-version-compatibility-overview.sh
@@ -76,7 +76,7 @@ for eps_version in ${eps_versions}; do
       # Before the introduction of an `.sdkmanrc` file, all released Error Prone
       # Support versions were compatible with Java 17. Error Prone 2.43.0 raised
       # the baseline from Java 17 to Java 21.
-      default_java_version="$(echo -e "2.43.0\n${ep_version}" | sort -CV && echo 25.0.2-tem || echo 17.0.18-tem)"
+      default_java_version="$(echo -e "2.43.0\n${ep_version}" | sort -CV && echo 25.0.4-tem || echo 17.0.20-tem)"
       echo n | sdk install java "${default_java_version}"
       sdk use java "${default_java_version}"
 


### PR DESCRIPTION
Suggested commit message:
```
Upgrade JDKs used by GitHub Actions builds (#2288)

Summary of changes:
- Use JDK 17.0.20 instead of 17.0.18.
- Use JDK 21.0.12 instead of 21.0.10.
- Use JDK 25.0.4 instead of 25.0.2.
- Use JDK 26.0.2 instead of 26.
- Have GitHub issue template reference more recent version numbers.

See:
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.19+10
- https://adoptium.net/temurin/release-notes/?version=jdk-17.0.20+8
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.11+10
- https://adoptium.net/temurin/release-notes/?version=jdk-21.0.12+8
- https://adoptium.net/temurin/release-notes/?version=jdk-25.0.3+9
- https://adoptium.net/temurin/release-notes/?version=jdk-25.0.4+7
- https://adoptium.net/temurin/release-notes/?version=jdk-26.0.1+8
- https://adoptium.net/temurin/release-notes/?version=jdk-26.0.2+10
```