### PR TITLE
Split integration tests into `patch` and `validate` phases

### DIFF
--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ on:
   issue_comment:
     types: [ created ]
   push:
-    branches: [ master ]
+    branches: [ master, 'sschroevers/speed-up-integration-tests' ]
 permissions:
   contents: read
 env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -14,7 +14,7 @@ on:
   issue_comment:
     types: [ created ]
   push:
-    branches: [ master, 'sschroevers/speed-up-integration-tests' ]
+    branches: [ master ]
 permissions:
   contents: read
 env:

--- a/.github/workflows/integration-tests.yml
+++ b/.github/workflows/integration-tests.yml
@@ -97,12 +97,12 @@ jobs:
             });
 
             core.setOutput('commentId', response.data.id);
-  test:
-    name: Integration test
-    # On push events the `acknowledge` job is skipped; `always()` ensures this
-    # job still runs in that case.
+  patch:
+    name: Apply patches
+    # On push events the `acknowledge` job is skipped; `!cancelled()` ensures
+    # this job still runs in that case.
     needs: [ matrix, acknowledge ]
-    if: ${{ always() && needs.matrix.result == 'success' }}
+    if: ${{ !cancelled() && needs.matrix.result == 'success' }}
     runs-on: ubuntu-24.04
     strategy:
       fail-fast: false
@@ -112,27 +112,17 @@ jobs:
       - name: Install Harden-Runner
         uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
-          # We can't use `disable-sudo-and-containers` here, as some
-          # integration test projects have unit tests that start Docker
-          # containers.
-          disable-sudo: true
-          # XXX: After updating the validation build flags in
-          # `integration-tests/prometheus-java-client.sh`, review whether the
-          # Docker domains specified here can be dropped.
+          disable-sudo-and-containers: true
           allowed-endpoints: >
             api.adoptium.net:443
-            auth.docker.io:443
-            checkstyle.org:443
+            api.github.com:443
             github.com:443
             hosted-compute-watchdog-prod-*.githubapp.com:443
             objects.githubusercontent.com:443
             oss.sonatype.org:443
-            production.cloudflare.docker.com:443
-            raw.githubusercontent.com:443
-            registry-1.docker.io:443
             release-assets.githubusercontent.com:443
             repo.maven.apache.org:443
-            repository.sonatype.org:443
+            results-receiver.actions.githubusercontent.com:443
       - name: Check out code and set up JDK and Maven
         uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
         with:
@@ -144,8 +134,74 @@ jobs:
           maven-version: 3.9.16
       - name: Install project to local Maven repository
         run: mvn install -DskipTests -Dverification.skip
-      - name: Run integration test
-        run: xvfb-run "./integration-tests/${INTEGRATION_TEST}.sh" "${{ runner.temp }}/artifacts"
+      - name: Apply patches
+        run: |
+          "./integration-tests/${INTEGRATION_TEST}.sh" --phase=patch "${{ runner.temp }}/artifacts"
+        env:
+          INTEGRATION_TEST: ${{ matrix.integration-test }}
+          JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
+      # The `validate` job replays the changes recorded here, so these
+      # artifacts are uploaded even if this job reported unexpected changes; in
+      # that case they are also the primary evidence of what went wrong.
+      - name: Upload patch phase artifacts
+        if: ${{ !cancelled() }}
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: "integration-test-patch-${{ matrix.integration-test }}"
+          path: "${{ runner.temp }}/artifacts"
+          if-no-files-found: error
+          retention-days: 7
+      - name: Remove installed project artifacts
+        run: mvn dependency:purge-local-repository -DmanualInclude='${project.groupId}' -DresolutionFuzziness=groupId
+  validate:
+    name: Validate patched code
+    # Runs even if the `patch` job reported unexpected changes, so that the
+    # validation build's result is observed in the same run.
+    needs: [ matrix, patch ]
+    if: ${{ !cancelled() && needs.matrix.result == 'success' }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        integration-test: ${{ fromJson(needs.matrix.outputs.matrix) }}
+    steps:
+      - name: Install Harden-Runner
+        uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          disable-sudo-and-containers: true
+          allowed-endpoints: >
+            api.adoptium.net:443
+            api.github.com:443
+            checkstyle.org:443
+            github.com:443
+            hosted-compute-watchdog-prod-*.githubapp.com:443
+            objects.githubusercontent.com:443
+            oss.sonatype.org:443
+            raw.githubusercontent.com:443
+            release-assets.githubusercontent.com:443
+            repo.maven.apache.org:443
+            results-receiver.actions.githubusercontent.com:443
+      # Download the `patch` job's output before the more expensive setup
+      # steps, so that a missing artifact is reported within seconds.
+      - name: Download patch phase artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: "integration-test-patch-${{ matrix.integration-test }}"
+          path: "${{ runner.temp }}/artifacts"
+      - name: Check out code and set up JDK and Maven
+        uses: s4u/setup-maven-action@ba34de01b7f4ba2ab8e2860df8993a29f4477056 # v1.20.0
+        with:
+          checkout-ref: ${{ env.CHECKOUT_REF }}
+          java-version: |
+            21.0.12
+            25.0.4
+          java-distribution: temurin
+          maven-version: 3.9.16
+      - name: Install project to local Maven repository
+        run: mvn install -DskipTests -Dverification.skip
+      - name: Validate patched code
+        run: |
+          "./integration-tests/${INTEGRATION_TEST}.sh" --phase=validate "${{ runner.temp }}/artifacts"
         env:
           INTEGRATION_TEST: ${{ matrix.integration-test }}
           JAVA_HOME: ${{ env.JAVA_HOME_21_X64 }}
@@ -153,13 +209,13 @@ jobs:
         if: ${{ failure() }}
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
-          name: "integration-test-${{ matrix.integration-test }}"
+          name: "integration-test-validate-${{ matrix.integration-test }}"
           path: "${{ runner.temp }}/artifacts"
       - name: Remove installed project artifacts
         run: mvn dependency:purge-local-repository -DmanualInclude='${project.groupId}' -DresolutionFuzziness=groupId
   report:
     name: Report integration test result
-    needs: [ acknowledge, test ]
+    needs: [ acknowledge, patch, validate ]
     # Using `always()` ensures that this job runs even if previous jobs failed
     # or were cancelled.
     if: ${{ always() && github.event.issue.pull_request && needs.acknowledge.outputs.comment_id }}
@@ -177,11 +233,13 @@ jobs:
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         env:
           COMMENT_ID: ${{ needs.acknowledge.outputs.comment_id }}
-          CONCLUSION: ${{ needs.test.result }}
+          CONCLUSION: ${{ (needs.patch.result == 'success' && needs.validate.result) || needs.patch.result }}
         with:
           script: |
             const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-            const conclusion = process.env.CONCLUSION;
+            // A phase that has not started by the time the workflow is
+            // cancelled is reported as skipped rather than cancelled.
+            const conclusion = process.env.CONCLUSION === 'skipped' ? 'cancelled' : process.env.CONCLUSION;
 
             let [statusEmoji, message] = (() => {
               switch (conclusion) {

--- a/integration-tests/checkstyle.sh
+++ b/integration-tests/checkstyle.sh
@@ -15,11 +15,6 @@ validation_error_prone_flags=''
 # closing tags that are removed by Google Java Format.
 validation_build_flags='-Dtest=!AllChecksTest#allCheckstyleModulesHaveXdocDocumentation,!XdocsCategoryIndexTest#allChecksListedInCategoryIndexAndDescriptionMatches,!XdocsJavaDocsTest#allCheckSectionJavaDocs,!XdocsMobileWrapperTest#allCheckSectionMobileWrapper,!XdocsPagesTest#allCheckSections,!XdocsPagesTest#allModulesPageInSyncWithModuleSummaries,!XdocsPagesTest#allSubSections,!XdocsPagesTest#allXmlExamples'
 
-if [ "${#}" -gt 2 ] || ([ "${#}" = 2 ] && [ "${1:---sync}" != '--sync' ]); then
-  echo "Usage: ${0} [--sync] [<report_directory>]" >&2
-  exit 1
-fi
-
 "$(dirname "${0}")/run-integration-test.sh" \
   "${test_name}" \
   "${project}" \
@@ -31,4 +26,4 @@ fi
   "${patch_error_prone_flags}" \
   "${validation_error_prone_flags}" \
   "${validation_build_flags}" \
-  $@
+  "${@}"

--- a/integration-tests/metrics-expected-warnings.txt
+++ b/integration-tests/metrics-expected-warnings.txt
@@ -1,67 +1,10 @@
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/CollectdReporter.java:[306,57] [rawtypes] found raw type: Gauge
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/PacketWriter.java:[164,12] [cast] redundant cast to ByteBuffer
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/PacketWriter.java:[169,11] [cast] redundant cast to ByteBuffer
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/PacketWriter.java:[175,17] [cast] redundant cast to ByteBuffer
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/PacketWriter.java:[200,8] [cast] redundant cast to ByteBuffer
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/PacketWriter.java:[203,21] [cast] redundant cast to ByteBuffer
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/PacketWriter.java:[206,11] [cast] redundant cast to ByteBuffer
-metrics-collectd/src/main/java/io/dropwizard/metrics5/collectd/PacketWriter.java:[250,36] [cast] redundant cast to ByteBuffer
-metrics-core/src/main/java/io/dropwizard/metrics5/CsvReporter.java:[390,35] [FormatStringConcatenation] Defer string concatenation to the invoked method
-metrics-core/src/main/java/io/dropwizard/metrics5/InstrumentedExecutorService.java:[244,25] [try] auto-closeable resource durationContext is never referenced in body of corresponding try statement
-metrics-core/src/main/java/io/dropwizard/metrics5/InstrumentedExecutorService.java:[266,25] [try] auto-closeable resource context is never referenced in body of corresponding try statement
-metrics-core/src/main/java/io/dropwizard/metrics5/MetricRegistry.java:[56,27] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-core/src/main/java/io/dropwizard/metrics5/ScheduledReporter.java:[40,12] [removal] SecurityManager in java.lang has been deprecated and marked for removal
-metrics-core/src/main/java/io/dropwizard/metrics5/ScheduledReporter.java:[40,38] [removal] getSecurityManager() in System has been deprecated and marked for removal
-metrics-core/src/test/java/io/dropwizard/metrics5/MetricNameTest.java:[882,83] [deprecation] getId() in Thread has been deprecated
-metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java:[431,17] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
-metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java:[436,19] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
-metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java:[449,20] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
-metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/HealthCheckRegistry.java:[270,32] [removal] getSecurityManager() in System has been deprecated and marked for removal
-metrics-healthchecks/src/main/java/io/dropwizard/metrics5/health/HealthCheckRegistry.java:[270,6] [removal] SecurityManager in java.lang has been deprecated and marked for removal
-metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckTest.java:[189,46] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone
-metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckTest.java:[203,46] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone
-metrics-httpasyncclient/src/main/java/io/dropwizard/metrics5/httpasyncclient/InstrumentedNClientConnManager.java:[40,8] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-httpclient/src/main/java/io/dropwizard/metrics5/httpclient/InstrumentedHttpClientConnectionManager.java:[114,8] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-httpclient/src/test/java/io/dropwizard/metrics5/httpclient/HttpClientMetricNameStrategiesTest.java:[124,22] [deprecation] rewriteURI(URI,HttpHost,boolean) in URIUtils has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedAsyncClientConnectionManager.java:[29,62] [deprecation] getDefault() in DefaultClientTlsStrategy has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java:[116,50] [deprecation] ConnectionSocketFactory in org.apache.hc.client5.http.socket has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java:[160,12] [deprecation] DefaultHttpClientConnectionOperator(Lookup<ConnectionSocketFactory>,SchemePortResolver,DnsResolver) in DefaultHttpClientConnectionOperator has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java:[30,28] [deprecation] ConnectionSocketFactory in org.apache.hc.client5.http.socket has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java:[31,28] [deprecation] ConnectionSocketFactory in org.apache.hc.client5.http.socket has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java:[32,37] [deprecation] PlainConnectionSocketFactory in org.apache.hc.client5.http.socket has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java:[33,38] [deprecation] SSLConnectionSocketFactory in org.apache.hc.client5.http.ssl has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientConnectionManager.java:[96,21] [deprecation] ConnectionSocketFactory in org.apache.hc.client5.http.socket has been deprecated
-metrics-httpclient5/src/main/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpRequestExecutor.java:[49,4] [deprecation] HttpRequestExecutor(Timeout,ConnectionReuseStrategy,Http1StreamListener) in HttpRequestExecutor has been deprecated
-metrics-httpclient5/src/test/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientsTest.java:[46,10] [deprecation] execute(ClassicHttpRequest) in HttpClient has been deprecated
-metrics-httpclient5/src/test/java/io/dropwizard/metrics5/httpclient5/InstrumentedHttpClientsTest.java:[68,12] [deprecation] execute(ClassicHttpRequest) in HttpClient has been deprecated
-metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java:[282,17] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
-metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java:[287,19] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
-metrics-jakarta-servlets/src/main/java/io/dropwizard/metrics5/servlets/CpuProfileServlet.java:[23,21] [serial] non-transient instance field of a serializable class declared with a non-serializable type
-metrics-jakarta-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java:[31,67] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone
-metrics-jdbi3/src/main/java/io/dropwizard/metrics5/jdbi3/InstrumentedTimingCollector.java:[20,52] [removal] TimingCollector in org.jdbi.v3.core.statement has been deprecated and marked for removal
-metrics-jdbi3/src/main/java/io/dropwizard/metrics5/jdbi3/InstrumentedTimingCollector.java:[36,14] [removal] collect(long,StatementContext) in TimingCollector has been deprecated and marked for removal
-metrics-jdbi3/src/test/java/io/dropwizard/metrics5/jdbi3/strategies/SmartNameStrategyTest.java:[18,10] [deprecation] InstrumentedTimingCollector in io.dropwizard.metrics5.jdbi3 has been deprecated
-metrics-jdbi3/src/test/java/io/dropwizard/metrics5/jdbi3/strategies/SmartNameStrategyTest.java:[24,20] [deprecation] InstrumentedTimingCollector in io.dropwizard.metrics5.jdbi3 has been deprecated
-metrics-jetty10/src/main/java/io/dropwizard/metrics5/jetty10/InstrumentedConnectionFactory.java:[26,11] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-jetty11/src/main/java/io/dropwizard/metrics5/jetty11/InstrumentedConnectionFactory.java:[26,11] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-jetty12/src/main/java/io/dropwizard/metrics/jetty12/InstrumentedConnectionFactory.java:[26,11] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-json/src/main/java/io/dropwizard/metrics5/json/MetricsModule.java:[189,31] [serial] non-transient instance field of a serializable class declared with a non-serializable type
-metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/BufferPoolMetricSetTest.java:[101,74] [unchecked] unchecked cast
-metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/BufferPoolMetricSetTest.java:[56,74] [unchecked] unchecked cast
-metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/BufferPoolMetricSetTest.java:[65,74] [unchecked] unchecked cast
-metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/BufferPoolMetricSetTest.java:[74,74] [unchecked] unchecked cast
-metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/BufferPoolMetricSetTest.java:[83,74] [unchecked] unchecked cast
-metrics-jvm/src/test/java/io/dropwizard/metrics5/jvm/BufferPoolMetricSetTest.java:[92,74] [unchecked] unchecked cast
-metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java:[108,27] [rawtypes] found raw type: Gauge
-metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java:[112,27] [rawtypes] found raw type: Gauge
-metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java:[51,49] [rawtypes] found raw type: Gauge
-metrics-legacy-adapter/src/main/java/com/codahale/metrics/MetricRegistry.java:[51,9] [rawtypes] found raw type: Gauge
-metrics-legacy-adapter/src/test/java/com/codahale/metrics/MetricRegistryTest.java:[367,22] [rawtypes] found raw type: Gauge
-metrics-legacy-adapter/src/test/java/com/codahale/metrics/MetricRegistryTest.java:[50,4] [rawtypes] found raw type: Gauge
-metrics-log4j2/src/main/java/io/dropwizard/metrics5/log4j2/InstrumentedAppender.java:[85,4] [deprecation] AbstractAppender(String,Filter,Layout<? extends Serializable>,boolean) in AbstractAppender has been deprecated
-metrics-log4j2/src/main/java/io/dropwizard/metrics5/log4j2/InstrumentedAppender.java:[96,4] [deprecation] AbstractAppender(String,Filter,Layout<? extends Serializable>,boolean) in AbstractAppender has been deprecated
-metrics-logback13/src/main/java/io/dropwizard/metrics/logback13/InstrumentedAppender.java:[51,11] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-logback14/src/main/java/io/dropwizard/metrics/logback14/InstrumentedAppender.java:[51,11] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-logback15/src/main/java/io/dropwizard/metrics5/logback15/InstrumentedAppender.java:[51,11] [this-escape] possible 'this' escape before subclass is fully initialized
-metrics-servlets/src/main/java/io/dropwizard/metrics5/servlets/CpuProfileServlet.java:[23,21] [serial] non-transient instance field of a serializable class declared with a non-serializable type
-metrics-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java:[31,67] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone
+metrics-core/src/main/java/io/dropwizard/metrics5/CsvReporter.java:[390,36] [FormatStringConcatenation] Defer string concatenation to the invoked method
+metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java:[431,18] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
+metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java:[436,20] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
+metrics-graphite/src/main/java/io/dropwizard/metrics5/graphite/GraphiteReporter.java:[449,21] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
+metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckTest.java:[189,47] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone
+metrics-healthchecks/src/test/java/io/dropwizard/metrics5/health/HealthCheckTest.java:[203,47] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone
+metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java:[282,18] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
+metrics-influxdb/src/main/java/io/dropwizard/metrics5/influxdb/InfluxDbReporter.java:[287,20] [Slf4jLogStatement] Log statement contains 0 placeholders, but specifies 1 matching argument(s)
+metrics-jakarta-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java:[31,68] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone
+metrics-servlets/src/test/java/io/dropwizard/metrics5/servlets/HealthCheckServletTest.java:[31,68] [TimeZoneUsage] Derive the current time from an existing `Clock` Spring bean, and don't rely on a `Clock`'s time zone

--- a/integration-tests/metrics-init.patch
+++ b/integration-tests/metrics-init.patch
@@ -1,3 +1,17 @@
+new file mode 100644
+--- /dev/null
++++ b/.mvn/jvm.config
+@@ -0,0 +1,10 @@
++--add-exports jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED
++--add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED
++--add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED
++--add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED
++--add-exports jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED
++--add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED
++--add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED
++--add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED
++--add-opens jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED
++--add-opens jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED
 --- a/metrics-jakarta-servlets/src/main/java/io/dropwizard/metrics5/servlets/MetricsServlet.java
 +++ b/metrics-jakarta-servlets/src/main/java/io/dropwizard/metrics5/servlets/MetricsServlet.java
 @@ -188,6 +188,9 @@ public class MetricsServlet extends HttpServlet {
@@ -52,21 +66,30 @@
      <profiles>
          <profile>
              <id>jdk17</id>
-@@ -145,7 +166,9 @@
+@@ -140,28 +161,32 @@
+                         <groupId>org.apache.maven.plugins</groupId>
+                         <artifactId>maven-compiler-plugin</artifactId>
+                         <configuration>
+-                            <fork>true</fork>
++                            <!-- XXX: `javac` is not forked here; drop this deviation, and `.mvn/jvm.config`, if/when https://github.com/dropwizard/metrics/pull/5366 lands. -->
+                             <compilerArgs>
                                  <arg>-Xlint:all</arg>
                                  <arg>-XDcompilePolicy=simple</arg>
                                  <arg>--should-stop=ifError=FLOW</arg>
 -                                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.*</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.parser=ALL-UNNAMED</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED</arg>
+-                                <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
+-                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
+-                                <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
 +                                <!-- XXX: Drop this flag once the project uses Error Prone 2.46.0+ by default. -->
 +                                <arg>-XDaddTypeAnnotationsToSymbol=true</arg>
 +                                <arg>-Xplugin:ErrorProne -XepExcludedPaths:.*/target/generated-sources/.* ${error-prone.configuration-args}</arg>
-                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.api=ALL-UNNAMED</arg>
-                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED</arg>
-                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED</arg>
-@@ -156,12 +179,24 @@
-                                 <arg>-J--add-exports=jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</arg>
-                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED</arg>
-                                 <arg>-J--add-opens=jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED</arg>
 +                                <arg>-Xmaxwarns</arg>
 +                                <arg>1000000</arg>
                              </compilerArgs>
@@ -89,12 +112,14 @@
                                  </path>
                              </annotationProcessorPaths>
                          </configuration>
-@@ -283,7 +318,7 @@
+@@ -283,8 +308,8 @@
                  <groupId>org.apache.maven.plugins</groupId>
                  <artifactId>maven-compiler-plugin</artifactId>
                  <configuration>
 -                    <release>17</release>
+-                    <fork>true</fork>
 +                    <release>21</release>
-                     <fork>true</fork>
++                    <!-- XXX: `javac` is not forked here; drop this deviation, and `.mvn/jvm.config`, if/when https://github.com/dropwizard/metrics/pull/5366 lands. -->
                      <parameters>true</parameters>
                      <showWarnings>true</showWarnings>
+                     <compilerArgs>

--- a/integration-tests/metrics.sh
+++ b/integration-tests/metrics.sh
@@ -21,11 +21,6 @@ validation_error_prone_flags=''
 # Harden-Runner configuration.
 validation_build_flags='-Dtest=!InstrumentedHttpClientsTest#registersExpectedMetricsGivenNameStrategy -Dsurefire.failIfNoSpecifiedTests=false'
 
-if [ "${#}" -gt 2 ] || ([ "${#}" = 2 ] && [ "${1:---sync}" != '--sync' ]); then
-  echo "Usage: ${0} [--sync] [<report_directory>]" >&2
-  exit 1
-fi
-
 "$(dirname "${0}")/run-integration-test.sh" \
   "${test_name}" \
   "${project}" \
@@ -37,4 +32,4 @@ fi
   "${patch_error_prone_flags}" \
   "${validation_error_prone_flags}" \
   "${validation_build_flags}" \
-  $@
+  "${@}"

--- a/integration-tests/prometheus-java-client-expected-changes.patch
+++ b/integration-tests/prometheus-java-client-expected-changes.patch
@@ -4672,25 +4672,25 @@
  import static org.awaitility.Awaitility.await;
  
  import com.github.tomakehurst.wiremock.http.Request;
-@@ -35,7 +35,7 @@ import org.junit.jupiter.api.BeforeEach;
- import org.junit.jupiter.api.Test;
+@@ -37,7 +37,7 @@ import org.junit.jupiter.api.Test;
  
- @WireMockTest(httpPort = 4317)
+ // XXX: Drop these changes if/when https://github.com/prometheus/client_java/pull/2407 lands.
+ @WireMockTest
 -class ExemplarTest {
 +final class ExemplarTest {
    private static final String ENDPOINT_PATH = "/v1/metrics";
    private static final int TIMEOUT = 3;
    private static final String INSTRUMENTATION_SCOPE_NAME = "testInstrumentationScope";
-@@ -45,7 +45,7 @@ class ExemplarTest {
+@@ -47,7 +47,7 @@ class ExemplarTest {
    private OpenTelemetryExporter openTelemetryExporter;
  
    @BeforeEach
--  public void setUp() {
-+  void setUp() {
+-  public void setUp(WireMockRuntimeInfo wireMockRuntimeInfo) {
++  void setUp(WireMockRuntimeInfo wireMockRuntimeInfo) {
      openTelemetryExporter =
          OpenTelemetryExporter.builder()
-             .endpoint("http://localhost:4317")
-@@ -64,14 +64,14 @@ class ExemplarTest {
+             .endpoint(wireMockRuntimeInfo.getHttpBaseUrl())
+@@ -66,14 +66,14 @@ class ExemplarTest {
    }
  
    @AfterEach
@@ -4708,7 +4708,7 @@
      try (SdkTracerProvider sdkTracerProvider =
          SdkTracerProvider.builder().setSampler(Sampler.alwaysOn()).build()) {
  
-@@ -95,9 +95,9 @@ class ExemplarTest {
+@@ -97,9 +97,9 @@ class ExemplarTest {
              });
    }
  
@@ -4720,7 +4720,7 @@
      try (SdkTracerProvider sdkTracerProvider =
          SdkTracerProvider.builder().setSampler(Sampler.alwaysOff()).build()) {
  
-@@ -108,8 +108,7 @@ class ExemplarTest {
+@@ -110,8 +110,7 @@ class ExemplarTest {
        }
      }
  
@@ -4730,7 +4730,7 @@
              () ->
                  await()
                      .atMost(TIMEOUT, SECONDS)
-@@ -122,7 +121,8 @@ class ExemplarTest {
+@@ -124,7 +123,8 @@ class ExemplarTest {
                                    .withHeader("Content-Type", equalTo("application/x-protobuf"))
                                    .andMatching(getExemplarCountMatcher(1)));
                            return true;

--- a/integration-tests/prometheus-java-client-init.patch
+++ b/integration-tests/prometheus-java-client-init.patch
@@ -9,6 +9,70 @@
              .withFileSystemBind(sampleAppVolume.getHostPath(), "/app", BindMode.READ_ONLY)
              .withWorkingDirectory("/app")
              .withLogConsumer(LogConsumer.withPrefix(sampleApp))
+--- a/integration-tests/it-exporter/it-exporter-test/pom.xml
++++ b/integration-tests/it-exporter/it-exporter-test/pom.xml
+@@ -24,5 +24,24 @@
+       <version>${project.version}</version>
+       <scope>test</scope>
+     </dependency>
++    <!-- XXX: Drop this if/when https://github.com/prometheus/client_java/pull/2407 lands. -->
++    <dependency>
++      <groupId>io.prometheus</groupId>
++      <artifactId>it-exporter-servlet-tomcat-sample</artifactId>
++      <version>${project.version}</version>
++      <scope>test</scope>
++    </dependency>
++    <dependency>
++      <groupId>io.prometheus</groupId>
++      <artifactId>it-exporter-servlet-jetty-sample</artifactId>
++      <version>${project.version}</version>
++      <scope>test</scope>
++    </dependency>
++    <dependency>
++      <groupId>io.prometheus</groupId>
++      <artifactId>it-exporter-httpserver-sample</artifactId>
++      <version>${project.version}</version>
++      <scope>test</scope>
++    </dependency>
+   </dependencies>
+ </project>
+--- a/integration-tests/it-exporter/it-no-protobuf-test/pom.xml
++++ b/integration-tests/it-exporter/it-no-protobuf-test/pom.xml
+@@ -24,5 +24,12 @@
+       <version>${project.version}</version>
+       <scope>test</scope>
+     </dependency>
++    <!-- XXX: Drop this if/when https://github.com/prometheus/client_java/pull/2407 lands. -->
++    <dependency>
++      <groupId>io.prometheus</groupId>
++      <artifactId>it-exporter-no-protobuf</artifactId>
++      <version>${project.version}</version>
++      <scope>test</scope>
++    </dependency>
+   </dependencies>
+ </project>
+--- a/integration-tests/it-spring-boot-smoke-test/pom.xml
++++ b/integration-tests/it-spring-boot-smoke-test/pom.xml
+@@ -58,6 +58,19 @@
+       <artifactId>micrometer-registry-prometheus</artifactId>
+       <scope>runtime</scope>
+     </dependency>
++    <!-- XXX: Drop this if/when https://github.com/prometheus/client_java/pull/2407 lands. -->
++    <dependency>
++      <groupId>io.prometheus</groupId>
++      <artifactId>prometheus-metrics-core</artifactId>
++      <version>${project.version}</version>
++      <scope>runtime</scope>
++      <exclusions>
++        <exclusion>
++          <groupId>io.prometheus</groupId>
++          <artifactId>prometheus-metrics-tracer-initializer</artifactId>
++        </exclusion>
++      </exclusions>
++    </dependency>
+     <dependency>
+       <groupId>org.springframework.boot</groupId>
+       <artifactId>spring-boot-starter-test</artifactId>
 --- a/pom.xml
 +++ b/pom.xml
 @@ -252,36 +252,49 @@
@@ -74,6 +138,39 @@
          </dependency>
          <dependency>
            <groupId>org.slf4j</groupId>
+--- a/prometheus-metrics-exporter-opentelemetry/src/test/java/io/prometheus/metrics/exporter/opentelemetry/ExemplarTest.java
++++ b/prometheus-metrics-exporter-opentelemetry/src/test/java/io/prometheus/metrics/exporter/opentelemetry/ExemplarTest.java
+@@ -13,6 +13,7 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
+ import static org.awaitility.Awaitility.await;
+ 
+ import com.github.tomakehurst.wiremock.http.Request;
++import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+ import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+ import com.github.tomakehurst.wiremock.matching.MatchResult;
+ import com.github.tomakehurst.wiremock.matching.ValueMatcher;
+@@ -34,7 +35,8 @@ import org.junit.jupiter.api.AfterEach;
+ import org.junit.jupiter.api.BeforeEach;
+ import org.junit.jupiter.api.Test;
+ 
+-@WireMockTest(httpPort = 4317)
++// XXX: Drop these changes if/when https://github.com/prometheus/client_java/pull/2407 lands.
++@WireMockTest
+ class ExemplarTest {
+   private static final String ENDPOINT_PATH = "/v1/metrics";
+   private static final int TIMEOUT = 3;
+@@ -45,10 +47,10 @@ class ExemplarTest {
+   private OpenTelemetryExporter openTelemetryExporter;
+ 
+   @BeforeEach
+-  public void setUp() {
++  public void setUp(WireMockRuntimeInfo wireMockRuntimeInfo) {
+     openTelemetryExporter =
+         OpenTelemetryExporter.builder()
+-            .endpoint("http://localhost:4317")
++            .endpoint(wireMockRuntimeInfo.getHttpBaseUrl())
+             .protocol("http/protobuf")
+             .intervalSeconds(1)
+             .buildAndStart();
 --- a/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
 +++ b/prometheus-metrics-exposition-textformats/src/test/java/io/prometheus/metrics/expositionformats/ExpositionFormatsTest.java
 @@ -32,6 +32,8 @@ import org.junit.jupiter.api.Test;

--- a/integration-tests/prometheus-java-client.sh
+++ b/integration-tests/prometheus-java-client.sh
@@ -6,6 +6,13 @@ test_name="$(basename "${0}" .sh)"
 project='prometheus-java-client'
 repository='https://github.com/prometheus/client_java.git'
 revision='v1.4.1'
+# XXX: The `prometheus-metrics-{exporter-opentelemetry,exposition-formats}-shaded`
+# modules copy the sources of the sibling module they shade during their
+# `validate` phase, without declaring a dependency on it. Under `-T1C` such a
+# copy may therefore observe sources that Error Prone is concurrently
+# rewriting. Declaring the missing dependencies would change what the Shade
+# plugin bundles, so this is left to
+# https://github.com/prometheus/client_java/pull/2407.
 additional_build_flags='-Djava.version=21 -Dwarnings='
 additional_source_directories=''
 shared_error_prone_flags=''

--- a/integration-tests/prometheus-java-client.sh
+++ b/integration-tests/prometheus-java-client.sh
@@ -6,13 +6,6 @@ test_name="$(basename "${0}" .sh)"
 project='prometheus-java-client'
 repository='https://github.com/prometheus/client_java.git'
 revision='v1.4.1'
-# XXX: The `prometheus-metrics-{exporter-opentelemetry,exposition-formats}-shaded`
-# modules copy the sources of the sibling module they shade during their
-# `validate` phase, without declaring a dependency on it. Under `-T1C` such a
-# copy may therefore observe sources that Error Prone is concurrently
-# rewriting. Declaring the missing dependencies would change what the Shade
-# plugin bundles, so this is left to
-# https://github.com/prometheus/client_java/pull/2407.
 additional_build_flags='-Djava.version=21 -Dwarnings='
 additional_source_directories=''
 shared_error_prone_flags=''

--- a/integration-tests/prometheus-java-client.sh
+++ b/integration-tests/prometheus-java-client.sh
@@ -13,11 +13,6 @@ patch_error_prone_flags=''
 validation_error_prone_flags=''
 validation_build_flags=''
 
-if [ "${#}" -gt 2 ] || ([ "${#}" = 2 ] && [ "${1:---sync}" != '--sync' ]); then
-  echo "Usage: ${0} [--sync] [<report_directory>]" >&2
-  exit 1
-fi
-
 "$(dirname "${0}")/run-integration-test.sh" \
   "${test_name}" \
   "${project}" \
@@ -29,4 +24,4 @@ fi
   "${patch_error_prone_flags}" \
   "${validation_error_prone_flags}" \
   "${validation_build_flags}" \
-  $@
+  "${@}"

--- a/integration-tests/run-integration-test.sh
+++ b/integration-tests/run-integration-test.sh
@@ -16,8 +16,8 @@ integration_test_root="$(cd "$(dirname -- "${0}")" && pwd)"
 error_prone_support_root="${integration_test_root}/.."
 repos_root="${integration_test_root}/.repos"
 
-if [ "${#}" -lt 10 ] || [ "${#}" -gt 12 ] || ([ "${#}" = 12 ] && [ "${11:---sync}" != '--sync' ]); then
-  echo "Usage: $(basename "${0}") <test_name> <project> <repository> <revision> <additional_build_flags> <additional_source_directories> <shared_error_prone_flags> <patch_error_prone_flags> <validation_error_prone_flags> <validation_build_flags> [--sync] [<report_directory>]" >&2
+if [ "${#}" -lt 10 ]; then
+  echo "Usage: $(basename "${0}") <test_name> <project> <repository> <revision> <additional_build_flags> <additional_source_directories> <shared_error_prone_flags> <patch_error_prone_flags> <validation_error_prone_flags> <validation_build_flags> [<option>...]" >&2
   exit 1
 fi
 
@@ -31,8 +31,57 @@ shared_error_prone_flags="${7}"
 patch_error_prone_flags="${8}"
 validation_error_prone_flags="${9}"
 validation_build_flags="${10}"
-do_sync="$([ "${#}" = 10 ] || [ "${11:-}" != '--sync' ] || echo 1)"
-report_directory="$([ "${#}" = 10 ] || ([ -z "${do_sync}" ] && echo "${11}") || ([ "${#}" = 11 ] || echo "${12}"))"
+shift 10
+
+# The remaining options are forwarded verbatim by the top-level integration
+# test scripts, so they are reported in terms of those.
+function usage() {
+  echo "Usage: ${test_name}.sh [--phase={patch,validate}] [--sync] [<report_directory>]" >&2
+  exit 1
+}
+
+# The `patch` phase applies Error Prone Support's suggested changes and
+# validates the resulting diff, while the `validate` phase replays those
+# changes, builds and tests the resulting code, and validates the emitted
+# diagnostics. Selecting a single phase allows the two to be distributed over
+# separate CI jobs. By default both phases are executed in sequence.
+phase='all'
+do_sync=''
+report_directory=''
+while [ "${#}" -gt 0 ]; do
+  case "${1}" in
+    --phase=patch | --phase=validate)
+      phase="${1#--phase=}"
+      ;;
+    --sync)
+      do_sync=1
+      ;;
+    -*)
+      usage
+      ;;
+    *)
+      [ -z "${report_directory}" ] || usage
+      report_directory="${1}"
+      ;;
+  esac
+  shift
+done
+
+if [ "${phase}" != 'all' ]; then
+  # Each phase refreshes only the expected output it produces, so syncing would
+  # leave the remaining files stale.
+  if [ -n "${do_sync}" ]; then
+    echo 'Cannot sync expected output unless both phases are executed.' >&2
+    exit 1
+  fi
+
+  # The `patch` phase communicates its result to the `validate` phase through
+  # the report directory, so a transient one will not do.
+  if [ -z "${report_directory}" ]; then
+    echo 'A report directory must be specified when executing a single phase.' >&2
+    exit 1
+  fi
+fi
 
 if [ -n "${report_directory}" ]; then
   mkdir -p "${report_directory}"
@@ -57,6 +106,7 @@ case "$(uname -s)" in
 esac
 
 shared_build_flags="
+  -T1C
   -Derror-prone.version=$(
     mvn -f "${error_prone_support_root}" help:evaluate -Dexpression=version.error-prone -q -DforceStdout
   )
@@ -126,8 +176,8 @@ git config user.name || git config user.name 'Integration Test'
 # Prepare the code for analysis by applying the minimal set of changes required
 # to run Error Prone with Error Prone Support.
 initial_patch="${integration_test_root}/${test_name}-init.patch"
-git clean -fdx
-git apply < "${initial_patch}"
+git clean -ffdx
+git apply --index < "${initial_patch}"
 git commit -m 'dependency: Introduce Error Prone Support' .
 if [ -n "${do_sync}" ]; then
   # The initial patch applied successfully, but if it was created against a
@@ -143,14 +193,24 @@ mvn ${shared_build_flags} "${format_goal}"
 git commit -m 'minor: Reformat using Google Java Format' .
 diff_base="$(git rev-parse HEAD)"
 
-# Apply Error Prone Support-suggested changes until a fixed point is reached.
-function apply_patch() {
-  local extra_build_args="${1}"
+# Files containing the changes applied by the `patch` phase, and the tree they
+# yield, respectively. Tracking the latter enables guarding against the two
+# phases analyzing different code, including for reasons the patch does not
+# itself describe: for example, `git apply` silently ignores file mode changes
+# not expressed in the `diff` headers stripped below.
+actual_changes="${report_directory}/${test_name}-changes.patch"
+patched_tree="${report_directory}/${test_name}-patched-tree.txt"
 
+# Apply Error Prone Support-suggested changes until a fixed point is reached.
+# Every round recompiles all sources, as there are cases in which violations
+# are missed during incremental compilation. Doing so is generally also faster:
+# a round that recompiles only the files changed by its predecessor is cheaper,
+# but often more rounds are then required to reach the fixed point.
+function apply_patch() {
   (
     set -x \
-      && mvn ${shared_build_flags} ${extra_build_args} \
-           package "${format_goal}" \
+      && mvn ${shared_build_flags} \
+           clean package "${format_goal}" \
            -Derror-prone.configuration-args="${error_prone_patch_flags}" \
            -DskipTests
   )
@@ -159,59 +219,80 @@ function apply_patch() {
     git commit -m 'minor: Apply patches' .
 
     # Changes were applied, so another compilation round may apply yet more
-    # changes. For performance reasons we perform incremental compilation,
-    # enabled using a misleading flag. (See
-    # https://issues.apache.org/jira/browse/MCOMPILER-209 for details.)
-    apply_patch '-Dmaven.compiler.useIncrementalCompilation=false'
-  elif [ "${extra_build_args}" != 'clean' ]; then
-    # No changes were applied. We'll attempt one more round in which all files
-    # are recompiled, because there are cases in which violations are missed
-    # during incremental compilation.
-    apply_patch 'clean'
+    # changes.
+    apply_patch
   fi
 }
-apply_patch ''
+if [ "${phase}" != 'validate' ]; then
+  apply_patch
+  git rev-parse 'HEAD^{tree}' > "${patched_tree}"
 
-# Run one more full build and log the output.
-#
-# By also running the tests, we validate that the (majority of) applied changes
-# are behavior preserving.
-validation_build_log="${report_directory}/${test_name}-validation-build-log.txt"
-(
-  set -x \
-    && mvn ${shared_build_flags} \
-         clean package \
-         -Derror-prone.configuration-args="${error_prone_validation_flags}" \
-         ${validation_build_flags}
-) | tee "${validation_build_log}" || failure=1
+  # Collect the applied changes.
+  expected_changes="${integration_test_root}/${test_name}-expected-changes.patch"
+  git diff "${diff_base}"..HEAD | ("${grep_command}" -vP '^(diff|index)' || true) > "${actual_changes}"
 
-# Collect the applied changes.
-expected_changes="${integration_test_root}/${test_name}-expected-changes.patch"
-actual_changes="${report_directory}/${test_name}-changes.patch"
-(git diff "${diff_base}"..HEAD | "${grep_command}" -vP '^(diff|index)' || true) > "${actual_changes}"
-
-# Collect the warnings reported by Error Prone Support checks.
-expected_warnings="${integration_test_root}/${test_name}-expected-warnings.txt"
-actual_warnings="${report_directory}/${test_name}-validation-build-warnings.txt"
-("${grep_command}" -oP "(?<=^\\Q[WARNING] ${PWD}/\\E).*" "${validation_build_log}" | "${grep_command}" -P '\] \[' || true) | LC_ALL=C sort > "${actual_warnings}"
-
-# Persist or validate the applied changes and reported warnings.
-if [ -n "${do_sync}" ]; then
-  echo 'Saving changes...'
-  cp "${actual_changes}" "${expected_changes}"
-  cp "${actual_warnings}" "${expected_warnings}"
-else
-  echo 'Inspecting changes...'
-  # XXX: This "diff of diffs" also contains vacuous sections, introduced due to
-  # line offset differences. Try to omit those from the final output.
-  if ! diff -u "${expected_changes}" "${actual_changes}"; then
-    echo 'There are unexpected changes. Inspect the preceding output for details.'
-    failure=1
+  # Persist or validate the applied changes.
+  if [ -n "${do_sync}" ]; then
+    echo 'Saving changes...'
+    cp "${actual_changes}" "${expected_changes}"
+  else
+    echo 'Inspecting changes...'
+    # XXX: This "diff of diffs" also contains vacuous sections, introduced due
+    # to line offset differences. Try to omit those from the final output.
+    if ! diff -u "${expected_changes}" "${actual_changes}"; then
+      echo 'There are unexpected changes. Inspect the preceding output for details.'
+      failure=1
+    fi
   fi
-  echo 'Inspecting emitted warnings...'
-  if ! diff -u "${expected_warnings}" "${actual_warnings}"; then
-    echo 'Diagnostics output changed. Inspect the preceding output for details.'
-    failure=1
+else
+  if [ ! -f "${actual_changes}" ] || [ ! -f "${patched_tree}" ]; then
+    echo "Output of the 'patch' phase not found in '${report_directory}'." >&2
+    exit 1
+  fi
+
+  # Replay the changes applied by the `patch` phase, so that the validation
+  # build analyzes the same code. An empty patch means that Error Prone Support
+  # suggested no changes at all.
+  if [ -s "${actual_changes}" ]; then
+    git apply --index "${actual_changes}"
+    git commit -m 'minor: Apply patches' .
+  fi
+
+  if [ "$(git rev-parse 'HEAD^{tree}')" != "$(cat "${patched_tree}")" ]; then
+    echo "Replayed code differs from that produced by the 'patch' phase." >&2
+    exit 1
+  fi
+fi
+
+if [ "${phase}" != 'patch' ]; then
+  # Run a full build and log the output.
+  #
+  # By also running the tests, we validate that the (majority of) applied
+  # changes are behavior preserving.
+  validation_build_log="${report_directory}/${test_name}-validation-build-log.txt"
+  (
+    set -x \
+      && mvn ${shared_build_flags} \
+           clean package \
+           -Derror-prone.configuration-args="${error_prone_validation_flags}" \
+           ${validation_build_flags}
+  ) | tee "${validation_build_log}" || failure=1
+
+  # Collect the warnings reported by Error Prone Support checks.
+  expected_warnings="${integration_test_root}/${test_name}-expected-warnings.txt"
+  actual_warnings="${report_directory}/${test_name}-validation-build-warnings.txt"
+  ("${grep_command}" -oP "(?<=^\\Q[WARNING] ${PWD}/\\E).*" "${validation_build_log}" | "${grep_command}" -P '\] \[' || true) | LC_ALL=C sort > "${actual_warnings}"
+
+  # Persist or validate the reported warnings.
+  if [ -n "${do_sync}" ]; then
+    echo 'Saving warnings...'
+    cp "${actual_warnings}" "${expected_warnings}"
+  else
+    echo 'Inspecting emitted warnings...'
+    if ! diff -u "${expected_warnings}" "${actual_warnings}"; then
+      echo 'Diagnostics output changed. Inspect the preceding output for details.'
+      failure=1
+    fi
   fi
 fi
 

--- a/integration-tests/run-integration-test.sh
+++ b/integration-tests/run-integration-test.sh
@@ -254,7 +254,12 @@ else
   # build analyzes the same code. An empty patch means that Error Prone Support
   # suggested no changes at all.
   if [ -s "${actual_changes}" ]; then
-    git apply --index "${actual_changes}"
+    if ! git apply --index "${actual_changes}"; then
+      # The two phases run on separate machines, so say which two things
+      # disagree; the raw `git apply` output does not.
+      echo "Cannot replay the changes produced by the 'patch' phase." >&2
+      exit 1
+    fi
     git commit -m 'minor: Apply patches' .
   fi
 

--- a/integration-tests/run-integration-test.sh
+++ b/integration-tests/run-integration-test.sh
@@ -255,8 +255,6 @@ else
   # suggested no changes at all.
   if [ -s "${actual_changes}" ]; then
     if ! git apply --index "${actual_changes}"; then
-      # The two phases run on separate machines, so say which two things
-      # disagree; the raw `git apply` output does not.
       echo "Cannot replay the changes produced by the 'patch' phase." >&2
       exit 1
     fi


### PR DESCRIPTION
Suggested commit message:
```
Split integration tests into `patch` and `validate` phases (#2318)

GitHub reclaims long-running jobs; since mid-August the `Integration
test` jobs were routinely killed with `The runner has received a
shutdown signal`, at times not even twelve minutes in. The kill time is
not a fixed cap, so this change both lowers the time any single runner
must survive and shortens the underlying builds.

The `patch` phase applies Error Prone Support's suggested changes and 
validates the resulting diff; the `validate` phase replays those
changes, builds and tests the result, and validates the emitted
diagnostics. The two hand off through an artifact, and compare the tree
they each analyze so that they cannot silently diverge. A `--phase` flag
selects one of them; by default both still run in sequence.

Summary of key changes:
- Every patch round now recompiles all sources. Partial recompilation
  makes a round cheaper, but such a round analyzes only the files its 
  predecessor changed, so more rounds are then required to reach the 
  fixed point.
- The Maven reactor is now parallelized using `-T1C`. The workflow
  already requested this through `MAVEN_ARGS`, but the script clears
  that variable so that the environment cannot influence the test
  result. This change does require extending the 
  `prometheus-java-client` initialization patch to ensure compatibility
  with concurrent builds.
- Through another initialization patch change, the `metrics` build now 
  compiles in-process. This speeds it up, and as a nice side-effect the 
  build no longer emits the 57 javac lint warnings that `<showWarnings>`
  surfaced only in forked mode.
```
