### PR TITLE
Suggest JDK-native unmodifiable collectors in CollectorMutability

### DIFF
--- a/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
+++ b/error-prone-contrib/src/main/java/tech/picnic/errorprone/bugpatterns/CollectorMutability.java
@@ -20,6 +20,7 @@ import com.google.errorprone.matchers.Description;
 import com.google.errorprone.matchers.Matcher;
 import com.sun.source.tree.ExpressionTree;
 import com.sun.source.tree.MethodInvocationTree;
+import com.sun.tools.javac.code.Source;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -58,8 +59,7 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
 
   @Override
   public Description matchMethodInvocation(MethodInvocationTree tree, VisitorState state) {
-    if (!ThirdPartyLibrary.GUAVA.isIntroductionAllowed(state)
-        || !COLLECTOR_METHOD.matches(tree, state)) {
+    if (!COLLECTOR_METHOD.matches(tree, state)) {
       return Description.NO_MATCH;
     }
 
@@ -67,6 +67,7 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
       return suggestToCollectionAlternatives(
           tree,
           ImmutableList.class.getCanonicalName() + ".toImmutableList",
+          Collectors.class.getCanonicalName() + ".toUnmodifiableList",
           ArrayList.class.getCanonicalName(),
           state);
     }
@@ -79,6 +80,7 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
       return suggestToCollectionAlternatives(
           tree,
           ImmutableSet.class.getCanonicalName() + ".toImmutableSet",
+          Collectors.class.getCanonicalName() + ".toUnmodifiableSet",
           HashSet.class.getCanonicalName(),
           state);
     }
@@ -89,21 +91,30 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
   private Description suggestToCollectionAlternatives(
       MethodInvocationTree tree,
       String immutableReplacement,
+      String unmodifiableReplacement,
       String mutableReplacement,
       VisitorState state) {
+    Description.Builder description = buildDescription(tree);
+
+    if (ThirdPartyLibrary.GUAVA.isIntroductionAllowed(state)) {
+      description.addFix(replaceMethodInvocation(tree, immutableReplacement, state));
+    }
+
+    if (isJdk10Plus(state)) {
+      description.addFix(replaceMethodInvocation(tree, unmodifiableReplacement, state));
+    }
+
     SuggestedFix.Builder mutableFix = SuggestedFix.builder();
     String toCollectionSelect =
         SuggestedFixes.qualifyStaticImport(
             Collectors.class.getCanonicalName() + ".toCollection", mutableFix, state);
     String mutableCollection = SuggestedFixes.qualifyType(state, mutableFix, mutableReplacement);
+    description.addFix(
+        mutableFix
+            .replace(tree, "%s(%s::new)".formatted(toCollectionSelect, mutableCollection))
+            .build());
 
-    return buildDescription(tree)
-        .addFix(replaceMethodInvocation(tree, immutableReplacement, state))
-        .addFix(
-            mutableFix
-                .replace(tree, "%s(%s::new)".formatted(toCollectionSelect, mutableCollection))
-                .build())
-        .build();
+    return description.build();
   }
 
   private Description suggestToMapAlternatives(MethodInvocationTree tree, VisitorState state) {
@@ -112,22 +123,37 @@ public final class CollectorMutability extends BugChecker implements MethodInvoc
       return Description.NO_MATCH;
     }
 
+    Description.Builder description = buildDescription(tree);
+
+    if (ThirdPartyLibrary.GUAVA.isIntroductionAllowed(state)) {
+      description.addFix(
+          replaceMethodInvocation(
+              tree, ImmutableMap.class.getCanonicalName() + ".toImmutableMap", state));
+    }
+
+    if (isJdk10Plus(state)) {
+      description.addFix(
+          replaceMethodInvocation(
+              tree, Collectors.class.getCanonicalName() + ".toUnmodifiableMap", state));
+    }
+
     SuggestedFix.Builder mutableFix = SuggestedFix.builder();
     String hashMap =
         SuggestedFixes.qualifyType(state, mutableFix, HashMap.class.getCanonicalName());
+    description.addFix(
+        mutableFix
+            .postfixWith(
+                tree.getArguments().get(argCount - 1),
+                (argCount == 2 ? ", (a, b) -> { throw new IllegalStateException(); }" : "")
+                    + ", %s::new".formatted(hashMap))
+            .build());
 
-    return buildDescription(tree)
-        .addFix(
-            replaceMethodInvocation(
-                tree, ImmutableMap.class.getCanonicalName() + ".toImmutableMap", state))
-        .addFix(
-            mutableFix
-                .postfixWith(
-                    tree.getArguments().get(argCount - 1),
-                    (argCount == 2 ? ", (a, b) -> { throw new IllegalStateException(); }" : "")
-                        + ", %s::new".formatted(hashMap))
-                .build())
-        .build();
+    return description.build();
+  }
+
+  private static boolean isJdk10Plus(VisitorState state) {
+    Source lowerBound = Source.lookup("10");
+    return lowerBound != null && Source.instance(state.context).compareTo(lowerBound) >= 0;
   }
 
   private static SuggestedFix replaceMethodInvocation(

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/CollectorMutabilityTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/CollectorMutabilityTest.java
@@ -65,6 +65,32 @@ final class CollectorMutabilityTest {
     CompilationTestHelper.newInstance(CollectorMutability.class, getClass())
         .withClasspath()
         .expectErrorMessage("X", m -> !m.contains("toImmutableList"))
+        .expectErrorMessage("Y", m -> !m.contains("toImmutableMap"))
+        .expectErrorMessage("Z", m -> !m.contains("toImmutableSet"))
+        .addSourceLines(
+            "A.java",
+            "import java.util.stream.Collectors;",
+            "import java.util.stream.Stream;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    // BUG: Diagnostic matches: X",
+            "    Stream.empty().collect(Collectors.toList());",
+            "    // BUG: Diagnostic matches: Y",
+            "    Stream.empty().collect(Collectors.toMap(o -> o, o -> o));",
+            "    // BUG: Diagnostic matches: Z",
+            "    Stream.empty().collect(Collectors.toSet());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void identificationWithoutGuavaAtExactlyJdk10OnClasspath() {
+    CompilationTestHelper.newInstance(CollectorMutability.class, getClass())
+        .withClasspath()
+        .setArgs("--release", "10")
+        .expectErrorMessage("X", m -> m.contains("toUnmodifiableList"))
         .addSourceLines(
             "A.java",
             "import java.util.stream.Collectors;",

--- a/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/CollectorMutabilityTest.java
+++ b/error-prone-contrib/src/test/java/tech/picnic/errorprone/bugpatterns/CollectorMutabilityTest.java
@@ -1,6 +1,7 @@
 package tech.picnic.errorprone.bugpatterns;
 
 import static com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers.SECOND;
+import static com.google.errorprone.BugCheckerRefactoringTestHelper.FixChoosers.THIRD;
 
 import com.google.errorprone.BugCheckerRefactoringTestHelper;
 import com.google.errorprone.CompilationTestHelper;
@@ -63,6 +64,7 @@ final class CollectorMutabilityTest {
   void identificationWithoutGuavaOnClasspath() {
     CompilationTestHelper.newInstance(CollectorMutability.class, getClass())
         .withClasspath()
+        .expectErrorMessage("X", m -> !m.contains("toImmutableList"))
         .addSourceLines(
             "A.java",
             "import java.util.stream.Collectors;",
@@ -70,6 +72,28 @@ final class CollectorMutabilityTest {
             "",
             "class A {",
             "  void m() {",
+            "    // BUG: Diagnostic matches: X",
+            "    Stream.empty().collect(Collectors.toList());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void identificationWithoutGuavaAndOlderJdkOnClasspath() {
+    CompilationTestHelper.newInstance(CollectorMutability.class, getClass())
+        .withClasspath()
+        .setArgs("--release", "9")
+        .expectErrorMessage(
+            "X", m -> !m.contains("toImmutableList") && !m.contains("toUnmodifiableList"))
+        .addSourceLines(
+            "A.java",
+            "import java.util.stream.Collectors;",
+            "import java.util.stream.Stream;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    // BUG: Diagnostic matches: X",
             "    Stream.empty().collect(Collectors.toList());",
             "  }",
             "}")
@@ -137,6 +161,64 @@ final class CollectorMutabilityTest {
   void replacementSecondSuggestedFix() {
     BugCheckerRefactoringTestHelper.newInstance(CollectorMutability.class, getClass())
         .setFixChooser(SECOND)
+        .addInputLines(
+            "A.java",
+            "import static java.util.stream.Collectors.toList;",
+            "import static java.util.stream.Collectors.toMap;",
+            "import static java.util.stream.Collectors.toSet;",
+            "",
+            "import java.util.stream.Collectors;",
+            "import java.util.stream.Stream;",
+            "import reactor.core.publisher.Flux;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    Flux.just(1).collect(Collectors.toList());",
+            "    Flux.just(2).collect(toList());",
+            "",
+            "    Stream.of(\"foo\").collect(Collectors.toMap(String::getBytes, String::length));",
+            "    Stream.of(\"bar\").collect(toMap(String::getBytes, String::length));",
+            "    Flux.just(\"baz\").collect(Collectors.toMap(String::getBytes, String::length, (a, b) -> b));",
+            "    Flux.just(\"qux\").collect(toMap(String::getBytes, String::length, (a, b) -> b));",
+            "",
+            "    Stream.of(1).collect(Collectors.toSet());",
+            "    Stream.of(2).collect(toSet());",
+            "  }",
+            "}")
+        .addOutputLines(
+            "A.java",
+            "import static java.util.stream.Collectors.toList;",
+            "import static java.util.stream.Collectors.toMap;",
+            "import static java.util.stream.Collectors.toSet;",
+            "import static java.util.stream.Collectors.toUnmodifiableList;",
+            "import static java.util.stream.Collectors.toUnmodifiableMap;",
+            "import static java.util.stream.Collectors.toUnmodifiableSet;",
+            "",
+            "import java.util.stream.Collectors;",
+            "import java.util.stream.Stream;",
+            "import reactor.core.publisher.Flux;",
+            "",
+            "class A {",
+            "  void m() {",
+            "    Flux.just(1).collect(toUnmodifiableList());",
+            "    Flux.just(2).collect(toUnmodifiableList());",
+            "",
+            "    Stream.of(\"foo\").collect(toUnmodifiableMap(String::getBytes, String::length));",
+            "    Stream.of(\"bar\").collect(toUnmodifiableMap(String::getBytes, String::length));",
+            "    Flux.just(\"baz\").collect(toUnmodifiableMap(String::getBytes, String::length, (a, b) -> b));",
+            "    Flux.just(\"qux\").collect(toUnmodifiableMap(String::getBytes, String::length, (a, b) -> b));",
+            "",
+            "    Stream.of(1).collect(toUnmodifiableSet());",
+            "    Stream.of(2).collect(toUnmodifiableSet());",
+            "  }",
+            "}")
+        .doTest();
+  }
+
+  @Test
+  void replacementThirdSuggestedFix() {
+    BugCheckerRefactoringTestHelper.newInstance(CollectorMutability.class, getClass())
+        .setFixChooser(THIRD)
         .addInputLines(
             "A.java",
             "import static java.util.stream.Collectors.toList;",


### PR DESCRIPTION
Fixes #954

`CollectorMutability` previously returned `Description.NO_MATCH` entirely when Guava was absent from the classpath, which meant even the Guava-independent mutable fallback fix (`toCollection(...)`) was suppressed. This restructures the checker to always build a `Description`, following the same pattern already used in `FluxImplicitBlock`.

On top of that fix, when the compilation target is JDK 10+, the checker now offers `Collectors.toUnmodifiable{List,Set,Map}()` as an additional suggested fix, a good middle ground for projects (like Checkstyle) that want to avoid a Guava dependency while still clearly communicating (im)mutability.

Fix ordering, when all are applicable:
1. Guava immutable (`Immutable{List,Set,Map}.toImmutable...`)
2. JDK-native unmodifiable (`Collectors.toUnmodifiable...`), JDK 10+ only
3. Explicit mutable fallback (`toCollection(...)` / `HashMap::new`)

The `toMap` case required separate handling from `toList`/`toSet`, since `toUnmodifiableMap` only has 2-arg and 3-arg overloads matching `toMap`'s existing 2-arg/3-arg cases the 4-arg case was already out of scope (returns `NO_MATCH`) before this change.

Tests updated/added:
- `identificationWithoutGuavaOnClasspath` now expects a diagnostic (previously expected none)
- New `identificationWithoutGuavaAndOlderJdkOnClasspath` covers the pre-JDK-10 case, where neither Guava nor the unmodifiable fix should be offered
- `replacementSecondSuggestedFix` now covers the JDK-unmodifiable fix; the previous mutable-fix assertions moved to a new `replacementThirdSuggestedFix`, matching the updated fix ordering